### PR TITLE
fix: fix repo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,4 +55,3 @@ traffic that sits between client applications and LLM backends.
   `claude` / `codex` / `openclaw` launchers.
 - Inference Hub integration docs are out of scope for this release.
 
-[0.1.0]: https://github.com/NVIDIA-dev/switchyard/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ See [Development](DEVELOPMENT.md) for full setup instructions.
 Quick start:
 
 ```bash
-git clone https://github.com/NVIDIA-dev/switchyard.git
+git clone https://github.com/NVIDIA-NeMo/Switchyard.git
 cd switchyard
 uv sync
 uvx pre-commit install --install-hooks --hook-type pre-commit --hook-type commit-msg
@@ -162,7 +162,7 @@ When adding a new component:
 - **Setup issues?** See [Development](DEVELOPMENT.md)
 - **Architecture questions?** See [Agents](AGENTS.md)
 - **Design docs?** See [docs/](docs/)
-- **Report a bug?** [Open an issue](https://github.com/NVIDIA-dev/switchyard/issues)
+- **Report a bug?** [Open an issue](https://github.com/NVIDIA-NeMo/Switchyard/issues)
 
 ## Code of Conduct
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ members = [
 authors = ["NVIDIA Corporation"]
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/NVIDIA-dev/switchyard"
+repository = "https://github.com/NVIDIA-NeMo/Switchyard"
 rust-version = "1.94"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ and dependencies. Install `uv` first if you don't have it
 (`curl -LsSf https://astral.sh/uv/install.sh | sh`), then:
 
 ```bash
-git clone https://github.com/NVIDIA-dev/switchyard.git
+git clone https://github.com/NVIDIA-NeMo/Switchyard.git
 cd switchyard
 
 uv sync                      # creates .venv, installs core + dev tooling

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install "switchyard[cli,server]"
 ### Install from source for local use (requires uv)
 
 ```bash
-git clone git@github.com:NVIDIA-dev/switchyard.git
+git clone git@github.com:NVIDIA-NeMo/Switchyard.git
 cd switchyard
 uv tool install --editable '.[server,cli]'
 ```
@@ -38,7 +38,7 @@ uv tool install --editable '.[server,cli]'
 ### Install from source for contributors (requires uv)
 
 ```bash
-git clone git@github.com:NVIDIA-dev/switchyard.git
+git clone git@github.com:NVIDIA-NeMo/Switchyard.git
 cd switchyard
 uv sync
 uv run switchyard ...
@@ -226,7 +226,7 @@ See [Installation](INSTALLATION.md) for a full breakdown of what each extra adds
 
 ## Community
 
-- **Issues**: [GitHub Issues](https://github.com/NVIDIA-dev/switchyard/issues)
+- **Issues**: [GitHub Issues](https://github.com/NVIDIA-NeMo/Switchyard/issues)
 - **Code of Conduct**: [Code of Conduct](CODE_OF_CONDUCT.md)
 - **Contributing**: [Contributing](CONTRIBUTING.md)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -213,7 +213,7 @@ export SWITCHYARD_TELEMETRY_OPT_OUT=1
 **Development setup**
 
 ```bash
-git clone https://github.com/NVIDIA-dev/switchyard.git
+git clone https://github.com/NVIDIA-NeMo/Switchyard.git
 cd switchyard
 uv sync
 source .venv/bin/activate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Switchyard
 site_description: Typed, composable LLM routing and format translation for Python
-repo_url: https://github.com/NVIDIA-dev/switchyard
-repo_name: NVIDIA-dev/switchyard
+repo_url: https://github.com/NVIDIA-NeMo/Switchyard
+repo_name: NVIDIA-NeMo/Switchyard
 edit_uri: edit/main/docs/
 extra:
   source_ref: !ENV [MKDOCS_SOURCE_REF, main]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,9 @@ managed = true
 switchyard = "switchyard.cli.switchyard_cli:main"
 
 [project.urls]
-Homepage = "https://github.com/NVIDIA-dev/switchyard"
-Repository = "https://github.com/NVIDIA-dev/switchyard"
-Issues = "https://github.com/NVIDIA-dev/switchyard/issues"
+Homepage = "https://github.com/NVIDIA-NeMo/Switchyard"
+Repository = "https://github.com/NVIDIA-NeMo/Switchyard"
+Issues = "https://github.com/NVIDIA-NeMo/Switchyard/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## What

Update all GitHub repository links to the canonical public repo `NVIDIA-NeMo/Switchyard`, and drop the premature `v0.1.0` release-tag link.

- `mkdocs.yml` — fix `repo_url` / `repo_name` (this is what made the docs header GitHub link point at the old dev repo)
- `README.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `docs/getting_started.md` — clone URLs and Issues links
- `CHANGELOG.md` — repo link; removed the `[0.1.0]` release-tag link definition (no tag exists yet, so it would 404)
- `Cargo.toml`, `pyproject.toml` — package `repository` / `Homepage` / `Issues` metadata

## Why

All these links pointed at `NVIDIA-dev/switchyard`, a leftover from before the open-source move. The rendered docs and package metadata sent users to a repo that isn't the public one.

Closes #

## How tested

Docs/metadata-only change — no Python source touched, so the lint/type/test gates below are N/A:

- [ ] `uv run ruff check .` clean — N/A (no code changed)
- [ ] `uv run mypy switchyard` clean — N/A (no code changed)
- [ ] `uv run pytest tests/` green — N/A (no code changed)
- [x] Verified `grep -rn NVIDIA-dev` returns zero matches across the repo

## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class. — N/A
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. — N/A
- [ ] Unit tests added for new components / bug fixes. — N/A (link/string fix only)
- [ ] README / `--help` updated if customer-facing surface changed. — README links updated
- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.