### PR TITLE
docs: add core concepts page, polish README, and fix stale doc commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Minimal steps to reproduce. Include the command line, the inbound request shape,
 
 ```bash
 # example
-switchyard passthrough --port 4000
+switchyard serve --config profiles.yaml --port 4000
 curl -s http://localhost:4000/v1/chat/completions -d '{"model":"...","messages":[...]}'
 ```
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -283,7 +283,7 @@
         "filename": "README.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 165
       }
     ],
     "crates/switchyard-components-v2/src/profiles/cascade.rs": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,31 +247,24 @@ and their transitives never appear in downstream vulnerability scans.
 export OPENAI_API_KEY="sk-..."       # or NVIDIA_API_KEY / ANTHROPIC_API_KEY where supported
 export OPENROUTER_API_KEY="sk-or-..." # pass with --api-key or save via configure
 
-# Passthrough — single OpenAI-compatible backend, all three inbound formats
-switchyard passthrough --port 4000
-switchyard passthrough --inbound anthropic --port 4000
-switchyard passthrough --inbound both --base-url https://... --api-key sk-...
-switchyard passthrough --base-url https://openrouter.ai/api/v1 --api-key "$OPENROUTER_API_KEY"
+# Serve a profile config (passthrough, random-routing, llm-routing, cascade).
+# Endpoints, targets, and profiles live in the YAML; see docs/routing_algorithms/overview.md.
+switchyard serve --config profiles.yaml --port 4000
+switchyard serve --config profiles.yaml --inbound anthropic --port 4000
 
-# Random-routing — weighted strong/weak coin for benchmarks
-switchyard random-routing \
-    --strong-model openai/openai/gpt-5.2 \
-    --weak-model openai/nvidia/nemotron-3-super \
-    --strong-probability 0.3 --port 4000
-
-# One-command launchers
-switchyard launch claude --model nvidia/moonshotai/kimi-k2.5
-switchyard launch claude --preset opus_kimi --strong-probability 0.5
-switchyard launch codex --model nvidia/moonshotai/kimi-k2.5
-switchyard launch codex --model openai/gpt-5.2 \
+# One-command launchers — single-model passthrough via --model
+switchyard launch claude --model openai/gpt-4o-mini \
+    --base-url https://openrouter.ai/api/v1 --api-key "$OPENROUTER_API_KEY"
+switchyard launch codex --model openai/gpt-4o-mini \
     --base-url https://openrouter.ai/api/v1 --api-key "$OPENROUTER_API_KEY"
 
-# Built-in routing strategies (zero-config)
-switchyard launch codex --deterministic       # LLM-classifier strong/weak
-switchyard launch codex --plan-execute        # strong planner + weak executor
+# Launchers default to built-in LLM-classifier routing; tune the tiers:
+switchyard launch claude \
+    --weak-model openai/gpt-4o-mini --classifier-model openai/gpt-4o \
+    --classifier-min-confidence 0.6
 
-# Verification and status
-switchyard verify --model openai/openai/gpt-5.2
+# Verification and saved config
+switchyard verify --model openai/gpt-4o-mini
 switchyard configure --show
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Quick start:
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Switchyard.git
-cd switchyard
+cd Switchyard
 uv sync
 uvx pre-commit install --install-hooks --hook-type pre-commit --hook-type commit-msg
 source .venv/bin/activate

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,7 +15,7 @@ and dependencies. Install `uv` first if you don't have it
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Switchyard.git
-cd switchyard
+cd Switchyard
 
 uv sync                      # creates .venv, installs core + dev tooling
 uvx pre-commit install --install-hooks --hook-type pre-commit --hook-type commit-msg

--- a/README.md
+++ b/README.md
@@ -4,11 +4,24 @@
 
 # Switchyard
 
-Typed, composable LLM routing and format translation for Python. Route traffic between multiple LLM providers, translate between OpenAI and Anthropic APIs, collect usage statistics, and build profile-backed routing flows with strong typing and minimal boilerplate.
+Switchyard is a Python proxy for LLM traffic. It routes requests across
+providers, translates between the OpenAI and Anthropic APIs, collects usage
+statistics, and lets you build typed, profile-backed routing flows with little
+boilerplate.
 
-**Why Switchyard?** Point coding agents like **Claude Code** and **Codex** at compatible open-source models. Switchyard transparently translates between OpenAI Chat, Anthropic Messages, and OpenAI Responses formats, so each agent keeps speaking its native API while requests are served by vLLM, NVIDIA NIM, Ollama, or any OpenAI-compatible endpoint. The same proxy can also **route across multiple models** for A/B benchmarking splits, signal-driven cascade escalation, or a custom router you wire in.
+**Why Switchyard?** Point a coding agent such as Claude Code or Codex at an
+open-source model. Switchyard translates between the OpenAI Chat, Anthropic
+Messages, and OpenAI Responses formats, so the agent keeps speaking its native
+API while the request is served by vLLM, NVIDIA NIM, Ollama, or any
+OpenAI-compatible endpoint. The same proxy can spread traffic across several
+models for A/B benchmarking, signal-driven cascade escalation, or a router you
+write yourself.
 
-**Launcher routing is explicit**: launchers default to built-in LLM-classifier routing, which you can tune with `--weak-model`, `--classifier-model`, `--profile`, and `--classifier-min-confidence`; use `--model X` for single-model passthrough. The deprecated `--routing-profiles FILE` path remains for launcher-owned legacy bundles.
+**Launcher routing is explicit.** By default, launchers use the built-in
+LLM-classifier router, which you tune with `--weak-model`, `--classifier-model`,
+`--profile`, and `--classifier-min-confidence`. Use `--model X` for
+single-model passthrough. The `--routing-profiles FILE` path is deprecated and
+remains only for launcher-owned legacy bundles.
 
 ## Features
 
@@ -167,17 +180,23 @@ asyncio.run(main())
 
 ## Architecture
 
-Switchyard sits between client applications and one or more LLM backends:
+Switchyard sits between your client applications and one or more LLM backends:
 
-```text
-clients --> Switchyard --> model backends
-            +--------> routing, translation, and fallback
+```mermaid
+flowchart LR
+    clients["Clients"]
+    switchyard["Switchyard<br/>routing · translation · fallback"]
+    backends["Model backends"]
+
+    clients -->|"OpenAI / Anthropic API"| switchyard
+    switchyard -->|"provider-native format"| backends
 ```
 
-Clients keep their supported OpenAI or Anthropic API format while Switchyard
-selects a configured model endpoint and translates the response back to the
-expected shape. See [Architecture](docs/architecture.md) for system context and
-the end-to-end request flow.
+Clients keep their native OpenAI or Anthropic API format. Switchyard picks a
+configured backend, forwards the request in that backend's own format, and
+translates the response back into the shape the client expects. See
+[Architecture](docs/architecture.md) for the system context and the full
+request flow.
 
 ## Installation Options
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install "switchyard[cli,server]"
 
 ```bash
 git clone git@github.com:NVIDIA-NeMo/Switchyard.git
-cd switchyard
+cd Switchyard
 uv tool install --editable '.[server,cli]'
 ```
 
@@ -39,7 +39,7 @@ uv tool install --editable '.[server,cli]'
 
 ```bash
 git clone git@github.com:NVIDIA-NeMo/Switchyard.git
-cd switchyard
+cd Switchyard
 uv sync
 uv run switchyard ...
 ```

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -1,0 +1,103 @@
+# Core Concepts
+
+This page explains the vocabulary the rest of the documentation takes for
+granted. Read it once and the configuration examples elsewhere will make sense.
+It is not a setup guide: to install and run Switchyard, see
+[Getting Started](getting_started.md), and to follow a request through the
+system, see [Architecture](architecture.md).
+
+## How it fits together
+
+Switchyard is a proxy. Clients (coding agents, SDKs, your own services) talk to
+it on one side, and model backends (hosted providers, private endpoints, local
+models) sit on the other. A client never asks for a backend by name. It sends a
+model ID, and the configuration behind that ID decides what actually runs.
+
+```mermaid
+flowchart LR
+    client["Client<br/>picks a model ID"]
+    profile["Profile<br/>routing policy"]
+    target["Target<br/>upstream model"]
+    endpoint["Endpoint<br/>provider connection"]
+    backend["Model backend"]
+
+    client -->|"model field"| profile
+    profile -->|"selects"| target
+    target -->|"uses"| endpoint
+    endpoint --> backend
+```
+
+## Endpoints, targets, and profiles
+
+A standalone deployment is described by a profile config: one file with three
+sections that keep provider connectivity, upstream models, and client-facing
+policy apart. Three terms carry most of the weight.
+
+| Term | What it is | YAML section |
+|---|---|---|
+| Endpoint | A provider connection: a `base_url` and its credentials. Many targets can share one. | `endpoints:` |
+| Target | A single upstream model you can call. It names an endpoint, a `model`, and a wire `format`. | `targets:` |
+| Profile | A client-facing routing policy over one or more targets. Its `type` is the routing strategy. | `profiles:` |
+
+The three nest. An endpoint is reused by targets, and targets are referenced by
+profiles. You set credentials in one place, add a model once, and build as many
+policies on top as you need. The [Routing Overview](routing_algorithms/overview.md)
+has a complete, runnable config and the full schema.
+
+## Model IDs
+
+Clients choose what happens through the `model` field on a request. Switchyard
+registers three kinds of model IDs and lists them all on `GET /v1/models`:
+profile IDs, which apply a routing policy; target IDs, which skip routing and
+call that one model; and the upstream model name itself, registered as an alias
+whenever it differs from its target ID. Send a profile ID when you want routing,
+or a target or upstream name when you want to pin a single model.
+
+## Tiers and routing strategies
+
+Most routing strategies divide traffic between two tiers: a strong target that
+is more capable and more expensive, and a weak target that is cheaper and
+faster. A tier is a role you hand to a target rather than a fixed property of it,
+so the same target can be the strong tier in one profile and the weak tier in
+another.
+
+A profile's `type` sets the strategy. `passthrough` sends everything to one
+target with no routing. `random-routing` splits traffic on a fixed probability.
+`llm-routing` asks a classifier model to pick a tier for each turn. `cascade`
+escalates from weak to strong when request signals call for it. The
+[Routing Overview](routing_algorithms/overview.md) covers when to use each and
+how to tune it.
+
+!!! warning "There is no `type: model`"
+    The current profile config does not have a `type: model`. To expose a single
+    model, point clients at a target ID directly, or add a `passthrough` profile
+    when you want a second name for it. `type: model` survives only in the
+    deprecated `--routing-profiles` bundles used by the launcher compatibility
+    path.
+
+Session affinity, or sticky routing, pins a conversation to one tier so later
+turns reuse it instead of being classified again. It belongs to `llm-routing`
+and is not a strategy of its own; random and cascade routing decide every
+request on its own merits. [Sticky Routing](routing_algorithms/sticky_routing.md)
+covers it in full.
+
+## Formats and translation
+
+Clients reach Switchyard in one of three inbound formats: OpenAI Chat
+Completions, Anthropic Messages, or OpenAI Responses. Each target has its own
+backend format, set by its `format:` field, which is one of `openai`,
+`anthropic`, `responses`, or `auto`. When the two differ, Switchyard translates
+the request on the way out and the response on the way back.
+
+That translation is what lets Claude Code, which speaks Anthropic Messages, run
+against an OpenAI-compatible model, and the reverse. The
+[Architecture](architecture.md) page documents every backend format, the `auto`
+probe, and the neutral representation used to convert between them.
+
+## Where to go next
+
+- [Getting Started](getting_started.md) to install and send a first request.
+- [Routing Overview](routing_algorithms/overview.md) to choose and tune a strategy.
+- [Agent Launchers](guides/agent_launchers.md) to run Claude Code, Codex, or OpenClaw.
+- [Architecture](architecture.md) to see a request travel end to end.
+- [CLI Reference](cli_reference.md) for flags and environment variables.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -214,7 +214,7 @@ export SWITCHYARD_TELEMETRY_OPT_OUT=1
 
 ```bash
 git clone https://github.com/NVIDIA-NeMo/Switchyard.git
-cd switchyard
+cd Switchyard
 uv sync
 source .venv/bin/activate
 uv run pytest tests/ -v

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Guides:
       - Agent Launchers: guides/agent_launchers.md
   - Concepts:
+      - Core Concepts: core_concepts.md
       - Architecture: architecture.md
   - Routing:
       - Overview: routing_algorithms/overview.md


### PR DESCRIPTION
## What

Documentation pass with three related changes:

1. **New Core Concepts page** (`docs/core_concepts.md`, added to the `Concepts` nav before Architecture). Defines the vocabulary the rest of the docs assume: endpoint, target, profile, model ID, strong/weak tiers, routing strategy (the profile `type`), session affinity, and the inbound-vs-backend format distinction. Scoped to vocabulary only; links out instead of duplicating Getting Started or Architecture.
2. **Doc-error fixes found while walking the setup flow:**
   - `cd switchyard` → `cd Switchyard` (the clone creates `Switchyard`; lowercase fails on case-sensitive filesystems) in README, DEVELOPMENT, CONTRIBUTING, and Getting Started.
   - `AGENTS.md` command block rewritten to drop removed commands/flags (`switchyard passthrough`, `switchyard random-routing`, `--preset`, `--strong-probability`, `--deterministic`, `--plan-execute`, `--strong-model`) in favor of the current `serve --config` / `launch --model` / classifier-tuning flags.
   - Bug-report issue template repro updated from the removed `switchyard passthrough` to `switchyard serve --config`.
3. **README intro and Architecture section rewritten** for clarity: broke up run-on, marketing-style sentences; replaced the broken ASCII architecture diagram with a mermaid flowchart consistent with `docs/architecture.md`.

## Why

The config examples across the docs lean on terms (*endpoint*, *target*, *profile*, *tier*) that were never defined in one place, several command examples referenced CLI verbs/flags that no longer exist (verified against `--help` and `CHANGELOG`), and the README intro/architecture copy read as boilerplate with a malformed diagram.

Closes #

## How tested

Docs-only change:

- [x] `uv run --only-group docs mkdocs build --strict` passes (no broken links or nav errors)
- [x] Removed CLI commands/flags verified against actual `switchyard --help` output
- [ ] `ruff` / `mypy` / `pytest` — N/A (no code changed)

## Checklist

- [x] README / docs updated for customer-facing surface.
- [x] Commits signed off (`Signed-off-by`) per the DCO.
- [ ] One class per file / new exports / unit tests — N/A (docs only).

## Notes for reviewers

Clone-URL lines on this branch use `NVIDIA-NeMo` (the repo-link fix from #1 is already on `main`); this PR only adds the `cd` casing fix on those lines. The README architecture diagram uses a `mermaid` block, which GitHub renders natively.
