### PR TITLE
chore: rename distribution package to nemo-switchyard

### DIFF
--- a/.agents/skills/switchyard-testing-ci/SKILL.md
+++ b/.agents/skills/switchyard-testing-ci/SKILL.md
@@ -65,7 +65,7 @@ The hard GitHub Actions gates live in `.github/workflows/ci.yml`:
 - Rust workspace gate: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
   and `cargo test --workspace`
 - slim-install smoke: isolated `uv run --with` default install/import checks, heavy-package
-  absence, and CLI help checks with `switchyard[cli,server] @ file://...`
+  absence, and CLI help checks with `nemo-switchyard[cli,server] @ file://...`
 - `uv run mypy switchyard` is a signal job (`continue-on-error`) but should still be run for typed
   package code, public APIs, profiles, route bundles, backends, request/response models, and translation changes.
 
@@ -137,8 +137,8 @@ default install:
 
 ```bash
 SWITCHYARD_ROOT="$(git rev-parse --show-toplevel)"
-SWITCHYARD_DEFAULT_PACKAGE="switchyard @ file://${SWITCHYARD_ROOT}"
-SWITCHYARD_EXTRAS_PACKAGE="switchyard[cli,server] @ file://${SWITCHYARD_ROOT}"
+SWITCHYARD_DEFAULT_PACKAGE="nemo-switchyard @ file://${SWITCHYARD_ROOT}"
+SWITCHYARD_EXTRAS_PACKAGE="nemo-switchyard[cli,server] @ file://${SWITCHYARD_ROOT}"
 cd /tmp
 uv run --isolated --no-project --python 3.12 \
   --with "${SWITCHYARD_DEFAULT_PACKAGE}" \

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ curl -s http://localhost:4000/v1/chat/completions -d '{"model":"...","messages":
 - Switchyard version (or commit SHA):
 - Python version (`python --version`):
 - OS / arch:
-- Install path (`uv sync`, `pip install switchyard`, source build, etc.):
+- Install path (`uv sync`, `pip install nemo-switchyard`, source build, etc.):
 - Inbound format (Chat Completions / Anthropic Messages / Responses):
 - Backend (OpenAI / Anthropic / NVIDIA Inference Hub / other):
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - name: pytest
         run: uv run pytest tests/ -v -m "not integration"
 
-  # Regression guard: the default install of switchyard (without extras)
+  # Regression guard: the default install of nemo-switchyard (without extras)
   # must NOT drag in torch / transformers / routellm / litellm /
   # openai-agents / docx. Catches accidental top-level imports of
   # heavy packages before they hit users as ~1 GB of install bloat.
@@ -142,8 +142,8 @@ jobs:
     name: Slim install smoke test
     runs-on: ubuntu-latest
     env:
-      SWITCHYARD_DEFAULT_PACKAGE: "switchyard @ file://${{ github.workspace }}"
-      SWITCHYARD_EXTRAS_PACKAGE: "switchyard[cli,server] @ file://${{ github.workspace }}"
+      SWITCHYARD_DEFAULT_PACKAGE: "nemo-switchyard @ file://${{ github.workspace }}"
+      SWITCHYARD_EXTRAS_PACKAGE: "nemo-switchyard[cli,server] @ file://${{ github.workspace }}"
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ traffic that sits between client applications and LLM backends.
 - **Rust core** (PyO3) — chain execution, the latency-aware router, and the
   tool-result signal collector are implemented in Rust and re-exported to
   Python.
-- **Packaging** — `pip install switchyard` with optional extras `[server]`,
+- **Packaging** — `pip install nemo-switchyard` with optional extras `[server]`,
   `[cli]`, `[gpu]`, `[all]`. See [Installation](INSTALLATION.md).
 
 ### Deprecated

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,7 +12,7 @@ Switchyard supports modular installation based on your use case. Install only th
 For applications that use Switchyard as a Python library for routing and recipe composition:
 
 ```bash
-pip install switchyard
+pip install nemo-switchyard
 ```
 
 **Includes:**
@@ -34,7 +34,7 @@ pip install switchyard
 Add FastAPI and Uvicorn to run Switchyard as a standalone HTTP proxy:
 
 ```bash
-pip install switchyard[server]
+pip install nemo-switchyard[server]
 ```
 
 **Adds:**
@@ -49,7 +49,7 @@ pip install switchyard[server]
 Add terminal UI support for the `switchyard launch claude` command:
 
 ```bash
-pip install switchyard[cli]
+pip install nemo-switchyard[cli]
 ```
 
 **Adds:**
@@ -64,7 +64,7 @@ pip install switchyard[cli]
 All optional dependencies for complete feature set:
 
 ```bash
-pip install switchyard[all]
+pip install nemo-switchyard[all]
 ```
 
 Equivalent to: `switchyard[server,cli]`
@@ -73,22 +73,22 @@ Equivalent to: `switchyard[server,cli]`
 
 **Middleware plugin (no server/CLI):**
 ```bash
-pip install switchyard                  # Core only
+pip install nemo-switchyard                  # Core only
 ```
 
 **Proxy server without launcher:**
 ```bash
-pip install switchyard[server]
+pip install nemo-switchyard[server]
 ```
 
 **Full Claude Code integration:**
 ```bash
-pip install switchyard[cli]             # Includes core
+pip install nemo-switchyard[cli]             # Includes core
 ```
 
 **Production deployment with all features:**
 ```bash
-pip install switchyard[all]
+pip install nemo-switchyard[all]
 ```
 
 ## Dependency Structure
@@ -131,7 +131,7 @@ You're trying to run the HTTP server without the `[server]` extra:
 
 ```bash
 # Install with server support
-pip install switchyard[server]
+pip install nemo-switchyard[server]
 ```
 
 ```python
@@ -145,7 +145,7 @@ You're trying to run the CLI launcher without the `[cli]` extra:
 
 ```bash
 # Install CLI support
-pip install switchyard[cli]
+pip install nemo-switchyard[cli]
 ```
 
 ```python
@@ -174,7 +174,7 @@ This includes:
 - pytest, ruff, mypy, respx for testing
 
 > **Note:** dev tooling lives in a PEP 735 dependency group, not an extra,
-> so `pip install switchyard[dev]` is **not supported** and dev tooling
+> so `pip install nemo-switchyard[dev]` is **not supported** and dev tooling
 > never appears in the published wheel's METADATA (it's invisible to
 > downstream vulnerability scans).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ remains only for launcher-owned legacy bundles.
 ### Install from PyPI
 
 ```bash
-pip install "switchyard[cli,server]"
+pip install "nemo-switchyard[cli,server]"
 ```
 
 ### Install from source for local use (requires uv)
@@ -203,15 +203,15 @@ request flow.
 Install from PyPI:
 
 ```bash
-pip install switchyard
+pip install nemo-switchyard
 ```
 
 Optional extras:
 
 ```bash
-pip install "switchyard[server]"   # FastAPI / Uvicorn HTTP endpoints
-pip install "switchyard[cli]"      # Interactive CLI launchers (Claude / Codex)
-pip install "switchyard[all]"      # Server, CLI, GPU routing, and tracing extras
+pip install "nemo-switchyard[server]"   # FastAPI / Uvicorn HTTP endpoints
+pip install "nemo-switchyard[cli]"      # Interactive CLI launchers (Claude / Codex)
+pip install "nemo-switchyard[all]"      # Server, CLI, GPU routing, and tracing extras
 ```
 
 See [Installation](INSTALLATION.md) for a full breakdown of what each extra adds.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@
 ## Install
 
 ```bash
-pip install "switchyard[cli,server]"
+pip install "nemo-switchyard[cli,server]"
 ```
 
 ## Configure

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ For system context and request lifecycle diagrams, see
 ## First Run
 
 ```bash
-pip install "switchyard[cli,server]"
+pip install "nemo-switchyard[cli,server]"
 switchyard configure
 switchyard launch claude
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.9,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "switchyard"
+name = "nemo-switchyard"
 version = "0.1.0"
 description = "Typed, composable LLM routing with request/response translation and multi-backend orchestration"
 readme = "README.md"
@@ -26,10 +26,10 @@ classifiers = [
 # Core dependencies — minimal set for the foundation library (core/ + recipes/).
 # No server, CLI, ML, GPU, or orchestrator packages.
 # Users install extras based on their use case:
-#   pip install switchyard                 # Core + recipes only
-#   pip install switchyard[server]         # Add FastAPI/Uvicorn for e2e
-#   pip install switchyard[cli]            # Add prompt-toolkit for CLI
-#   pip install switchyard[all]            # Everything
+#   pip install nemo-switchyard                 # Core + recipes only
+#   pip install nemo-switchyard[server]         # Add FastAPI/Uvicorn for e2e
+#   pip install nemo-switchyard[cli]            # Add prompt-toolkit for CLI
+#   pip install nemo-switchyard[all]            # Everything
 dependencies = [
     "openai>=2.34.0,<3.0",
     "anthropic>=0.99.0,<1.0",
@@ -77,14 +77,14 @@ tracing = [
 
 # Intake — NeMo Platform SDK required by IntakeClient for telemetry capture.
 # Only needed when --intake-enabled is passed to ``switchyard launch``.
-# Install with: pip install switchyard[intake]
+# Install with: pip install nemo-switchyard[intake]
 intake = [
     "nemo-platform>=0.1.0,<1.0",
 ]
 
 # Everything — all optional dependencies for full-featured deployment.
 all = [
-    "switchyard[server,cli,gpu,tracing,intake]",
+    "nemo-switchyard[server,cli,gpu,tracing,intake]",
 ]
 
 # Dev tooling lives in a PEP 735 dependency group rather than an optional
@@ -113,7 +113,7 @@ dev = [
     # Harbor is needed for local evaluation runs and supports the package floor.
     # Package users still do not see it in published metadata.
     "harbor @ git+https://github.com/harbor-framework/harbor.git@v0.6.4 ; python_version >= '3.12'",
-    "switchyard[server]",
+    "nemo-switchyard[server]",
     "pytest-markdown-docs>=0.9.2",
 ]
 docs = [

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -852,7 +852,7 @@ def _switchyard_version() -> str:
     with ``pyproject.toml``.
     """
     try:
-        return version("switchyard")
+        return version("nemo-switchyard")
     except PackageNotFoundError:
         from switchyard import __version__
 

--- a/switchyard/lib/processors/intake_payload_builder.py
+++ b/switchyard/lib/processors/intake_payload_builder.py
@@ -289,7 +289,7 @@ def _str_or_none(value: object) -> str | None:
 @cache
 def _switchyard_version() -> str:
     try:
-        return version("switchyard")
+        return version("nemo-switchyard")
     except PackageNotFoundError:
         return "unknown"
 

--- a/switchyard/lib/prometheus_exposition.py
+++ b/switchyard/lib/prometheus_exposition.py
@@ -33,7 +33,7 @@ from importlib.metadata import version as _pkg_version
 from typing import Any
 
 try:
-    _SWITCHYARD_VERSION = _pkg_version("switchyard")
+    _SWITCHYARD_VERSION = _pkg_version("nemo-switchyard")
 except Exception:
     _SWITCHYARD_VERSION = "unknown"
 

--- a/switchyard/telemetry.py
+++ b/switchyard/telemetry.py
@@ -47,7 +47,7 @@ def _is_opted_out() -> bool:
 def _get_version() -> str:
     """Read the installed ``switchyard`` package version once."""
     try:
-        return importlib.metadata.version("switchyard")
+        return importlib.metadata.version("nemo-switchyard")
     except Exception:
         log.debug("telemetry: could not read switchyard package version", exc_info=True)
         return "unknown"

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -24,7 +24,7 @@ def test_version_flag_prints_version_and_exits(capsys: pytest.CaptureFixture[str
 
 
 def test_switchyard_version_matches_installed_metadata() -> None:
-    assert _switchyard_version() == version("switchyard")
+    assert _switchyard_version() == version("nemo-switchyard")
 
 
 def test_switchyard_version_falls_back_to_dunder_when_uninstalled() -> None:
@@ -32,6 +32,6 @@ def test_switchyard_version_falls_back_to_dunder_when_uninstalled() -> None:
 
     with patch(
         "switchyard.cli.switchyard_cli.version",
-        side_effect=PackageNotFoundError("switchyard"),
+        side_effect=PackageNotFoundError("nemo-switchyard"),
     ):
         assert _switchyard_version() == __version__

--- a/tests/test_prometheus_exposition.py
+++ b/tests/test_prometheus_exposition.py
@@ -161,7 +161,7 @@ def test_label_value_escapes_backslash_quote_and_newline():
 
 def test_build_info_gauge_present() -> None:
     from importlib.metadata import version as pkg_version
-    ver = pkg_version("switchyard")
+    ver = pkg_version("nemo-switchyard")
     text = render_prometheus({"total_requests": 0, "total_errors": 0, "models": {}})
     _, type_map, samples = _parse(text)
     assert type_map.get("switchyard_build_info") == "gauge"
@@ -171,6 +171,6 @@ def test_build_info_gauge_present() -> None:
 
 def test_build_info_gauge_carries_version_label() -> None:
     from importlib.metadata import version as pkg_version
-    expected = pkg_version("switchyard")
+    expected = pkg_version("nemo-switchyard")
     text = render_prometheus({"total_requests": 0, "total_errors": 0, "models": {}})
     assert f'version="{expected}"' in text

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -41,7 +41,7 @@ def test_get_telemetry_headers_uses_switchyard_package_version(
     monkeypatch.setattr(importlib.metadata, "version", fake_version)
 
     assert get_telemetry_headers() == {HEADER_NAME: "1.2.3"}
-    assert package_names == ["switchyard"]
+    assert package_names == ["nemo-switchyard"]
 
 
 @pytest.mark.parametrize("envvar", [OPT_OUT_ENVVAR, LEGACY_OPT_OUT_ENVVAR])

--- a/tests/test_version_package_name.py
+++ b/tests/test_version_package_name.py
@@ -10,8 +10,8 @@ from unittest.mock import patch
 
 
 def _mock_version(name: str) -> str:
-    """Simulate an environment that only has ``switchyard`` installed."""
-    if name == "switchyard":
+    """Simulate an environment that only has ``nemo-switchyard`` installed."""
+    if name == "nemo-switchyard":
         return "1.0.0"
     raise PackageNotFoundError(name)
 
@@ -35,7 +35,7 @@ def test_intake_payload_builder_version_fallback_is_unknown() -> None:
     intake_payload_builder._switchyard_version.cache_clear()
     with patch(
         "switchyard.lib.processors.intake_payload_builder.version",
-        side_effect=PackageNotFoundError("switchyard"),
+        side_effect=PackageNotFoundError("nemo-switchyard"),
     ):
         result = intake_payload_builder._switchyard_version()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2272,6 +2272,113 @@ wheels = [
 ]
 
 [[package]]
+name = "nemo-switchyard"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "ddtrace" },
+    { name = "fastapi" },
+    { name = "nemo-platform" },
+    { name = "prompt-toolkit" },
+    { name = "routellm", extra = ["serve"] },
+    { name = "sse-starlette" },
+    { name = "transformers" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+cli = [
+    { name = "prompt-toolkit" },
+]
+gpu = [
+    { name = "routellm", extra = ["serve"] },
+    { name = "transformers" },
+]
+intake = [
+    { name = "nemo-platform" },
+]
+server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+tracing = [
+    { name = "ddtrace" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "harbor" },
+    { name = "httpx" },
+    { name = "maturin" },
+    { name = "mypy" },
+    { name = "nemo-switchyard", extra = ["server"] },
+    { name = "prometheus-client" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-markdown-docs" },
+    { name = "pytest-mock" },
+    { name = "pytest-timeout" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "socksio" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "watchdog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.99.0,<1.0" },
+    { name = "ddtrace", marker = "extra == 'tracing'", specifier = ">=2.9,<4" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.136.1,<1.0" },
+    { name = "httpx", specifier = ">=0.28.1,<1.0" },
+    { name = "nemo-platform", marker = "extra == 'intake'", specifier = ">=0.1.0,<1.0" },
+    { name = "nemo-switchyard", extras = ["server", "cli", "gpu", "tracing", "intake"], marker = "extra == 'all'" },
+    { name = "openai", specifier = ">=2.34.0,<3.0" },
+    { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3.0.52,<4.0" },
+    { name = "pydantic", specifier = ">=2.13.3,<3.0" },
+    { name = "routellm", extras = ["serve"], marker = "extra == 'gpu'", specifier = ">=0.2.0,<1.0" },
+    { name = "sse-starlette", marker = "extra == 'server'", specifier = ">=3.4.1,<4.0" },
+    { name = "transformers", marker = "extra == 'gpu'", specifier = ">=5.8.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.46.0,<1.0" },
+]
+provides-extras = ["server", "cli", "gpu", "tracing", "intake", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "harbor", marker = "python_full_version >= '3.12'", git = "https://github.com/harbor-framework/harbor.git?rev=v0.6.4" },
+    { name = "httpx", specifier = ">=0.28.1,<1.0" },
+    { name = "maturin", specifier = ">=1.9,<2.0" },
+    { name = "mypy", specifier = ">=1.20.2,<2.0" },
+    { name = "nemo-switchyard", extras = ["server"] },
+    { name = "prometheus-client", specifier = ">=0.21.0,<1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0,<8.0" },
+    { name = "pytest-markdown-docs", specifier = ">=0.9.2" },
+    { name = "pytest-mock", specifier = ">=3.15.1,<4.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0,<3.0" },
+    { name = "respx", specifier = ">=0.23.1,<1.0" },
+    { name = "ruff", specifier = ">=0.15.12,<1.0" },
+    { name = "socksio", specifier = ">=1.0.0,<2.0" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.0,<2.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0,<10.0" },
+    { name = "watchdog", specifier = ">=4.0.0,<5.0" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4349,113 +4456,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/5cd8559ec2bb332e6027840c1be292f9989c2fc7b47bf40800aec5586791/supabase_functions-2.30.0.tar.gz", hash = "sha256:025acfd25f1c000ba43d0f7b8e366b0d2e9dfc784b842528e21973eb33006113", size = 4683, upload-time = "2026-05-06T17:35:32.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/da/9dedab32775df04cc22ca72f194b78e895d940f195bed3e02882a65daa9b/supabase_functions-2.30.0-py3-none-any.whl", hash = "sha256:92419459f102767b954cd034856e4ded8e34c78660b32442d66c8b2899c68011", size = 8803, upload-time = "2026-05-06T17:35:31.342Z" },
-]
-
-[[package]]
-name = "switchyard"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "anthropic" },
-    { name = "httpx" },
-    { name = "openai" },
-    { name = "pydantic" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "ddtrace" },
-    { name = "fastapi" },
-    { name = "nemo-platform" },
-    { name = "prompt-toolkit" },
-    { name = "routellm", extra = ["serve"] },
-    { name = "sse-starlette" },
-    { name = "transformers" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-cli = [
-    { name = "prompt-toolkit" },
-]
-gpu = [
-    { name = "routellm", extra = ["serve"] },
-    { name = "transformers" },
-]
-intake = [
-    { name = "nemo-platform" },
-]
-server = [
-    { name = "fastapi" },
-    { name = "sse-starlette" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-tracing = [
-    { name = "ddtrace" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "harbor" },
-    { name = "httpx" },
-    { name = "maturin" },
-    { name = "mypy" },
-    { name = "prometheus-client" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-markdown-docs" },
-    { name = "pytest-mock" },
-    { name = "pytest-timeout" },
-    { name = "respx" },
-    { name = "ruff" },
-    { name = "socksio" },
-    { name = "switchyard", extra = ["server"] },
-]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
-    { name = "watchdog" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.99.0,<1.0" },
-    { name = "ddtrace", marker = "extra == 'tracing'", specifier = ">=2.9,<4" },
-    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.136.1,<1.0" },
-    { name = "httpx", specifier = ">=0.28.1,<1.0" },
-    { name = "nemo-platform", marker = "extra == 'intake'", specifier = ">=0.1.0,<1.0" },
-    { name = "openai", specifier = ">=2.34.0,<3.0" },
-    { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3.0.52,<4.0" },
-    { name = "pydantic", specifier = ">=2.13.3,<3.0" },
-    { name = "routellm", extras = ["serve"], marker = "extra == 'gpu'", specifier = ">=0.2.0,<1.0" },
-    { name = "sse-starlette", marker = "extra == 'server'", specifier = ">=3.4.1,<4.0" },
-    { name = "switchyard", extras = ["server", "cli", "gpu", "tracing", "intake"], marker = "extra == 'all'" },
-    { name = "transformers", marker = "extra == 'gpu'", specifier = ">=5.8.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.46.0,<1.0" },
-]
-provides-extras = ["server", "cli", "gpu", "tracing", "intake", "all"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "harbor", marker = "python_full_version >= '3.12'", git = "https://github.com/harbor-framework/harbor.git?rev=v0.6.4" },
-    { name = "httpx", specifier = ">=0.28.1,<1.0" },
-    { name = "maturin", specifier = ">=1.9,<2.0" },
-    { name = "mypy", specifier = ">=1.20.2,<2.0" },
-    { name = "prometheus-client", specifier = ">=0.21.0,<1.0" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0,<8.0" },
-    { name = "pytest-markdown-docs", specifier = ">=0.9.2" },
-    { name = "pytest-mock", specifier = ">=3.15.1,<4.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0,<3.0" },
-    { name = "respx", specifier = ">=0.23.1,<1.0" },
-    { name = "ruff", specifier = ">=0.15.12,<1.0" },
-    { name = "socksio", specifier = ">=1.0.0,<2.0" },
-    { name = "switchyard", extras = ["server"] },
-]
-docs = [
-    { name = "mkdocs", specifier = ">=1.6.0,<2.0" },
-    { name = "mkdocs-material", specifier = ">=9.5.0,<10.0" },
-    { name = "watchdog", specifier = ">=4.0.0,<5.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Renames the published distribution to `nemo-switchyard` to match the package name on PyPI. The import package and CLI command remain `switchyard` (unchanged for users).

Changes:
- `pyproject.toml` `[project].name` -> `nemo-switchyard`. The maturin config sets `module-name` and `python-packages` explicitly, so imports (`import switchyard`, `switchyard_rust`) and the build are unaffected.
- Docs: `pip install switchyard...` -> `pip install nemo-switchyard...` (README, INSTALLATION, getting_started, index, CHANGELOG, issue template).
- Self-version lookups (`importlib.metadata.version(...)`) updated to the new distribution name so `--version`, telemetry, and `/metrics` build/version reporting stay accurate; tests updated to match.

Import name, CLI command (`switchyard`), and module layout are intentionally unchanged.