### PR TITLE
feat: add Relay routing Decision API

### DIFF
--- a/crates/switchyard-components-v2/DESIGN.md
+++ b/crates/switchyard-components-v2/DESIGN.md
@@ -74,7 +74,8 @@ bundles, or backend wrappers by hand.
 
 The v2 runtime has two surfaces:
 
-- an object-safe serving surface for code that only needs to run a profile;
+- an object-safe runtime surface for code that needs to run a profile or request a
+  decision without selected-backend dispatch;
 - a typed hook surface for code that wants to inspect or embed the profile's request and response
   hooks.
 
@@ -84,6 +85,12 @@ In Rust, that target shape is:
 #[async_trait]
 pub trait Profile: Send + Sync {
     async fn run(&self, input: ProfileInput) -> Result<ChatResponse>;
+
+    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+        Err(SwitchyardError::DecisionUnsupported {
+            profile_id: request.decision_profile.profile_id,
+        })
+    }
 }
 
 #[async_trait]
@@ -105,12 +112,14 @@ Conceptually:
 ```text
 process(request)              -> profile-specific processed request
 run(request)                  -> final response
+decide(routing_request)       -> routing decision without selected-backend dispatch
 rprocess(processed, response) -> processed response
 ```
 
-`Profile` is the erased serving contract. Servers, config loaders, and generic profile tables
-can store `Box<dyn Profile>` and call `run()` without knowing a profile's private request
-state.
+`Profile` is the erased runtime contract. Servers, config loaders, and generic profile tables
+can store `Box<dyn Profile>` and call `run()` or `decide()` without knowing a profile's private
+request state. `decide()` defaults to a typed unsupported-profile error so the one configured
+runtime registry can serve both full requests and capability-checked decision calls.
 
 `ProfileHooks` is the typed authoring and embedding contract. The associated `ProcessedRequest`
 type is the profile-owned wrapper around the prepared request and any request-side decision the
@@ -122,6 +131,8 @@ hidden pipeline:
 
 - `run()` is the authoritative serving path. It owns the complete request lifecycle and is the
   method a Switchyard server should call.
+- `decide()` is the decision-only path. Supporting profiles reuse their request-side policy but
+  stop before selected-backend dispatch; other profiles return a typed unsupported error.
 - `process()` is the request-side library hook. It returns the prepared request plus any typed
   profile-specific state needed later, such as a random-routing decision or an initial
   latency-service target selection.
@@ -206,8 +217,9 @@ of one universal metadata object.
 
 Do not implement unsupported hooks with `panic!`, `unimplemented!()`, or runtime
 `NotImplementedError`. If every profile must expose the hook, make the hook total with a meaningful
-identity wrapper for simple profiles. If a future capability only applies to some profiles, split it
-into a separate trait instead of adding a method that most profiles cannot honestly implement.
+identity wrapper for simple profiles. Decision-only routing is the explicit exception: it stays on
+the object-safe profile contract so one registry owns each runtime, and unsupported profiles return
+the typed `DecisionUnsupported` error instead of being rebuilt in a parallel capability registry.
 
 ## What A Profile Owns
 

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -8,15 +8,10 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use switchyard_core::{
-    BackendFormat, ChatRequest, ChatRequestType, LlmTarget, ProfileId, RequestId, Result,
-    SwitchyardError,
+    BackendFormat, ChatRequest, ChatRequestType, ProfileId, RequestId, Result, SwitchyardError,
 };
 
-use crate::profiles::{
-    LlmRoutingProcessedRequest, LlmRoutingProfile, RandomRoutingProcessedRequest,
-    RandomRoutingProfile,
-};
-use crate::{ProfileHooks, ProfileInput, RequestMetadata};
+use crate::{ProfileInput, RequestMetadata};
 
 /// Schema identifier for routing requests.
 pub const ROUTING_REQUEST_SCHEMA_VERSION: &str = "switchyard.routing_request.v1";
@@ -65,6 +60,28 @@ impl RoutingRequest {
                 "routing_attempt must not exceed a non-zero max_routing_attempts".to_string(),
             ));
         }
+        require_non_blank(
+            "decision_profile.profile_id",
+            self.decision_profile.profile_id.as_str(),
+        )?;
+        require_non_blank("identity.session_id", &self.identity.session_id)?;
+        require_non_blank("identity.request_id", &self.identity.request_id)?;
+        require_non_blank("identity.harness", &self.identity.harness)?;
+        require_non_blank("identity.source", &self.identity.source)?;
+        for (field, value) in [
+            ("protocol.inbound_profile", &self.protocol.inbound_profile),
+            ("protocol.inbound_endpoint", &self.protocol.inbound_endpoint),
+            (
+                "protocol.desired_response_profile",
+                &self.protocol.desired_response_profile,
+            ),
+        ] {
+            require_non_blank(field, value)?;
+        }
+        if let Some(owner_id) = self.identity.owner_id.as_deref() {
+            require_non_blank("identity.owner_id", owner_id)?;
+        }
+        validate_current_request_materialization(self)?;
         parse_inbound_profile(&self.protocol.inbound_profile).map(|_| ())
     }
 }
@@ -247,30 +264,8 @@ pub fn route_endpoint_for_format(format: BackendFormat) -> Result<&'static str> 
     }
 }
 
-/// Produces a decision-only Random routing response without backend dispatch.
-pub async fn decision_for_random_routing(
-    profile: &RandomRoutingProfile,
-    request: RoutingRequest,
-) -> Result<RoutingDecision> {
-    request.validate()?;
-    let input = summary_profile_input(&request)?;
-    let processed = profile.process(input).await?;
-    random_processed_to_decision(profile, &request, processed)
-}
-
-/// Produces a decision-only LLM-routing response without selected-backend dispatch.
-pub async fn decision_for_llm_routing(
-    profile: &LlmRoutingProfile,
-    request: RoutingRequest,
-) -> Result<RoutingDecision> {
-    request.validate()?;
-    let input = materialized_profile_input(&request)?;
-    let processed = profile.process(input).await?;
-    llm_routing_processed_to_decision(profile, &request, processed)
-}
-
 // Builds the request-only state needed by policies that can route from summaries.
-fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
+pub(crate) fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
     let mut body = serde_json::Map::new();
     if let Some(model) = &request.request_summary.client_requested_model {
         body.insert("model".to_string(), Value::String(model.clone()));
@@ -279,7 +274,8 @@ fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
 }
 
 // Requires concrete prompt content before a classifier can spend an upstream call.
-fn materialized_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
+pub(crate) fn materialized_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
+    validate_current_request_materialization(request)?;
     if matches!(
         request.decision_profile.request_materialization,
         CurrentRequestMaterialization::None | CurrentRequestMaterialization::SummaryOnly
@@ -454,81 +450,10 @@ fn has_non_whitespace(value: &str) -> bool {
     !value.trim().is_empty()
 }
 
-fn random_processed_to_decision(
-    profile: &RandomRoutingProfile,
-    request: &RoutingRequest,
-    processed: RandomRoutingProcessedRequest,
-) -> Result<RoutingDecision> {
-    let target = profile.target_for_decision(&processed.decision)?;
-    Ok(RoutingDecision {
-        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
-        decision_id: format!(
-            "{}:{}:{}",
-            request.identity.request_id,
-            processed.decision.selected_target,
-            processed.decision.draw
-        ),
-        router: DecisionProvider {
-            name: "random-routing".to_string(),
-            version: "v1".to_string(),
-        },
-        route: routing_target(target, processed.decision.tier.as_str().to_string())?,
-        confidence: None,
-        reason_code: Some("random_weighted".to_string()),
-        reason_summary: Some("selected by weighted random routing".to_string()),
-        metadata: BTreeMap::from([
-            (
-                "strong_probability".to_string(),
-                Value::from(processed.decision.strong_probability),
-            ),
-            ("draw".to_string(), Value::from(processed.decision.draw)),
-        ]),
-    })
-}
-
-fn llm_routing_processed_to_decision(
-    profile: &LlmRoutingProfile,
-    request: &RoutingRequest,
-    processed: LlmRoutingProcessedRequest,
-) -> Result<RoutingDecision> {
-    let target = profile.target_for_decision(&processed.decision)?;
-    let mut metadata = BTreeMap::from([(
-        "source".to_string(),
-        Value::from(processed.decision.source.clone()),
-    )]);
-    if let Some(policy_tier) = &processed.decision.policy_tier {
-        metadata.insert("policy_tier".to_string(), Value::from(policy_tier.clone()));
-    }
-    if let Some(recommended_tier) = &processed.decision.llm_recommended_tier {
-        metadata.insert(
-            "llm_recommended_tier".to_string(),
-            Value::from(recommended_tier.clone()),
-        );
-    }
-    if let Some(signals) = &processed.decision.signals {
-        metadata.insert("signals".to_string(), signals.clone());
-    }
-    Ok(RoutingDecision {
-        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
-        decision_id: format!(
-            "{}:{}:{}",
-            request.identity.request_id,
-            processed.decision.selected_target,
-            processed.decision.source
-        ),
-        router: DecisionProvider {
-            name: "llm-routing".to_string(),
-            version: profile.decision_router_version(),
-        },
-        route: routing_target(target, processed.decision.tier.clone())?,
-        confidence: processed.decision.confidence,
-        reason_code: Some(processed.decision.source),
-        reason_summary: Some(processed.decision.reason),
-        metadata,
-    })
-}
-
-fn routing_target(target: &LlmTarget, tier: String) -> Result<RoutingTarget> {
+pub(crate) fn routing_target(
+    target: &switchyard_core::LlmTarget,
+    tier: String,
+) -> Result<RoutingTarget> {
     Ok(RoutingTarget {
         tier,
         target_model: target.model.as_str().to_string(),
@@ -538,10 +463,52 @@ fn routing_target(target: &LlmTarget, tier: String) -> Result<RoutingTarget> {
     })
 }
 
+fn require_non_blank(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(SwitchyardError::InvalidRequest(format!(
+            "{field} must be a non-empty string"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_current_request_materialization(request: &RoutingRequest) -> Result<()> {
+    let mode = request.decision_profile.request_materialization;
+    match mode {
+        CurrentRequestMaterialization::None | CurrentRequestMaterialization::SummaryOnly => {
+            if request.current_request.is_some() {
+                return Err(SwitchyardError::InvalidRequest(format!(
+                    "request_materialization {mode:?} must not include current_request"
+                )));
+            }
+        }
+        CurrentRequestMaterialization::LatestUserPrompt
+        | CurrentRequestMaterialization::RecentMessageWindow
+        | CurrentRequestMaterialization::AnnotatedRequest
+        | CurrentRequestMaterialization::FullBody => {
+            let body = request
+                .current_request
+                .as_ref()
+                .and_then(|current| current.get("body"))
+                .ok_or_else(|| {
+                    SwitchyardError::InvalidRequest(format!(
+                        "request_materialization {mode:?} requires current_request.body"
+                    ))
+                })?;
+            if !body.is_object() {
+                return Err(SwitchyardError::InvalidRequest(
+                    "current_request.body must be a JSON object".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use switchyard_core::{BackendFormat, LlmTargetId, ModelId};
+    use switchyard_core::{BackendFormat, LlmTarget, LlmTargetId, ModelId};
 
     use crate::{NoopProfileConfig, Profile, ProfileConfig, RandomRoutingProfileConfig};
 

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -579,6 +579,41 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn routing_request_validation_requires_identity_protocol_and_materialization_shape(
+    ) -> TestResult {
+        let mut request = routing_request()?;
+        request.identity.request_id = "  ".to_string();
+        let error = request
+            .validate()
+            .expect_err("blank request ID must be rejected");
+        assert!(error.to_string().contains("identity.request_id"));
+
+        let mut request = routing_request()?;
+        request.protocol.inbound_endpoint = "\t".to_string();
+        let error = request
+            .validate()
+            .expect_err("blank inbound endpoint must be rejected");
+        assert!(error.to_string().contains("protocol.inbound_endpoint"));
+
+        let mut request = routing_request()?;
+        request.current_request = Some(json!({"body": {}}));
+        let error = request
+            .validate()
+            .expect_err("summary-only requests must not carry a body");
+        assert!(error
+            .to_string()
+            .contains("must not include current_request"));
+
+        let mut request = routing_request()?;
+        request.decision_profile.request_materialization = CurrentRequestMaterialization::FullBody;
+        let error = request
+            .validate()
+            .expect_err("materialized requests must carry a body");
+        assert!(error.to_string().contains("requires current_request.body"));
+        Ok(())
+    }
+
     #[tokio::test]
     async fn random_decision_uses_summary_without_dispatching_selected_backend() -> TestResult {
         let profile = RandomRoutingProfileConfig {

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -1,0 +1,819 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! JSON-first routing decision contract for Relay integration.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use switchyard_core::{
+    BackendFormat, ChatRequest, ChatRequestType, LlmTarget, ProfileId, RequestId, Result,
+    SwitchyardError,
+};
+
+use crate::profiles::{
+    LlmRoutingProcessedRequest, LlmRoutingProfile, RandomRoutingProcessedRequest,
+    RandomRoutingProfile,
+};
+use crate::{ProfileHooks, ProfileInput, RequestMetadata};
+
+/// Schema identifier for routing requests.
+pub const ROUTING_REQUEST_SCHEMA_VERSION: &str = "switchyard.routing_request.v1";
+
+/// Schema identifier for routing decisions.
+pub const ROUTING_DECISION_SCHEMA_VERSION: &str = "switchyard.routing_decision.v1";
+
+/// Relay request-time routing request.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RoutingRequest {
+    /// Versioned request schema identifier.
+    pub schema_version: String,
+    /// Concrete Switchyard profile selection and materialization policy.
+    pub decision_profile: DecisionProfile,
+    /// Normalized request identity.
+    pub identity: RequestIdentity,
+    /// Inbound protocol details.
+    pub protocol: RequestProtocol,
+    /// Cheap request summary.
+    pub request_summary: RequestSummary,
+    /// Optional current-request materialization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_request: Option<Value>,
+    /// Routing attempt metadata.
+    pub attempt: DecisionAttempt,
+}
+
+impl RoutingRequest {
+    /// Validates envelope invariants shared by every decision-capable profile.
+    pub fn validate(&self) -> Result<()> {
+        if self.schema_version != ROUTING_REQUEST_SCHEMA_VERSION {
+            return Err(SwitchyardError::InvalidRequest(format!(
+                "unsupported routing request schema_version {:?}; expected {ROUTING_REQUEST_SCHEMA_VERSION:?}",
+                self.schema_version
+            )));
+        }
+        if self.attempt.routing_attempt == 0 {
+            return Err(SwitchyardError::InvalidRequest(
+                "routing_attempt must be at least 1".to_string(),
+            ));
+        }
+        if self.attempt.max_routing_attempts == 0
+            || self.attempt.routing_attempt > self.attempt.max_routing_attempts
+        {
+            return Err(SwitchyardError::InvalidRequest(
+                "routing_attempt must not exceed a non-zero max_routing_attempts".to_string(),
+            ));
+        }
+        parse_inbound_profile(&self.protocol.inbound_profile).map(|_| ())
+    }
+}
+
+/// Concrete profile selection and request materialization policy.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DecisionProfile {
+    /// Required Switchyard profile ID from the loaded configuration.
+    pub profile_id: ProfileId,
+    /// Current-request materialization mode supplied by Relay.
+    pub request_materialization: CurrentRequestMaterialization,
+}
+
+/// Current-request materialization modes.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CurrentRequestMaterialization {
+    /// No request material is included.
+    None,
+    /// Only `request_summary` is included.
+    SummaryOnly,
+    /// Includes the latest user prompt.
+    LatestUserPrompt,
+    /// Includes a bounded recent message window.
+    RecentMessageWindow,
+    /// Includes annotated or canonicalized request material.
+    AnnotatedRequest,
+    /// Includes the full inbound request body.
+    FullBody,
+}
+
+/// Normalized identity passed by Relay.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RequestIdentity {
+    /// Stable session identifier.
+    pub session_id: String,
+    /// Per-request identifier.
+    pub request_id: String,
+    /// Optional turn identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Optional parent scope identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_scope_id: Option<String>,
+    /// Optional root scope identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_scope_id: Option<String>,
+    /// Harness or agent source.
+    pub harness: String,
+    /// Request source.
+    pub source: String,
+    /// Optional resolved owner, such as a subagent or root work owner.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<String>,
+    /// Identity quality marker for native versus synthesized fields.
+    #[serde(default)]
+    pub quality: IdentityQuality,
+}
+
+/// Identity quality marker.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityQuality {
+    /// All required identity fields came from native request/session data.
+    Native,
+    /// One or more required fields were synthesized by Relay.
+    #[default]
+    Synthetic,
+    /// Identity was supplied explicitly by Relay/plugin config.
+    Explicit,
+}
+
+/// Inbound protocol metadata.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RequestProtocol {
+    /// Inbound wire profile string.
+    pub inbound_profile: String,
+    /// Inbound endpoint path.
+    pub inbound_endpoint: String,
+    /// Desired response profile for the client.
+    pub desired_response_profile: String,
+}
+
+/// Cheap request summary produced by Relay.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct RequestSummary {
+    /// Model requested by the client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_requested_model: Option<String>,
+    /// Estimated prompt token count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_token_estimate: Option<u64>,
+    /// Number of tools in the payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_count_in_payload: Option<u64>,
+    /// Whether the request includes a system prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_system_prompt: Option<bool>,
+}
+
+/// Routing attempt metadata.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DecisionAttempt {
+    /// 1-indexed routing attempt.
+    pub routing_attempt: u32,
+    /// Maximum routing attempts.
+    pub max_routing_attempts: u32,
+}
+
+/// Switchyard routing decision returned to Relay.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RoutingDecision {
+    /// Versioned decision schema identifier.
+    pub schema_version: String,
+    /// Stable per-decision identifier.
+    pub decision_id: String,
+    /// Router implementation metadata.
+    pub router: DecisionProvider,
+    /// Target route selected by Switchyard.
+    pub route: RoutingTarget,
+    /// Optional confidence score.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    /// Optional reason code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
+    /// Optional human-readable summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_summary: Option<String>,
+    /// Additional router metadata.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+/// Router implementation metadata in a decision response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DecisionProvider {
+    /// Router implementation name derived from the configured profile type.
+    pub name: String,
+    /// Router implementation version derived from the profile runtime.
+    pub version: String,
+}
+
+/// Selected Switchyard route.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RoutingTarget {
+    /// Tier label such as `strong` or `weak`.
+    pub tier: String,
+    /// Target model to send upstream.
+    pub target_model: String,
+    /// Switchyard target ID.
+    pub backend_id: String,
+    /// Switchyard wire protocol profile.
+    pub target_protocol_profile: String,
+    /// Endpoint selected for the target wire protocol.
+    pub target_endpoint: String,
+}
+
+/// Maps a Switchyard backend format to the Decision API wire protocol label.
+pub fn route_protocol_for_format(format: BackendFormat) -> Result<&'static str> {
+    match format {
+        BackendFormat::OpenAi => Ok("openai_chat"),
+        BackendFormat::Responses => Ok("openai_responses"),
+        BackendFormat::Anthropic => Ok("anthropic_messages"),
+        BackendFormat::Auto => Err(SwitchyardError::InvalidConfig(
+            "cannot produce routing decision for unresolved auto backend format".to_string(),
+        )),
+    }
+}
+
+/// Maps a Switchyard backend format to the upstream endpoint path.
+pub fn route_endpoint_for_format(format: BackendFormat) -> Result<&'static str> {
+    match format {
+        BackendFormat::OpenAi => Ok("/v1/chat/completions"),
+        BackendFormat::Responses => Ok("/v1/responses"),
+        BackendFormat::Anthropic => Ok("/v1/messages"),
+        BackendFormat::Auto => Err(SwitchyardError::InvalidConfig(
+            "cannot produce routing decision for unresolved auto backend format".to_string(),
+        )),
+    }
+}
+
+/// Produces a decision-only Random routing response without backend dispatch.
+pub async fn decision_for_random_routing(
+    profile: &RandomRoutingProfile,
+    request: RoutingRequest,
+) -> Result<RoutingDecision> {
+    request.validate()?;
+    let input = summary_profile_input(&request)?;
+    let processed = profile.process(input).await?;
+    random_processed_to_decision(profile, &request, processed)
+}
+
+/// Produces a decision-only LLM-routing response without selected-backend dispatch.
+pub async fn decision_for_llm_routing(
+    profile: &LlmRoutingProfile,
+    request: RoutingRequest,
+) -> Result<RoutingDecision> {
+    request.validate()?;
+    let input = materialized_profile_input(&request)?;
+    let processed = profile.process(input).await?;
+    llm_routing_processed_to_decision(profile, &request, processed)
+}
+
+// Builds the request-only state needed by policies that can route from summaries.
+fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
+    let mut body = serde_json::Map::new();
+    if let Some(model) = &request.request_summary.client_requested_model {
+        body.insert("model".to_string(), Value::String(model.clone()));
+    }
+    profile_input(request, Value::Object(body))
+}
+
+// Requires concrete prompt content before a classifier can spend an upstream call.
+fn materialized_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
+    if matches!(
+        request.decision_profile.request_materialization,
+        CurrentRequestMaterialization::None | CurrentRequestMaterialization::SummaryOnly
+    ) {
+        return Err(SwitchyardError::InvalidRequest(
+            "llm-routing requires a materialized current_request.body".to_string(),
+        ));
+    }
+    let body = request
+        .current_request
+        .as_ref()
+        .and_then(|current| current.get("body"))
+        .cloned()
+        .ok_or_else(|| {
+            SwitchyardError::InvalidRequest(
+                "llm-routing requires current_request.body for prompt classification".to_string(),
+            )
+        })?;
+    if !body.is_object() {
+        return Err(SwitchyardError::InvalidRequest(
+            "current_request.body must be a JSON object".to_string(),
+        ));
+    }
+    let request_type = parse_inbound_profile(&request.protocol.inbound_profile)?;
+    if !has_materialized_prompt(&body, request_type) {
+        return Err(SwitchyardError::InvalidRequest(
+            "llm-routing current_request.body must contain non-empty prompt material".to_string(),
+        ));
+    }
+    profile_input(request, body)
+}
+
+fn profile_input(request: &RoutingRequest, body: Value) -> Result<ProfileInput> {
+    let request_type = parse_inbound_profile(&request.protocol.inbound_profile)?;
+    let chat_request = chat_request_for_type(request_type, body);
+    chat_request.validate()?;
+    Ok(ProfileInput {
+        request: chat_request,
+        metadata: RequestMetadata {
+            request_id: Some(RequestId::new(request.identity.request_id.clone())?),
+            inbound_format: Some(request_type),
+            ..RequestMetadata::default()
+        },
+    })
+}
+
+// Keeps the wire field extensible as a string while accepting only documented aliases.
+fn parse_inbound_profile(profile: &str) -> Result<ChatRequestType> {
+    match profile {
+        "openai_chat" | "openai_chat_completions" | "openai_chat_completions.v1" => {
+            Ok(ChatRequestType::OpenAiChat)
+        }
+        "openai_responses" | "openai_responses.v1" => Ok(ChatRequestType::OpenAiResponses),
+        "anthropic" | "anthropic_messages" | "anthropic_messages.v1" => {
+            Ok(ChatRequestType::Anthropic)
+        }
+        unsupported => Err(SwitchyardError::InvalidRequest(format!(
+            "unsupported inbound_profile {unsupported:?}; expected a documented OpenAI Chat, OpenAI Responses, or Anthropic Messages profile"
+        ))),
+    }
+}
+
+fn chat_request_for_type(request_type: ChatRequestType, body: Value) -> ChatRequest {
+    match request_type {
+        ChatRequestType::OpenAiChat => ChatRequest::openai_chat(body),
+        ChatRequestType::OpenAiResponses => ChatRequest::openai_responses(body),
+        ChatRequestType::Anthropic => ChatRequest::anthropic(body),
+    }
+}
+
+fn has_materialized_prompt(body: &Value, request_type: ChatRequestType) -> bool {
+    match request_type {
+        ChatRequestType::OpenAiChat | ChatRequestType::Anthropic => body
+            .get("messages")
+            .and_then(Value::as_array)
+            .is_some_and(|messages| messages.iter().any(message_has_user_prompt)),
+        ChatRequestType::OpenAiResponses => body
+            .get("input")
+            .is_some_and(responses_input_has_user_prompt),
+    }
+}
+
+fn message_has_user_prompt(message: &Value) -> bool {
+    message.get("role").and_then(Value::as_str) == Some("user")
+        && message
+            .get("content")
+            .is_some_and(content_has_prompt_material)
+}
+
+fn responses_input_has_user_prompt(input: &Value) -> bool {
+    match input {
+        Value::String(text) => has_non_whitespace(text),
+        Value::Array(items) => items.iter().any(responses_item_has_user_prompt),
+        _ => false,
+    }
+}
+
+fn responses_item_has_user_prompt(item: &Value) -> bool {
+    match item {
+        Value::String(text) => has_non_whitespace(text),
+        Value::Object(object) => match object.get("role").and_then(Value::as_str) {
+            Some("user") => object
+                .get("content")
+                .is_some_and(content_has_prompt_material),
+            Some(_) => false,
+            None => {
+                matches!(
+                    object.get("type").and_then(Value::as_str),
+                    Some("input_text" | "input_image" | "input_file")
+                ) && content_part_has_prompt_material(item)
+            }
+        },
+        _ => false,
+    }
+}
+
+fn content_has_prompt_material(content: &Value) -> bool {
+    match content {
+        Value::String(text) => has_non_whitespace(text),
+        Value::Array(parts) => parts.iter().any(content_part_has_prompt_material),
+        Value::Object(_) => content_part_has_prompt_material(content),
+        _ => false,
+    }
+}
+
+fn content_part_has_prompt_material(part: &Value) -> bool {
+    let Some(object) = part.as_object() else {
+        return part.as_str().is_some_and(has_non_whitespace);
+    };
+    if object
+        .get("text")
+        .and_then(Value::as_str)
+        .is_some_and(has_non_whitespace)
+    {
+        return true;
+    }
+    if object
+        .get("content")
+        .is_some_and(content_has_prompt_material)
+    {
+        return true;
+    }
+    if object
+        .get("image_url")
+        .is_some_and(reference_has_prompt_material)
+        || ["file_id", "file_url", "file_data"]
+            .into_iter()
+            .any(|key| object.get(key).is_some_and(reference_has_prompt_material))
+    {
+        return true;
+    }
+    object.get("source").is_some_and(|source| {
+        ["data", "url"]
+            .into_iter()
+            .any(|key| source.get(key).is_some_and(reference_has_prompt_material))
+    })
+}
+
+fn reference_has_prompt_material(reference: &Value) -> bool {
+    match reference {
+        Value::String(value) => has_non_whitespace(value),
+        Value::Object(object) => object
+            .get("url")
+            .or_else(|| object.get("data"))
+            .or_else(|| object.get("file_id"))
+            .is_some_and(reference_has_prompt_material),
+        _ => false,
+    }
+}
+
+fn has_non_whitespace(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+
+fn random_processed_to_decision(
+    profile: &RandomRoutingProfile,
+    request: &RoutingRequest,
+    processed: RandomRoutingProcessedRequest,
+) -> Result<RoutingDecision> {
+    let target = profile.target_for_decision(&processed.decision)?;
+    Ok(RoutingDecision {
+        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
+        decision_id: format!(
+            "{}:{}:{}",
+            request.identity.request_id,
+            processed.decision.selected_target,
+            processed.decision.draw
+        ),
+        router: DecisionProvider {
+            name: "random-routing".to_string(),
+            version: "v1".to_string(),
+        },
+        route: routing_target(target, processed.decision.tier.as_str().to_string())?,
+        confidence: None,
+        reason_code: Some("random_weighted".to_string()),
+        reason_summary: Some("selected by weighted random routing".to_string()),
+        metadata: BTreeMap::from([
+            (
+                "strong_probability".to_string(),
+                Value::from(processed.decision.strong_probability),
+            ),
+            ("draw".to_string(), Value::from(processed.decision.draw)),
+        ]),
+    })
+}
+
+fn llm_routing_processed_to_decision(
+    profile: &LlmRoutingProfile,
+    request: &RoutingRequest,
+    processed: LlmRoutingProcessedRequest,
+) -> Result<RoutingDecision> {
+    let target = profile.target_for_decision(&processed.decision)?;
+    let mut metadata = BTreeMap::from([(
+        "source".to_string(),
+        Value::from(processed.decision.source.clone()),
+    )]);
+    if let Some(policy_tier) = &processed.decision.policy_tier {
+        metadata.insert("policy_tier".to_string(), Value::from(policy_tier.clone()));
+    }
+    if let Some(recommended_tier) = &processed.decision.llm_recommended_tier {
+        metadata.insert(
+            "llm_recommended_tier".to_string(),
+            Value::from(recommended_tier.clone()),
+        );
+    }
+    if let Some(signals) = &processed.decision.signals {
+        metadata.insert("signals".to_string(), signals.clone());
+    }
+    Ok(RoutingDecision {
+        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
+        decision_id: format!(
+            "{}:{}:{}",
+            request.identity.request_id,
+            processed.decision.selected_target,
+            processed.decision.source
+        ),
+        router: DecisionProvider {
+            name: "llm-routing".to_string(),
+            version: profile.decision_router_version(),
+        },
+        route: routing_target(target, processed.decision.tier.clone())?,
+        confidence: processed.decision.confidence,
+        reason_code: Some(processed.decision.source),
+        reason_summary: Some(processed.decision.reason),
+        metadata,
+    })
+}
+
+fn routing_target(target: &LlmTarget, tier: String) -> Result<RoutingTarget> {
+    Ok(RoutingTarget {
+        tier,
+        target_model: target.model.as_str().to_string(),
+        backend_id: target.id.as_str().to_string(),
+        target_protocol_profile: route_protocol_for_format(target.format)?.to_string(),
+        target_endpoint: route_endpoint_for_format(target.format)?.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use switchyard_core::{BackendFormat, LlmTargetId, ModelId};
+
+    use crate::{NoopProfileConfig, Profile, ProfileConfig, RandomRoutingProfileConfig};
+
+    use super::*;
+
+    type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    fn target(id: &str, model: &str, format: BackendFormat) -> Result<LlmTarget> {
+        let mut target = LlmTarget::new(LlmTargetId::new(id)?, ModelId::new(model)?);
+        target.format = format;
+        target.endpoint.base_url = Some("http://127.0.0.1:1/v1".to_string());
+        Ok(target)
+    }
+
+    fn routing_request() -> Result<RoutingRequest> {
+        Ok(RoutingRequest {
+            schema_version: ROUTING_REQUEST_SCHEMA_VERSION.to_string(),
+            decision_profile: DecisionProfile {
+                profile_id: ProfileId::new("remote-random")?,
+                request_materialization: CurrentRequestMaterialization::SummaryOnly,
+            },
+            identity: RequestIdentity {
+                session_id: "session-1".to_string(),
+                request_id: "request-1".to_string(),
+                turn_id: Some("turn-1".to_string()),
+                parent_scope_id: None,
+                root_scope_id: None,
+                harness: "unit-test".to_string(),
+                source: "nemo-relay".to_string(),
+                owner_id: None,
+                quality: IdentityQuality::Native,
+            },
+            protocol: RequestProtocol {
+                inbound_profile: "openai_chat".to_string(),
+                inbound_endpoint: "/v1/chat/completions".to_string(),
+                desired_response_profile: "openai_chat".to_string(),
+            },
+            request_summary: RequestSummary {
+                client_requested_model: Some("client/model".to_string()),
+                ..RequestSummary::default()
+            },
+            current_request: None,
+            attempt: DecisionAttempt {
+                routing_attempt: 1,
+                max_routing_attempts: 1,
+            },
+        })
+    }
+
+    fn materialized_request(inbound_profile: &str, body: Value) -> Result<RoutingRequest> {
+        let mut request = routing_request()?;
+        request.decision_profile.request_materialization = CurrentRequestMaterialization::FullBody;
+        request.protocol.inbound_profile = inbound_profile.to_string();
+        request.current_request = Some(json!({"body": body}));
+        Ok(request)
+    }
+
+    #[test]
+    fn routing_request_contract_requires_profile_id_and_omits_router() -> TestResult {
+        let encoded = serde_json::to_value(routing_request()?)?;
+
+        assert_eq!(encoded["decision_profile"]["profile_id"], "remote-random");
+        assert!(encoded["decision_profile"].get("router").is_none());
+
+        let mut missing_profile_id = encoded;
+        missing_profile_id["decision_profile"]
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("decision_profile was not an object".into()))?
+            .remove("profile_id");
+        assert!(serde_json::from_value::<RoutingRequest>(missing_profile_id).is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn random_decision_uses_summary_without_dispatching_selected_backend() -> TestResult {
+        let profile = RandomRoutingProfileConfig {
+            strong: target("strong-target", "frontier/model", BackendFormat::OpenAi)?,
+            weak: target("weak-target", "cheap/model", BackendFormat::Responses)?,
+            strong_probability: 1.0,
+            rng_seed: Some(7),
+        }
+        .build()?;
+
+        let decision = profile.decide(routing_request()?).await?;
+
+        assert_eq!(decision.route.backend_id, "strong-target");
+        assert_eq!(decision.route.target_model, "frontier/model");
+        assert_eq!(decision.route.target_protocol_profile, "openai_chat");
+        assert_eq!(decision.router.name, "random-routing");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_rejects_unknown_inbound_profile_without_fallback() -> TestResult {
+        let profile = RandomRoutingProfileConfig {
+            strong: target("strong-target", "frontier/model", BackendFormat::OpenAi)?,
+            weak: target("weak-target", "cheap/model", BackendFormat::OpenAi)?,
+            strong_probability: 1.0,
+            rng_seed: Some(7),
+        }
+        .build()?;
+        let mut request = routing_request()?;
+        request.protocol.inbound_profile = "future_protocol".to_string();
+
+        let error = profile.decide(request).await;
+
+        assert!(
+            matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("unsupported inbound_profile"))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn llm_materialization_rejects_summary_only_before_classifier_dispatch() -> TestResult {
+        let request = routing_request()?;
+        let error = materialized_profile_input(&request);
+
+        assert!(
+            matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("materialized current_request.body"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn llm_materialization_validates_wrapper_shape_and_prompt_content() -> TestResult {
+        let mut request = routing_request()?;
+        request.decision_profile.request_materialization = CurrentRequestMaterialization::FullBody;
+        request.current_request = Some(json!({"body": []}));
+
+        let non_object = materialized_profile_input(&request);
+        assert!(
+            matches!(non_object, Err(SwitchyardError::InvalidRequest(message)) if message.contains("must be a JSON object"))
+        );
+
+        request.current_request = Some(json!({"body": {"model": "client/model"}}));
+        let missing_prompt = materialized_profile_input(&request);
+        assert!(
+            matches!(missing_prompt, Err(SwitchyardError::InvalidRequest(message)) if message.contains("non-empty prompt material"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn llm_materialization_rejects_promptless_message_shapes() -> TestResult {
+        for (profile, body) in [
+            (
+                "openai_chat",
+                json!({"messages": [{"role": "user", "content": " \n\t "}]}),
+            ),
+            (
+                "openai_chat",
+                json!({"messages": [{"role": "user", "content": []}]}),
+            ),
+            (
+                "openai_chat",
+                json!({"messages": [{"role": "assistant", "content": "not a user prompt"}]}),
+            ),
+            (
+                "anthropic_messages",
+                json!({"messages": [{"role": "user", "content": [{"type": "text", "text": "  "}]}]}),
+            ),
+            (
+                "anthropic_messages",
+                json!({"messages": [{"role": "assistant", "content": "not a user prompt"}]}),
+            ),
+        ] {
+            let request = materialized_request(profile, body)?;
+            let error = materialized_profile_input(&request);
+            assert!(
+                matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("non-empty prompt material")),
+                "{profile} promptless body should be rejected"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn llm_materialization_accepts_supported_user_prompt_shapes() -> TestResult {
+        for (profile, body) in [
+            (
+                "openai_chat",
+                json!({"messages": [{"role": "user", "content": "implement this"}]}),
+            ),
+            (
+                "openai_chat",
+                json!({"messages": [{"role": "user", "content": [{"type": "text", "text": "implement this"}]}]}),
+            ),
+            (
+                "anthropic_messages",
+                json!({"messages": [{"role": "user", "content": [{"type": "text", "text": "implement this"}]}]}),
+            ),
+            (
+                "anthropic_messages",
+                json!({"messages": [{"role": "user", "content": [{"type": "image", "source": {"type": "base64", "data": "abc123"}}]}]}),
+            ),
+            ("openai_responses", json!({"input": "implement this"})),
+            (
+                "openai_responses",
+                json!({"input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "implement this"}]}]}),
+            ),
+            (
+                "openai_responses",
+                json!({"input": [{"type": "input_text", "text": "implement this"}]}),
+            ),
+        ] {
+            let request = materialized_request(profile, body)?;
+            assert!(
+                materialized_profile_input(&request).is_ok(),
+                "{profile} user prompt should be accepted"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn responses_materialization_rejects_structurally_nonempty_promptless_input() -> TestResult {
+        for input in [
+            json!([{"type": "message", "role": "user", "content": []}]),
+            json!([{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "  "}]}]),
+            json!([{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "assistant only"}]}]),
+            json!([{"type": "reasoning", "summary": [{"type": "summary_text", "text": "not user input"}]}]),
+            json!([{"type": "input_image", "image_url": "  "}]),
+        ] {
+            let request = materialized_request("openai_responses", json!({"input": input}))?;
+            let error = materialized_profile_input(&request);
+            assert!(
+                matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("non-empty prompt material"))
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn default_profile_decision_is_typed_unsupported() -> TestResult {
+        let profile = NoopProfileConfig {}.build()?;
+        let request = routing_request()?;
+        let profile_id = request.decision_profile.profile_id.clone();
+
+        let error = profile.decide(request).await;
+
+        assert!(
+            matches!(error, Err(SwitchyardError::DecisionUnsupported { profile_id: rejected }) if rejected == profile_id)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn documented_inbound_aliases_parse_but_unknown_values_do_not() -> TestResult {
+        for profile in [
+            "openai_chat",
+            "openai_chat_completions.v1",
+            "openai_responses",
+            "openai_responses.v1",
+            "anthropic",
+            "anthropic_messages.v1",
+        ] {
+            parse_inbound_profile(profile)?;
+        }
+        assert!(parse_inbound_profile("openai").is_err());
+        assert!(parse_inbound_profile("chat").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn routing_request_round_trips_additive_fields() -> TestResult {
+        let mut encoded = serde_json::to_value(routing_request()?)?;
+        encoded["future_envelope_field"] = json!({"accepted": true});
+        encoded["decision_profile"]["router"] = json!("legacy-relay-router");
+
+        let decoded: RoutingRequest = serde_json::from_value(encoded)?;
+
+        assert_eq!(decoded, routing_request()?);
+        Ok(())
+    }
+}

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -78,9 +78,6 @@ impl RoutingRequest {
         ] {
             require_non_blank(field, value)?;
         }
-        if let Some(owner_id) = self.identity.owner_id.as_deref() {
-            require_non_blank("identity.owner_id", owner_id)?;
-        }
         validate_current_request_materialization(self)?;
         parse_inbound_profile(&self.protocol.inbound_profile).map(|_| ())
     }

--- a/crates/switchyard-components-v2/src/lib.rs
+++ b/crates/switchyard-components-v2/src/lib.rs
@@ -10,6 +10,7 @@ extern crate self as switchyard_components_v2;
 
 mod backend;
 mod config;
+pub mod decision;
 mod profile;
 pub mod profiles;
 mod stats;
@@ -17,6 +18,13 @@ mod stats;
 pub use config::{
     parse_profile_config_path, parse_profile_config_str, parse_profile_config_str_with_env_lookup,
     ProfileConfig, ProfileConfigDocument, ProfileConfigFormat, ProfileConfigPlan,
+};
+pub use decision::{
+    decision_for_llm_routing, decision_for_random_routing, route_endpoint_for_format,
+    route_protocol_for_format, CurrentRequestMaterialization, DecisionAttempt, DecisionProfile,
+    DecisionProvider, IdentityQuality, RequestIdentity, RequestProtocol, RequestSummary,
+    RoutingDecision, RoutingRequest, RoutingTarget, ROUTING_DECISION_SCHEMA_VERSION,
+    ROUTING_REQUEST_SCHEMA_VERSION,
 };
 pub use profile::{
     Profile, ProfileHooks, ProfileInput, ProfileResponse, RequestMetadata, RoutingMetadata,

--- a/crates/switchyard-components-v2/src/lib.rs
+++ b/crates/switchyard-components-v2/src/lib.rs
@@ -20,23 +20,23 @@ pub use config::{
     ProfileConfig, ProfileConfigDocument, ProfileConfigFormat, ProfileConfigPlan,
 };
 pub use decision::{
-    decision_for_llm_routing, decision_for_random_routing, route_endpoint_for_format,
-    route_protocol_for_format, CurrentRequestMaterialization, DecisionAttempt, DecisionProfile,
-    DecisionProvider, IdentityQuality, RequestIdentity, RequestProtocol, RequestSummary,
-    RoutingDecision, RoutingRequest, RoutingTarget, ROUTING_DECISION_SCHEMA_VERSION,
-    ROUTING_REQUEST_SCHEMA_VERSION,
+    route_endpoint_for_format, route_protocol_for_format, CurrentRequestMaterialization,
+    DecisionAttempt, DecisionProfile, DecisionProvider, IdentityQuality, RequestIdentity,
+    RequestProtocol, RequestSummary, RoutingDecision, RoutingRequest, RoutingTarget,
+    ROUTING_DECISION_SCHEMA_VERSION, ROUTING_REQUEST_SCHEMA_VERSION,
 };
 pub use profile::{
     Profile, ProfileHooks, ProfileInput, ProfileResponse, RequestMetadata, RoutingMetadata,
 };
 pub use profiles::{
-    EndpointHealth, EndpointHealthStatus, LatencyServiceProcessedRequest, LatencyServiceProfile,
-    LatencyServiceProfileConfig, LlmRoutingDecision, LlmRoutingProcessedRequest, LlmRoutingProfile,
-    LlmRoutingProfileConfig, LlmRoutingTierMapping, NoopProfile, NoopProfileConfig,
-    PassthroughProfile, PassthroughProfileConfig, RandomRoutingProcessedRequest,
-    RandomRoutingProfile, RandomRoutingProfileConfig, SelectedTarget, StageRouterClassifierConfig,
-    StageRouterDecision, StageRouterDecisionSource, StageRouterPickerMode,
-    StageRouterProcessedRequest, StageRouterProfile, StageRouterProfileConfig, StageRouterTier,
+    decision_for_llm_routing, decision_for_random_routing, EndpointHealth, EndpointHealthStatus,
+    LatencyServiceProcessedRequest, LatencyServiceProfile, LatencyServiceProfileConfig,
+    LlmRoutingDecision, LlmRoutingProcessedRequest, LlmRoutingProfile, LlmRoutingProfileConfig,
+    LlmRoutingTierMapping, NoopProfile, NoopProfileConfig, PassthroughProfile,
+    PassthroughProfileConfig, RandomRoutingProcessedRequest, RandomRoutingProfile,
+    RandomRoutingProfileConfig, SelectedTarget, StageRouterClassifierConfig, StageRouterDecision,
+    StageRouterDecisionSource, StageRouterPickerMode, StageRouterProcessedRequest,
+    StageRouterProfile, StageRouterProfileConfig, StageRouterTier,
 };
 pub use stats::profile_stats_accumulator;
 pub use switchyard_components_v2_macros::profile_config;

--- a/crates/switchyard-components-v2/src/profile.rs
+++ b/crates/switchyard-components-v2/src/profile.rs
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 
 use switchyard_core::{ChatRequest, ChatRequestType, ChatResponse, RequestId, Result};
 
+use crate::decision::{RoutingDecision, RoutingRequest};
+
 /// Explicit per-request metadata passed to v2 profiles.
 ///
 /// Header keys are stored as lowercase ASCII names. Repeated header values are
@@ -115,13 +117,24 @@ impl From<ChatResponse> for ProfileResponse {
 /// Object-safe runtime surface for a complete profile.
 ///
 /// Servers and config-built profile maps use this trait when they need to run
-/// an entire profile and receive a final response. It intentionally exposes
-/// only `run()` so dynamic dispatch does not erase profile-specific processed
-/// state returned by hook-level APIs.
+/// an entire profile or request a decision without selected-backend dispatch.
+/// Hook-level processed state remains on [`ProfileHooks`] so dynamic dispatch
+/// does not erase profile-specific authoring APIs.
 #[async_trait]
 pub trait Profile: Send + Sync {
     /// Executes the complete profile flow and returns the final response.
     async fn run(&self, input: ProfileInput) -> Result<ProfileResponse>;
+
+    /// Returns a routing decision without dispatching the selected backend.
+    ///
+    /// Profiles that do not implement decision-only routing return a typed
+    /// unsupported-profile error by default.
+    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+        request.validate()?;
+        Err(switchyard_core::SwitchyardError::DecisionUnsupported {
+            profile_id: request.decision_profile.profile_id,
+        })
+    }
 }
 
 /// Typed hook surface for profile authors and embedders.

--- a/crates/switchyard-components-v2/src/profiles/llm_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/llm_routing.rs
@@ -18,8 +18,8 @@ use switchyard_core::{
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
 use crate::{
-    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
-    RoutingMetadata,
+    decision_for_llm_routing, profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput,
+    ProfileResponse, RoutingDecision, RoutingMetadata, RoutingRequest,
 };
 
 const TIER_STRONG: &str = "strong";
@@ -418,6 +418,17 @@ impl LlmRoutingProfile {
         }
     }
 
+    /// Returns selected target metadata for a decision-only integration.
+    pub(crate) fn target_for_decision(&self, decision: &LlmRoutingDecision) -> Result<&LlmTarget> {
+        self.backend_for_target_id_str(&decision.selected_target)
+            .map(TargetBackend::target)
+    }
+
+    /// Returns the configured classifier-policy version for Decision API metadata.
+    pub(crate) fn decision_router_version(&self) -> String {
+        format!("{}:v1", self.policy.as_str())
+    }
+
     fn record_success(
         &self,
         decision: &LlmRoutingDecision,
@@ -539,6 +550,11 @@ impl Profile for LlmRoutingProfile {
                 return Err(error);
             }
         }
+    }
+
+    /// Classifies a materialized request without dispatching the selected target.
+    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+        decision_for_llm_routing(self, request).await
     }
 }
 

--- a/crates/switchyard-components-v2/src/profiles/llm_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/llm_routing.rs
@@ -3,7 +3,7 @@
 
 //! LLM classifier routing as a profile-owned runtime.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -16,10 +16,12 @@ use switchyard_core::{
 };
 
 use crate::backend::{native_target_backend, TargetBackend};
+use crate::decision::{materialized_profile_input, routing_target};
+use crate::decision::{DecisionProvider, ROUTING_DECISION_SCHEMA_VERSION};
 use crate::profile_stats_accumulator;
 use crate::{
-    decision_for_llm_routing, profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput,
-    ProfileResponse, RoutingDecision, RoutingMetadata, RoutingRequest,
+    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
+    RoutingDecision, RoutingMetadata, RoutingRequest,
 };
 
 const TIER_STRONG: &str = "strong";
@@ -556,6 +558,51 @@ impl Profile for LlmRoutingProfile {
     async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
         decision_for_llm_routing(self, request).await
     }
+}
+
+/// Produces a decision-only LLM-routing response without selected-backend dispatch.
+pub async fn decision_for_llm_routing(
+    profile: &LlmRoutingProfile,
+    request: RoutingRequest,
+) -> Result<RoutingDecision> {
+    request.validate()?;
+    let input = materialized_profile_input(&request)?;
+    let processed = profile.process(input).await?;
+    let target = profile.target_for_decision(&processed.decision)?;
+    let mut metadata = BTreeMap::from([(
+        "source".to_string(),
+        Value::from(processed.decision.source.clone()),
+    )]);
+    if let Some(policy_tier) = &processed.decision.policy_tier {
+        metadata.insert("policy_tier".to_string(), Value::from(policy_tier.clone()));
+    }
+    if let Some(recommended_tier) = &processed.decision.llm_recommended_tier {
+        metadata.insert(
+            "llm_recommended_tier".to_string(),
+            Value::from(recommended_tier.clone()),
+        );
+    }
+    if let Some(signals) = &processed.decision.signals {
+        metadata.insert("signals".to_string(), signals.clone());
+    }
+    Ok(RoutingDecision {
+        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
+        decision_id: format!(
+            "{}:{}:{}",
+            request.identity.request_id,
+            processed.decision.selected_target,
+            processed.decision.source
+        ),
+        router: DecisionProvider {
+            name: "llm-routing".to_string(),
+            version: profile.decision_router_version(),
+        },
+        route: routing_target(target, processed.decision.tier.clone())?,
+        confidence: processed.decision.confidence,
+        reason_code: Some(processed.decision.source),
+        reason_summary: Some(processed.decision.reason),
+        metadata,
+    })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/switchyard-components-v2/src/profiles/mod.rs
+++ b/crates/switchyard-components-v2/src/profiles/mod.rs
@@ -17,14 +17,15 @@ pub use latency_service::{
     LatencyServiceProfileConfig, SelectedTarget,
 };
 pub use llm_routing::{
-    LlmRoutingDecision, LlmRoutingProcessedRequest, LlmRoutingProfile, LlmRoutingProfileConfig,
-    LlmRoutingTierMapping,
+    decision_for_llm_routing, LlmRoutingDecision, LlmRoutingProcessedRequest, LlmRoutingProfile,
+    LlmRoutingProfileConfig, LlmRoutingTierMapping,
 };
 pub use noop::{NoopProfile, NoopProfileConfig};
 pub use passthrough::{PassthroughProfile, PassthroughProfileConfig};
 pub(crate) use profile_types::{parse_profile_config, ProfileConfigEntry};
 pub use random_routing::{
-    RandomRoutingProcessedRequest, RandomRoutingProfile, RandomRoutingProfileConfig,
+    decision_for_random_routing, RandomRoutingProcessedRequest, RandomRoutingProfile,
+    RandomRoutingProfileConfig,
 };
 pub use stage_router::{
     StageRouterClassifierConfig, StageRouterDecision, StageRouterDecisionSource,

--- a/crates/switchyard-components-v2/src/profiles/random_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/random_routing.rs
@@ -3,9 +3,11 @@
 
 //! Random-routing profile implemented as a single profile-owned runtime.
 
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use serde_json::Value;
 use switchyard_components::request_processors::{
     RandomRoutingDecision, RandomRoutingEngine, RandomRoutingProcessorConfig, RandomRoutingTier,
 };
@@ -14,10 +16,12 @@ use switchyard_components::StatsAccumulator;
 use switchyard_core::{ChatResponse, LlmTarget, Result, SwitchyardError};
 
 use crate::backend::{native_target_backend, TargetBackend};
+use crate::decision::{routing_target, summary_profile_input};
+use crate::decision::{DecisionProvider, ROUTING_DECISION_SCHEMA_VERSION};
 use crate::profile_stats_accumulator;
 use crate::{
-    decision_for_random_routing, profile_config, Profile, ProfileConfig, ProfileHooks,
-    ProfileInput, ProfileResponse, RoutingDecision, RoutingMetadata, RoutingRequest,
+    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
+    RoutingDecision, RoutingMetadata, RoutingRequest,
 };
 
 /// Config for the flatter random-routing profile.
@@ -196,6 +200,41 @@ impl Profile for RandomRoutingProfile {
     async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
         decision_for_random_routing(self, request).await
     }
+}
+
+/// Produces a decision-only Random routing response without backend dispatch.
+pub async fn decision_for_random_routing(
+    profile: &RandomRoutingProfile,
+    request: RoutingRequest,
+) -> Result<RoutingDecision> {
+    request.validate()?;
+    let input = summary_profile_input(&request)?;
+    let processed = profile.process(input).await?;
+    let target = profile.target_for_decision(&processed.decision)?;
+    Ok(RoutingDecision {
+        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
+        decision_id: format!(
+            "{}:{}:{}",
+            request.identity.request_id,
+            processed.decision.selected_target,
+            processed.decision.draw
+        ),
+        router: DecisionProvider {
+            name: "random-routing".to_string(),
+            version: "v1".to_string(),
+        },
+        route: routing_target(target, processed.decision.tier.as_str().to_string())?,
+        confidence: None,
+        reason_code: Some("random_weighted".to_string()),
+        reason_summary: Some("selected by weighted random routing".to_string()),
+        metadata: BTreeMap::from([
+            (
+                "strong_probability".to_string(),
+                Value::from(processed.decision.strong_probability),
+            ),
+            ("draw".to_string(), Value::from(processed.decision.draw)),
+        ]),
+    })
 }
 
 /// Default probability matches the existing random-routing config.

--- a/crates/switchyard-components-v2/src/profiles/random_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/random_routing.rs
@@ -16,8 +16,8 @@ use switchyard_core::{ChatResponse, LlmTarget, Result, SwitchyardError};
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
 use crate::{
-    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
-    RoutingMetadata,
+    decision_for_random_routing, profile_config, Profile, ProfileConfig, ProfileHooks,
+    ProfileInput, ProfileResponse, RoutingDecision, RoutingMetadata, RoutingRequest,
 };
 
 /// Config for the flatter random-routing profile.
@@ -96,6 +96,14 @@ impl RandomRoutingProfile {
                 decision.selected_target
             )))
         }
+    }
+
+    /// Returns selected target metadata for a decision-only integration.
+    pub(crate) fn target_for_decision(
+        &self,
+        decision: &RandomRoutingDecision,
+    ) -> Result<&LlmTarget> {
+        self.selected_backend(decision).map(TargetBackend::target)
     }
 
     fn routing_metadata(&self, decision: &RandomRoutingDecision) -> RoutingMetadata {
@@ -182,6 +190,11 @@ impl Profile for RandomRoutingProfile {
             response,
             self.routing_metadata(decision),
         ))
+    }
+
+    /// Selects a configured target without dispatching it.
+    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+        decision_for_random_routing(self, request).await
     }
 }
 

--- a/crates/switchyard-core/src/error.rs
+++ b/crates/switchyard-core/src/error.rs
@@ -5,7 +5,7 @@
 
 use thiserror::Error;
 
-use crate::ids::{InvalidId, ModelId};
+use crate::ids::{InvalidId, ModelId, ProfileId};
 use crate::types::ChatRequestType;
 
 /// Result alias for core Switchyard operations.
@@ -25,6 +25,12 @@ pub enum SwitchyardError {
 
     #[error("no model registered for {model}")]
     ModelNotFound { model: ModelId },
+
+    #[error("no Decision API profile registered for {profile_id}")]
+    DecisionProfileNotFound { profile_id: ProfileId },
+
+    #[error("profile {profile_id} does not support the Decision API")]
+    DecisionUnsupported { profile_id: ProfileId },
 
     #[error("{component} does not support request type {request_type:?}")]
     UnsupportedRequestType {

--- a/crates/switchyard-py/src/errors.rs
+++ b/crates/switchyard-py/src/errors.rs
@@ -97,6 +97,10 @@ pub(crate) fn py_core_error(error: SwitchyardError) -> PyErr {
             SwitchyardDuplicateRegistrationError::new_err(message)
         }
         SwitchyardError::ModelNotFound { .. } => SwitchyardModelNotFoundError::new_err(message),
+        SwitchyardError::DecisionProfileNotFound { .. }
+        | SwitchyardError::DecisionUnsupported { .. } => {
+            SwitchyardInvalidRequestError::new_err(message)
+        }
         SwitchyardError::UnsupportedRequestType { .. } => {
             SwitchyardUnsupportedRequestTypeError::new_err(message)
         }

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -24,7 +24,7 @@ use axum::{Json, Router};
 use serde_json::{json, Value};
 use switchyard_components_v2::{
     parse_profile_config_path, profile_stats_accumulator, ProfileConfigPlan, ProfileInput,
-    ProfileResponse, RequestMetadata, RoutingMetadata,
+    ProfileResponse, RequestMetadata, RoutingMetadata, RoutingRequest,
 };
 use switchyard_core::{ChatRequest, ChatRequestType, RequestId, Result, SwitchyardError};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
@@ -78,6 +78,14 @@ impl ServerState {
         let profile = self.registry.lookup(input.request.model())?;
         profile.run(input).await
     }
+
+    /// Produces one routing decision through the configured profile registry.
+    async fn decide_route(
+        &self,
+        request: RoutingRequest,
+    ) -> Result<switchyard_components_v2::RoutingDecision> {
+        self.registry.decide(request).await
+    }
 }
 
 /// Runtime options shared by the Rust binary and Python binding.
@@ -124,6 +132,7 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
         .route("/v1/chat/completions", post(openai_chat_completions))
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/responses", post(openai_responses))
+        .route("/v1/routing/decision", post(routing_decision))
         .route("/v1/models", get(models))
         // Keep the legacy routing stats aliases wired to the same handlers.
         .route("/v1/stats", get(stats))
@@ -237,6 +246,31 @@ async fn openai_responses(
         metadata_from_headers(&headers, ChatRequestType::OpenAiResponses),
     )
     .await
+}
+
+async fn routing_decision(
+    State(state): State<ServerState>,
+    body: std::result::Result<Json<RoutingRequest>, JsonRejection>,
+) -> Response {
+    let request = match routing_json_body(body) {
+        Ok(request) => request,
+        Err(response) => return *response,
+    };
+    match state.decide_route(request).await {
+        Ok(decision) => Json(decision).into_response(),
+        Err(error) => llm_error(error),
+    }
+}
+
+fn routing_json_body(
+    body: std::result::Result<Json<RoutingRequest>, JsonRejection>,
+) -> std::result::Result<RoutingRequest, Box<Response>> {
+    match body {
+        Ok(Json(value)) => Ok(value),
+        Err(error) => Err(Box::new(invalid_body_error(format!(
+            "Routing decision request body must match the JSON contract: {error}"
+        )))),
+    }
 }
 
 fn llm_json_body(
@@ -363,6 +397,28 @@ fn llm_error(error: SwitchyardError) -> Response {
                     "message": format!("No route registered for model {}", model.as_str()),
                     "type": "model_not_found",
                     "code": "model_not_found",
+                }
+            })),
+        )
+            .into_response(),
+        SwitchyardError::DecisionProfileNotFound { profile_id } => (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": {
+                    "message": format!("No Decision API profile registered for {profile_id}"),
+                    "type": "decision_profile_not_found",
+                    "code": "decision_profile_not_found",
+                }
+            })),
+        )
+            .into_response(),
+        SwitchyardError::DecisionUnsupported { profile_id } => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({
+                "error": {
+                    "message": format!("Profile {profile_id} does not support the Decision API"),
+                    "type": "unsupported_profile_error",
+                    "code": "decision_not_supported",
                 }
             })),
         )
@@ -533,6 +589,7 @@ fn startup_banner(options: &ServerRunOptions, registry: &ProfileRegistry) -> Str
     push_line(&mut output, "    POST /v1/chat/completions");
     push_line(&mut output, "    POST /v1/messages");
     push_line(&mut output, "    POST /v1/responses");
+    push_line(&mut output, "    POST /v1/routing/decision");
     push_line(&mut output, "    GET  /v1/routing/stats");
     push_line(&mut output, "    POST /v1/routing/stats/reset");
     push_line(&mut output, "");

--- a/crates/switchyard-server/src/registry.rs
+++ b/crates/switchyard-server/src/registry.rs
@@ -7,9 +7,10 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use switchyard_components_v2::{
-    PassthroughProfileConfig, Profile, ProfileConfig, ProfileConfigPlan,
+    PassthroughProfileConfig, Profile, ProfileConfig, ProfileConfigPlan, RoutingDecision,
+    RoutingRequest,
 };
-use switchyard_core::{ModelId, Result, SwitchyardError};
+use switchyard_core::{ModelId, ProfileId, Result, SwitchyardError};
 
 /// Public model entry advertised by `/v1/models`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -26,10 +27,20 @@ struct RegistryEntry {
     profile: Arc<dyn Profile>,
 }
 
-/// Exact-match registry from inbound `model` values to components-v2 profiles.
+#[derive(Clone)]
+struct DecisionProfileEntry {
+    id: ProfileId,
+    profile: Arc<dyn Profile>,
+}
+
+/// Shared registry for model dispatch and profile-ID decision lookup.
+///
+/// Configured profile runtimes are built once and the same [`Arc`] is used by
+/// both paths so stateful routing policy cannot diverge between endpoints.
 #[derive(Clone, Default)]
 pub struct ProfileRegistry {
     entries: Vec<RegistryEntry>,
+    decision_profiles: Vec<DecisionProfileEntry>,
 }
 
 impl ProfileRegistry {
@@ -39,6 +50,10 @@ impl ProfileRegistry {
     ) -> Result<Self> {
         let mut registry = Self::default();
         for (model_id, profile, display_name) in entries {
+            registry.insert_decision_profile(
+                ProfileId::new(model_id.as_str())?,
+                Arc::clone(&profile),
+            )?;
             registry.insert(model_id, profile, display_name)?;
         }
         Ok(registry)
@@ -52,6 +67,7 @@ impl ProfileRegistry {
             let model_id = ModelId::new(profile_id.as_str())?;
             let profile: Arc<dyn Profile> = Arc::from(plan.build_profile(profile_id)?);
             let display_name = plan.profile_type(profile_id).unwrap_or("profile");
+            registry.insert_decision_profile(profile_id.clone(), Arc::clone(&profile))?;
             registry.insert(model_id, profile, display_name)?;
         }
 
@@ -94,6 +110,19 @@ impl ProfileRegistry {
             .ok_or(SwitchyardError::ModelNotFound { model })
     }
 
+    /// Produces a decision through the configured profile runtime with the requested ID.
+    pub async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+        request.validate()?;
+        let profile_id = request.decision_profile.profile_id.clone();
+        let profile = self
+            .decision_profiles
+            .iter()
+            .find(|entry| entry.id == profile_id)
+            .map(|entry| Arc::clone(&entry.profile))
+            .ok_or(SwitchyardError::DecisionProfileNotFound { profile_id })?;
+        profile.decide(request).await
+    }
+
     /// Returns model entries in deterministic registration order.
     pub fn served_models(&self) -> Vec<ServedModel> {
         self.entries
@@ -119,6 +148,28 @@ impl ProfileRegistry {
                 id: model_id,
                 display_name: display_name.into(),
             },
+            profile,
+        });
+        Ok(())
+    }
+
+    fn insert_decision_profile(
+        &mut self,
+        profile_id: ProfileId,
+        profile: Arc<dyn Profile>,
+    ) -> Result<()> {
+        if self
+            .decision_profiles
+            .iter()
+            .any(|entry| entry.id == profile_id)
+        {
+            return Err(SwitchyardError::DuplicateRegistration {
+                kind: "profile",
+                id: profile_id.to_string(),
+            });
+        }
+        self.decision_profiles.push(DecisionProfileEntry {
+            id: profile_id,
             profile,
         });
         Ok(())

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -16,7 +16,8 @@ use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use switchyard_components_v2::{
     parse_profile_config_str, profile_stats_accumulator, Profile, ProfileConfigFormat,
-    ProfileInput, ProfileResponse, RoutingMetadata,
+    ProfileInput, ProfileResponse, RoutingMetadata, ROUTING_DECISION_SCHEMA_VERSION,
+    ROUTING_REQUEST_SCHEMA_VERSION,
 };
 use switchyard_core::{
     ChatRequestType, ChatResponse, ModelId, Result, StreamEvent, SwitchyardError,
@@ -69,6 +70,326 @@ profiles:
         json_body(chat).await?["choices"][0]["message"]["content"],
         "ok"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_uses_configured_random_profile_without_backend_dispatch() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+targets:
+  strong:
+    model: upstream-strong
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  weak:
+    model: upstream-weak
+    format: responses
+    base_url: http://127.0.0.1:1/v1
+profiles:
+  remote-random:
+    type: random-routing
+    strong: strong
+    weak: weak
+    strong_probability: 1.0
+    rng_seed: 7
+"#,
+    )?);
+
+    let response = app
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json("remote-random", "none", None)),
+        )?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let decision = json_body(response).await?;
+    assert_eq!(decision["schema_version"], ROUTING_DECISION_SCHEMA_VERSION);
+    assert_eq!(decision["router"]["name"], "random-routing");
+    assert_eq!(decision["route"]["backend_id"], "strong");
+    assert_eq!(decision["route"]["target_model"], "upstream-strong");
+    assert_eq!(decision["route"]["target_protocol_profile"], "openai_chat");
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_classifies_materialized_llm_request_without_target_dispatch(
+) -> TestResult {
+    let classifier_response = json!({
+        "id": "chatcmpl-classifier",
+        "object": "chat.completion",
+        "model": "classifier-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-route",
+                    "type": "function",
+                    "function": {
+                        "name": "select_route",
+                        "arguments": {
+                            "recommended_tier": "complex",
+                            "confidence": 0.95,
+                            "abstain": false,
+                            "turn_type": "debug",
+                            "code_modification_scope": "cross_module",
+                            "tool_call_count_estimate": 4,
+                            "requires_codebase_context": true
+                        }
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+    });
+    let Some(classifier) = HttpStub::start_with_response(1, classifier_response)? else {
+        log_loopback_bind_skip();
+        return Ok(());
+    };
+    let app = build_switchyard_router(state_from_yaml(&format!(
+        r#"
+targets:
+  strong:
+    model: upstream-strong
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  weak:
+    model: upstream-weak
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  classifier:
+    model: classifier-model
+    format: openai
+    base_url: {classifier_url}
+profiles:
+  remote-llm:
+    type: llm-routing
+    strong: strong
+    weak: weak
+    classifier: classifier
+    fallback_target_on_evict: strong
+    profile_name: coding_agent
+    classifier_min_confidence: 0.0
+"#,
+        classifier_url = classifier.base_url
+    ))?);
+
+    let response = app
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json(
+                "remote-llm",
+                "full_body",
+                Some(json!({
+                    "body": {
+                        "model": "client/model",
+                        "messages": [{"role": "user", "content": "debug failing tests"}]
+                    }
+                })),
+            )),
+        )?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let decision = json_body(response).await?;
+    assert_eq!(decision["router"]["name"], "llm-routing");
+    assert_eq!(decision["route"]["backend_id"], "strong");
+    assert_eq!(decision["confidence"], 0.95);
+    assert_eq!(classifier.requests()?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_distinguishes_malformed_unknown_and_unsupported_profiles() -> TestResult
+{
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?);
+
+    let malformed = app
+        .clone()
+        .oneshot(raw_request("POST", "/v1/routing/decision", "{")?)
+        .await?;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(malformed).await?["error"]["code"], "invalid_body");
+
+    let mut missing_id = routing_request_json("bench", "summary_only", None);
+    missing_id["decision_profile"]
+        .as_object_mut()
+        .ok_or("decision_profile was not an object")?
+        .remove("profile_id");
+    let missing_id = app
+        .clone()
+        .oneshot(request("POST", "/v1/routing/decision", Some(missing_id))?)
+        .await?;
+    assert_eq!(missing_id.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json_body(missing_id).await?["error"]["code"],
+        "invalid_body"
+    );
+
+    let unknown = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json("missing", "summary_only", None)),
+        )?)
+        .await?;
+    assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        json_body(unknown).await?["error"]["code"],
+        "decision_profile_not_found"
+    );
+
+    let unsupported = app
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json("bench", "summary_only", None)),
+        )?)
+        .await?;
+    assert_eq!(unsupported.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        json_body(unsupported).await?["error"]["code"],
+        "decision_not_supported"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_validates_schema_and_attempt_before_unknown_profile_lookup() -> TestResult
+{
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?);
+
+    let mut invalid_schema = routing_request_json("missing", "summary_only", None);
+    invalid_schema["schema_version"] = json!("switchyard.routing_request.v999");
+    let response = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(invalid_schema),
+        )?)
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error = json_body(response).await?;
+    assert_eq!(error["error"]["code"], "invalid_request_error");
+    assert!(error["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("schema_version")));
+
+    for (routing_attempt, max_routing_attempts) in [(0, 1), (2, 1), (1, 0)] {
+        let mut invalid_attempt = routing_request_json("missing", "summary_only", None);
+        invalid_attempt["attempt"]["routing_attempt"] = json!(routing_attempt);
+        invalid_attempt["attempt"]["max_routing_attempts"] = json!(max_routing_attempts);
+        let response = app
+            .clone()
+            .oneshot(request(
+                "POST",
+                "/v1/routing/decision",
+                Some(invalid_attempt),
+            )?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = json_body(response).await?;
+        assert_eq!(error["error"]["code"], "invalid_request_error");
+        assert!(error["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("routing_attempt")));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_rejects_unknown_inbound_before_unknown_profile_lookup() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+targets:
+  strong:
+    model: upstream-strong
+    format: openai
+  weak:
+    model: upstream-weak
+    format: openai
+profiles:
+  remote-random:
+    type: random-routing
+    strong: strong
+    weak: weak
+    strong_probability: 1.0
+"#,
+    )?);
+    let mut body = routing_request_json("missing", "summary_only", None);
+    body["protocol"]["inbound_profile"] = json!("unrecognized-chat-format");
+
+    let response = app
+        .oneshot(request("POST", "/v1/routing/decision", Some(body))?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error = json_body(response).await?;
+    assert_eq!(error["error"]["code"], "invalid_request_error");
+    assert!(error["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("unsupported inbound_profile")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn llm_decision_rejects_summary_only_materialization_before_classifier_call() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+targets:
+  strong:
+    model: upstream-strong
+    format: openai
+  weak:
+    model: upstream-weak
+    format: openai
+  classifier:
+    model: classifier-model
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+profiles:
+  remote-llm:
+    type: llm-routing
+    strong: strong
+    weak: weak
+    classifier: classifier
+    fallback_target_on_evict: strong
+    profile_name: coding_agent
+"#,
+    )?);
+
+    let response = app
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json("remote-llm", "summary_only", None)),
+        )?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error = json_body(response).await?;
+    assert!(error["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("materialized current_request.body")));
     Ok(())
 }
 
@@ -727,6 +1048,28 @@ struct HttpStub {
 impl HttpStub {
     /// Binds an ephemeral port and accepts the expected number of stub requests.
     fn start(expected_requests: usize) -> TestResult<Option<Self>> {
+        Self::start_with_response(
+            expected_requests,
+            json!({
+                "id": "chatcmpl-stub",
+                "object": "chat.completion",
+                "model": "stub",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "stub-ok"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }),
+        )
+    }
+
+    /// Binds an ephemeral port and serves a caller-supplied JSON response.
+    fn start_with_response(expected_requests: usize, response: Value) -> TestResult<Option<Self>> {
         let listener = match StdTcpListener::bind("127.0.0.1:0") {
             Ok(listener) => listener,
             Err(error) if error.kind() == ErrorKind::PermissionDenied => return Ok(None),
@@ -747,22 +1090,7 @@ impl HttpStub {
                         }
                     }
                 }
-                let response = json!({
-                    "id": "chatcmpl-stub",
-                    "object": "chat.completion",
-                    "model": "stub",
-                    "choices": [{
-                        "index": 0,
-                        "message": {"role": "assistant", "content": "stub-ok"},
-                        "finish_reason": "stop",
-                    }],
-                    "usage": {
-                        "prompt_tokens": 1,
-                        "completion_tokens": 1,
-                        "total_tokens": 2,
-                    },
-                })
-                .to_string();
+                let response = response.to_string();
                 let _ = write!(
                     stream,
                     "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -845,6 +1173,46 @@ fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack
         .windows(needle.len())
         .position(|window| window == needle)
+}
+
+fn routing_request_json(
+    profile_id: &str,
+    request_materialization: &str,
+    current_request: Option<Value>,
+) -> Value {
+    let mut request = json!({
+        "schema_version": ROUTING_REQUEST_SCHEMA_VERSION,
+        "decision_profile": {
+            "profile_id": profile_id,
+            "router": "legacy-relay-router",
+            "request_materialization": request_materialization
+        },
+        "identity": {
+            "session_id": "session-1",
+            "request_id": "request-1",
+            "harness": "server-test",
+            "source": "nemo-relay",
+            "quality": "native"
+        },
+        "protocol": {
+            "inbound_profile": "openai_chat",
+            "inbound_endpoint": "/v1/chat/completions",
+            "desired_response_profile": "openai_chat"
+        },
+        "request_summary": {
+            "client_requested_model": "client/model",
+            "tool_count_in_payload": 0,
+            "has_system_prompt": false
+        },
+        "attempt": {
+            "routing_attempt": 1,
+            "max_routing_attempts": 1
+        }
+    });
+    if let Some(current_request) = current_request {
+        request["current_request"] = current_request;
+    }
+    request
 }
 
 fn state_from_yaml(input: &str) -> TestResult<ServerState> {


### PR DESCRIPTION
## What

### Summary

Adds the first, independently functional layer of the [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay) integration:

- a versioned JSON routing-request and routing-decision contract;
- decision-only Random and LLM routing through the existing profile runtimes;
- `POST /v1/routing/decision` with distinct malformed, unknown-profile, and unsupported-profile errors;
- Relay-compatible route metadata, including the configured Switchyard target ID as `backend_id`.

This is the Decision API slice of a previous end-to-end implementation, split into a focused public-repository change.

## Why

Relay needs Switchyard to select a configured target without dispatching that target itself. Keeping this contract and the two existing v2 routing profiles in a focused first PR makes the wire API, profile capability boundary, and server error behavior reviewable before ATOF state or Cascade routing are introduced.

## How tested

### Testing summary

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p switchyard-components-v2` (46 unit tests plus profile integration suites)
- [x] `cargo test -p switchyard-server` (21 server tests plus migration coverage)
- [x] `cargo test --workspace --exclude switchyard-py`
- [x] `cargo check -p switchyard-py`
- [x] Loopback classifier integration verifies LLM classification without calling the selected target.
- [ ] `uv run ruff check .` — not applicable; no Python source changed.
- [ ] `uv run mypy switchyard` — not applicable; no Python source changed.
- [ ] `uv run pytest tests/` — not applicable; the affected API is covered by Rust component/server tests.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A: Rust API change.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: symbols are exported from the Rust crate root.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (`DESIGN.md` documents the runtime contract.)
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

### Review guidelines

Suggested review order:

1. `decision.rs` for the wire contract, protocol/materialization validation, and response conversion.
2. `profile.rs` and `registry.rs` for the single-runtime capability path.
3. Random/LLM profile adapters to verify that decision-only routing stops before selected-target dispatch.
4. Server endpoint/error tests for Relay compatibility and status-code precedence.

The legacy Relay payload still includes `decision_profile.router`. Serde intentionally ignores that additive field; `profile_id` is authoritative. The response still includes `router` and all five route fields required by Relay.

### Previous feedback addressed

- Replaced the parallel `DecisionRuntimeRegistry` design with `Profile::decide()` on the same `Arc<dyn Profile>` already used for serving; configured runtimes are built once.
- Removed typed request-side `DecisionProfile.router` while retaining legacy wire compatibility for the extra field.
- Validates schema, attempt bounds, and inbound protocol before profile lookup, so malformed requests remain `400` even when the profile ID is unknown.
- Rejects unknown inbound profiles rather than silently treating them as OpenAI Chat.
- Validates actual user prompt material before an LLM classifier call, including adversarial empty/assistant-only shapes.
- Replaced fallible test `.expect()` usage with typed error propagation.
- Keeps malformed (`400`), unknown profile (`404`), and unsupported profile (`422`) failures distinct.

ATOF ingestion and Relay snapshots are intentionally deferred to [#9](https://github.com/NVIDIA-NeMo/Switchyard/pull/9); Relay-aware Cascade routing and unified session metadata are deferred to [#11](https://github.com/NVIDIA-NeMo/Switchyard/pull/11).

### Follow-up fixes

- Keeps Random and LLM decision-response conversion with their profile implementations; decision.rs now owns only shared contract and materialization helpers.
- Validates required identity/protocol strings and rejects contradictory materialization modes or missing current_request.body before profile execution.
- Adds focused envelope-validation coverage.