### PR TITLE
feat: add bounded Relay ATOF snapshots

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -99,10 +99,6 @@
       "filename": ".secrets.baseline"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -308,7 +304,7 @@
         "filename": "docs/cli_reference.md",
         "hashed_secret": "414cb2d928610e260b1b00de84c809d2adef2480",
         "is_verified": false,
-        "line_number": 561
+        "line_number": 605
       }
     ],
     "examples/minimal.py": [
@@ -934,49 +930,49 @@
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "e449e5bb663d63621f25ba82fb419387782120e3",
         "is_verified": false,
-        "line_number": 783
+        "line_number": 818
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "c0ed1602c8d31fdc29a4e11eedd725778fdca908",
         "is_verified": false,
-        "line_number": 792
+        "line_number": 827
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_verified": false,
-        "line_number": 969
+        "line_number": 1004
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "59d6d82c4087ecd7141b9a3c2dc1ee4cdc27aeba",
         "is_verified": false,
-        "line_number": 1318
+        "line_number": 1353
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "918f32a837ac1a55756aabe04a8e6c696707da4e",
         "is_verified": false,
-        "line_number": 1323
+        "line_number": 1358
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "fe72967536aedcae9b1b1e4eaf2c53494e17a638",
         "is_verified": false,
-        "line_number": 1350
+        "line_number": 1385
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_route_bundle.py",
         "hashed_secret": "2468398e45ffff540a52cbb98cd84e7c07d92832",
         "is_verified": false,
-        "line_number": 1465
+        "line_number": 1500
       }
     ],
     "tests/test_route_table.py": [
@@ -1193,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-06T23:24:20Z"
+  "generated_at": "2026-07-08T13:34:25Z"
 }

--- a/crates/switchyard-components-v2/src/features.rs
+++ b/crates/switchyard-components-v2/src/features.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use serde::Serialize;
 use serde_json::{json, Value};
 use switchyard_core::{Result, SwitchyardError};
@@ -16,12 +16,18 @@ pub const DEFAULT_MAX_RELAY_IDENTITIES: usize = 10_000;
 pub const DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY: usize = 256;
 /// Default maximum number of event idempotency keys retained in memory.
 pub const DEFAULT_MAX_RELAY_DEDUPE_ENTRIES: usize = 100_000;
-/// Default maximum encoded/string bytes retained across all Relay state.
+/// Default maximum conservative retained-memory budget across all Relay state.
 pub const DEFAULT_MAX_RELAY_RETAINED_BYTES: usize = 64 * 1024 * 1024;
 /// Default maximum encoded size accepted for one ATOF event.
 pub const DEFAULT_MAX_ATOF_EVENT_BYTES: usize = 256 * 1024;
 /// Default maximum encoded size accepted for one ATOF request batch.
 pub const DEFAULT_MAX_ATOF_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+// JSON values retain both serialized content and heap-backed container
+// allocations. Reserve a conservative second payload-sized copy plus a small
+// node allowance so the configured cap bounds retained heap growth, not only
+// wire bytes.
+const RETAINED_VALUE_OVERHEAD_BYTES: usize = 128;
 
 /// Exact identity key used for Relay snapshot accumulation and lookup.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -60,7 +66,7 @@ pub struct RelaySnapshotLimits {
     pub max_history_per_identity: usize,
     /// Maximum global event idempotency keys retained at once.
     pub max_dedupe_entries: usize,
-    /// Maximum encoded/string bytes retained across identities, history, and dedupe keys.
+    /// Conservative retained-memory budget across identities, history, and dedupe keys.
     pub max_retained_bytes: usize,
     /// Maximum serialized size of one event.
     pub max_event_bytes: usize,
@@ -142,9 +148,9 @@ pub struct RelayIngestReport {
     pub pruned_history_entries: u64,
     /// Old idempotency keys pruned because the dedupe cap was reached.
     pub pruned_dedupe_entries: u64,
-    /// Encoded/string bytes removed while pruning retained state.
+    /// Accounted retained bytes removed while pruning retained state.
     pub pruned_state_bytes: u64,
-    /// Encoded/string bytes retained after this batch.
+    /// Accounted retained bytes retained after this batch.
     pub retained_state_bytes: u64,
 }
 
@@ -187,9 +193,9 @@ pub struct RelayAccumulatorCounters {
     pub pruned_history_entries: u64,
     /// Idempotency keys pruned by the configured cap.
     pub pruned_dedupe_entries: u64,
-    /// Encoded/string bytes removed while pruning retained state.
+    /// Accounted retained bytes removed while pruning retained state.
     pub pruned_state_bytes: u64,
-    /// Current encoded/string bytes retained by the accumulator.
+    /// Current accounted retained bytes held by the accumulator.
     pub retained_state_bytes: u64,
 }
 
@@ -228,7 +234,7 @@ impl RelayAccumulatorCounters {
 #[derive(Debug)]
 pub struct RelaySnapshotAccumulator {
     limits: RelaySnapshotLimits,
-    inner: Mutex<RelayAccumulatorState>,
+    inner: RwLock<RelayAccumulatorState>,
 }
 
 impl RelaySnapshotAccumulator {
@@ -236,7 +242,7 @@ impl RelaySnapshotAccumulator {
     pub fn with_limits(limits: RelaySnapshotLimits) -> Result<Self> {
         Ok(Self {
             limits: limits.validate()?,
-            inner: Mutex::new(RelayAccumulatorState::default()),
+            inner: RwLock::new(RelayAccumulatorState::default()),
         })
     }
 
@@ -277,7 +283,7 @@ impl RelaySnapshotAccumulator {
             received_events: prepared.len() as u64,
             ..RelayIngestReport::default()
         };
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.write();
         for event in prepared {
             match event {
                 PreparedRelayEvent::Drop(reason) => report.record_drop(reason),
@@ -293,7 +299,7 @@ impl RelaySnapshotAccumulator {
 
     /// Returns a snapshot only for the exact `(session_id, owner_id)` key.
     pub fn snapshot(&self, key: &RelayIdentityKey) -> Option<RelaySnapshot> {
-        let inner = self.inner.lock();
+        let inner = self.inner.read();
         inner.identities.get(key).map(|state| RelaySnapshot {
             identity: key.clone(),
             messages: state
@@ -308,17 +314,17 @@ impl RelaySnapshotAccumulator {
 
     /// Returns lifetime ingestion and pruning counters.
     pub fn counters(&self) -> RelayAccumulatorCounters {
-        self.inner.lock().counters
+        self.inner.read().counters
     }
 
     /// Returns the number of retained exact identities.
     pub fn identity_count(&self) -> usize {
-        self.inner.lock().identities.len()
+        self.inner.read().identities.len()
     }
 
     /// Returns exact encoded/string bytes counted against the retained-state cap.
     pub fn retained_state_bytes(&self) -> usize {
-        self.inner.lock().retained_state_bytes
+        self.inner.read().retained_state_bytes
     }
 
     fn prepare_event(
@@ -379,7 +385,7 @@ impl Default for RelaySnapshotAccumulator {
     fn default() -> Self {
         Self {
             limits: RelaySnapshotLimits::default(),
-            inner: Mutex::new(RelayAccumulatorState::default()),
+            inner: RwLock::new(RelayAccumulatorState::default()),
         }
     }
 }
@@ -497,7 +503,7 @@ impl RelayAccumulatorState {
             RelayUpdate::Message(message) => {
                 self.retained_state_bytes = self
                     .retained_state_bytes
-                    .saturating_add(message.encoded_bytes);
+                    .saturating_add(message.retained_bytes);
                 state.messages.push_back(message);
             }
         }
@@ -522,8 +528,8 @@ impl RelayAccumulatorState {
             };
             self.retained_state_bytes = self
                 .retained_state_bytes
-                .saturating_sub(message.encoded_bytes);
-            record_pruned_bytes(report, message.encoded_bytes);
+                .saturating_sub(message.retained_bytes);
+            record_pruned_bytes(report, message.retained_bytes);
             report.pruned_history_entries = report.pruned_history_entries.saturating_add(1);
         }
     }
@@ -552,7 +558,7 @@ impl RelayAccumulatorState {
         let message_bytes = removed
             .messages
             .iter()
-            .map(|message| message.encoded_bytes)
+            .map(|message| message.retained_bytes)
             .sum::<usize>();
         let removed_bytes = removed.retained_key_bytes.saturating_add(message_bytes);
         self.retained_state_bytes = self.retained_state_bytes.saturating_sub(removed_bytes);
@@ -605,7 +611,7 @@ impl RelayUpdate {
     fn retained_bytes(&self) -> usize {
         match self {
             Self::TurnStart | Self::TurnEnd => 0,
-            Self::Message(message) => message.encoded_bytes,
+            Self::Message(message) => message.retained_bytes,
         }
     }
 }
@@ -613,7 +619,7 @@ impl RelayUpdate {
 #[derive(Debug)]
 struct RetainedMessage {
     value: Value,
-    encoded_bytes: usize,
+    retained_bytes: usize,
 }
 
 #[derive(Debug)]
@@ -697,9 +703,17 @@ fn retained_message(value: Value) -> Result<RetainedMessage> {
     let encoded_bytes = serde_json::to_vec(&value)
         .map_err(|error| SwitchyardError::InvalidRequest(error.to_string()))?
         .len();
+    let retained_bytes = encoded_bytes
+        .checked_mul(2)
+        .and_then(|bytes| bytes.checked_add(RETAINED_VALUE_OVERHEAD_BYTES))
+        .ok_or_else(|| {
+            SwitchyardError::InvalidRequest(
+                "Relay message retained-state footprint overflowed usize".to_string(),
+            )
+        })?;
     Ok(RetainedMessage {
         value,
-        encoded_bytes,
+        retained_bytes,
     })
 }
 

--- a/crates/switchyard-components-v2/src/features.rs
+++ b/crates/switchyard-components-v2/src/features.rs
@@ -1,0 +1,1331 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded, router-neutral snapshots reconstructed from Relay ATOF events.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use serde_json::{json, Value};
+use switchyard_core::{Result, SwitchyardError};
+
+/// Default maximum number of routing identities retained in memory.
+pub const DEFAULT_MAX_RELAY_IDENTITIES: usize = 10_000;
+/// Default maximum reconstructed messages retained for one identity.
+pub const DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY: usize = 256;
+/// Default maximum number of event idempotency keys retained in memory.
+pub const DEFAULT_MAX_RELAY_DEDUPE_ENTRIES: usize = 100_000;
+/// Default maximum encoded/string bytes retained across all Relay state.
+pub const DEFAULT_MAX_RELAY_RETAINED_BYTES: usize = 64 * 1024 * 1024;
+/// Default maximum encoded size accepted for one ATOF event.
+pub const DEFAULT_MAX_ATOF_EVENT_BYTES: usize = 256 * 1024;
+/// Default maximum encoded size accepted for one ATOF request batch.
+pub const DEFAULT_MAX_ATOF_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+/// Exact identity key used for Relay snapshot accumulation and lookup.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct RelayIdentityKey {
+    /// Stable session identifier.
+    pub session_id: String,
+    /// Optional owner identifier, usually a subagent or resolved scope owner.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<String>,
+}
+
+impl RelayIdentityKey {
+    /// Builds a key scoped only by session.
+    pub fn session_only(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            owner_id: None,
+        }
+    }
+
+    /// Builds a key scoped by session and optional owner.
+    pub fn new(session_id: impl Into<String>, owner_id: Option<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            owner_id,
+        }
+    }
+}
+
+/// Deterministic memory and request-size limits for Relay accumulation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct RelaySnapshotLimits {
+    /// Maximum number of exact identity keys retained at once.
+    pub max_identities: usize,
+    /// Maximum reconstructed messages retained for each identity.
+    pub max_history_per_identity: usize,
+    /// Maximum global event idempotency keys retained at once.
+    pub max_dedupe_entries: usize,
+    /// Maximum encoded/string bytes retained across identities, history, and dedupe keys.
+    pub max_retained_bytes: usize,
+    /// Maximum serialized size of one event.
+    pub max_event_bytes: usize,
+    /// Maximum encoded size of one HTTP ingestion batch.
+    pub max_batch_bytes: usize,
+}
+
+impl RelaySnapshotLimits {
+    /// Validates that every fixed-size bound retains at least one entry or byte.
+    pub fn validate(self) -> Result<Self> {
+        for (name, value) in [
+            ("max_identities", self.max_identities),
+            ("max_history_per_identity", self.max_history_per_identity),
+            ("max_dedupe_entries", self.max_dedupe_entries),
+            ("max_retained_bytes", self.max_retained_bytes),
+            ("max_event_bytes", self.max_event_bytes),
+            ("max_batch_bytes", self.max_batch_bytes),
+        ] {
+            if value == 0 {
+                return Err(SwitchyardError::InvalidConfig(format!(
+                    "Relay snapshot limit {name} must be greater than zero"
+                )));
+            }
+        }
+        if self.max_event_bytes > self.max_batch_bytes {
+            return Err(SwitchyardError::InvalidConfig(format!(
+                "Relay snapshot max_event_bytes ({}) cannot exceed max_batch_bytes ({})",
+                self.max_event_bytes, self.max_batch_bytes
+            )));
+        }
+        Ok(self)
+    }
+}
+
+impl Default for RelaySnapshotLimits {
+    fn default() -> Self {
+        Self {
+            max_identities: DEFAULT_MAX_RELAY_IDENTITIES,
+            max_history_per_identity: DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
+            max_dedupe_entries: DEFAULT_MAX_RELAY_DEDUPE_ENTRIES,
+            max_retained_bytes: DEFAULT_MAX_RELAY_RETAINED_BYTES,
+            max_event_bytes: DEFAULT_MAX_ATOF_EVENT_BYTES,
+            max_batch_bytes: DEFAULT_MAX_ATOF_BATCH_BYTES,
+        }
+    }
+}
+
+/// Router-neutral state reconstructed for one exact Relay identity.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RelaySnapshot {
+    /// Identity that owns this snapshot.
+    pub identity: RelayIdentityKey,
+    /// OpenAI-shaped tool-call and tool-result messages in retained event order.
+    pub messages: Vec<Value>,
+    /// Number of observed Relay turn-start scopes for this identity.
+    pub turn_depth: u64,
+    /// Number of unique recognized events ingested for this identity.
+    pub event_count: u64,
+}
+
+/// Per-batch ingestion outcome, including every non-mutating drop category.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RelayIngestReport {
+    /// Number of parsed event objects supplied to the accumulator.
+    pub received_events: u64,
+    /// Number of unique recognized events that mutated identity state.
+    pub ingested_events: u64,
+    /// Number of recognized events ignored because their idempotency key was retained.
+    pub duplicate_events: u64,
+    /// Total events dropped without mutating identity state, including duplicates.
+    pub dropped_events: u64,
+    /// Events that were not supported scope/phase combinations.
+    pub dropped_unrecognized_events: u64,
+    /// Recognized events for which no session identity could be resolved.
+    pub dropped_missing_identity_events: u64,
+    /// Identity snapshots pruned because the identity cap was reached.
+    pub pruned_identities: u64,
+    /// Reconstructed messages pruned by identity or per-identity history bounds.
+    pub pruned_history_entries: u64,
+    /// Old idempotency keys pruned because the dedupe cap was reached.
+    pub pruned_dedupe_entries: u64,
+    /// Encoded/string bytes removed while pruning retained state.
+    pub pruned_state_bytes: u64,
+    /// Encoded/string bytes retained after this batch.
+    pub retained_state_bytes: u64,
+}
+
+impl RelayIngestReport {
+    fn record_drop(&mut self, reason: RelayDropReason) {
+        self.dropped_events = self.dropped_events.saturating_add(1);
+        match reason {
+            RelayDropReason::Unrecognized => {
+                self.dropped_unrecognized_events =
+                    self.dropped_unrecognized_events.saturating_add(1);
+            }
+            RelayDropReason::MissingIdentity => {
+                self.dropped_missing_identity_events =
+                    self.dropped_missing_identity_events.saturating_add(1);
+            }
+        }
+    }
+}
+
+/// Lifetime counters for one Relay snapshot accumulator.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RelayAccumulatorCounters {
+    /// Number of successfully validated and applied batches.
+    pub batches: u64,
+    /// Number of parsed event objects supplied across successful batches.
+    pub received_events: u64,
+    /// Number of unique recognized events that mutated state.
+    pub ingested_events: u64,
+    /// Number of recognized duplicate events ignored.
+    pub duplicate_events: u64,
+    /// Total events dropped without mutating identity state.
+    pub dropped_events: u64,
+    /// Unsupported event kinds or scope/phase combinations dropped.
+    pub dropped_unrecognized_events: u64,
+    /// Recognized events lacking a resolvable session identity dropped.
+    pub dropped_missing_identity_events: u64,
+    /// Identity snapshots pruned by the configured cap.
+    pub pruned_identities: u64,
+    /// Reconstructed history entries pruned by configured caps.
+    pub pruned_history_entries: u64,
+    /// Idempotency keys pruned by the configured cap.
+    pub pruned_dedupe_entries: u64,
+    /// Encoded/string bytes removed while pruning retained state.
+    pub pruned_state_bytes: u64,
+    /// Current encoded/string bytes retained by the accumulator.
+    pub retained_state_bytes: u64,
+}
+
+impl RelayAccumulatorCounters {
+    fn record(&mut self, report: RelayIngestReport) {
+        self.batches = self.batches.saturating_add(1);
+        self.received_events = self.received_events.saturating_add(report.received_events);
+        self.ingested_events = self.ingested_events.saturating_add(report.ingested_events);
+        self.duplicate_events = self
+            .duplicate_events
+            .saturating_add(report.duplicate_events);
+        self.dropped_events = self.dropped_events.saturating_add(report.dropped_events);
+        self.dropped_unrecognized_events = self
+            .dropped_unrecognized_events
+            .saturating_add(report.dropped_unrecognized_events);
+        self.dropped_missing_identity_events = self
+            .dropped_missing_identity_events
+            .saturating_add(report.dropped_missing_identity_events);
+        self.pruned_identities = self
+            .pruned_identities
+            .saturating_add(report.pruned_identities);
+        self.pruned_history_entries = self
+            .pruned_history_entries
+            .saturating_add(report.pruned_history_entries);
+        self.pruned_dedupe_entries = self
+            .pruned_dedupe_entries
+            .saturating_add(report.pruned_dedupe_entries);
+        self.pruned_state_bytes = self
+            .pruned_state_bytes
+            .saturating_add(report.pruned_state_bytes);
+        self.retained_state_bytes = report.retained_state_bytes;
+    }
+}
+
+/// In-process accumulator for bounded Relay ATOF-derived history snapshots.
+#[derive(Debug)]
+pub struct RelaySnapshotAccumulator {
+    limits: RelaySnapshotLimits,
+    inner: Mutex<RelayAccumulatorState>,
+}
+
+impl RelaySnapshotAccumulator {
+    /// Builds an empty accumulator using validated limits.
+    pub fn with_limits(limits: RelaySnapshotLimits) -> Result<Self> {
+        Ok(Self {
+            limits: limits.validate()?,
+            inner: Mutex::new(RelayAccumulatorState::default()),
+        })
+    }
+
+    /// Returns this accumulator's immutable limits.
+    pub fn limits(&self) -> RelaySnapshotLimits {
+        self.limits
+    }
+
+    /// Validates the full batch, then applies it under one state lock.
+    ///
+    /// Invalid objects or oversized events fail before any state is mutated.
+    pub fn ingest_batch(&self, events: &[Value]) -> Result<RelayIngestReport> {
+        let mut prepared = Vec::with_capacity(events.len());
+        let mut encoded_batch_size = 0_usize;
+        for (index, event) in events.iter().enumerate() {
+            let encoded_size = serde_json::to_vec(event)
+                .map_err(|error| SwitchyardError::InvalidRequest(error.to_string()))?
+                .len();
+            // Count the minimum NDJSON separator between canonical event values.
+            encoded_batch_size = encoded_batch_size
+                .checked_add(usize::from(index > 0))
+                .and_then(|size| size.checked_add(encoded_size))
+                .ok_or_else(|| {
+                    SwitchyardError::InvalidRequest(
+                        "ATOF encoded batch size overflowed usize".to_string(),
+                    )
+                })?;
+            if encoded_batch_size > self.limits.max_batch_bytes {
+                return Err(SwitchyardError::InvalidRequest(format!(
+                    "ATOF batch is at least {encoded_batch_size} bytes; maximum is {} bytes",
+                    self.limits.max_batch_bytes
+                )));
+            }
+            prepared.push(self.prepare_event(index, event, encoded_size)?);
+        }
+
+        let mut report = RelayIngestReport {
+            received_events: prepared.len() as u64,
+            ..RelayIngestReport::default()
+        };
+        let mut inner = self.inner.lock();
+        for event in prepared {
+            match event {
+                PreparedRelayEvent::Drop(reason) => report.record_drop(reason),
+                PreparedRelayEvent::Recognized(event) => {
+                    inner.ingest(event, self.limits, &mut report);
+                }
+            }
+        }
+        report.retained_state_bytes = inner.retained_state_bytes as u64;
+        inner.counters.record(report);
+        Ok(report)
+    }
+
+    /// Returns a snapshot only for the exact `(session_id, owner_id)` key.
+    pub fn snapshot(&self, key: &RelayIdentityKey) -> Option<RelaySnapshot> {
+        let inner = self.inner.lock();
+        inner.identities.get(key).map(|state| RelaySnapshot {
+            identity: key.clone(),
+            messages: state
+                .messages
+                .iter()
+                .map(|message| message.value.clone())
+                .collect(),
+            turn_depth: state.turn_depth,
+            event_count: state.event_count,
+        })
+    }
+
+    /// Returns lifetime ingestion and pruning counters.
+    pub fn counters(&self) -> RelayAccumulatorCounters {
+        self.inner.lock().counters
+    }
+
+    /// Returns the number of retained exact identities.
+    pub fn identity_count(&self) -> usize {
+        self.inner.lock().identities.len()
+    }
+
+    /// Returns exact encoded/string bytes counted against the retained-state cap.
+    pub fn retained_state_bytes(&self) -> usize {
+        self.inner.lock().retained_state_bytes
+    }
+
+    fn prepare_event(
+        &self,
+        index: usize,
+        event: &Value,
+        encoded_size: usize,
+    ) -> Result<PreparedRelayEvent> {
+        if !event.is_object() {
+            return Err(SwitchyardError::InvalidRequest(format!(
+                "ATOF event {} must be a JSON object",
+                index + 1
+            )));
+        }
+        if encoded_size > self.limits.max_event_bytes {
+            return Err(SwitchyardError::InvalidRequest(format!(
+                "ATOF event {} is {encoded_size} bytes; maximum is {} bytes",
+                index + 1,
+                self.limits.max_event_bytes
+            )));
+        }
+
+        let Some((update, dedupe_key)) = relay_update(event, index)? else {
+            return Ok(PreparedRelayEvent::Drop(RelayDropReason::Unrecognized));
+        };
+        let Some(identity) = relay_identity_key_from_atof_event(event) else {
+            return Ok(PreparedRelayEvent::Drop(RelayDropReason::MissingIdentity));
+        };
+        let identity_retained_bytes = retained_identity_bytes(&identity)?;
+        let dedupe_retained_bytes = retained_string_copies_bytes(&dedupe_key)?;
+        let max_new_state_bytes = identity_retained_bytes
+            .checked_add(dedupe_retained_bytes)
+            .and_then(|bytes| bytes.checked_add(update.retained_bytes()))
+            .ok_or_else(|| {
+                SwitchyardError::InvalidRequest(format!(
+                    "ATOF event {} retained-state footprint overflowed usize",
+                    index + 1
+                ))
+            })?;
+        if max_new_state_bytes > self.limits.max_retained_bytes {
+            return Err(SwitchyardError::InvalidRequest(format!(
+                "ATOF event {} can retain {max_new_state_bytes} bytes; maximum retained state is {} bytes",
+                index + 1,
+                self.limits.max_retained_bytes
+            )));
+        }
+        Ok(PreparedRelayEvent::Recognized(RecognizedRelayEvent {
+            identity,
+            dedupe_key,
+            identity_retained_bytes,
+            dedupe_retained_bytes,
+            update,
+        }))
+    }
+}
+
+impl Default for RelaySnapshotAccumulator {
+    fn default() -> Self {
+        Self {
+            limits: RelaySnapshotLimits::default(),
+            inner: Mutex::new(RelayAccumulatorState::default()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RelayAccumulatorState {
+    identities: BTreeMap<RelayIdentityKey, RelayIdentityState>,
+    identity_order: VecDeque<RelayIdentityKey>,
+    seen_events: BTreeSet<String>,
+    dedupe_order: VecDeque<RetainedDedupeKey>,
+    retained_state_bytes: usize,
+    counters: RelayAccumulatorCounters,
+}
+
+impl RelayAccumulatorState {
+    fn ingest(
+        &mut self,
+        event: RecognizedRelayEvent,
+        limits: RelaySnapshotLimits,
+        report: &mut RelayIngestReport,
+    ) {
+        if self.seen_events.contains(&event.dedupe_key) {
+            report.duplicate_events = report.duplicate_events.saturating_add(1);
+            report.dropped_events = report.dropped_events.saturating_add(1);
+            return;
+        }
+
+        if self.dedupe_order.len() >= limits.max_dedupe_entries {
+            self.prune_oldest_dedupe(report);
+        }
+        if !self.identities.contains_key(&event.identity)
+            && self.identities.len() >= limits.max_identities
+        {
+            self.prune_oldest_identity(report);
+        }
+        self.prune_history_for_incoming(
+            &event.identity,
+            event.update.retained_bytes(),
+            limits.max_history_per_identity,
+            report,
+        );
+        self.make_room_for(&event, limits.max_retained_bytes, report);
+
+        self.insert_dedupe(event.dedupe_key, event.dedupe_retained_bytes);
+        self.ensure_identity(event.identity.clone(), event.identity_retained_bytes);
+        self.apply_update(&event.identity, event.update);
+        report.ingested_events = report.ingested_events.saturating_add(1);
+    }
+
+    fn make_room_for(
+        &mut self,
+        event: &RecognizedRelayEvent,
+        max_retained_bytes: usize,
+        report: &mut RelayIngestReport,
+    ) {
+        loop {
+            let identity_bytes = if self.identities.contains_key(&event.identity) {
+                0
+            } else {
+                event.identity_retained_bytes
+            };
+            let additional = identity_bytes
+                .saturating_add(event.dedupe_retained_bytes)
+                .saturating_add(event.update.retained_bytes());
+            if self
+                .retained_state_bytes
+                .checked_add(additional)
+                .is_some_and(|total| total <= max_retained_bytes)
+            {
+                break;
+            }
+            if self.prune_oldest_dedupe(report) || self.prune_oldest_identity(report) {
+                continue;
+            }
+            // Preparation rejects any single event whose worst-case footprint
+            // exceeds the cap, so empty state always has enough room.
+            break;
+        }
+    }
+
+    fn insert_dedupe(&mut self, key: String, retained_bytes: usize) {
+        self.seen_events.insert(key.clone());
+        self.dedupe_order.push_back(RetainedDedupeKey {
+            key,
+            retained_bytes,
+        });
+        self.retained_state_bytes = self.retained_state_bytes.saturating_add(retained_bytes);
+    }
+
+    fn ensure_identity(&mut self, key: RelayIdentityKey, retained_key_bytes: usize) {
+        if self.identities.contains_key(&key) {
+            return;
+        }
+        self.identity_order.push_back(key.clone());
+        self.identities.insert(
+            key,
+            RelayIdentityState {
+                retained_key_bytes,
+                ..RelayIdentityState::default()
+            },
+        );
+        self.retained_state_bytes = self.retained_state_bytes.saturating_add(retained_key_bytes);
+    }
+
+    fn apply_update(&mut self, key: &RelayIdentityKey, update: RelayUpdate) {
+        let Some(state) = self.identities.get_mut(key) else {
+            return;
+        };
+        state.event_count = state.event_count.saturating_add(1);
+        match update {
+            RelayUpdate::TurnStart => {
+                state.turn_depth = state.turn_depth.saturating_add(1);
+            }
+            RelayUpdate::TurnEnd => {}
+            RelayUpdate::Message(message) => {
+                self.retained_state_bytes = self
+                    .retained_state_bytes
+                    .saturating_add(message.encoded_bytes);
+                state.messages.push_back(message);
+            }
+        }
+    }
+
+    fn prune_history_for_incoming(
+        &mut self,
+        key: &RelayIdentityKey,
+        incoming_message_bytes: usize,
+        max_history: usize,
+        report: &mut RelayIngestReport,
+    ) {
+        if incoming_message_bytes == 0 {
+            return;
+        }
+        let Some(state) = self.identities.get_mut(key) else {
+            return;
+        };
+        while state.messages.len() >= max_history {
+            let Some(message) = state.messages.pop_front() else {
+                break;
+            };
+            self.retained_state_bytes = self
+                .retained_state_bytes
+                .saturating_sub(message.encoded_bytes);
+            record_pruned_bytes(report, message.encoded_bytes);
+            report.pruned_history_entries = report.pruned_history_entries.saturating_add(1);
+        }
+    }
+
+    fn prune_oldest_dedupe(&mut self, report: &mut RelayIngestReport) -> bool {
+        let Some(oldest) = self.dedupe_order.pop_front() else {
+            return false;
+        };
+        self.seen_events.remove(&oldest.key);
+        self.retained_state_bytes = self
+            .retained_state_bytes
+            .saturating_sub(oldest.retained_bytes);
+        record_pruned_bytes(report, oldest.retained_bytes);
+        report.pruned_dedupe_entries = report.pruned_dedupe_entries.saturating_add(1);
+        true
+    }
+
+    /// Identity eviction is FIFO by first insertion, making pruning repeatable.
+    fn prune_oldest_identity(&mut self, report: &mut RelayIngestReport) -> bool {
+        let Some(oldest) = self.identity_order.pop_front() else {
+            return false;
+        };
+        let Some(removed) = self.identities.remove(&oldest) else {
+            return false;
+        };
+        let message_bytes = removed
+            .messages
+            .iter()
+            .map(|message| message.encoded_bytes)
+            .sum::<usize>();
+        let removed_bytes = removed.retained_key_bytes.saturating_add(message_bytes);
+        self.retained_state_bytes = self.retained_state_bytes.saturating_sub(removed_bytes);
+        record_pruned_bytes(report, removed_bytes);
+        report.pruned_identities = report.pruned_identities.saturating_add(1);
+        report.pruned_history_entries = report
+            .pruned_history_entries
+            .saturating_add(removed.messages.len() as u64);
+        true
+    }
+}
+
+#[derive(Debug, Default)]
+struct RelayIdentityState {
+    messages: VecDeque<RetainedMessage>,
+    turn_depth: u64,
+    event_count: u64,
+    retained_key_bytes: usize,
+}
+
+#[derive(Debug)]
+enum PreparedRelayEvent {
+    Drop(RelayDropReason),
+    Recognized(RecognizedRelayEvent),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RelayDropReason {
+    Unrecognized,
+    MissingIdentity,
+}
+
+#[derive(Debug)]
+struct RecognizedRelayEvent {
+    identity: RelayIdentityKey,
+    dedupe_key: String,
+    identity_retained_bytes: usize,
+    dedupe_retained_bytes: usize,
+    update: RelayUpdate,
+}
+
+#[derive(Debug)]
+enum RelayUpdate {
+    TurnStart,
+    TurnEnd,
+    Message(RetainedMessage),
+}
+
+impl RelayUpdate {
+    fn retained_bytes(&self) -> usize {
+        match self {
+            Self::TurnStart | Self::TurnEnd => 0,
+            Self::Message(message) => message.encoded_bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RetainedMessage {
+    value: Value,
+    encoded_bytes: usize,
+}
+
+#[derive(Debug)]
+struct RetainedDedupeKey {
+    key: String,
+    retained_bytes: usize,
+}
+
+/// Resolves an identity using the compatibility fallback order from Relay PR integration.
+pub fn relay_identity_key_from_atof_event(event: &Value) -> Option<RelayIdentityKey> {
+    let metadata = event.get("metadata").unwrap_or(&Value::Null);
+    let data = event.get("data").unwrap_or(&Value::Null);
+    let session_id = non_empty_json_string_at(metadata, &["session_id"])
+        .or_else(|| non_empty_json_string_at(metadata, &["hermes_session_id"]))
+        .or_else(|| non_empty_json_string_at(data, &["session_id"]))
+        .or_else(|| {
+            non_empty_json_string_at(data, &["request", "headers", "x-nemo-relay-session-id"])
+        })?;
+    let owner_id = non_empty_json_string_at(metadata, &["switchyard_owner_id"])
+        .or_else(|| non_empty_json_string_at(metadata, &["llm_correlation_subagent_id"]))
+        .or_else(|| non_empty_json_string_at(metadata, &["tool_correlation_subagent_id"]))
+        .or_else(|| non_empty_json_string_at(metadata, &["subagent_id"]))
+        .or_else(|| non_empty_json_string_at(metadata, &["subagent_session_id"]))
+        .or_else(|| non_empty_json_string_at(metadata, &["hermes_subagent_session_id"]))
+        .or_else(|| {
+            non_empty_json_string_at(data, &["request", "headers", "x-nemo-relay-owner-id"])
+        });
+    Some(RelayIdentityKey::new(session_id, owner_id))
+}
+
+/// Returns a scope-event idempotency key when a UUID is available.
+pub fn atof_event_dedupe_key(event: &Value) -> Option<String> {
+    let uuid = non_empty_json_string_at(event, &["uuid"])?;
+    let phase =
+        non_empty_json_string_at(event, &["scope_category"]).unwrap_or_else(|| "mark".to_string());
+    Some(format!("{uuid}:{phase}"))
+}
+
+/// Reads a string from a nested JSON object path.
+pub fn json_string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn non_empty_json_string_at(value: &Value, path: &[&str]) -> Option<String> {
+    json_string_at(value, path).and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn retained_identity_bytes(identity: &RelayIdentityKey) -> Result<usize> {
+    let one_copy = identity
+        .session_id
+        .len()
+        .checked_add(identity.owner_id.as_deref().map_or(0, str::len))
+        .ok_or_else(|| {
+            SwitchyardError::InvalidRequest(
+                "Relay identity retained-state footprint overflowed usize".to_string(),
+            )
+        })?;
+    one_copy.checked_mul(2).ok_or_else(|| {
+        SwitchyardError::InvalidRequest(
+            "Relay identity retained-state footprint overflowed usize".to_string(),
+        )
+    })
+}
+
+fn retained_string_copies_bytes(value: &str) -> Result<usize> {
+    value.len().checked_mul(2).ok_or_else(|| {
+        SwitchyardError::InvalidRequest(
+            "Relay dedupe retained-state footprint overflowed usize".to_string(),
+        )
+    })
+}
+
+fn retained_message(value: Value) -> Result<RetainedMessage> {
+    let encoded_bytes = serde_json::to_vec(&value)
+        .map_err(|error| SwitchyardError::InvalidRequest(error.to_string()))?
+        .len();
+    Ok(RetainedMessage {
+        value,
+        encoded_bytes,
+    })
+}
+
+fn record_pruned_bytes(report: &mut RelayIngestReport, bytes: usize) {
+    report.pruned_state_bytes = report.pruned_state_bytes.saturating_add(bytes as u64);
+}
+
+/// Semantically validates recognized scope events before accumulator locking.
+fn relay_update(event: &Value, index: usize) -> Result<Option<(RelayUpdate, String)>> {
+    if event.get("kind").and_then(Value::as_str) != Some("scope") {
+        return Ok(None);
+    }
+    let turn_scope = is_turn_scope(event);
+    let tool_scope = event.get("category").and_then(Value::as_str) == Some("tool");
+    if !turn_scope && !tool_scope {
+        return Ok(None);
+    }
+
+    let uuid = required_event_string(event, &["uuid"], "uuid", index)?;
+    let phase = required_event_string(event, &["scope_category"], "scope_category", index)?;
+    if !matches!(phase.as_str(), "start" | "end") {
+        return Err(invalid_recognized_event(
+            index,
+            format!("scope_category must be start or end, got {phase:?}"),
+        ));
+    }
+    let dedupe_key = format!("{uuid}:{phase}");
+
+    if turn_scope {
+        let update = if phase == "start" {
+            RelayUpdate::TurnStart
+        } else {
+            RelayUpdate::TurnEnd
+        };
+        return Ok(Some((update, dedupe_key)));
+    }
+
+    let name = required_event_string(event, &["name"], "name", index)?;
+    let tool_call_id = required_event_string(
+        event,
+        &["category_profile", "tool_call_id"],
+        "category_profile.tool_call_id",
+        index,
+    )?;
+    let data = event
+        .get("data")
+        .filter(|value| !value.is_null())
+        .ok_or_else(|| invalid_recognized_event(index, "data must be present and non-null"))?;
+    let message = if phase == "start" {
+        tool_call_message(&name, &tool_call_id, data)
+    } else {
+        tool_result_message(&tool_call_id, data)
+    };
+    Ok(Some((
+        RelayUpdate::Message(retained_message(message)?),
+        dedupe_key,
+    )))
+}
+
+fn is_turn_scope(event: &Value) -> bool {
+    non_empty_json_string_at(event, &["metadata", "nemo_relay_scope_role"]).as_deref()
+        == Some("turn")
+}
+
+fn required_event_string(
+    event: &Value,
+    path: &[&str],
+    field: &str,
+    index: usize,
+) -> Result<String> {
+    non_empty_json_string_at(event, path).ok_or_else(|| {
+        invalid_recognized_event(index, format!("{field} must be a non-empty string"))
+    })
+}
+
+fn invalid_recognized_event(index: usize, message: impl Into<String>) -> SwitchyardError {
+    SwitchyardError::InvalidRequest(format!(
+        "ATOF event {} is not a canonical recognized scope: {}",
+        index + 1,
+        message.into()
+    ))
+}
+
+fn tool_call_message(name: &str, tool_call_id: &str, arguments: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "tool_calls": [{
+            "id": tool_call_id,
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": arguments.to_string(),
+            },
+        }],
+    })
+}
+
+fn tool_result_message(tool_call_id: &str, data: &Value) -> Value {
+    let content = event_data_to_text(data);
+    json!({
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content,
+    })
+}
+
+fn event_data_to_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Object(object) => object
+            .get("output")
+            .or_else(|| object.get("result"))
+            .or_else(|| object.get("content"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| value.to_string()),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn limits(
+        max_identities: usize,
+        max_history_per_identity: usize,
+        max_dedupe_entries: usize,
+    ) -> RelaySnapshotLimits {
+        RelaySnapshotLimits {
+            max_identities,
+            max_history_per_identity,
+            max_dedupe_entries,
+            max_retained_bytes: 64 * 1024,
+            max_event_bytes: 4_096,
+            max_batch_bytes: 16_384,
+        }
+    }
+
+    fn tool_event(
+        session_id: Option<&str>,
+        owner_id: Option<&str>,
+        uuid: &str,
+        phase: &str,
+        data: Value,
+    ) -> Value {
+        let mut metadata = serde_json::Map::new();
+        if let Some(session_id) = session_id {
+            metadata.insert("hermes_session_id".to_string(), json!(session_id));
+        }
+        if let Some(owner_id) = owner_id {
+            metadata.insert("switchyard_owner_id".to_string(), json!(owner_id));
+        }
+        json!({
+            "kind": "scope",
+            "uuid": uuid,
+            "scope_category": phase,
+            "name": "Bash",
+            "category": "tool",
+            "category_profile": {"tool_call_id": uuid},
+            "data": data,
+            "metadata": metadata,
+        })
+    }
+
+    fn turn_event(session_id: &str, uuid: &str, phase: &str) -> Value {
+        json!({
+            "kind": "scope",
+            "uuid": uuid,
+            "scope_category": phase,
+            "name": "turn",
+            "category": "agent",
+            "metadata": {
+                "hermes_session_id": session_id,
+                "nemo_relay_scope_role": "turn",
+            },
+        })
+    }
+
+    fn retained_footprint(event: &Value) -> Result<usize> {
+        let identity = relay_identity_key_from_atof_event(event)
+            .ok_or_else(|| SwitchyardError::Other("test event identity missing".to_string()))?;
+        let (update, dedupe_key) = relay_update(event, 0)?
+            .ok_or_else(|| SwitchyardError::Other("test event was not recognized".to_string()))?;
+        retained_identity_bytes(&identity)?
+            .checked_add(retained_string_copies_bytes(&dedupe_key)?)
+            .and_then(|bytes| bytes.checked_add(update.retained_bytes()))
+            .ok_or_else(|| SwitchyardError::Other("test footprint overflow".to_string()))
+    }
+
+    #[test]
+    fn default_limits_are_valid() -> Result<()> {
+        let limits = RelaySnapshotLimits::default().validate()?;
+        assert!(limits.max_batch_bytes >= limits.max_event_bytes);
+        assert_eq!(limits.max_retained_bytes, 64 * 1024 * 1024);
+        Ok(())
+    }
+
+    #[test]
+    fn zero_and_inverted_limits_are_rejected() {
+        let zero = RelaySnapshotLimits {
+            max_identities: 0,
+            ..RelaySnapshotLimits::default()
+        };
+        assert!(zero.validate().is_err());
+
+        let inverted = RelaySnapshotLimits {
+            max_event_bytes: 5,
+            max_batch_bytes: 4,
+            ..RelaySnapshotLimits::default()
+        };
+        assert!(inverted.validate().is_err());
+    }
+
+    #[test]
+    fn identity_extraction_preserves_session_and_owner_fallback_order() {
+        let mut session_event = json!({
+            "metadata": {
+                "session_id": "session-primary",
+                "hermes_session_id": "session-secondary",
+            },
+            "data": {
+                "session_id": "session-data",
+                "request": {"headers": {
+                    "x-nemo-relay-session-id": "session-header",
+                }},
+            },
+        });
+        for (expected, remove_from_metadata) in [
+            ("session-primary", Some("session_id")),
+            ("session-secondary", Some("hermes_session_id")),
+            ("session-data", None),
+        ] {
+            assert_eq!(
+                relay_identity_key_from_atof_event(&session_event),
+                Some(RelayIdentityKey::session_only(expected))
+            );
+            if let Some(field) = remove_from_metadata {
+                if let Some(metadata) = session_event["metadata"].as_object_mut() {
+                    metadata.remove(field);
+                }
+            } else if let Some(data) = session_event["data"].as_object_mut() {
+                data.remove("session_id");
+            }
+        }
+        assert_eq!(
+            relay_identity_key_from_atof_event(&session_event),
+            Some(RelayIdentityKey::session_only("session-header"))
+        );
+
+        let mut owner_event = json!({
+            "metadata": {
+                "hermes_session_id": "s",
+                "switchyard_owner_id": "owner-switchyard",
+                "llm_correlation_subagent_id": "owner-llm",
+                "tool_correlation_subagent_id": "owner-tool",
+                "subagent_id": "owner-subagent",
+                "subagent_session_id": "owner-session",
+                "hermes_subagent_session_id": "owner-hermes",
+            },
+            "data": {"request": {"headers": {
+                "x-nemo-relay-owner-id": "owner-header"
+            }}},
+        });
+        for (field, expected) in [
+            ("switchyard_owner_id", "owner-switchyard"),
+            ("llm_correlation_subagent_id", "owner-llm"),
+            ("tool_correlation_subagent_id", "owner-tool"),
+            ("subagent_id", "owner-subagent"),
+            ("subagent_session_id", "owner-session"),
+            ("hermes_subagent_session_id", "owner-hermes"),
+        ] {
+            assert_eq!(
+                relay_identity_key_from_atof_event(&owner_event),
+                Some(RelayIdentityKey::new("s", Some(expected.to_string())))
+            );
+            if let Some(metadata) = owner_event["metadata"].as_object_mut() {
+                metadata.remove(field);
+            }
+        }
+        assert_eq!(
+            relay_identity_key_from_atof_event(&owner_event),
+            Some(RelayIdentityKey::new("s", Some("owner-header".to_string())))
+        );
+    }
+
+    #[test]
+    fn reconstructs_router_neutral_snapshot_and_uses_exact_lookup() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+        let events = vec![
+            turn_event("session-1", "turn-1", "start"),
+            tool_event(
+                Some("session-1"),
+                Some("owner-a"),
+                "tool-1",
+                "start",
+                json!({"command": "cargo test"}),
+            ),
+            tool_event(
+                Some("session-1"),
+                Some("owner-a"),
+                "tool-1",
+                "end",
+                json!({"output": "ok"}),
+            ),
+        ];
+        let report = accumulator.ingest_batch(&events)?;
+        assert_eq!(report.ingested_events, 3);
+
+        let session = accumulator
+            .snapshot(&RelayIdentityKey::session_only("session-1"))
+            .ok_or_else(|| SwitchyardError::Other("missing session snapshot".to_string()))?;
+        assert_eq!(session.turn_depth, 1);
+        assert!(session.messages.is_empty());
+        assert_eq!(session.event_count, 1);
+
+        let owner_key = RelayIdentityKey::new("session-1", Some("owner-a".to_string()));
+        let owner = accumulator
+            .snapshot(&owner_key)
+            .ok_or_else(|| SwitchyardError::Other("missing owner snapshot".to_string()))?;
+        assert_eq!(owner.turn_depth, 0);
+        assert_eq!(owner.event_count, 2);
+        assert_eq!(owner.messages.len(), 2);
+        assert_eq!(owner.messages[0]["role"], "assistant");
+        assert_eq!(owner.messages[1]["role"], "tool");
+        assert_eq!(owner.messages[1]["content"], "ok");
+        assert!(accumulator
+            .snapshot(&RelayIdentityKey::new(
+                "session-1",
+                Some("owner-b".to_string())
+            ))
+            .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_batch_is_atomic() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+        let events = vec![
+            tool_event(Some("session-1"), None, "tool-1", "start", json!({})),
+            json!(["not", "an", "object"]),
+        ];
+
+        assert!(accumulator.ingest_batch(&events).is_err());
+        assert!(accumulator
+            .snapshot(&RelayIdentityKey::session_only("session-1"))
+            .is_none());
+        assert_eq!(accumulator.counters(), RelayAccumulatorCounters::default());
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_recognized_scopes_reject_entire_batch_before_mutation() -> Result<()> {
+        let valid = tool_event(Some("session-1"), None, "valid-tool", "start", json!({}));
+        let mut missing_tool_uuid = valid.clone();
+        missing_tool_uuid
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("test tool event must be object".to_string()))?
+            .remove("uuid");
+        let mut missing_name = valid.clone();
+        missing_name
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("test tool event must be object".to_string()))?
+            .remove("name");
+        let mut missing_profile = valid.clone();
+        missing_profile
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("test tool event must be object".to_string()))?
+            .remove("category_profile");
+        let mut missing_data = valid.clone();
+        missing_data
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("test tool event must be object".to_string()))?
+            .remove("data");
+        let mut missing_turn_uuid = turn_event("session-1", "turn-1", "start");
+        missing_turn_uuid
+            .as_object_mut()
+            .ok_or_else(|| SwitchyardError::Other("test turn event must be object".to_string()))?
+            .remove("uuid");
+        let mut invalid_phase = valid.clone();
+        invalid_phase["scope_category"] = json!("middle");
+
+        for malformed in [
+            missing_tool_uuid,
+            missing_name,
+            missing_profile,
+            missing_data,
+            missing_turn_uuid,
+            invalid_phase,
+        ] {
+            let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+            let error = accumulator
+                .ingest_batch(&[valid.clone(), malformed])
+                .err()
+                .ok_or_else(|| {
+                    SwitchyardError::Other("expected canonical scope error".to_string())
+                })?;
+            assert!(error.to_string().contains("canonical recognized scope"));
+            assert_eq!(accumulator.identity_count(), 0);
+            assert_eq!(accumulator.retained_state_bytes(), 0);
+            assert_eq!(accumulator.counters(), RelayAccumulatorCounters::default());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn global_uuid_phase_dedupe_cannot_be_bypassed_by_identity_metadata() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+        let first = tool_event(
+            Some("session-a"),
+            Some("owner-a"),
+            "shared-uuid",
+            "start",
+            json!({"command": "first"}),
+        );
+        let replay = tool_event(
+            Some("session-b"),
+            Some("owner-b"),
+            "shared-uuid",
+            "start",
+            json!({"command": "changed"}),
+        );
+
+        assert_eq!(accumulator.ingest_batch(&[first])?.ingested_events, 1);
+        let report = accumulator.ingest_batch(&[replay])?;
+        assert_eq!(report.ingested_events, 0);
+        assert_eq!(report.duplicate_events, 1);
+        assert!(accumulator
+            .snapshot(&RelayIdentityKey::new(
+                "session-b",
+                Some("owner-b".to_string())
+            ))
+            .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn retained_byte_accounting_covers_identity_message_and_dedupe_copies() -> Result<()> {
+        let event = tool_event(Some("s"), Some("o"), "u", "start", json!({"command": "x"}));
+        let expected = retained_footprint(&event)?;
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+
+        let report = accumulator.ingest_batch(&[event])?;
+
+        assert_eq!(report.retained_state_bytes, expected as u64);
+        assert_eq!(accumulator.retained_state_bytes(), expected);
+        assert_eq!(accumulator.counters().retained_state_bytes, expected as u64);
+        Ok(())
+    }
+
+    #[test]
+    fn total_retained_byte_cap_prunes_and_accounts_before_inserting() -> Result<()> {
+        let first = tool_event(
+            Some("session"),
+            None,
+            "tool-a",
+            "start",
+            json!({"command": "a"}),
+        );
+        let second = tool_event(
+            Some("session"),
+            None,
+            "tool-b",
+            "start",
+            json!({"command": "b"}),
+        );
+        let cap = retained_footprint(&first)?;
+        assert_eq!(cap, retained_footprint(&second)?);
+        let accumulator = RelaySnapshotAccumulator::with_limits(RelaySnapshotLimits {
+            max_retained_bytes: cap,
+            ..limits(4, 8, 16)
+        })?;
+
+        accumulator.ingest_batch(&[first])?;
+        let report = accumulator.ingest_batch(&[second])?;
+
+        assert_eq!(report.pruned_dedupe_entries, 1);
+        assert_eq!(report.pruned_identities, 1);
+        assert_eq!(report.pruned_history_entries, 1);
+        assert_eq!(report.pruned_state_bytes, cap as u64);
+        assert_eq!(report.retained_state_bytes, cap as u64);
+        assert_eq!(accumulator.retained_state_bytes(), cap);
+        assert!(accumulator.retained_state_bytes() <= accumulator.limits().max_retained_bytes);
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_retained_footprint_rejects_batch_before_lock() -> Result<()> {
+        let event = tool_event(
+            Some("session"),
+            None,
+            "tool-a",
+            "start",
+            json!({"command": "a"}),
+        );
+        let footprint = retained_footprint(&event)?;
+        let accumulator = RelaySnapshotAccumulator::with_limits(RelaySnapshotLimits {
+            max_retained_bytes: footprint.saturating_sub(1),
+            ..limits(4, 8, 16)
+        })?;
+
+        let error = accumulator
+            .ingest_batch(&[event])
+            .err()
+            .ok_or_else(|| SwitchyardError::Other("expected retained limit error".to_string()))?;
+        assert!(error.to_string().contains("maximum retained state"));
+        assert_eq!(accumulator.counters(), RelayAccumulatorCounters::default());
+        assert_eq!(accumulator.retained_state_bytes(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_event_rejects_whole_batch() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(RelaySnapshotLimits {
+            max_event_bytes: 200,
+            max_batch_bytes: 1_000,
+            ..limits(4, 8, 16)
+        })?;
+        let events = vec![
+            turn_event("session-1", "turn-1", "start"),
+            tool_event(
+                Some("session-1"),
+                None,
+                "tool-1",
+                "end",
+                json!({"output": "x".repeat(500)}),
+            ),
+        ];
+
+        let error = accumulator
+            .ingest_batch(&events)
+            .err()
+            .ok_or_else(|| SwitchyardError::Other("expected event limit error".to_string()))?;
+        assert!(error.to_string().contains("ATOF event 2"));
+        assert_eq!(accumulator.identity_count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn encoded_batch_limit_is_enforced_before_mutation() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(RelaySnapshotLimits {
+            max_event_bytes: 300,
+            max_batch_bytes: 300,
+            ..limits(4, 8, 16)
+        })?;
+        let events = vec![
+            tool_event(
+                Some("session-1"),
+                None,
+                "tool-1",
+                "start",
+                json!({"command": "x".repeat(80)}),
+            ),
+            tool_event(
+                Some("session-1"),
+                None,
+                "tool-2",
+                "start",
+                json!({"command": "y".repeat(80)}),
+            ),
+        ];
+
+        let error = accumulator
+            .ingest_batch(&events)
+            .err()
+            .ok_or_else(|| SwitchyardError::Other("expected batch limit error".to_string()))?;
+        assert!(error.to_string().contains("ATOF batch"));
+        assert_eq!(accumulator.identity_count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn reports_duplicates_and_non_feature_drops() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(4, 8, 16))?;
+        let event = tool_event(Some("session-1"), None, "tool-1", "start", json!({}));
+        let missing_identity = tool_event(None, None, "tool-2", "start", json!({}));
+        let report = accumulator.ingest_batch(&[
+            event.clone(),
+            event,
+            missing_identity,
+            json!({"kind": "mark", "uuid": "mark-1"}),
+        ])?;
+
+        assert_eq!(report.received_events, 4);
+        assert_eq!(report.ingested_events, 1);
+        assert_eq!(report.duplicate_events, 1);
+        assert_eq!(report.dropped_events, 3);
+        assert_eq!(report.dropped_missing_identity_events, 1);
+        assert_eq!(report.dropped_unrecognized_events, 1);
+        let counters = accumulator.counters();
+        assert_eq!(counters.batches, 1);
+        assert_eq!(counters.dropped_events, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_caps_prune_fifo_identity_history_and_dedupe_state() -> Result<()> {
+        let accumulator = RelaySnapshotAccumulator::with_limits(limits(2, 2, 2))?;
+        let report = accumulator.ingest_batch(&[
+            tool_event(Some("a"), None, "a-1", "start", json!({})),
+            tool_event(Some("b"), None, "b-1", "start", json!({})),
+            tool_event(Some("c"), None, "c-1", "start", json!({})),
+            tool_event(Some("c"), None, "c-2", "end", json!("one")),
+            tool_event(Some("c"), None, "c-3", "end", json!("two")),
+        ])?;
+
+        assert_eq!(accumulator.identity_count(), 2);
+        assert!(accumulator
+            .snapshot(&RelayIdentityKey::session_only("a"))
+            .is_none());
+        let c = accumulator
+            .snapshot(&RelayIdentityKey::session_only("c"))
+            .ok_or_else(|| SwitchyardError::Other("missing c snapshot".to_string()))?;
+        assert_eq!(c.messages.len(), 2);
+        assert_eq!(c.messages[0]["content"], "one");
+        assert_eq!(c.messages[1]["content"], "two");
+        assert_eq!(report.pruned_identities, 1);
+        assert_eq!(report.pruned_history_entries, 2);
+        assert_eq!(report.pruned_dedupe_entries, 3);
+
+        // a-1's key was pruned from the bounded dedupe history, so replay is accepted.
+        let replay =
+            accumulator.ingest_batch(&[tool_event(Some("a"), None, "a-1", "start", json!({}))])?;
+        assert_eq!(replay.ingested_events, 1);
+        Ok(())
+    }
+}

--- a/crates/switchyard-components-v2/src/lib.rs
+++ b/crates/switchyard-components-v2/src/lib.rs
@@ -11,6 +11,7 @@ extern crate self as switchyard_components_v2;
 mod backend;
 mod config;
 pub mod decision;
+mod features;
 mod profile;
 pub mod profiles;
 mod stats;
@@ -24,6 +25,14 @@ pub use decision::{
     DecisionAttempt, DecisionProfile, DecisionProvider, IdentityQuality, RequestIdentity,
     RequestProtocol, RequestSummary, RoutingDecision, RoutingRequest, RoutingTarget,
     ROUTING_DECISION_SCHEMA_VERSION, ROUTING_REQUEST_SCHEMA_VERSION,
+};
+pub use features::{
+    atof_event_dedupe_key, json_string_at, relay_identity_key_from_atof_event,
+    RelayAccumulatorCounters, RelayIdentityKey, RelayIngestReport, RelaySnapshot,
+    RelaySnapshotAccumulator, RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES,
+    DEFAULT_MAX_ATOF_EVENT_BYTES, DEFAULT_MAX_RELAY_DEDUPE_ENTRIES,
+    DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY, DEFAULT_MAX_RELAY_IDENTITIES,
+    DEFAULT_MAX_RELAY_RETAINED_BYTES,
 };
 pub use profile::{
     Profile, ProfileHooks, ProfileInput, ProfileResponse, RequestMetadata, RoutingMetadata,

--- a/crates/switchyard-py/src/server_bindings.rs
+++ b/crates/switchyard-py/src/server_bindings.rs
@@ -8,6 +8,11 @@ use std::path::PathBuf;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use switchyard_components_v2::{
+    RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES, DEFAULT_MAX_ATOF_EVENT_BYTES,
+    DEFAULT_MAX_RELAY_DEDUPE_ENTRIES, DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
+    DEFAULT_MAX_RELAY_IDENTITIES, DEFAULT_MAX_RELAY_RETAINED_BYTES,
+};
 use switchyard_server::{run_server, ServerRunOptions, DEFAULT_LISTEN_BACKLOG};
 
 use crate::errors::py_core_error;
@@ -20,7 +25,17 @@ use crate::errors::py_core_error;
     port = 4000,
     backlog = DEFAULT_LISTEN_BACKLOG,
     dry_run = false,
+    atof_bearer_token = None,
+    atof_max_identities = DEFAULT_MAX_RELAY_IDENTITIES,
+    atof_max_history_per_identity = DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
+    atof_max_dedupe_entries = DEFAULT_MAX_RELAY_DEDUPE_ENTRIES,
+    atof_max_retained_bytes = DEFAULT_MAX_RELAY_RETAINED_BYTES,
+    atof_max_event_bytes = DEFAULT_MAX_ATOF_EVENT_BYTES,
+    atof_max_batch_bytes = DEFAULT_MAX_ATOF_BATCH_BYTES,
 ))]
+// PyO3 exposes these as named Python deployment options; grouping them would
+// replace simple keyword arguments with a binding-only configuration class.
+#[allow(clippy::too_many_arguments)]
 fn run_profile_server(
     py: Python<'_>,
     config_path: String,
@@ -28,6 +43,13 @@ fn run_profile_server(
     port: u16,
     backlog: u32,
     dry_run: bool,
+    atof_bearer_token: Option<String>,
+    atof_max_identities: usize,
+    atof_max_history_per_identity: usize,
+    atof_max_dedupe_entries: usize,
+    atof_max_retained_bytes: usize,
+    atof_max_event_bytes: usize,
+    atof_max_batch_bytes: usize,
 ) -> PyResult<()> {
     let ip: IpAddr = host.parse().map_err(|error| {
         PyValueError::new_err(format!(
@@ -39,6 +61,15 @@ fn run_profile_server(
         addr: SocketAddr::new(ip, port),
         backlog,
         dry_run,
+        atof_bearer_token,
+        relay_snapshot_limits: RelaySnapshotLimits {
+            max_identities: atof_max_identities,
+            max_history_per_identity: atof_max_history_per_identity,
+            max_dedupe_entries: atof_max_dedupe_entries,
+            max_retained_bytes: atof_max_retained_bytes,
+            max_event_bytes: atof_max_event_bytes,
+            max_batch_bytes: atof_max_batch_bytes,
+        },
     };
 
     // `detach` runs synchronously with the GIL released, so startup errors still

--- a/crates/switchyard-server/src/cli.rs
+++ b/crates/switchyard-server/src/cli.rs
@@ -7,6 +7,11 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use clap::Parser;
+use switchyard_components_v2::{
+    RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES, DEFAULT_MAX_ATOF_EVENT_BYTES,
+    DEFAULT_MAX_RELAY_DEDUPE_ENTRIES, DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
+    DEFAULT_MAX_RELAY_IDENTITIES, DEFAULT_MAX_RELAY_RETAINED_BYTES,
+};
 use switchyard_core::Result;
 use switchyard_server::{run_server, ServerRunOptions, DEFAULT_LISTEN_BACKLOG};
 
@@ -40,6 +45,58 @@ pub(crate) struct ServerArgs {
     /// Validate and build the config without starting the HTTP listener.
     #[arg(long)]
     pub(crate) dry_run: bool,
+
+    /// Optional bearer token required by POST /v1/atof/events.
+    #[arg(long, env = "SWITCHYARD_ATOF_BEARER_TOKEN", value_name = "TOKEN")]
+    pub(crate) atof_bearer_token: Option<String>,
+
+    /// Maximum exact Relay identities retained in memory.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_IDENTITIES",
+        default_value_t = DEFAULT_MAX_RELAY_IDENTITIES
+    )]
+    pub(crate) atof_max_identities: usize,
+
+    /// Maximum reconstructed messages retained for each Relay identity.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_HISTORY_PER_IDENTITY",
+        default_value_t = DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY
+    )]
+    pub(crate) atof_max_history_per_identity: usize,
+
+    /// Maximum ATOF event idempotency keys retained in memory.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_DEDUPE_ENTRIES",
+        default_value_t = DEFAULT_MAX_RELAY_DEDUPE_ENTRIES
+    )]
+    pub(crate) atof_max_dedupe_entries: usize,
+
+    /// Maximum encoded/string bytes retained across all Relay state.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_RETAINED_BYTES",
+        default_value_t = DEFAULT_MAX_RELAY_RETAINED_BYTES
+    )]
+    pub(crate) atof_max_retained_bytes: usize,
+
+    /// Maximum encoded size accepted for one ATOF event.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_EVENT_BYTES",
+        default_value_t = DEFAULT_MAX_ATOF_EVENT_BYTES
+    )]
+    pub(crate) atof_max_event_bytes: usize,
+
+    /// Maximum encoded size accepted for one ATOF HTTP POST batch.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_BATCH_BYTES",
+        default_value_t = DEFAULT_MAX_ATOF_BATCH_BYTES
+    )]
+    pub(crate) atof_max_batch_bytes: usize,
 }
 
 impl ServerArgs {
@@ -54,6 +111,15 @@ impl ServerArgs {
             addr: SocketAddr::new(self.host, self.port),
             backlog: self.backlog,
             dry_run: self.dry_run,
+            atof_bearer_token: self.atof_bearer_token,
+            relay_snapshot_limits: RelaySnapshotLimits {
+                max_identities: self.atof_max_identities,
+                max_history_per_identity: self.atof_max_history_per_identity,
+                max_dedupe_entries: self.atof_max_dedupe_entries,
+                max_retained_bytes: self.atof_max_retained_bytes,
+                max_event_bytes: self.atof_max_event_bytes,
+                max_batch_bytes: self.atof_max_batch_bytes,
+            },
         }
     }
 }
@@ -61,4 +127,43 @@ impl ServerArgs {
 /// Loads config, optionally validates it, then starts the Rust server.
 pub(crate) async fn run(args: ServerArgs) -> Result<()> {
     run_server(args.into_options()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atof_options_are_forwarded_to_server_runtime(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let args = ServerArgs::try_parse_from([
+            "switchyard-server",
+            "--config",
+            "profiles.yaml",
+            "--atof-bearer-token",
+            "relay-secret",
+            "--atof-max-identities",
+            "17",
+            "--atof-max-history-per-identity",
+            "18",
+            "--atof-max-dedupe-entries",
+            "19",
+            "--atof-max-retained-bytes",
+            "2000",
+            "--atof-max-event-bytes",
+            "1024",
+            "--atof-max-batch-bytes",
+            "2048",
+        ])?;
+
+        let options = args.into_options();
+        assert_eq!(options.atof_bearer_token.as_deref(), Some("relay-secret"));
+        assert_eq!(options.relay_snapshot_limits.max_identities, 17);
+        assert_eq!(options.relay_snapshot_limits.max_history_per_identity, 18);
+        assert_eq!(options.relay_snapshot_limits.max_dedupe_entries, 19);
+        assert_eq!(options.relay_snapshot_limits.max_retained_bytes, 2000);
+        assert_eq!(options.relay_snapshot_limits.max_event_bytes, 1024);
+        assert_eq!(options.relay_snapshot_limits.max_batch_bytes, 2048);
+        Ok(())
+    }
 }

--- a/crates/switchyard-server/src/cli.rs
+++ b/crates/switchyard-server/src/cli.rs
@@ -46,7 +46,7 @@ pub(crate) struct ServerArgs {
     #[arg(long)]
     pub(crate) dry_run: bool,
 
-    /// Optional bearer token required by POST /v1/atof/events.
+    /// Optional bearer token required by the Relay Decision and ATOF endpoints.
     #[arg(long, env = "SWITCHYARD_ATOF_BEARER_TOKEN", value_name = "TOKEN")]
     pub(crate) atof_bearer_token: Option<String>,
 

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -16,7 +16,9 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use axum::extract::{rejection::JsonRejection, State};
+use axum::body::to_bytes;
+use axum::extract::{rejection::JsonRejection, Request, State};
+use axum::http::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, WWW_AUTHENTICATE};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -24,7 +26,8 @@ use axum::{Json, Router};
 use serde_json::{json, Value};
 use switchyard_components_v2::{
     parse_profile_config_path, profile_stats_accumulator, ProfileConfigPlan, ProfileInput,
-    ProfileResponse, RequestMetadata, RoutingMetadata, RoutingRequest,
+    ProfileResponse, RelaySnapshotAccumulator, RelaySnapshotLimits, RequestMetadata,
+    RoutingMetadata, RoutingRequest,
 };
 use switchyard_core::{ChatRequest, ChatRequestType, RequestId, Result, SwitchyardError};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
@@ -51,6 +54,8 @@ pub struct ServerState {
     registry: Arc<ProfileRegistry>,
     translation: Arc<TranslationEngine>,
     translation_policy: TranslationPolicy,
+    relay_snapshots: Arc<RelaySnapshotAccumulator>,
+    atof_bearer_token: Arc<Option<String>>,
 }
 
 impl ServerState {
@@ -60,6 +65,8 @@ impl ServerState {
             registry: Arc::new(registry),
             translation: Arc::new(TranslationEngine::default()),
             translation_policy: TranslationPolicy::default(),
+            relay_snapshots: Arc::new(RelaySnapshotAccumulator::default()),
+            atof_bearer_token: Arc::new(None),
         }
     }
 
@@ -68,9 +75,26 @@ impl ServerState {
         Ok(Self::new(ProfileRegistry::from_plan(plan)?))
     }
 
+    /// Returns a copy with optional auth; explicit blank tokens are invalid config.
+    pub fn with_atof_bearer_token(mut self, token: Option<String>) -> Result<Self> {
+        self.atof_bearer_token = Arc::new(validate_optional_bearer_token(token)?);
+        Ok(self)
+    }
+
+    /// Returns a copy of this state with an empty accumulator using explicit limits.
+    pub fn with_relay_snapshot_limits(mut self, limits: RelaySnapshotLimits) -> Result<Self> {
+        self.relay_snapshots = Arc::new(RelaySnapshotAccumulator::with_limits(limits)?);
+        Ok(self)
+    }
+
     /// Returns the profile registry used by this server.
     pub fn registry(&self) -> &ProfileRegistry {
         self.registry.as_ref()
+    }
+
+    /// Returns the server-owned Relay snapshot accumulator.
+    pub fn relay_snapshots(&self) -> &RelaySnapshotAccumulator {
+        self.relay_snapshots.as_ref()
     }
 
     /// Dispatches one request to the profile selected by its `model` field.
@@ -86,6 +110,25 @@ impl ServerState {
     ) -> Result<switchyard_components_v2::RoutingDecision> {
         self.registry.decide(request).await
     }
+
+    /// Allows unauthenticated ingestion only when no bearer token was configured.
+    fn authorize_atof_ingest(&self, headers: &HeaderMap) -> std::result::Result<(), Box<Response>> {
+        let Some(expected) = self.atof_bearer_token.as_ref() else {
+            return Ok(());
+        };
+        let authorized = headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(parse_bearer_token)
+            .is_some_and(|actual| actual == expected);
+        if authorized {
+            Ok(())
+        } else {
+            Err(Box::new(unauthorized_error(
+                "ATOF ingestion authorization failed",
+            )))
+        }
+    }
 }
 
 /// Runtime options shared by the Rust binary and Python binding.
@@ -99,6 +142,10 @@ pub struct ServerRunOptions {
     pub backlog: u32,
     /// Validate and print public model IDs without binding a socket.
     pub dry_run: bool,
+    /// Optional bearer token required by `POST /v1/atof/events`.
+    pub atof_bearer_token: Option<String>,
+    /// Fixed memory and request-size bounds for Relay snapshot accumulation.
+    pub relay_snapshot_limits: RelaySnapshotLimits,
 }
 
 /// Builds a server state by loading and resolving a profile config path.
@@ -110,7 +157,9 @@ pub fn state_from_config_path(path: impl AsRef<Path>) -> Result<ServerState> {
 
 /// Loads config, optionally validates it, then starts the Rust server.
 pub async fn run_server(options: ServerRunOptions) -> Result<()> {
-    let state = state_from_config_path(&options.config)?;
+    let state = state_from_config_path(&options.config)?
+        .with_relay_snapshot_limits(options.relay_snapshot_limits)?
+        .with_atof_bearer_token(options.atof_bearer_token.clone())?;
     if options.dry_run {
         println!("{}", dry_run_summary(&options.config, state.registry()));
         return Ok(());
@@ -133,6 +182,7 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/responses", post(openai_responses))
         .route("/v1/routing/decision", post(routing_decision))
+        .route("/v1/atof/events", post(atof_events))
         .route("/v1/models", get(models))
         // Keep the legacy routing stats aliases wired to the same handlers.
         .route("/v1/stats", get(stats))
@@ -271,6 +321,133 @@ fn routing_json_body(
             "Routing decision request body must match the JSON contract: {error}"
         )))),
     }
+}
+
+/// Accepts bounded Relay `http_post` batches encoded as one JSON object per line.
+async fn atof_events(State(state): State<ServerState>, request: Request) -> Response {
+    let (parts, body) = request.into_parts();
+    if let Err(response) = state.authorize_atof_ingest(&parts.headers) {
+        return *response;
+    }
+    if !is_ndjson_content_type(&parts.headers) {
+        return unsupported_media_type_error(
+            "ATOF ingestion requires content-type application/x-ndjson",
+        );
+    }
+
+    let limits = state.relay_snapshots().limits();
+    if content_length(&parts.headers).is_some_and(|length| length > limits.max_batch_bytes) {
+        return payload_too_large_error(format!(
+            "ATOF batch exceeds the {} byte maximum",
+            limits.max_batch_bytes
+        ));
+    }
+    let body = match to_bytes(body, limits.max_batch_bytes).await {
+        Ok(body) => body,
+        Err(error) => {
+            return payload_too_large_error(format!(
+                "ATOF batch exceeds the {} byte maximum: {error}",
+                limits.max_batch_bytes
+            ));
+        }
+    };
+    let events = match parse_atof_ndjson(&body, limits.max_event_bytes) {
+        Ok(events) => events,
+        Err(response) => return *response,
+    };
+    let report = match state.relay_snapshots().ingest_batch(&events) {
+        Ok(report) => report,
+        Err(error) => return llm_error(error),
+    };
+    let counters = state.relay_snapshots().counters();
+
+    Json(json!({
+        "status": "ok",
+        // Keep the original prototype names while exposing the complete report.
+        "accepted_events": report.received_events,
+        "accumulator_ingests": report.ingested_events,
+        "batch": report,
+        "cumulative": counters,
+    }))
+    .into_response()
+}
+
+fn parse_atof_ndjson(
+    body: &[u8],
+    max_event_bytes: usize,
+) -> std::result::Result<Vec<Value>, Box<Response>> {
+    // Parse every non-empty line before calling the accumulator so malformed
+    // batches cannot partially mutate retained state.
+    let mut events = Vec::new();
+    for (index, raw_line) in body.split(|byte| *byte == b'\n').enumerate() {
+        let line = trim_ascii_whitespace(raw_line);
+        if line.is_empty() {
+            continue;
+        }
+        if line.len() > max_event_bytes {
+            return Err(Box::new(payload_too_large_error(format!(
+                "ATOF NDJSON line {} is {} bytes; maximum is {max_event_bytes} bytes",
+                index + 1,
+                line.len()
+            ))));
+        }
+        match serde_json::from_slice::<Value>(line) {
+            Ok(event) => events.push(event),
+            Err(error) => {
+                return Err(Box::new(invalid_body_error(format!(
+                    "ATOF NDJSON line {} must be valid JSON: {error}",
+                    index + 1
+                ))));
+            }
+        }
+    }
+    Ok(events)
+}
+
+fn trim_ascii_whitespace(mut value: &[u8]) -> &[u8] {
+    while value.first().is_some_and(u8::is_ascii_whitespace) {
+        value = &value[1..];
+    }
+    while value.last().is_some_and(u8::is_ascii_whitespace) {
+        value = &value[..value.len() - 1];
+    }
+    value
+}
+
+/// Accepts the canonical NDJSON media type with optional MIME parameters.
+fn is_ndjson_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("application/x-ndjson"))
+}
+
+fn content_length(headers: &HeaderMap) -> Option<usize> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok())
+}
+
+/// Distinguishes disabled auth (`None`) from unsafe explicit blank configuration.
+fn validate_optional_bearer_token(token: Option<String>) -> Result<Option<String>> {
+    let Some(token) = token else {
+        return Ok(None);
+    };
+    let token = token.trim();
+    if token.is_empty() {
+        return Err(SwitchyardError::InvalidConfig(
+            "ATOF bearer token cannot be blank; omit it to disable authentication".to_string(),
+        ));
+    }
+    Ok(Some(token.to_string()))
+}
+
+/// Parses exactly one non-empty case-insensitive Bearer scheme and token.
+fn parse_bearer_token(value: &str) -> Option<&str> {
+    let (scheme, token) = value.split_once(' ')?;
+    (scheme.eq_ignore_ascii_case("bearer") && !token.is_empty()).then_some(token)
 }
 
 fn llm_json_body(
@@ -493,6 +670,52 @@ fn invalid_body_error(message: impl Into<String>) -> Response {
         .into_response()
 }
 
+fn unauthorized_error(message: impl Into<String>) -> Response {
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": {
+                "message": message.into(),
+                "type": "authentication_error",
+                "code": "unauthorized",
+            }
+        })),
+    )
+        .into_response();
+    response
+        .headers_mut()
+        .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+    response
+}
+
+fn unsupported_media_type_error(message: impl Into<String>) -> Response {
+    (
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        Json(json!({
+            "error": {
+                "message": message.into(),
+                "type": "invalid_request_error",
+                "code": "unsupported_media_type",
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn payload_too_large_error(message: impl Into<String>) -> Response {
+    (
+        StatusCode::PAYLOAD_TOO_LARGE,
+        Json(json!({
+            "error": {
+                "message": message.into(),
+                "type": "invalid_request_error",
+                "code": "payload_too_large",
+            }
+        })),
+    )
+        .into_response()
+}
+
 async fn models(State(state): State<ServerState>) -> Json<Value> {
     let entries = state.registry().served_models();
     Json(model_list_payload(&entries))
@@ -590,6 +813,7 @@ fn startup_banner(options: &ServerRunOptions, registry: &ProfileRegistry) -> Str
     push_line(&mut output, "    POST /v1/messages");
     push_line(&mut output, "    POST /v1/responses");
     push_line(&mut output, "    POST /v1/routing/decision");
+    push_line(&mut output, "    POST /v1/atof/events");
     push_line(&mut output, "    GET  /v1/routing/stats");
     push_line(&mut output, "    POST /v1/routing/stats/reset");
     push_line(&mut output, "");

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -363,8 +363,10 @@ async fn atof_events(State(state): State<ServerState>, request: Request) -> Resp
 
     Json(json!({
         "status": "ok",
-        // Keep the original prototype names while exposing the complete report.
-        "accepted_events": report.received_events,
+        // `accepted_events` counts events that actually mutated the snapshot;
+        // the complete parsed/drop breakdown remains available in `batch`.
+        "accepted_events": report.ingested_events,
+        "received_events": report.received_events,
         "accumulator_ingests": report.ingested_events,
         "batch": report,
         "cumulative": counters,

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -142,7 +142,7 @@ pub struct ServerRunOptions {
     pub backlog: u32,
     /// Validate and print public model IDs without binding a socket.
     pub dry_run: bool,
-    /// Optional bearer token required by `POST /v1/atof/events`.
+    /// Optional bearer token required by the Relay Decision and ATOF endpoints.
     pub atof_bearer_token: Option<String>,
     /// Fixed memory and request-size bounds for Relay snapshot accumulation.
     pub relay_snapshot_limits: RelaySnapshotLimits,
@@ -440,7 +440,7 @@ fn validate_optional_bearer_token(token: Option<String>) -> Result<Option<String
     let token = token.trim();
     if token.is_empty() {
         return Err(SwitchyardError::InvalidConfig(
-            "ATOF bearer token cannot be blank; omit it to disable authentication".to_string(),
+            "Relay bearer token cannot be blank; omit it to disable authentication".to_string(),
         ));
     }
     Ok(Some(token.to_string()))

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -16,8 +16,8 @@ use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use switchyard_components_v2::{
     parse_profile_config_str, profile_stats_accumulator, Profile, ProfileConfigFormat,
-    ProfileInput, ProfileResponse, RoutingMetadata, ROUTING_DECISION_SCHEMA_VERSION,
-    ROUTING_REQUEST_SCHEMA_VERSION,
+    ProfileInput, ProfileResponse, RelayIdentityKey, RelaySnapshotLimits, RoutingMetadata,
+    ROUTING_DECISION_SCHEMA_VERSION, ROUTING_REQUEST_SCHEMA_VERSION,
 };
 use switchyard_core::{
     ChatRequestType, ChatResponse, ModelId, Result, StreamEvent, SwitchyardError,
@@ -390,6 +390,239 @@ profiles:
     assert!(error["error"]["message"]
         .as_str()
         .is_some_and(|message| message.contains("materialized current_request.body")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn relay_http_post_events_build_one_router_neutral_snapshot() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?;
+    let app = build_switchyard_router(state.clone());
+    let start = tool_event(
+        "tool-1",
+        "start",
+        Some("session-1"),
+        Some("owner-a"),
+        json!({"command": "cargo test"}),
+    );
+    let end = tool_event(
+        "tool-1",
+        "end",
+        Some("session-1"),
+        Some("owner-a"),
+        json!({"output": "ok"}),
+    );
+
+    // Relay's selected `http_post` transport sends one NDJSON record per POST.
+    for (event, expected_count) in [(start, 1), (end, 2)] {
+        let response = app
+            .clone()
+            .oneshot(ndjson_request(&format!("{event}\n"), None)?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await?;
+        assert_eq!(body["accepted_events"], 1);
+        assert_eq!(body["accumulator_ingests"], 1);
+        assert_eq!(body["batch"]["ingested_events"], 1);
+        assert_eq!(body["cumulative"]["ingested_events"], expected_count);
+    }
+
+    let key = RelayIdentityKey::new("session-1", Some("owner-a".to_string()));
+    let snapshot = state
+        .relay_snapshots()
+        .snapshot(&key)
+        .ok_or("expected Relay snapshot")?;
+    assert_eq!(snapshot.identity, key);
+    assert_eq!(snapshot.messages.len(), 2);
+    assert_eq!(snapshot.messages[0]["role"], "assistant");
+    assert_eq!(snapshot.messages[1]["role"], "tool");
+    assert_eq!(snapshot.messages[1]["content"], "ok");
+    assert_eq!(snapshot.event_count, 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn atof_batch_parse_and_validation_fail_without_partial_ingest() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?;
+    let app = build_switchyard_router(state.clone());
+    let event = tool_event("tool-1", "start", Some("session-1"), None, json!({}));
+
+    let malformed = app
+        .clone()
+        .oneshot(ndjson_request(&format!("{event}\n{{not-json}}\n"), None)?)
+        .await?;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(malformed).await?["error"]["code"], "invalid_body");
+    assert!(state
+        .relay_snapshots()
+        .snapshot(&RelayIdentityKey::session_only("session-1"))
+        .is_none());
+
+    let non_object = app
+        .clone()
+        .oneshot(ndjson_request(&format!("{event}\n[]\n"), None)?)
+        .await?;
+    assert_eq!(non_object.status(), StatusCode::BAD_REQUEST);
+    assert!(state
+        .relay_snapshots()
+        .snapshot(&RelayIdentityKey::session_only("session-1"))
+        .is_none());
+
+    let mut malformed_scope = event.clone();
+    malformed_scope
+        .as_object_mut()
+        .ok_or("test ATOF event must be an object")?
+        .remove("name");
+    let semantic = app
+        .oneshot(ndjson_request(
+            &format!("{event}\n{malformed_scope}\n"),
+            None,
+        )?)
+        .await?;
+    assert_eq!(semantic.status(), StatusCode::BAD_REQUEST);
+    assert!(json_body(semantic).await?["error"]["message"]
+        .as_str()
+        .ok_or("semantic error message missing")?
+        .contains("canonical recognized scope"));
+    assert!(state
+        .relay_snapshots()
+        .snapshot(&RelayIdentityKey::session_only("session-1"))
+        .is_none());
+    assert_eq!(state.relay_snapshots().counters().batches, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn atof_endpoint_reports_duplicate_and_drop_categories() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?;
+    let app = build_switchyard_router(state);
+    let event = tool_event("tool-1", "start", Some("session-1"), None, json!({}));
+    let missing_identity = tool_event("tool-2", "start", None, None, json!({}));
+    let body = format!(
+        "{event}\n{event}\n{missing_identity}\n{}\n",
+        json!({"kind": "mark", "uuid": "mark-1"})
+    );
+
+    let response = app.oneshot(ndjson_request(&body, None)?).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_body(response).await?;
+    assert_eq!(body["batch"]["received_events"], 4);
+    assert_eq!(body["batch"]["ingested_events"], 1);
+    assert_eq!(body["batch"]["duplicate_events"], 1);
+    assert_eq!(body["batch"]["dropped_events"], 3);
+    assert_eq!(body["batch"]["dropped_missing_identity_events"], 1);
+    assert_eq!(body["batch"]["dropped_unrecognized_events"], 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn atof_endpoint_enforces_optional_bearer_token() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?
+    .with_atof_bearer_token(Some("expected-token".to_string()))?;
+    let app = build_switchyard_router(state);
+    let event = tool_event("tool-1", "start", Some("session-1"), None, json!({}));
+    let body = format!("{event}\n");
+
+    let missing = app.clone().oneshot(ndjson_request(&body, None)?).await?;
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(header(&missing, "www-authenticate"), Some("Bearer"));
+
+    let wrong = app
+        .clone()
+        .oneshot(ndjson_request(&body, Some("Bearer wrong"))?)
+        .await?;
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+    let accepted = app
+        .oneshot(ndjson_request(&body, Some("bearer expected-token"))?)
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[test]
+fn explicit_blank_atof_bearer_token_is_invalid_config() -> TestResult {
+    for token in ["", "   ", "\t\n"] {
+        let state = state_from_yaml(
+            r#"
+profiles:
+  bench:
+    type: noop
+"#,
+        )?;
+        let error = state
+            .with_atof_bearer_token(Some(token.to_string()))
+            .err()
+            .ok_or("expected blank ATOF bearer token error")?;
+        assert!(error.to_string().contains("cannot be blank"));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn atof_endpoint_enforces_content_type_event_and_batch_limits() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?
+    .with_relay_snapshot_limits(RelaySnapshotLimits {
+        max_identities: 4,
+        max_history_per_identity: 8,
+        max_dedupe_entries: 16,
+        max_retained_bytes: 4_096,
+        max_event_bytes: 256,
+        max_batch_bytes: 512,
+    })?;
+    let app = build_switchyard_router(state.clone());
+
+    let wrong_type = app
+        .clone()
+        .oneshot(raw_request("POST", "/v1/atof/events", "{}")?)
+        .await?;
+    assert_eq!(wrong_type.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+    let oversized_event = tool_event(
+        "tool-1",
+        "end",
+        Some("session-1"),
+        None,
+        json!({"output": "x".repeat(300)}),
+    );
+    let event_response = app
+        .clone()
+        .oneshot(ndjson_request(&format!("{oversized_event}\n"), None)?)
+        .await?;
+    assert_eq!(event_response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    let batch_response = app.oneshot(ndjson_request(&" ".repeat(513), None)?).await?;
+    assert_eq!(batch_response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(state.relay_snapshots().identity_count(), 0);
     Ok(())
 }
 
@@ -1215,6 +1448,32 @@ fn routing_request_json(
     request
 }
 
+fn tool_event(
+    uuid: &str,
+    phase: &str,
+    session_id: Option<&str>,
+    owner_id: Option<&str>,
+    data: Value,
+) -> Value {
+    let mut metadata = serde_json::Map::new();
+    if let Some(session_id) = session_id {
+        metadata.insert("hermes_session_id".to_string(), json!(session_id));
+    }
+    if let Some(owner_id) = owner_id {
+        metadata.insert("switchyard_owner_id".to_string(), json!(owner_id));
+    }
+    json!({
+        "kind": "scope",
+        "uuid": uuid,
+        "scope_category": phase,
+        "name": "Bash",
+        "category": "tool",
+        "category_profile": {"tool_call_id": uuid},
+        "data": data,
+        "metadata": metadata,
+    })
+}
+
 fn state_from_yaml(input: &str) -> TestResult<ServerState> {
     let plan = parse_profile_config_str(input, ProfileConfigFormat::Yaml)?.resolve()?;
     Ok(ServerState::from_plan(&plan)?)
@@ -1243,6 +1502,17 @@ fn raw_request(method: &str, uri: &str, body: &str) -> TestResult<Request<Body>>
         .method(method)
         .uri(uri)
         .header("content-type", "application/json");
+    Ok(builder.body(Body::from(body.to_string()))?)
+}
+
+fn ndjson_request(body: &str, authorization: Option<&str>) -> TestResult<Request<Body>> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/atof/events")
+        .header("content-type", "application/x-ndjson");
+    if let Some(authorization) = authorization {
+        builder = builder.header("authorization", authorization);
+    }
     Ok(builder.body(Body::from(body.to_string()))?)
 }
 

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -525,6 +525,8 @@ profiles:
     let body = json_body(response).await?;
     assert_eq!(body["batch"]["received_events"], 4);
     assert_eq!(body["batch"]["ingested_events"], 1);
+    assert_eq!(body["accepted_events"], 1);
+    assert_eq!(body["received_events"], 4);
     assert_eq!(body["batch"]["duplicate_events"], 1);
     assert_eq!(body["batch"]["dropped_events"], 3);
     assert_eq!(body["batch"]["dropped_missing_identity_events"], 1);

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -210,6 +210,13 @@ switchyard [--routing-profiles PATH] serve [--config PATH]
                  [--host HOST] [--port PORT] [--workers N]
                  [--reload] [--inbound FORMAT]
                  [--intake-enabled|--enable-intake [INTAKE OVERRIDES]]
+                 [--atof-bearer-token TOKEN]
+                 [--atof-max-identities COUNT]
+                 [--atof-max-history-per-identity COUNT]
+                 [--atof-max-dedupe-entries COUNT]
+                 [--atof-max-retained-bytes BYTES]
+                 [--atof-max-event-bytes BYTES]
+                 [--atof-max-batch-bytes BYTES]
 ```
 
 **Flags**
@@ -222,10 +229,14 @@ switchyard [--routing-profiles PATH] serve [--config PATH]
 | `--inbound FORMAT` | Valid only for legacy route-bundle serve (`--routing-profiles`); `serve --config` actively rejects it with an error. For legacy serve, the flag is a no-op — all request APIs are always registered regardless of the value (accepted for backwards compat only). |
 | `--workers` / `-w` | uvicorn worker count. |
 | `--intake-enabled` / `--enable-intake`, `--intake-base-url`, `--intake-workspace`, `--intake-api-key`, `--intake-nvdataflow-project` | [Intake sink](#intake-sink-serve-and-launchers). |
+| `--atof-bearer-token TOKEN` | Optional bearer token required by `POST /v1/atof/events`. Defaults to `SWITCHYARD_ATOF_BEARER_TOKEN` when set. Rust-only profile configs only. |
+| `--atof-max-identities`, `--atof-max-history-per-identity`, `--atof-max-dedupe-entries` | Fixed in-memory caps for exact Relay identities, reconstructed messages per identity, and event idempotency keys. The matching `SWITCHYARD_ATOF_MAX_*` environment variables are also accepted. |
+| `--atof-max-retained-bytes` | Hard cap on exact encoded message bytes plus retained identity and dedupe string bytes (default: 64 MiB). Defaults to `SWITCHYARD_ATOF_MAX_RETAINED_BYTES` when set. |
+| `--atof-max-event-bytes`, `--atof-max-batch-bytes` | Fixed request limits for one event and one finite HTTP batch. The event limit cannot exceed the batch limit. The matching `SWITCHYARD_ATOF_MAX_*` environment variables are also accepted. |
 
 **Notes**
 
-- `serve` always registers `POST /v1/chat/completions`, `POST /v1/messages`, `POST /v1/responses`, `GET /v1/models`, and `GET /health`. There is no flag to expose just one request API.
+- `serve --config` with Rust-only profiles also registers `POST /v1/atof/events`; all serve paths register `POST /v1/chat/completions`, `POST /v1/messages`, `POST /v1/responses`, `GET /v1/models`, and `GET /health`. There is no flag to expose just one request API.
 - `GET /v1/stats` and `GET /v1/routing/stats` are available on both serve paths.
 - The deprecated route-bundle path accepts `--inbound` for compatibility but ignores it; all supported request APIs are always registered.
 - `serve --config` does not support `--reload`, `--workers > 1`, Intake options, `--enable-rl-logging`, or any explicit `--inbound` value.
@@ -258,6 +269,39 @@ switchyard serve --port 4000
 
 # Multi-worker uvicorn (route-bundle path)
 SWITCHYARD_WORKERS=4 switchyard --routing-profiles routes.yaml -- serve
+```
+
+### Relay ATOF ingestion
+
+The Rust profile server accepts finite `application/x-ndjson` batches at
+`POST /v1/atof/events`. Configure Relay with `transport: http_post`; its selected
+integration sends one canonical ATOF JSON object per POST. A request may contain
+more than one non-empty JSON line, but Switchyard parses and validates the whole
+request before applying the batch, so a malformed or oversized line applies none
+of it. Relay's long-lived `transport: ndjson` upload is not supported by this
+atomic batch endpoint.
+
+Recognized turn and tool scopes accumulate into router-neutral snapshots keyed by
+the exact `(session_id, owner_id)` pair. Snapshots contain reconstructed tool-call
+and tool-result messages, turn depth, and a unique-event count. Unknown events,
+events without a session identity, and duplicates are reported as separate drop
+counters in the response. Identity, history, and dedupe state use deterministic
+fixed-size pruning rather than unbounded retention.
+
+Use [the shipped Relay plugin fixture](../examples/relay_atof_switchyard.toml),
+which pins `transport = "http_post"`, `field_name_policy = "preserve"`, and
+the bearer header. Replace `replace-with-shared-token` in that file and pass the
+identical value to Switchyard; Relay does not expand environment variables in
+arbitrary endpoint-header values.
+
+```bash
+switchyard serve --config examples/profiles.yaml \
+  --atof-bearer-token "$RELAY_TO_SWITCHYARD_TOKEN"
+
+curl localhost:4000/v1/atof/events \
+  -H 'Content-Type: application/x-ndjson' \
+  -H "Authorization: Bearer $RELAY_TO_SWITCHYARD_TOKEN" \
+  --data-binary '{"kind":"scope","uuid":"tool-1","scope_category":"start","category":"tool","name":"Bash","category_profile":{"tool_call_id":"tool-1"},"metadata":{"hermes_session_id":"session-1"},"data":{"command":"cargo test"}}'
 ```
 
 ## `switchyard launch claude`

--- a/examples/relay_atof_switchyard.toml
+++ b/examples/relay_atof_switchyard.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# NeMo Relay plugin config for finite, atomic ATOF delivery to Switchyard.
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config]
+version = 1
+
+[components.config.atof]
+enabled = true
+
+[[components.config.atof.endpoints]]
+url = "http://127.0.0.1:4000/v1/atof/events"
+transport = "http_post"
+field_name_policy = "preserve"
+
+[components.config.atof.endpoints.headers]
+Authorization = "Bearer replace-with-shared-token"

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -101,6 +101,14 @@ from switchyard.server.server_util import (
     resolve_port,
     resolve_rl_log_dir,
 )
+from switchyard_rust.server import (
+    DEFAULT_MAX_ATOF_BATCH_BYTES,
+    DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+    DEFAULT_MAX_ATOF_EVENT_BYTES,
+    DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+    DEFAULT_MAX_ATOF_IDENTITIES,
+    DEFAULT_MAX_ATOF_RETAINED_BYTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -281,6 +289,78 @@ def _add_common_intake_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_atof_ingest_args(parser: argparse.ArgumentParser) -> None:
+    """Attach bounded Relay ATOF `http_post` ingestion options."""
+    parser.add_argument(
+        "--atof-bearer-token",
+        default=os.environ.get("SWITCHYARD_ATOF_BEARER_TOKEN"),
+        metavar="TOKEN",
+        help=(
+            "Require this bearer token on POST /v1/atof/events "
+            "(or SWITCHYARD_ATOF_BEARER_TOKEN)."
+        ),
+    )
+    parser.add_argument(
+        "--atof-max-identities",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_IDENTITIES", DEFAULT_MAX_ATOF_IDENTITIES,
+        )),
+        metavar="COUNT",
+        help="Maximum exact Relay identities retained in memory.",
+    )
+    parser.add_argument(
+        "--atof-max-history-per-identity",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_HISTORY_PER_IDENTITY",
+            DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+        )),
+        metavar="COUNT",
+        help="Maximum reconstructed messages retained per Relay identity.",
+    )
+    parser.add_argument(
+        "--atof-max-dedupe-entries",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_DEDUPE_ENTRIES",
+            DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+        )),
+        metavar="COUNT",
+        help="Maximum ATOF event idempotency keys retained in memory.",
+    )
+    parser.add_argument(
+        "--atof-max-event-bytes",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_EVENT_BYTES", DEFAULT_MAX_ATOF_EVENT_BYTES,
+        )),
+        metavar="BYTES",
+        help="Maximum encoded size accepted for one ATOF event.",
+    )
+    parser.add_argument(
+        "--atof-max-retained-bytes",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_RETAINED_BYTES", DEFAULT_MAX_ATOF_RETAINED_BYTES,
+        )),
+        metavar="BYTES",
+        help="Maximum encoded/string bytes retained across all Relay state.",
+    )
+    parser.add_argument(
+        "--atof-max-batch-bytes",
+        type=int,
+        default=int(os.environ.get(
+            "SWITCHYARD_ATOF_MAX_BATCH_BYTES", DEFAULT_MAX_ATOF_BATCH_BYTES,
+        )),
+        metavar="BYTES",
+        help=(
+            "Maximum encoded size accepted for one Relay http_post ATOF batch; "
+            "long-lived ndjson uploads are not supported."
+        ),
+    )
+
+
 _DETERMINISTIC_PROFILE_CHOICES = ("general", "coding_agent", "openclaw")
 
 
@@ -412,6 +492,8 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     if args.config:
         _cmd_serve_profile_config(args)
         return
+    if _atof_options_requested(args):
+        raise SystemExit("ATOF ingestion options require `serve --config PATH`.")
 
     # Intake sink + local RL trace logging both attach as chain processors;
     # combine them so a single serve invocation can run either or both.
@@ -507,6 +589,11 @@ def _cmd_serve_profile_config(args: argparse.Namespace) -> None:
             f"Python-defined profiles: {exc}"
         ) from exc
     if python_profiles:
+        if _atof_options_requested(args):
+            raise SystemExit(
+                "ATOF ingestion options require a config containing only "
+                "Rust-defined profiles."
+            )
         _cmd_serve_mixed_profile_config(args, python_profiles)
         return
 
@@ -517,7 +604,61 @@ def _cmd_serve_profile_config(args: argparse.Namespace) -> None:
         "Switchyard components-v2 profile config loaded from %s",
         args.config,
     )
-    run_profile_server(args.config, args.host, port)
+    run_profile_server(
+        args.config,
+        args.host,
+        port,
+        atof_bearer_token=getattr(args, "atof_bearer_token", None),
+        atof_max_identities=getattr(
+            args, "atof_max_identities", DEFAULT_MAX_ATOF_IDENTITIES,
+        ),
+        atof_max_history_per_identity=getattr(
+            args,
+            "atof_max_history_per_identity",
+            DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+        ),
+        atof_max_dedupe_entries=getattr(
+            args,
+            "atof_max_dedupe_entries",
+            DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+        ),
+        atof_max_retained_bytes=getattr(
+            args, "atof_max_retained_bytes", DEFAULT_MAX_ATOF_RETAINED_BYTES,
+        ),
+        atof_max_event_bytes=getattr(
+            args, "atof_max_event_bytes", DEFAULT_MAX_ATOF_EVENT_BYTES,
+        ),
+        atof_max_batch_bytes=getattr(
+            args, "atof_max_batch_bytes", DEFAULT_MAX_ATOF_BATCH_BYTES,
+        ),
+    )
+
+
+def _atof_options_requested(args: argparse.Namespace) -> bool:
+    """Return whether a non-default Rust ATOF option was selected."""
+    return any((
+        getattr(args, "atof_bearer_token", None),
+        getattr(args, "atof_max_identities", DEFAULT_MAX_ATOF_IDENTITIES)
+        != DEFAULT_MAX_ATOF_IDENTITIES,
+        getattr(
+            args,
+            "atof_max_history_per_identity",
+            DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+        )
+        != DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+        getattr(
+            args,
+            "atof_max_dedupe_entries",
+            DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+        )
+        != DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+        getattr(args, "atof_max_event_bytes", DEFAULT_MAX_ATOF_EVENT_BYTES)
+        != DEFAULT_MAX_ATOF_EVENT_BYTES,
+        getattr(args, "atof_max_retained_bytes", DEFAULT_MAX_ATOF_RETAINED_BYTES)
+        != DEFAULT_MAX_ATOF_RETAINED_BYTES,
+        getattr(args, "atof_max_batch_bytes", DEFAULT_MAX_ATOF_BATCH_BYTES)
+        != DEFAULT_MAX_ATOF_BATCH_BYTES,
+    ))
 
 
 def _cmd_serve_mixed_profile_config(
@@ -930,6 +1071,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "adapter."
         ),
     )
+    _add_atof_ingest_args(serve)
     serve.add_argument(
         "--workers", "-w", type=int,
         default=int(os.environ.get("SWITCHYARD_WORKERS", "1")),

--- a/switchyard_rust/core.py
+++ b/switchyard_rust/core.py
@@ -248,6 +248,13 @@ class _NativeModule(Protocol):
         port: int,
         backlog: int,
         dry_run: bool,
+        atof_bearer_token: str | None,
+        atof_max_identities: int,
+        atof_max_history_per_identity: int,
+        atof_max_dedupe_entries: int,
+        atof_max_retained_bytes: int,
+        atof_max_event_bytes: int,
+        atof_max_batch_bytes: int,
     ) -> None: ...
 
 

--- a/switchyard_rust/server.py
+++ b/switchyard_rust/server.py
@@ -27,7 +27,7 @@ def run_profile_server(
     atof_max_event_bytes: int = DEFAULT_MAX_ATOF_EVENT_BYTES,
     atof_max_batch_bytes: int = DEFAULT_MAX_ATOF_BATCH_BYTES,
 ) -> None:
-    """Run the bounded Rust profile server and optional Relay ATOF receiver."""
+    """Run the bounded Rust profile server and optional authenticated Relay endpoints."""
     _load_native().run_profile_server(
         config_path,
         host,

--- a/switchyard_rust/server.py
+++ b/switchyard_rust/server.py
@@ -5,6 +5,13 @@
 
 from switchyard_rust.core import _load_native
 
+DEFAULT_MAX_ATOF_IDENTITIES = 10_000
+DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY = 256
+DEFAULT_MAX_ATOF_DEDUPE_ENTRIES = 100_000
+DEFAULT_MAX_ATOF_RETAINED_BYTES = 64 * 1024 * 1024
+DEFAULT_MAX_ATOF_EVENT_BYTES = 256 * 1024
+DEFAULT_MAX_ATOF_BATCH_BYTES = 4 * 1024 * 1024
+
 
 def run_profile_server(
     config_path: str,
@@ -12,9 +19,37 @@ def run_profile_server(
     port: int = 4000,
     backlog: int = 65_535,
     dry_run: bool = False,
+    atof_bearer_token: str | None = None,
+    atof_max_identities: int = DEFAULT_MAX_ATOF_IDENTITIES,
+    atof_max_history_per_identity: int = DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY,
+    atof_max_dedupe_entries: int = DEFAULT_MAX_ATOF_DEDUPE_ENTRIES,
+    atof_max_retained_bytes: int = DEFAULT_MAX_ATOF_RETAINED_BYTES,
+    atof_max_event_bytes: int = DEFAULT_MAX_ATOF_EVENT_BYTES,
+    atof_max_batch_bytes: int = DEFAULT_MAX_ATOF_BATCH_BYTES,
 ) -> None:
-    """Run the Rust components-v2 profile server from an installed package."""
-    _load_native().run_profile_server(config_path, host, port, backlog, dry_run)
+    """Run the bounded Rust profile server and optional Relay ATOF receiver."""
+    _load_native().run_profile_server(
+        config_path,
+        host,
+        port,
+        backlog,
+        dry_run,
+        atof_bearer_token,
+        atof_max_identities,
+        atof_max_history_per_identity,
+        atof_max_dedupe_entries,
+        atof_max_retained_bytes,
+        atof_max_event_bytes,
+        atof_max_batch_bytes,
+    )
 
 
-__all__ = ["run_profile_server"]
+__all__ = [
+    "DEFAULT_MAX_ATOF_BATCH_BYTES",
+    "DEFAULT_MAX_ATOF_DEDUPE_ENTRIES",
+    "DEFAULT_MAX_ATOF_EVENT_BYTES",
+    "DEFAULT_MAX_ATOF_HISTORY_PER_IDENTITY",
+    "DEFAULT_MAX_ATOF_IDENTITIES",
+    "DEFAULT_MAX_ATOF_RETAINED_BYTES",
+    "run_profile_server",
+]

--- a/tests/test_profile_migration.py
+++ b/tests/test_profile_migration.py
@@ -554,12 +554,26 @@ def test_cli_serve_config_delegates_to_rust_profile_server(
         port: int = 4000,
         backlog: int = 65_535,
         dry_run: bool = False,
+        atof_bearer_token: str | None = None,
+        atof_max_identities: int = 10_000,
+        atof_max_history_per_identity: int = 256,
+        atof_max_dedupe_entries: int = 100_000,
+        atof_max_retained_bytes: int = 64 * 1024 * 1024,
+        atof_max_event_bytes: int = 256 * 1024,
+        atof_max_batch_bytes: int = 4 * 1024 * 1024,
     ) -> None:
         captured["config_path"] = config_path
         captured["host"] = host
         captured["port"] = port
         captured["backlog"] = backlog
         captured["dry_run"] = dry_run
+        captured["atof_bearer_token"] = atof_bearer_token
+        captured["atof_max_identities"] = atof_max_identities
+        captured["atof_max_history_per_identity"] = atof_max_history_per_identity
+        captured["atof_max_dedupe_entries"] = atof_max_dedupe_entries
+        captured["atof_max_retained_bytes"] = atof_max_retained_bytes
+        captured["atof_max_event_bytes"] = atof_max_event_bytes
+        captured["atof_max_batch_bytes"] = atof_max_batch_bytes
 
     mocker.patch.object(
         rust_server,
@@ -604,4 +618,11 @@ def test_cli_serve_config_delegates_to_rust_profile_server(
         "port": 4555,
         "backlog": 65_535,
         "dry_run": False,
+        "atof_bearer_token": None,
+        "atof_max_identities": 10_000,
+        "atof_max_history_per_identity": 256,
+        "atof_max_dedupe_entries": 100_000,
+        "atof_max_retained_bytes": 64 * 1024 * 1024,
+        "atof_max_event_bytes": 256 * 1024,
+        "atof_max_batch_bytes": 4 * 1024 * 1024,
     }

--- a/tests/test_route_bundle.py
+++ b/tests/test_route_bundle.py
@@ -479,12 +479,26 @@ def test_serve_config_delegates_to_rust_profile_server(
         port: int = 4000,
         backlog: int = 65_535,
         dry_run: bool = False,
+        atof_bearer_token: str | None = None,
+        atof_max_identities: int = 10_000,
+        atof_max_history_per_identity: int = 256,
+        atof_max_dedupe_entries: int = 100_000,
+        atof_max_retained_bytes: int = 64 * 1024 * 1024,
+        atof_max_event_bytes: int = 256 * 1024,
+        atof_max_batch_bytes: int = 4 * 1024 * 1024,
     ) -> None:
         captured["config_path"] = config_path
         captured["host"] = host
         captured["port"] = port
         captured["backlog"] = backlog
         captured["dry_run"] = dry_run
+        captured["atof_bearer_token"] = atof_bearer_token
+        captured["atof_max_identities"] = atof_max_identities
+        captured["atof_max_history_per_identity"] = atof_max_history_per_identity
+        captured["atof_max_dedupe_entries"] = atof_max_dedupe_entries
+        captured["atof_max_retained_bytes"] = atof_max_retained_bytes
+        captured["atof_max_event_bytes"] = atof_max_event_bytes
+        captured["atof_max_batch_bytes"] = atof_max_batch_bytes
 
     mocker.patch.object(
         rust_server,
@@ -517,6 +531,20 @@ def test_serve_config_delegates_to_rust_profile_server(
         "127.0.0.1",
         "--port",
         "4555",
+        "--atof-bearer-token",
+        "relay-secret",
+        "--atof-max-identities",
+        "17",
+        "--atof-max-history-per-identity",
+        "18",
+        "--atof-max-dedupe-entries",
+        "19",
+        "--atof-max-event-bytes",
+        "1024",
+        "--atof-max-retained-bytes",
+        "2000",
+        "--atof-max-batch-bytes",
+        "2048",
     ])
     args.func(args)
 
@@ -526,6 +554,13 @@ def test_serve_config_delegates_to_rust_profile_server(
         "port": 4555,
         "backlog": 65_535,
         "dry_run": False,
+        "atof_bearer_token": "relay-secret",
+        "atof_max_identities": 17,
+        "atof_max_history_per_identity": 18,
+        "atof_max_dedupe_entries": 19,
+        "atof_max_retained_bytes": 2000,
+        "atof_max_event_bytes": 1024,
+        "atof_max_batch_bytes": 2048,
     }
 
 

--- a/tests/test_serve_profile_config.py
+++ b/tests/test_serve_profile_config.py
@@ -12,6 +12,7 @@ the same paths.
 import argparse
 import json
 import threading
+import tomllib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -163,6 +164,49 @@ def test_dry_run_validates_rust_profiles_and_direct_targets(tmp_path: Path) -> N
     run_profile_server(str(path), dry_run=True)
 
 
+def test_python_server_wrapper_forwards_atof_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: tuple[object, ...] | None = None
+
+    class _Native:
+        def run_profile_server(self, *args: object) -> None:
+            nonlocal captured
+            captured = args
+
+    monkeypatch.setattr("switchyard_rust.server._load_native", lambda: _Native())
+
+    run_profile_server(
+        "profiles.yaml",
+        "127.0.0.2",
+        4555,
+        123,
+        True,
+        "relay-secret",
+        17,
+        18,
+        19,
+        2000,
+        1024,
+        2048,
+    )
+
+    assert captured == (
+        "profiles.yaml",
+        "127.0.0.2",
+        4555,
+        123,
+        True,
+        "relay-secret",
+        17,
+        18,
+        19,
+        2000,
+        1024,
+        2048,
+    )
+
+
 def test_dry_run_rejects_invalid_config(tmp_path: Path) -> None:
     path = _write(tmp_path, "profiles:\n  bad:\n    type: passthrough\n    target: ghost\n")
     with pytest.raises(SwitchyardConfigError):
@@ -174,6 +218,18 @@ def test_shipped_example_config_is_servable(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("OPENROUTER_API_KEY", "dummy-key")
     example = Path(__file__).resolve().parents[1] / "examples" / "profiles.yaml"
     run_profile_server(str(example), dry_run=True)
+
+
+def test_relay_atof_fixture_pins_http_post_preserve_and_bearer() -> None:
+    fixture = Path(__file__).resolve().parents[1] / "examples" / "relay_atof_switchyard.toml"
+    config = tomllib.loads(fixture.read_text(encoding="utf-8"))
+    endpoint = config["components"][0]["config"]["atof"]["endpoints"][0]
+
+    assert endpoint["transport"] == "http_post"
+    assert endpoint["field_name_policy"] == "preserve"
+    assert endpoint["headers"]["Authorization"] == (
+        "Bearer replace-with-shared-token"
+    )
 
 
 def test_python_profile_ids_classifies_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

### Summary

Adds the second independently functional [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay) layer on top of [#8](https://github.com/NVIDIA-NeMo/Switchyard/pull/8):

- a router-neutral `RelaySnapshotAccumulator` in `switchyard-components-v2::features`;
- atomic finite-NDJSON ingestion at `POST /v1/atof/events`;
- exact `(session_id, owner_id)` snapshots with Relay-compatible identity fallbacks;
- deterministic identity, history, dedupe, request-size, and 64 MiB total retained-state bounds;
- optional bearer authentication through the Rust CLI, PyO3 binding, Python wrapper, and Python CLI;
- a checked-in Relay `http_post` / `field_name_policy = "preserve"` fixture.

This is the ATOF subscription and accumulation slice of a previous end-to-end implementation, split into a focused public-repository change.

## Why

History-aware routers need one bounded, reusable snapshot source rather than per-router event state. This PR deliberately stops at ingestion and router-neutral reconstruction: Cascade projection and decision behavior remain in PR 3.

## How tested

### Testing summary

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude switchyard-py`
- [x] `cargo check -p switchyard-py`
- [x] `uv run ruff check` on all changed Python/test files
- [x] `uv run mypy switchyard/cli/switchyard_cli.py switchyard_rust/core.py switchyard_rust/server.py`
- [x] `uv run maturin develop`
- [x] `uv run pytest tests/test_serve_profile_config.py tests/test_route_bundle.py tests/test_profile_migration.py -q -o addopts=` (97 passed)
- [x] One-record Relay-style POST, multiline atomic rejection, auth, media type, event size, batch size, count pruning, total-byte pruning/accounting, global dedupe, canonical-event validation, and every identity fallback are covered.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A: Rust/Python functional API change.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: Rust symbols are exported from the crate root; Python constants are exported from `switchyard_rust.server`.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

### Dependency and delta

This PR depends on [#8](https://github.com/NVIDIA-NeMo/Switchyard/pull/8). Because the author has read-only access to the upstream repository, this draft must target upstream `main` and temporarily contains the #8 commit as its prerequisite.

Review the #9 delta commits `edd342d0` (snapshot memory/reporting fixes), `3857a695` (envelope-validation coverage), and `e81cd9ec` (shared Relay auth documentation), or use the [exact fork delta](https://github.com/bbednarski9/Switchyard/compare/feature/relay-decision-api...feature/relay-atof-snapshots). The earlier commits are prerequisites from #8 and the original ATOF implementation; after #8 merges, this branch will be rebased onto updated `main`.

### Review guidelines

Suggested review order:

1. `features.rs` for atomic preparation, canonical event validation, identity resolution, global dedupe, and retained-byte accounting.
2. `switchyard-server` for optional auth, bounded body parsing, and the single server-owned accumulator.
3. Rust/Python CLI and binding propagation for every limit and the bearer token.
4. `examples/relay_atof_switchyard.toml` and CLI docs for the supported Relay transport contract.

The endpoint intentionally supports finite Relay `transport = "http_post"` requests (one event per POST or a finite multiline batch). Relay's long-lived `transport = "ndjson"` upload is out of scope because atomic batch application waits for request completion.

### Previous feedback addressed

- Replaced the Cascade-specific accumulator with a reusable router-neutral snapshot contract while honoring the selected source location in `components-v2::features`.
- Bounded identity count, per-identity history, global dedupe entries, event bytes, batch bytes, and total retained-memory accounting bytes (64 MiB default).
- Parses and semantically validates the entire batch before taking the mutation lock; malformed recognized scopes cannot partially warm state.
- Restored global UUID/phase idempotency so changed identity metadata cannot bypass dedupe.
- Preserved the previous implementation's full compatibility fallback order for four session and seven owner sources, with precedence tests.
- Threads optional bearer auth through both Rust and Python startup paths; explicitly blank tokens fail configuration instead of silently disabling auth.
- Removes fallible test `.expect()` usage and documents the auth/body-validation contract.
- The Relay fixture pins `http_post`, `field_name_policy = "preserve"`, and a replaceable bearer header without assuming unsupported header environment interpolation.

Relay-aware Cascade consumption, typed freshness, and unified request session metadata are intentionally deferred to [#11](https://github.com/NVIDIA-NeMo/Switchyard/pull/11).

### Follow-up fixes

- Uses a read/write lock so concurrent snapshot readers do not serialize behind one global mutex.
- Makes the retained-state cap a conservative heap-accounting budget (serialized payload plus value/container overhead), rather than a wire-byte-only limit.
- Defines accepted_events as state-mutating ingests and exposes parsed received_events separately.