### PR TITLE
feat: add Relay-aware Cascade routing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -270,7 +270,7 @@
         "filename": "crates/switchyard-components-v2/src/profiles/stage_router.rs",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 1341
+        "line_number": 1249
       }
     ],
     "crates/switchyard-components-v2/tests/stage_router_profile.rs": [
@@ -1189,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-08T13:34:25Z"
+  "generated_at": "2026-07-08T13:59:09Z"
 }

--- a/crates/switchyard-components-v2/DESIGN.md
+++ b/crates/switchyard-components-v2/DESIGN.md
@@ -86,9 +86,9 @@ In Rust, that target shape is:
 pub trait Profile: Send + Sync {
     async fn run(&self, input: ProfileInput) -> Result<ChatResponse>;
 
-    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
+    async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
         Err(SwitchyardError::DecisionUnsupported {
-            profile_id: request.decision_profile.profile_id,
+            profile_id: context.request().decision_profile.profile_id.clone(),
         })
     }
 }
@@ -112,7 +112,7 @@ Conceptually:
 ```text
 process(request)              -> profile-specific processed request
 run(request)                  -> final response
-decide(routing_request)       -> routing decision without selected-backend dispatch
+decide(decision_context)      -> routing decision without selected-backend dispatch
 rprocess(processed, response) -> processed response
 ```
 
@@ -139,6 +139,20 @@ hidden pipeline:
 - `rprocess()` is the response-side library hook. It receives the processed request state and the
   backend response so the profile can perform cleanup, normalization, or accounting without a
   side-channel.
+
+`DecisionContext` owns the typed `RoutingRequest` and any immutable, request-scoped resources
+resolved by the server. For Relay integration, `ServerState` owns one bounded snapshot accumulator,
+looks up only the exact `(session_id, owner_id)` identity, and passes the resulting optional
+snapshot through the existing registry to the same configured profile instance. Profiles do not
+own an accumulator, rebuild another runtime, or perform broader identity fallback. An absent or
+non-routing-ready snapshot remains explicit cold state; routing-ready state is represented by the
+typed `FeatureFreshness::Fresh` value when the concrete profile projects the snapshot into its own
+feature model.
+
+`RequestMetadata.session_id` is the typed session identity for normal profile execution. HTTP
+endpoints reconcile the legacy `proxy_x_session_id` and canonical
+`x-nemo-relay-session-id` aliases before entering a profile, while Decision inputs copy the
+validated body identity into the same field.
 
 `run()` should normally call `process()` and `rprocess()` when those hooks express the same
 lifecycle cleanly. If `process()` seems unable to carry the state that `run()` needs, the first fix
@@ -350,11 +364,11 @@ macro handles the repetitive serde and config-resolution surface:
 #[profile_config("random-routing")]
 pub struct RandomRoutingProfileConfig {
     #[profile_target]
-    pub strong: LlmTarget,
+    pub capable: LlmTarget,
     #[profile_target]
-    pub weak: LlmTarget,
-    #[serde(default = "default_strong_probability")]
-    pub strong_probability: f64,
+    pub efficient: LlmTarget,
+    #[serde(default = "default_capable_probability")]
+    pub capable_probability: f64,
     #[serde(default)]
     pub rng_seed: Option<u64>,
 }
@@ -477,15 +491,15 @@ impl ProfileConfig for RandomRoutingProfileConfig {
 
     fn build(&self) -> Result<Self::Runtime> {
         let router = RandomRoutingEngine::new(
-            RandomRoutingProcessorConfig::new(self.strong.clone(), self.weak.clone())
-                .with_strong_probability(self.strong_probability)?
+            RandomRoutingProcessorConfig::new(self.capable.clone(), self.efficient.clone())
+                .with_capable_probability(self.capable_probability)?
                 .with_rng_seed(self.rng_seed),
         )?;
 
         Ok(RandomRoutingProfile {
             router,
-            strong_backend: native_target_backend(self.strong.clone())?,
-            weak_backend: native_target_backend(self.weak.clone())?,
+            capable_backend: native_target_backend(self.capable.clone())?,
+            efficient_backend: native_target_backend(self.efficient.clone())?,
             stats: profile_stats_accumulator(),
         })
     }
@@ -514,7 +528,7 @@ Profile modules own everything profile-specific:
 - backend/runtime construction,
 - profile-specific error semantics.
 
-This is why `#[profile_target]` matters. The file can say `strong: strong`, but the runtime config
+This is why `#[profile_target]` matters. The file can say `capable: capable`, but the runtime config
 still receives a real `LlmTarget`. The profile author writes the natural runtime type, while the
 macro handles the file-facing ID indirection.
 
@@ -530,10 +544,10 @@ The Rust shape should make the full lifecycle visible in one profile module:
 #[profile_config("random-routing")]
 pub struct RandomRoutingProfileConfig {
     #[profile_target]
-    pub strong: LlmTarget,
+    pub capable: LlmTarget,
     #[profile_target]
-    pub weak: LlmTarget,
-    pub strong_probability: f64,
+    pub efficient: LlmTarget,
+    pub capable_probability: f64,
     pub rng_seed: Option<u64>,
 }
 
@@ -541,12 +555,12 @@ impl ProfileConfig for RandomRoutingProfileConfig {
     type Runtime = RandomRoutingProfile;
 
     fn build(&self) -> Result<Self::Runtime> {
-        validate_probability(self.strong_probability)?;
+        validate_probability(self.capable_probability)?;
 
         Ok(RandomRoutingProfile {
             router: RandomRoutingEngine::from_config(self)?,
-            strong_backend: native_target_backend(self.strong.clone())?,
-            weak_backend: native_target_backend(self.weak.clone())?,
+            capable_backend: native_target_backend(self.capable.clone())?,
+            efficient_backend: native_target_backend(self.efficient.clone())?,
             stats: profile_stats_accumulator(),
         })
     }
@@ -554,8 +568,8 @@ impl ProfileConfig for RandomRoutingProfileConfig {
 
 pub struct RandomRoutingProfile {
     router: RandomRoutingEngine,
-    strong_backend: TargetBackend,
-    weak_backend: TargetBackend,
+    capable_backend: TargetBackend,
+    efficient_backend: TargetBackend,
     stats: StatsAccumulator,
 }
 
@@ -633,22 +647,22 @@ class ProfileHooks(Protocol[ProcessedRequestT]):
 @profile_config("random-routing")
 @dataclass
 class RandomRoutingProfileConfig:
-    strong: LlmTarget
-    weak: LlmTarget
-    strong_probability: float = 0.5
+    capable: LlmTarget
+    efficient: LlmTarget
+    capable_probability: float = 0.5
     rng_seed: int | None = None
 
     def build(self) -> "RandomRoutingProfile":
-        validate_probability(self.strong_probability)
+        validate_probability(self.capable_probability)
         return RandomRoutingProfile(
             router=RandomRoutingEngine(
-                strong=self.strong,
-                weak=self.weak,
-                strong_probability=self.strong_probability,
+                capable=self.capable,
+                efficient=self.efficient,
+                capable_probability=self.capable_probability,
                 rng_seed=self.rng_seed,
             ),
-            strong_backend=native_target_backend(self.strong),
-            weak_backend=native_target_backend(self.weak),
+            capable_backend=native_target_backend(self.capable),
+            efficient_backend=native_target_backend(self.efficient),
             stats=profile_stats_accumulator(),
         )
 
@@ -664,13 +678,13 @@ class RandomRoutingProfile(Profile[RandomRoutingProcessedRequest]):
         self,
         *,
         router: RandomRoutingEngine,
-        strong_backend: TargetBackend,
-        weak_backend: TargetBackend,
+        capable_backend: TargetBackend,
+        efficient_backend: TargetBackend,
         stats: StatsAccumulator,
     ) -> None:
         self.router = router
-        self.strong_backend = strong_backend
-        self.weak_backend = weak_backend
+        self.capable_backend = capable_backend
+        self.efficient_backend = efficient_backend
         self.stats = stats
 
     async def process(self, request: ChatRequest) -> RandomRoutingProcessedRequest:

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -11,7 +11,8 @@ use switchyard_core::{
     BackendFormat, ChatRequest, ChatRequestType, ProfileId, RequestId, Result, SwitchyardError,
 };
 
-use crate::{ProfileInput, RequestMetadata};
+use crate::profiles::{StageRouterProcessedRequest, StageRouterProfile};
+use crate::{FeatureFreshness, ProfileInput, RelaySnapshot, RequestMetadata};
 
 /// Schema identifier for routing requests.
 pub const ROUTING_REQUEST_SCHEMA_VERSION: &str = "switchyard.routing_request.v1";
@@ -60,6 +61,11 @@ impl RoutingRequest {
                 "routing_attempt must not exceed a non-zero max_routing_attempts".to_string(),
             ));
         }
+        if self.identity.session_id.trim().is_empty() {
+            return Err(SwitchyardError::InvalidRequest(
+                "identity.session_id must be a non-empty string".to_string(),
+            ));
+        }
         require_non_blank(
             "decision_profile.profile_id",
             self.decision_profile.profile_id.as_str(),
@@ -80,6 +86,44 @@ impl RoutingRequest {
         }
         validate_current_request_materialization(self)?;
         parse_inbound_profile(&self.protocol.inbound_profile).map(|_| ())
+    }
+}
+
+/// Owned request-scoped inputs available to object-safe decision routing.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DecisionContext {
+    request: RoutingRequest,
+    relay_snapshot: Option<RelaySnapshot>,
+}
+
+impl DecisionContext {
+    /// Creates a decision context from the wire request and exact Relay snapshot lookup.
+    pub fn new(request: RoutingRequest, relay_snapshot: Option<RelaySnapshot>) -> Self {
+        Self {
+            request,
+            relay_snapshot,
+        }
+    }
+
+    /// Returns the Decision API request.
+    pub fn request(&self) -> &RoutingRequest {
+        &self.request
+    }
+
+    /// Returns the exact request-scoped Relay snapshot, when one was found.
+    pub fn relay_snapshot(&self) -> Option<&RelaySnapshot> {
+        self.relay_snapshot.as_ref()
+    }
+
+    /// Splits the owned request from its optional snapshot.
+    pub fn into_parts(self) -> (RoutingRequest, Option<RelaySnapshot>) {
+        (self.request, self.relay_snapshot)
+    }
+}
+
+impl From<RoutingRequest> for DecisionContext {
+    fn from(request: RoutingRequest) -> Self {
+        Self::new(request, None)
     }
 }
 
@@ -225,7 +269,7 @@ pub struct DecisionProvider {
 /// Selected Switchyard route.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct RoutingTarget {
-    /// Tier label such as `strong` or `weak`.
+    /// Tier label such as `capable` or `efficient`.
     pub tier: String,
     /// Target model to send upstream.
     pub target_model: String,
@@ -261,6 +305,19 @@ pub fn route_endpoint_for_format(format: BackendFormat) -> Result<&'static str> 
     }
 }
 
+/// Produces a decision-only StageRouter response from an exact Relay snapshot.
+pub async fn decision_for_stage_router_routing(
+    profile: &StageRouterProfile,
+    context: DecisionContext,
+) -> Result<RoutingDecision> {
+    let (request, relay_snapshot) = context.into_parts();
+    request.validate()?;
+    let input = summary_profile_input(&request)?;
+    let (processed, freshness) = profile
+        .process_decision_snapshot(input, relay_snapshot.as_ref())
+        .await?;
+    stage_router_processed_to_decision(profile, &request, processed, freshness)
+}
 // Builds the request-only state needed by policies that can route from summaries.
 pub(crate) fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
     let mut body = serde_json::Map::new();
@@ -312,6 +369,7 @@ fn profile_input(request: &RoutingRequest, body: Value) -> Result<ProfileInput> 
     Ok(ProfileInput {
         request: chat_request,
         metadata: RequestMetadata {
+            session_id: Some(request.identity.session_id.trim().to_string()),
             request_id: Some(RequestId::new(request.identity.request_id.clone())?),
             inbound_format: Some(request_type),
             ..RequestMetadata::default()
@@ -445,6 +503,56 @@ fn reference_has_prompt_material(reference: &Value) -> bool {
 
 fn has_non_whitespace(value: &str) -> bool {
     !value.trim().is_empty()
+}
+
+fn stage_router_processed_to_decision(
+    profile: &StageRouterProfile,
+    request: &RoutingRequest,
+    processed: StageRouterProcessedRequest,
+    freshness: Option<FeatureFreshness>,
+) -> Result<RoutingDecision> {
+    let target = profile.target_for_decision(&processed.decision)?;
+    let (reason_code, reason_summary, feature_state) = match freshness {
+        None => (
+            "stage_router_feature_cold_default".to_string(),
+            "selected the configured StageRouter picker default because Relay feature state is cold"
+                .to_string(),
+            "cold",
+        ),
+        Some(FeatureFreshness::Fresh) => (
+            processed.decision.source.as_str().to_string(),
+            format!(
+                "selected by the fresh StageRouter {} path",
+                processed.decision.source.as_str()
+            ),
+            "fresh",
+        ),
+    };
+    Ok(RoutingDecision {
+        schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
+        decision_id: format!(
+            "{}:{}:{}",
+            request.identity.request_id,
+            processed.decision.selected_target,
+            processed.decision.source.as_str()
+        ),
+        router: DecisionProvider {
+            name: "stage_router".to_string(),
+            version: "v1".to_string(),
+        },
+        route: routing_target(target, processed.decision.tier.as_str().to_string())?,
+        confidence: processed.decision.confidence,
+        reason_code: Some(reason_code),
+        reason_summary: Some(reason_summary),
+        metadata: BTreeMap::from([
+            (
+                "source".to_string(),
+                Value::from(processed.decision.source.as_str()),
+            ),
+            ("score".to_string(), Value::from(processed.decision.score)),
+            ("feature_state".to_string(), Value::from(feature_state)),
+        ]),
+    })
 }
 
 pub(crate) fn routing_target(
@@ -617,16 +725,16 @@ mod tests {
     #[tokio::test]
     async fn random_decision_uses_summary_without_dispatching_selected_backend() -> TestResult {
         let profile = RandomRoutingProfileConfig {
-            strong: target("strong-target", "frontier/model", BackendFormat::OpenAi)?,
-            weak: target("weak-target", "cheap/model", BackendFormat::Responses)?,
+            strong: target("capable-target", "frontier/model", BackendFormat::OpenAi)?,
+            weak: target("efficient-target", "cheap/model", BackendFormat::Responses)?,
             strong_probability: 1.0,
             rng_seed: Some(7),
         }
         .build()?;
 
-        let decision = profile.decide(routing_request()?).await?;
+        let decision = profile.decide(routing_request()?.into()).await?;
 
-        assert_eq!(decision.route.backend_id, "strong-target");
+        assert_eq!(decision.route.backend_id, "capable-target");
         assert_eq!(decision.route.target_model, "frontier/model");
         assert_eq!(decision.route.target_protocol_profile, "openai_chat");
         assert_eq!(decision.router.name, "random-routing");
@@ -636,8 +744,8 @@ mod tests {
     #[tokio::test]
     async fn decision_rejects_unknown_inbound_profile_without_fallback() -> TestResult {
         let profile = RandomRoutingProfileConfig {
-            strong: target("strong-target", "frontier/model", BackendFormat::OpenAi)?,
-            weak: target("weak-target", "cheap/model", BackendFormat::OpenAi)?,
+            strong: target("capable-target", "frontier/model", BackendFormat::OpenAi)?,
+            weak: target("efficient-target", "cheap/model", BackendFormat::OpenAi)?,
             strong_probability: 1.0,
             rng_seed: Some(7),
         }
@@ -645,7 +753,7 @@ mod tests {
         let mut request = routing_request()?;
         request.protocol.inbound_profile = "future_protocol".to_string();
 
-        let error = profile.decide(request).await;
+        let error = profile.decide(request.into()).await;
 
         assert!(
             matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("unsupported inbound_profile"))
@@ -779,7 +887,7 @@ mod tests {
         let request = routing_request()?;
         let profile_id = request.decision_profile.profile_id.clone();
 
-        let error = profile.decide(request).await;
+        let error = profile.decide(request.into()).await;
 
         assert!(
             matches!(error, Err(SwitchyardError::DecisionUnsupported { profile_id: rejected }) if rejected == profile_id)
@@ -801,6 +909,33 @@ mod tests {
         }
         assert!(parse_inbound_profile("openai").is_err());
         assert!(parse_inbound_profile("chat").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn decision_profile_input_carries_body_session_identity() -> TestResult {
+        let request = routing_request()?;
+
+        let input = summary_profile_input(&request)?;
+
+        assert_eq!(input.metadata.session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            input.metadata.request_id.as_ref().map(RequestId::as_str),
+            Some("request-1")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn routing_request_rejects_blank_session_identity() -> TestResult {
+        let mut request = routing_request()?;
+        request.identity.session_id = " \t\n ".to_string();
+
+        let error = request.validate();
+
+        assert!(
+            matches!(error, Err(SwitchyardError::InvalidRequest(message)) if message.contains("identity.session_id"))
+        );
         Ok(())
     }
 

--- a/crates/switchyard-components-v2/src/features.rs
+++ b/crates/switchyard-components-v2/src/features.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use parking_lot::RwLock;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use switchyard_core::{Result, SwitchyardError};
 
@@ -22,6 +22,16 @@ pub const DEFAULT_MAX_RELAY_RETAINED_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_MAX_ATOF_EVENT_BYTES: usize = 256 * 1024;
 /// Default maximum encoded size accepted for one ATOF request batch.
 pub const DEFAULT_MAX_ATOF_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+/// Readiness of an ATOF-derived feature snapshot consumed by a router.
+///
+/// Absence is represented as `None`; the initial typed state is fresh only.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeatureFreshness {
+    /// The snapshot contains routing-ready reconstructed history.
+    Fresh,
+}
 
 // JSON values retain both serialized content and heap-backed container
 // allocations. Reserve a conservative second payload-sized copy plus a small

--- a/crates/switchyard-components-v2/src/lib.rs
+++ b/crates/switchyard-components-v2/src/lib.rs
@@ -21,13 +21,14 @@ pub use config::{
     ProfileConfig, ProfileConfigDocument, ProfileConfigFormat, ProfileConfigPlan,
 };
 pub use decision::{
-    route_endpoint_for_format, route_protocol_for_format, CurrentRequestMaterialization,
-    DecisionAttempt, DecisionProfile, DecisionProvider, IdentityQuality, RequestIdentity,
-    RequestProtocol, RequestSummary, RoutingDecision, RoutingRequest, RoutingTarget,
-    ROUTING_DECISION_SCHEMA_VERSION, ROUTING_REQUEST_SCHEMA_VERSION,
+    decision_for_stage_router_routing, route_endpoint_for_format, route_protocol_for_format,
+    CurrentRequestMaterialization, DecisionAttempt, DecisionContext, DecisionProfile,
+    DecisionProvider, IdentityQuality, RequestIdentity, RequestProtocol, RequestSummary,
+    RoutingDecision, RoutingRequest, RoutingTarget, ROUTING_DECISION_SCHEMA_VERSION,
+    ROUTING_REQUEST_SCHEMA_VERSION,
 };
 pub use features::{
-    atof_event_dedupe_key, json_string_at, relay_identity_key_from_atof_event,
+    atof_event_dedupe_key, json_string_at, relay_identity_key_from_atof_event, FeatureFreshness,
     RelayAccumulatorCounters, RelayIdentityKey, RelayIngestReport, RelaySnapshot,
     RelaySnapshotAccumulator, RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES,
     DEFAULT_MAX_ATOF_EVENT_BYTES, DEFAULT_MAX_RELAY_DEDUPE_ENTRIES,
@@ -35,7 +36,9 @@ pub use features::{
     DEFAULT_MAX_RELAY_RETAINED_BYTES,
 };
 pub use profile::{
-    Profile, ProfileHooks, ProfileInput, ProfileResponse, RequestMetadata, RoutingMetadata,
+    reconcile_session_id, session_id_from_normalized_headers, Profile, ProfileHooks, ProfileInput,
+    ProfileResponse, RequestMetadata, RoutingMetadata, PROXY_SESSION_ID_HEADER,
+    RELAY_SESSION_ID_HEADER,
 };
 pub use profiles::{
     decision_for_llm_routing, decision_for_random_routing, EndpointHealth, EndpointHealthStatus,

--- a/crates/switchyard-components-v2/src/profile.rs
+++ b/crates/switchyard-components-v2/src/profile.rs
@@ -9,7 +9,12 @@ use std::collections::BTreeMap;
 
 use switchyard_core::{ChatRequest, ChatRequestType, ChatResponse, RequestId, Result};
 
-use crate::decision::{RoutingDecision, RoutingRequest};
+use crate::decision::{DecisionContext, RoutingDecision};
+
+/// Legacy proxy session header used by Switchyard Python endpoints.
+pub const PROXY_SESSION_ID_HEADER: &str = "proxy_x_session_id";
+/// Canonical Relay session header accepted alongside the proxy alias.
+pub const RELAY_SESSION_ID_HEADER: &str = "x-nemo-relay-session-id";
 
 /// Explicit per-request metadata passed to v2 profiles.
 ///
@@ -18,12 +23,72 @@ use crate::decision::{RoutingDecision, RoutingRequest};
 /// through multi-value headers without silently collapsing them.
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct RequestMetadata {
+    /// Canonical request/session identity resolved from endpoint headers or a Decision body.
+    pub session_id: Option<String>,
     /// Caller-provided request identifier, when present.
     pub request_id: Option<RequestId>,
     /// Inbound wire format recorded by the endpoint, when present.
     pub inbound_format: Option<ChatRequestType>,
     /// Request headers supplied by the caller, keyed by normalized header name.
     pub headers: BTreeMap<String, Vec<String>>,
+}
+
+/// Resolves all values from both supported session-header aliases.
+///
+/// Values are trimmed before comparison. Empty values and any disagreement
+/// across aliases or repeated values are rejected instead of being ignored.
+pub fn session_id_from_normalized_headers(
+    headers: &BTreeMap<String, Vec<String>>,
+) -> Result<Option<String>> {
+    let mut resolved = None;
+    for name in [PROXY_SESSION_ID_HEADER, RELAY_SESSION_ID_HEADER] {
+        let Some(values) = headers.get(name) else {
+            continue;
+        };
+        if values.is_empty() {
+            return Err(switchyard_core::SwitchyardError::InvalidRequest(format!(
+                "{name} must contain at least one non-empty session ID"
+            )));
+        }
+        for value in values {
+            merge_session_id(&mut resolved, value, name)?;
+        }
+    }
+    Ok(resolved)
+}
+
+/// Reconciles an explicit session ID with both normalized header aliases.
+pub fn reconcile_session_id(
+    explicit: Option<&str>,
+    headers: &BTreeMap<String, Vec<String>>,
+) -> Result<Option<String>> {
+    let mut resolved = None;
+    if let Some(explicit) = explicit {
+        merge_session_id(&mut resolved, explicit, "session_id")?;
+    }
+    if let Some(header_session_id) = session_id_from_normalized_headers(headers)? {
+        merge_session_id(&mut resolved, &header_session_id, "session header aliases")?;
+    }
+    Ok(resolved)
+}
+
+fn merge_session_id(resolved: &mut Option<String>, raw: &str, source: &str) -> Result<()> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(switchyard_core::SwitchyardError::InvalidRequest(format!(
+            "{source} must contain a non-empty session ID"
+        )));
+    }
+    if let Some(existing) = resolved {
+        if existing != value {
+            return Err(switchyard_core::SwitchyardError::InvalidRequest(format!(
+                "conflicting session IDs {existing:?} and {value:?}"
+            )));
+        }
+        return Ok(());
+    }
+    *resolved = Some(value.to_string());
+    Ok(())
 }
 
 /// Input object handed to v2 profiles.
@@ -129,10 +194,10 @@ pub trait Profile: Send + Sync {
     ///
     /// Profiles that do not implement decision-only routing return a typed
     /// unsupported-profile error by default.
-    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
-        request.validate()?;
+    async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
+        context.request().validate()?;
         Err(switchyard_core::SwitchyardError::DecisionUnsupported {
-            profile_id: request.decision_profile.profile_id,
+            profile_id: context.request().decision_profile.profile_id.clone(),
         })
     }
 }
@@ -172,6 +237,7 @@ mod tests {
     #[test]
     fn request_metadata_is_plain_data() {
         let metadata = RequestMetadata {
+            session_id: Some("session-1".to_string()),
             request_id: None,
             inbound_format: Some(ChatRequestType::OpenAiChat),
             headers: BTreeMap::from([(
@@ -188,6 +254,7 @@ mod tests {
             Some(&["abc123".to_string()][..])
         );
         assert_eq!(metadata.inbound_format, Some(ChatRequestType::OpenAiChat));
+        assert_eq!(metadata.session_id.as_deref(), Some("session-1"));
     }
 
     #[test]
@@ -198,6 +265,7 @@ mod tests {
                 "messages": [],
             })),
             metadata: RequestMetadata {
+                session_id: Some("session-1".to_string()),
                 request_id: None,
                 inbound_format: None,
                 headers: BTreeMap::from([(
@@ -217,5 +285,53 @@ mod tests {
             Some(&["unit-test".to_string()][..])
         );
         assert!(input.metadata.request_id.is_none());
+    }
+
+    #[test]
+    fn session_header_aliases_and_repeated_values_reconcile() -> Result<()> {
+        let headers = BTreeMap::from([
+            (
+                PROXY_SESSION_ID_HEADER.to_string(),
+                vec![" session-1 ".to_string(), "session-1".to_string()],
+            ),
+            (
+                RELAY_SESSION_ID_HEADER.to_string(),
+                vec!["session-1".to_string()],
+            ),
+        ]);
+
+        assert_eq!(
+            session_id_from_normalized_headers(&headers)?.as_deref(),
+            Some("session-1")
+        );
+        assert_eq!(
+            reconcile_session_id(Some(" session-1 "), &headers)?.as_deref(),
+            Some("session-1")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn session_header_aliases_reject_conflicts_and_empty_values() {
+        for headers in [
+            BTreeMap::from([(
+                PROXY_SESSION_ID_HEADER.to_string(),
+                vec!["session-1".to_string(), "session-2".to_string()],
+            )]),
+            BTreeMap::from([
+                (
+                    PROXY_SESSION_ID_HEADER.to_string(),
+                    vec!["session-1".to_string()],
+                ),
+                (
+                    RELAY_SESSION_ID_HEADER.to_string(),
+                    vec!["session-2".to_string()],
+                ),
+            ]),
+            BTreeMap::from([(RELAY_SESSION_ID_HEADER.to_string(), vec!["   ".to_string()])]),
+            BTreeMap::from([(PROXY_SESSION_ID_HEADER.to_string(), Vec::new())]),
+        ] {
+            assert!(session_id_from_normalized_headers(&headers).is_err());
+        }
     }
 }

--- a/crates/switchyard-components-v2/src/profiles/llm_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/llm_routing.rs
@@ -20,8 +20,8 @@ use crate::decision::{materialized_profile_input, routing_target};
 use crate::decision::{DecisionProvider, ROUTING_DECISION_SCHEMA_VERSION};
 use crate::profile_stats_accumulator;
 use crate::{
-    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
-    RoutingDecision, RoutingMetadata, RoutingRequest,
+    profile_config, DecisionContext, Profile, ProfileConfig, ProfileHooks, ProfileInput,
+    ProfileResponse, RoutingDecision, RoutingMetadata,
 };
 
 const TIER_STRONG: &str = "strong";
@@ -555,16 +555,17 @@ impl Profile for LlmRoutingProfile {
     }
 
     /// Classifies a materialized request without dispatching the selected target.
-    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
-        decision_for_llm_routing(self, request).await
+    async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
+        decision_for_llm_routing(self, context).await
     }
 }
 
 /// Produces a decision-only LLM-routing response without selected-backend dispatch.
 pub async fn decision_for_llm_routing(
     profile: &LlmRoutingProfile,
-    request: RoutingRequest,
+    context: DecisionContext,
 ) -> Result<RoutingDecision> {
+    let (request, _relay_snapshot) = context.into_parts();
     request.validate()?;
     let input = materialized_profile_input(&request)?;
     let processed = profile.process(input).await?;

--- a/crates/switchyard-components-v2/src/profiles/random_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/random_routing.rs
@@ -20,8 +20,8 @@ use crate::decision::{routing_target, summary_profile_input};
 use crate::decision::{DecisionProvider, ROUTING_DECISION_SCHEMA_VERSION};
 use crate::profile_stats_accumulator;
 use crate::{
-    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
-    RoutingDecision, RoutingMetadata, RoutingRequest,
+    profile_config, DecisionContext, Profile, ProfileConfig, ProfileHooks, ProfileInput,
+    ProfileResponse, RoutingDecision, RoutingMetadata,
 };
 
 /// Config for the flatter random-routing profile.
@@ -197,16 +197,17 @@ impl Profile for RandomRoutingProfile {
     }
 
     /// Selects a configured target without dispatching it.
-    async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
-        decision_for_random_routing(self, request).await
+    async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
+        decision_for_random_routing(self, context).await
     }
 }
 
 /// Produces a decision-only Random routing response without backend dispatch.
 pub async fn decision_for_random_routing(
     profile: &RandomRoutingProfile,
-    request: RoutingRequest,
+    context: DecisionContext,
 ) -> Result<RoutingDecision> {
+    let (request, _relay_snapshot) = context.into_parts();
     request.validate()?;
     let input = summary_profile_input(&request)?;
     let processed = profile.process(input).await?;

--- a/crates/switchyard-components-v2/src/profiles/stage_router.rs
+++ b/crates/switchyard-components-v2/src/profiles/stage_router.rs
@@ -150,7 +150,8 @@ impl StageRouterProfileConfig {
     fn validate(&self) -> Result<()> {
         if self.capable.id == self.efficient.id {
             return Err(SwitchyardError::InvalidConfig(
-                "stage_router capable and efficient targets must have distinct target ids".to_string(),
+                "stage_router capable and efficient targets must have distinct target ids"
+                    .to_string(),
             ));
         }
         if !self.confidence_threshold.is_finite()
@@ -1193,7 +1194,12 @@ mod tests {
                 calls.clone(),
                 capable_actions,
             ),
-            efficient_backend: target_backend(&efficient, "efficient-backend", calls.clone(), efficient_actions),
+            efficient_backend: target_backend(
+                &efficient,
+                "efficient-backend",
+                calls.clone(),
+                efficient_actions,
+            ),
             fallback_target_on_evict: capable.id.clone(),
             picker,
             confidence_threshold,
@@ -1237,15 +1243,17 @@ mod tests {
                 vec![BackendAction::Ok],
                 vec![BackendAction::Ok],
             )?;
-            profile.classifier = Some(StageRouterTierClassifier::new(&StageRouterClassifierConfig {
-                model: "unreachable-classifier".to_string(),
-                api_key: "test-key".to_string(),
-                base_url: Some("http://127.0.0.1:1/v1".to_string()),
-                timeout_secs: 0.01,
-                recent_turn_window: 1,
-                max_tokens: CLASSIFIER_MAX_TOKENS,
-                system_prompt: None,
-            })?);
+            profile.classifier = Some(StageRouterTierClassifier::new(
+                &StageRouterClassifierConfig {
+                    model: "unreachable-classifier".to_string(),
+                    api_key: "test-key".to_string(),
+                    base_url: Some("http://127.0.0.1:1/v1".to_string()),
+                    timeout_secs: 0.01,
+                    recent_turn_window: 1,
+                    max_tokens: CLASSIFIER_MAX_TOKENS,
+                    system_prompt: None,
+                },
+            )?);
 
             let (processed, freshness) = profile
                 .process_decision_snapshot(
@@ -1258,7 +1266,10 @@ mod tests {
 
             assert_eq!(freshness, None);
             assert_eq!(processed.decision.tier, expected_tier);
-            assert_eq!(processed.decision.source, StageRouterDecisionSource::FallOpen);
+            assert_eq!(
+                processed.decision.source,
+                StageRouterDecisionSource::FallOpen
+            );
             assert_eq!(processed.decision.confidence, None);
             assert_eq!(processed.decision.score, 0.0);
             assert_eq!(
@@ -1302,13 +1313,17 @@ mod tests {
 
         assert_eq!(freshness, None);
         assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
-        assert_eq!(processed.decision.source, StageRouterDecisionSource::FallOpen);
+        assert_eq!(
+            processed.decision.source,
+            StageRouterDecisionSource::FallOpen
+        );
         assert!(observed(&calls)?.is_empty());
         Ok(())
     }
 
     #[tokio::test]
-    async fn stage_router_decision_projects_fresh_relay_history_without_target_dispatch() -> Result<()> {
+    async fn stage_router_decision_projects_fresh_relay_history_without_target_dispatch(
+    ) -> Result<()> {
         let (profile, calls) = profile(
             target("capable", "frontier/model")?,
             target("efficient", "cheap/model")?,
@@ -1337,7 +1352,10 @@ mod tests {
 
         assert_eq!(freshness, Some(FeatureFreshness::Fresh));
         assert_eq!(processed.decision.tier, StageRouterTier::Capable);
-        assert_eq!(processed.decision.source, StageRouterDecisionSource::Override);
+        assert_eq!(
+            processed.decision.source,
+            StageRouterDecisionSource::Override
+        );
         assert_eq!(processed.decision.confidence, Some(1.0));
         assert!(observed(&calls)?.is_empty());
         Ok(())
@@ -1373,7 +1391,10 @@ mod tests {
 
         assert_eq!(freshness, Some(FeatureFreshness::Fresh));
         assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
-        assert_eq!(processed.decision.source, StageRouterDecisionSource::Dimensions);
+        assert_eq!(
+            processed.decision.source,
+            StageRouterDecisionSource::Dimensions
+        );
         assert!(observed(&calls)?.is_empty());
         Ok(())
     }
@@ -1520,7 +1541,10 @@ mod tests {
             .await?;
 
         assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
-        assert_eq!(processed.decision.source, StageRouterDecisionSource::Dimensions);
+        assert_eq!(
+            processed.decision.source,
+            StageRouterDecisionSource::Dimensions
+        );
         assert_eq!(processed.profile_input.request.model(), Some("cheap/model"));
         assert!(observed(&calls)?.is_empty());
         Ok(())

--- a/crates/switchyard-components-v2/src/profiles/stage_router.rs
+++ b/crates/switchyard-components-v2/src/profiles/stage_router.rs
@@ -18,7 +18,8 @@ use switchyard_core::{ChatRequest, ChatResponse, LlmTarget, LlmTargetId, Result,
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
 use crate::{
-    profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
+    decision_for_stage_router_routing, profile_config, DecisionContext, FeatureFreshness, Profile,
+    ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse, RelaySnapshot, RoutingDecision,
     RoutingMetadata,
 };
 
@@ -149,8 +150,7 @@ impl StageRouterProfileConfig {
     fn validate(&self) -> Result<()> {
         if self.capable.id == self.efficient.id {
             return Err(SwitchyardError::InvalidConfig(
-                "stage_router capable and efficient targets must have distinct target ids"
-                    .to_string(),
+                "stage_router capable and efficient targets must have distinct target ids".to_string(),
             ));
         }
         if !self.confidence_threshold.is_finite()
@@ -313,6 +313,55 @@ impl StageRouterProfile {
         })
     }
 
+    /// Routes an immutable Decision snapshot without dispatching the selected target.
+    pub(crate) async fn process_decision_snapshot(
+        &self,
+        mut input: ProfileInput,
+        snapshot: Option<&RelaySnapshot>,
+    ) -> Result<(StageRouterProcessedRequest, Option<FeatureFreshness>)> {
+        let original_model = input.request.model().map(std::borrow::ToOwned::to_owned);
+        let (decision, freshness) = match self.signal_from_relay_snapshot(snapshot) {
+            Some(signal) => (
+                self.pick(&input.request, &signal, original_model).await?,
+                Some(FeatureFreshness::Fresh),
+            ),
+            None => (
+                self.decision_for_tier(
+                    self.picker.default_tier(),
+                    original_model,
+                    StageRouterDecisionSource::FallOpen,
+                    0.0,
+                    None,
+                )?,
+                None,
+            ),
+        };
+        input.request.set_model(decision.selected_model.as_str());
+        self.record_decision_source(decision.source)?;
+        Ok((
+            StageRouterProcessedRequest {
+                profile_input: input,
+                decision,
+            },
+            freshness,
+        ))
+    }
+
+    // Projects router-neutral Relay history into StageRouter's existing feature model.
+    fn signal_from_relay_snapshot(
+        &self,
+        snapshot: Option<&RelaySnapshot>,
+    ) -> Option<ToolResultSignal> {
+        let snapshot = snapshot.filter(|snapshot| !snapshot.messages.is_empty())?;
+        let request = ChatRequest::openai_chat(json!({
+            "model": "stage_router-relay-snapshot",
+            "messages": snapshot.messages,
+        }));
+        let mut signal = extract_tool_signals_with_window(&request, self.signal_recent_window);
+        signal.turn_depth = u32::try_from(snapshot.turn_depth).unwrap_or(u32::MAX);
+        Some(signal)
+    }
+
     // Routing decision flow:
     // 1. Hard overrides choose capable for critical failures or efficient for clean tests.
     // 2. Dimensions scoring chooses by score sign when confidence clears the threshold.
@@ -441,6 +490,12 @@ impl StageRouterProfile {
                 "stage_router selected target {target_id} that is not configured for this profile"
             )))
         }
+    }
+
+    /// Returns selected target metadata for a decision-only integration.
+    pub(crate) fn target_for_decision(&self, decision: &StageRouterDecision) -> Result<&LlmTarget> {
+        self.backend_for_target(&decision.selected_target)
+            .map(TargetBackend::target)
     }
 
     fn tier_for_target(&self, target_id: &LlmTargetId) -> Result<StageRouterTier> {
@@ -611,6 +666,11 @@ impl Profile for StageRouterProfile {
                 return Err(error);
             }
         }
+    }
+
+    /// Routes from an exact Relay snapshot without dispatching the selected target.
+    async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
+        decision_for_stage_router_routing(self, context).await
     }
 }
 
@@ -880,11 +940,11 @@ fn summarise_signal(
     );
     let recent_messages = recent_messages(request, recent_window);
     if recent_messages.is_empty() {
-        return format!("Decide CAPABLE or EFFICIENT for the next call. {state_line}");
+        return format!("Decide STRONG or WEAK for the next call. {state_line}");
     }
 
     let mut lines = vec![
-        "Decide CAPABLE or EFFICIENT for the next call.".to_string(),
+        "Decide STRONG or WEAK for the next call.".to_string(),
         state_line,
         "Recent turns (most recent last):".to_string(),
     ];
@@ -1021,7 +1081,7 @@ mod tests {
     use switchyard_core::{BackendFormat, ModelId};
 
     use crate::backend::ProfileBackend;
-    use crate::RequestMetadata;
+    use crate::{RelayIdentityKey, RequestMetadata};
 
     use super::*;
 
@@ -1133,12 +1193,7 @@ mod tests {
                 calls.clone(),
                 capable_actions,
             ),
-            efficient_backend: target_backend(
-                &efficient,
-                "efficient-backend",
-                calls.clone(),
-                efficient_actions,
-            ),
+            efficient_backend: target_backend(&efficient, "efficient-backend", calls.clone(), efficient_actions),
             fallback_target_on_evict: capable.id.clone(),
             picker,
             confidence_threshold,
@@ -1148,6 +1203,233 @@ mod tests {
             enable_stats: true,
         };
         Ok((profile, calls))
+    }
+
+    fn relay_snapshot(messages: Vec<Value>, turn_depth: u64) -> RelaySnapshot {
+        RelaySnapshot {
+            identity: RelayIdentityKey::session_only("session-1"),
+            event_count: messages.len() as u64,
+            messages,
+            turn_depth,
+        }
+    }
+
+    #[tokio::test]
+    async fn stage_router_decision_cold_state_uses_configured_default_without_classifier_or_target_call(
+    ) -> Result<()> {
+        for (picker, expected_tier, expected_model) in [
+            (
+                StageRouterPickerMode::CapableFirst,
+                StageRouterTier::Capable,
+                "frontier/model",
+            ),
+            (
+                StageRouterPickerMode::EfficientFirst,
+                StageRouterTier::Efficient,
+                "cheap/model",
+            ),
+        ] {
+            let (mut profile, calls) = profile(
+                target("capable", "frontier/model")?,
+                target("efficient", "cheap/model")?,
+                picker,
+                1.0,
+                vec![BackendAction::Ok],
+                vec![BackendAction::Ok],
+            )?;
+            profile.classifier = Some(StageRouterTierClassifier::new(&StageRouterClassifierConfig {
+                model: "unreachable-classifier".to_string(),
+                api_key: "test-key".to_string(),
+                base_url: Some("http://127.0.0.1:1/v1".to_string()),
+                timeout_secs: 0.01,
+                recent_turn_window: 1,
+                max_tokens: CLASSIFIER_MAX_TOKENS,
+                system_prompt: None,
+            })?);
+
+            let (processed, freshness) = profile
+                .process_decision_snapshot(
+                    profile_input(ChatRequest::openai_chat(json!({
+                        "model": "smart-stage_router",
+                    }))),
+                    None,
+                )
+                .await?;
+
+            assert_eq!(freshness, None);
+            assert_eq!(processed.decision.tier, expected_tier);
+            assert_eq!(processed.decision.source, StageRouterDecisionSource::FallOpen);
+            assert_eq!(processed.decision.confidence, None);
+            assert_eq!(processed.decision.score, 0.0);
+            assert_eq!(
+                processed.profile_input.request.model(),
+                Some(expected_model)
+            );
+            assert!(observed(&calls)?.is_empty());
+            assert_eq!(
+                profile
+                    .stats
+                    .snapshot()?
+                    .routing_decisions
+                    .get("stage_router")
+                    .and_then(|sources| sources.get("fall_open")),
+                Some(&1)
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stage_router_decision_turn_only_snapshot_remains_cold() -> Result<()> {
+        let (profile, calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.0,
+            vec![BackendAction::Ok],
+            vec![BackendAction::Ok],
+        )?;
+        let snapshot = relay_snapshot(Vec::new(), 42);
+
+        let (processed, freshness) = profile
+            .process_decision_snapshot(
+                profile_input(ChatRequest::openai_chat(json!({
+                    "model": "smart-stage_router",
+                }))),
+                Some(&snapshot),
+            )
+            .await?;
+
+        assert_eq!(freshness, None);
+        assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
+        assert_eq!(processed.decision.source, StageRouterDecisionSource::FallOpen);
+        assert!(observed(&calls)?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stage_router_decision_projects_fresh_relay_history_without_target_dispatch() -> Result<()> {
+        let (profile, calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.7,
+            vec![BackendAction::Ok],
+            vec![BackendAction::Ok],
+        )?;
+        let snapshot = relay_snapshot(
+            vec![json!({
+                "role": "tool",
+                "tool_call_id": "call-oom",
+                "content": "process failed: out of memory",
+            })],
+            3,
+        );
+
+        let (processed, freshness) = profile
+            .process_decision_snapshot(
+                profile_input(ChatRequest::openai_chat(json!({
+                    "model": "smart-stage_router",
+                }))),
+                Some(&snapshot),
+            )
+            .await?;
+
+        assert_eq!(freshness, Some(FeatureFreshness::Fresh));
+        assert_eq!(processed.decision.tier, StageRouterTier::Capable);
+        assert_eq!(processed.decision.source, StageRouterDecisionSource::Override);
+        assert_eq!(processed.decision.confidence, Some(1.0));
+        assert!(observed(&calls)?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stage_router_decision_fresh_clean_signal_uses_dimensions() -> Result<()> {
+        let (profile, calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::CapableFirst,
+            0.0,
+            vec![BackendAction::Ok],
+            vec![BackendAction::Ok],
+        )?;
+        let snapshot = relay_snapshot(
+            vec![json!({
+                "role": "tool",
+                "tool_call_id": "call-tests",
+                "content": "all tests passed",
+            })],
+            1,
+        );
+
+        let (processed, freshness) = profile
+            .process_decision_snapshot(
+                profile_input(ChatRequest::openai_chat(json!({
+                    "model": "smart-stage_router",
+                }))),
+                Some(&snapshot),
+            )
+            .await?;
+
+        assert_eq!(freshness, Some(FeatureFreshness::Fresh));
+        assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
+        assert_eq!(processed.decision.source, StageRouterDecisionSource::Dimensions);
+        assert!(observed(&calls)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn stage_router_decision_snapshot_turn_depth_saturates_to_u32() -> Result<()> {
+        let (profile, _calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.7,
+            Vec::new(),
+            Vec::new(),
+        )?;
+        let snapshot = relay_snapshot(
+            vec![json!({"role": "user", "content": "continue"})],
+            u64::MAX,
+        );
+
+        let signal = profile
+            .signal_from_relay_snapshot(Some(&snapshot))
+            .ok_or_else(|| SwitchyardError::Other("expected fresh signal".to_string()))?;
+
+        assert_eq!(signal.turn_depth, u32::MAX);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stage_router_normal_run_still_extracts_request_signals_and_dispatches() -> Result<()> {
+        let (profile, calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.7,
+            vec![BackendAction::Ok],
+            vec![BackendAction::Ok],
+        )?;
+
+        let response = profile
+            .run(profile_input(ChatRequest::openai_chat(json!({
+                "model": "smart-stage_router",
+                "messages": [{"role": "user", "content": "continue"}],
+            }))))
+            .await?;
+
+        assert_eq!(
+            response
+                .routing_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.selected_tier.as_deref()),
+            Some("efficient")
+        );
+        let calls = observed(&calls)?;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].backend, "efficient-backend");
+        Ok(())
     }
 
     #[tokio::test]
@@ -1163,7 +1445,7 @@ mod tests {
 
         let response = profile
             .run(profile_input(ChatRequest::openai_chat(json!({
-                "model": "smart-stage-router",
+                "model": "smart-stage_router",
                 "messages": [
                     {"role": "assistant", "tool_calls": [{
                         "type": "function",
@@ -1232,16 +1514,13 @@ mod tests {
 
         let processed = profile
             .process(profile_input(ChatRequest::openai_chat(json!({
-                "model": "smart-stage-router",
+                "model": "smart-stage_router",
                 "messages": [{"role": "user", "content": "continue"}],
             }))))
             .await?;
 
         assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
-        assert_eq!(
-            processed.decision.source,
-            StageRouterDecisionSource::Dimensions
-        );
+        assert_eq!(processed.decision.source, StageRouterDecisionSource::Dimensions);
         assert_eq!(processed.profile_input.request.model(), Some("cheap/model"));
         assert!(observed(&calls)?.is_empty());
         Ok(())
@@ -1260,7 +1539,7 @@ mod tests {
 
         let response = profile
             .run(profile_input(ChatRequest::openai_chat(json!({
-                "model": "smart-stage-router",
+                "model": "smart-stage_router",
                 "messages": [{"role": "user", "content": "continue"}],
             }))))
             .await?;
@@ -1348,7 +1627,7 @@ mod tests {
 
         let body = classifier.request_body(
             &ChatRequest::openai_chat(json!({
-                "model": "smart-stage-router",
+                "model": "smart-stage_router",
                 "messages": [{"role": "user", "content": "hi"}],
             })),
             &ToolResultSignal::default(),

--- a/crates/switchyard-py/src/profile_bindings/typed.rs
+++ b/crates/switchyard-py/src/profile_bindings/typed.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyType};
-use switchyard_components_v2::{ProfileInput, RequestMetadata};
+use switchyard_components_v2::{reconcile_session_id, ProfileInput, RequestMetadata};
 use switchyard_core::RequestId;
 
 use crate::core_bindings::request::{request_type_from_python, request_type_object, PyChatRequest};
@@ -39,28 +39,32 @@ impl PyProfileRequestMetadata {
 #[pymethods]
 impl PyProfileRequestMetadata {
     #[new]
-    #[pyo3(signature = (request_id=None, inbound_format=None, headers=None))]
+    #[pyo3(signature = (request_id=None, inbound_format=None, headers=None, session_id=None))]
     fn new(
         request_id: Option<String>,
         inbound_format: Option<&Bound<'_, PyAny>>,
         headers: Option<&Bound<'_, PyAny>>,
+        session_id: Option<String>,
     ) -> PyResult<Self> {
+        let headers = match headers {
+            Some(headers) if !headers.is_none() => metadata_headers_from_python(headers)?,
+            _ => BTreeMap::new(),
+        };
+        let session_id = reconcile_profile_session_id(session_id.as_deref(), &headers)?;
         Ok(Self {
             inner: RequestMetadata {
+                session_id,
                 request_id: parse_request_id(request_id)?,
                 inbound_format: inbound_format
                     .filter(|value| !value.is_none())
                     .map(request_type_from_python)
                     .transpose()?,
-                headers: match headers {
-                    Some(headers) if !headers.is_none() => metadata_headers_from_python(headers)?,
-                    _ => BTreeMap::new(),
-                },
+                headers,
             },
         })
     }
 
-    /// Build metadata from headers, inferring `request_id` from `x-request-id`.
+    /// Build metadata from headers, inferring request and session IDs.
     #[classmethod]
     #[pyo3(signature = (headers, inbound_format=None))]
     fn from_headers(
@@ -73,8 +77,10 @@ impl PyProfileRequestMetadata {
             .get("x-request-id")
             .and_then(|values| values.first())
             .cloned();
+        let session_id = reconcile_profile_session_id(None, &headers)?;
         Ok(Self {
             inner: RequestMetadata {
+                session_id,
                 request_id: parse_request_id(request_id)?,
                 inbound_format: inbound_format
                     .filter(|value| !value.is_none())
@@ -83,6 +89,11 @@ impl PyProfileRequestMetadata {
                 headers,
             },
         })
+    }
+
+    #[getter]
+    fn session_id(&self) -> Option<String> {
+        self.inner.session_id.clone()
     }
 
     #[getter]
@@ -121,11 +132,16 @@ impl PyProfileRequestMetadata {
                 .map(crate::core_bindings::request::request_type_name),
         )?;
         dict.set_item("headers", self.headers(py)?)?;
+        dict.set_item("session_id", self.session_id())?;
         Ok(dict.unbind().into_any())
     }
 
     fn __repr__(&self) -> String {
-        format!("ProfileRequestMetadata(request_id={:?})", self.request_id())
+        format!(
+            "ProfileRequestMetadata(request_id={:?}, session_id={:?})",
+            self.request_id(),
+            self.session_id()
+        )
     }
 }
 
@@ -188,6 +204,14 @@ fn parse_request_id(request_id: Option<String>) -> PyResult<Option<RequestId>> {
         .map(RequestId::new)
         .transpose()
         .map_err(|error| PyValueError::new_err(format!("invalid request_id: {error}")))
+}
+
+fn reconcile_profile_session_id(
+    session_id: Option<&str>,
+    headers: &BTreeMap<String, Vec<String>>,
+) -> PyResult<Option<String>> {
+    reconcile_session_id(session_id, headers)
+        .map_err(|error| PyValueError::new_err(error.to_string()))
 }
 
 fn metadata_headers_from_python(

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -25,9 +25,10 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::{json, Value};
 use switchyard_components_v2::{
-    parse_profile_config_path, profile_stats_accumulator, ProfileConfigPlan, ProfileInput,
-    ProfileResponse, RelaySnapshotAccumulator, RelaySnapshotLimits, RequestMetadata,
-    RoutingMetadata, RoutingRequest,
+    parse_profile_config_path, profile_stats_accumulator, session_id_from_normalized_headers,
+    DecisionContext, ProfileConfigPlan, ProfileInput, ProfileResponse, RelayIdentityKey,
+    RelaySnapshotAccumulator, RelaySnapshotLimits, RequestMetadata, RoutingMetadata,
+    RoutingRequest, PROXY_SESSION_ID_HEADER, RELAY_SESSION_ID_HEADER,
 };
 use switchyard_core::{ChatRequest, ChatRequestType, RequestId, Result, SwitchyardError};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
@@ -75,7 +76,8 @@ impl ServerState {
         Ok(Self::new(ProfileRegistry::from_plan(plan)?))
     }
 
-    /// Returns a copy with optional auth; explicit blank tokens are invalid config.
+    /// Returns a copy with optional bearer auth for Relay decision and ATOF routes;
+    /// explicit blank tokens are invalid config.
     pub fn with_atof_bearer_token(mut self, token: Option<String>) -> Result<Self> {
         self.atof_bearer_token = Arc::new(validate_optional_bearer_token(token)?);
         Ok(self)
@@ -108,11 +110,26 @@ impl ServerState {
         &self,
         request: RoutingRequest,
     ) -> Result<switchyard_components_v2::RoutingDecision> {
-        self.registry.decide(request).await
+        request.validate()?;
+        let owner_id = request
+            .identity
+            .owner_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|owner_id| !owner_id.is_empty())
+            .map(ToOwned::to_owned);
+        let key = RelayIdentityKey::new(request.identity.session_id.trim(), owner_id);
+        let snapshot = self.relay_snapshots.snapshot(&key);
+        self.registry
+            .decide(DecisionContext::new(request, snapshot))
+            .await
     }
 
-    /// Allows unauthenticated ingestion only when no bearer token was configured.
-    fn authorize_atof_ingest(&self, headers: &HeaderMap) -> std::result::Result<(), Box<Response>> {
+    /// Authorizes Relay routes when a bearer token is configured.
+    fn authorize_relay_request(
+        &self,
+        headers: &HeaderMap,
+    ) -> std::result::Result<(), Box<Response>> {
         let Some(expected) = self.atof_bearer_token.as_ref() else {
             return Ok(());
         };
@@ -125,7 +142,7 @@ impl ServerState {
             Ok(())
         } else {
             Err(Box::new(unauthorized_error(
-                "ATOF ingestion authorization failed",
+                "Relay request authorization failed",
             )))
         }
     }
@@ -253,11 +270,15 @@ async fn openai_chat_completions(
         Ok(body) => body,
         Err(response) => return *response,
     };
+    let metadata = match metadata_from_headers(&headers, ChatRequestType::OpenAiChat) {
+        Ok(metadata) => metadata,
+        Err(error) => return llm_error(error),
+    };
     handle_llm_request(
         state,
         ChatRequest::openai_chat(body),
         WireFormat::OpenAiChat,
-        metadata_from_headers(&headers, ChatRequestType::OpenAiChat),
+        metadata,
     )
     .await
 }
@@ -271,11 +292,15 @@ async fn anthropic_messages(
         Ok(body) => body,
         Err(response) => return *response,
     };
+    let metadata = match metadata_from_headers(&headers, ChatRequestType::Anthropic) {
+        Ok(metadata) => metadata,
+        Err(error) => return llm_error(error),
+    };
     handle_llm_request(
         state,
         ChatRequest::anthropic(body),
         WireFormat::AnthropicMessages,
-        metadata_from_headers(&headers, ChatRequestType::Anthropic),
+        metadata,
     )
     .await
 }
@@ -289,23 +314,47 @@ async fn openai_responses(
         Ok(body) => body,
         Err(response) => return *response,
     };
+    let metadata = match metadata_from_headers(&headers, ChatRequestType::OpenAiResponses) {
+        Ok(metadata) => metadata,
+        Err(error) => return llm_error(error),
+    };
     handle_llm_request(
         state,
         ChatRequest::openai_responses(body),
         WireFormat::OpenAiResponses,
-        metadata_from_headers(&headers, ChatRequestType::OpenAiResponses),
+        metadata,
     )
     .await
 }
 
 async fn routing_decision(
     State(state): State<ServerState>,
+    headers: HeaderMap,
     body: std::result::Result<Json<RoutingRequest>, JsonRejection>,
 ) -> Response {
+    if let Err(response) = state.authorize_relay_request(&headers) {
+        return *response;
+    }
     let request = match routing_json_body(body) {
         Ok(request) => request,
         Err(response) => return *response,
     };
+    let normalized_headers = match normalized_headers(&headers) {
+        Ok(headers) => headers,
+        Err(error) => return llm_error(error),
+    };
+    let header_session_id = match session_id_from_normalized_headers(&normalized_headers) {
+        Ok(session_id) => session_id,
+        Err(error) => return llm_error(error),
+    };
+    if let Some(header_session_id) = header_session_id {
+        if header_session_id != request.identity.session_id.trim() {
+            return llm_error(SwitchyardError::InvalidRequest(format!(
+                "Decision session header {header_session_id:?} does not match identity.session_id {:?}",
+                request.identity.session_id
+            )));
+        }
+    }
     match state.decide_route(request).await {
         Ok(decision) => Json(decision).into_response(),
         Err(error) => llm_error(error),
@@ -326,7 +375,7 @@ fn routing_json_body(
 /// Accepts bounded Relay `http_post` batches encoded as one JSON object per line.
 async fn atof_events(State(state): State<ServerState>, request: Request) -> Response {
     let (parts, body) = request.into_parts();
-    if let Err(response) = state.authorize_atof_ingest(&parts.headers) {
+    if let Err(response) = state.authorize_relay_request(&parts.headers) {
         return *response;
     }
     if !is_ndjson_content_type(&parts.headers) {
@@ -538,12 +587,17 @@ fn sanitize_routing_header_value(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.chars().take(MAX_ROUTING_HEADER_VALUE_LEN).collect())
 }
 
-fn metadata_from_headers(headers: &HeaderMap, inbound_format: ChatRequestType) -> RequestMetadata {
-    RequestMetadata {
+fn metadata_from_headers(
+    headers: &HeaderMap,
+    inbound_format: ChatRequestType,
+) -> Result<RequestMetadata> {
+    let normalized = normalized_headers(headers)?;
+    Ok(RequestMetadata {
+        session_id: session_id_from_normalized_headers(&normalized)?,
         request_id: request_id_from_headers(headers),
         inbound_format: Some(inbound_format),
-        headers: normalized_headers(headers),
-    }
+        headers: normalized,
+    })
 }
 
 fn request_id_from_headers(headers: &HeaderMap) -> Option<RequestId> {
@@ -553,18 +607,32 @@ fn request_id_from_headers(headers: &HeaderMap) -> Option<RequestId> {
         .and_then(|value| RequestId::new(value.to_string()).ok())
 }
 
-fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, Vec<String>> {
+fn normalized_headers(headers: &HeaderMap) -> Result<BTreeMap<String, Vec<String>>> {
     let mut normalized = BTreeMap::<String, Vec<String>>::new();
-    for (name, value) in headers {
-        let Ok(value) = value.to_str() else {
-            continue;
-        };
-        normalized
-            .entry(name.as_str().to_ascii_lowercase())
-            .or_default()
-            .push(value.to_string());
+    for name in headers.keys() {
+        let name = name.as_str().to_ascii_lowercase();
+        for value in headers.get_all(name.as_str()) {
+            let value = match value.to_str() {
+                Ok(value) => value,
+                Err(_)
+                    if matches!(
+                        name.as_str(),
+                        PROXY_SESSION_ID_HEADER | RELAY_SESSION_ID_HEADER
+                    ) =>
+                {
+                    return Err(SwitchyardError::InvalidRequest(format!(
+                        "session header {name} must contain valid UTF-8"
+                    )));
+                }
+                Err(_) => continue,
+            };
+            normalized
+                .entry(name.clone())
+                .or_default()
+                .push(value.to_string());
+        }
     }
-    normalized
+    Ok(normalized)
 }
 
 fn llm_error(error: SwitchyardError) -> Response {

--- a/crates/switchyard-server/src/registry.rs
+++ b/crates/switchyard-server/src/registry.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use switchyard_components_v2::{
-    PassthroughProfileConfig, Profile, ProfileConfig, ProfileConfigPlan, RoutingDecision,
-    RoutingRequest,
+    DecisionContext, PassthroughProfileConfig, Profile, ProfileConfig, ProfileConfigPlan,
+    RoutingDecision,
 };
 use switchyard_core::{ModelId, ProfileId, Result, SwitchyardError};
 
@@ -111,16 +111,16 @@ impl ProfileRegistry {
     }
 
     /// Produces a decision through the configured profile runtime with the requested ID.
-    pub async fn decide(&self, request: RoutingRequest) -> Result<RoutingDecision> {
-        request.validate()?;
-        let profile_id = request.decision_profile.profile_id.clone();
+    pub async fn decide(&self, context: DecisionContext) -> Result<RoutingDecision> {
+        context.request().validate()?;
+        let profile_id = context.request().decision_profile.profile_id.clone();
         let profile = self
             .decision_profiles
             .iter()
             .find(|entry| entry.id == profile_id)
             .map(|entry| Arc::clone(&entry.profile))
             .ok_or(SwitchyardError::DecisionProfileNotFound { profile_id })?;
-        profile.decide(request).await
+        profile.decide(context).await
     }
 
     /// Returns model entries in deterministic registration order.

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -1179,7 +1179,7 @@ profiles:
     assert_eq!(response.status(), StatusCode::OK);
     for (name, expected) in [
         ("x-model-router-selected-model", "upstream-efficient"),
-        ("x-model-router-selected-tier", "efficient"),
+        ("x-model-router-selected-tier", "weak"),
         ("x-model-router-version", "random-routing:v1"),
         ("x-model-router-tolerance", "0.0000004"),
     ] {

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -142,7 +142,11 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
         .oneshot(request(
             "POST",
             "/v1/routing/decision",
-            Some(routing_request_json("remote-stage_router", "summary_only", None)),
+            Some(routing_request_json(
+                "remote-stage_router",
+                "summary_only",
+                None,
+            )),
         )?)
         .await?;
     assert_eq!(warm.status(), StatusCode::OK);
@@ -171,7 +175,8 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
 }
 
 #[tokio::test]
-async fn stage_router_decision_uses_exact_owner_identity_and_keeps_turn_only_state_cold() -> TestResult {
+async fn stage_router_decision_uses_exact_owner_identity_and_keeps_turn_only_state_cold(
+) -> TestResult {
     let state = state_from_yaml(stage_router_decision_yaml())?;
     let app = build_switchyard_router(state);
     let owner_event = tool_event(

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -11,13 +11,14 @@ use std::thread;
 
 use async_trait::async_trait;
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use switchyard_components_v2::{
     parse_profile_config_str, profile_stats_accumulator, Profile, ProfileConfigFormat,
     ProfileInput, ProfileResponse, RelayIdentityKey, RelaySnapshotLimits, RoutingMetadata,
-    ROUTING_DECISION_SCHEMA_VERSION, ROUTING_REQUEST_SCHEMA_VERSION,
+    PROXY_SESSION_ID_HEADER, RELAY_SESSION_ID_HEADER, ROUTING_DECISION_SCHEMA_VERSION,
+    ROUTING_REQUEST_SCHEMA_VERSION,
 };
 use switchyard_core::{
     ChatRequestType, ChatResponse, ModelId, Result, StreamEvent, SwitchyardError,
@@ -78,19 +79,19 @@ async fn decision_endpoint_uses_configured_random_profile_without_backend_dispat
     let app = build_switchyard_router(state_from_yaml(
         r#"
 targets:
-  strong:
-    model: upstream-strong
+  capable:
+    model: upstream-capable
     format: openai
     base_url: http://127.0.0.1:1/v1
-  weak:
-    model: upstream-weak
+  efficient:
+    model: upstream-efficient
     format: responses
     base_url: http://127.0.0.1:1/v1
 profiles:
   remote-random:
     type: random-routing
-    strong: strong
-    weak: weak
+    strong: capable
+    weak: efficient
     strong_probability: 1.0
     rng_seed: 7
 "#,
@@ -108,9 +109,225 @@ profiles:
     let decision = json_body(response).await?;
     assert_eq!(decision["schema_version"], ROUTING_DECISION_SCHEMA_VERSION);
     assert_eq!(decision["router"]["name"], "random-routing");
-    assert_eq!(decision["route"]["backend_id"], "strong");
-    assert_eq!(decision["route"]["target_model"], "upstream-strong");
+    assert_eq!(decision["route"]["backend_id"], "capable");
+    assert_eq!(decision["route"]["target_model"], "upstream-capable");
     assert_eq!(decision["route"]["target_protocol_profile"], "openai_chat");
+    Ok(())
+}
+
+#[tokio::test]
+async fn stage_router_decision_warms_from_one_relay_record_without_target_dispatch() -> TestResult {
+    let state = state_from_yaml(stage_router_decision_yaml())?;
+    let app = build_switchyard_router(state);
+    let event = tool_event(
+        "decision-oom",
+        "end",
+        Some("session-1"),
+        None,
+        json!({"output": "process failed: out of memory"}),
+    );
+
+    let ingest = app
+        .clone()
+        .oneshot(ndjson_request(&format!("{event}\n"), None)?)
+        .await?;
+    assert_eq!(ingest.status(), StatusCode::OK);
+    assert_eq!(json_body(ingest).await?["accepted_events"], 1);
+
+    // The legacy Relay fixture includes decision_profile.router and intentionally
+    // sends no session header. Both selected targets are unreachable; a 200 proves
+    // the decision-only path did not dispatch either target.
+    let warm = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json("remote-stage_router", "summary_only", None)),
+        )?)
+        .await?;
+    assert_eq!(warm.status(), StatusCode::OK);
+    let warm = json_body(warm).await?;
+    assert_eq!(warm["router"]["name"], "stage_router");
+    assert_eq!(warm["route"]["backend_id"], "capable");
+    assert_eq!(warm["route"]["target_model"], "provider/capable");
+    assert_eq!(warm["reason_code"], "override");
+    assert_eq!(warm["confidence"], 1.0);
+    assert_eq!(warm["metadata"]["feature_state"], "fresh");
+    assert_eq!(warm["metadata"]["source"], "override");
+
+    let mut cold_request = routing_request_json("remote-stage_router", "summary_only", None);
+    cold_request["identity"]["session_id"] = json!("different-session");
+    let cold = app
+        .oneshot(request("POST", "/v1/routing/decision", Some(cold_request))?)
+        .await?;
+    assert_eq!(cold.status(), StatusCode::OK);
+    let cold = json_body(cold).await?;
+    assert_eq!(cold["route"]["backend_id"], "efficient");
+    assert_eq!(cold["reason_code"], "stage_router_feature_cold_default");
+    assert!(cold["confidence"].is_null());
+    assert_eq!(cold["metadata"]["feature_state"], "cold");
+    assert_eq!(cold["metadata"]["source"], "fall_open");
+    Ok(())
+}
+
+#[tokio::test]
+async fn stage_router_decision_uses_exact_owner_identity_and_keeps_turn_only_state_cold() -> TestResult {
+    let state = state_from_yaml(stage_router_decision_yaml())?;
+    let app = build_switchyard_router(state);
+    let owner_event = tool_event(
+        "owner-oom",
+        "end",
+        Some("owner-session"),
+        Some("owner-a"),
+        json!({"output": "CUDA out of memory"}),
+    );
+    let session_only_event = tool_event(
+        "session-oom",
+        "end",
+        Some("owner-session"),
+        None,
+        json!({"output": "CUDA out of memory"}),
+    );
+    let turn_only = turn_event("turn-only-start", "turn-session", None);
+    for event in [owner_event, session_only_event, turn_only] {
+        let response = app
+            .clone()
+            .oneshot(ndjson_request(&format!("{event}\n"), None)?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let mut exact = routing_request_json("remote-stage_router", "summary_only", None);
+    exact["identity"]["session_id"] = json!("owner-session");
+    exact["identity"]["owner_id"] = json!("owner-a");
+    let exact = app
+        .clone()
+        .oneshot(request("POST", "/v1/routing/decision", Some(exact))?)
+        .await?;
+    assert_eq!(
+        json_body(exact).await?["metadata"]["feature_state"],
+        "fresh"
+    );
+
+    let mut padded_owner = routing_request_json("remote-stage_router", "summary_only", None);
+    padded_owner["identity"]["session_id"] = json!("owner-session");
+    padded_owner["identity"]["owner_id"] = json!(" owner-a ");
+
+    let mut session_only = routing_request_json("remote-stage_router", "summary_only", None);
+    session_only["identity"]["session_id"] = json!("owner-session");
+
+    let mut blank_owner = session_only.clone();
+    blank_owner["identity"]["owner_id"] = json!("   ");
+
+    for canonical_match in [padded_owner, session_only, blank_owner] {
+        let response = app
+            .clone()
+            .oneshot(request(
+                "POST",
+                "/v1/routing/decision",
+                Some(canonical_match),
+            )?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            json_body(response).await?["metadata"]["feature_state"],
+            "fresh"
+        );
+    }
+
+    let mut owner_mismatch = routing_request_json("remote-stage_router", "summary_only", None);
+    owner_mismatch["identity"]["session_id"] = json!("owner-session");
+    owner_mismatch["identity"]["owner_id"] = json!("owner-b");
+    owner_mismatch["identity"]["parent_scope_id"] = json!("owner-a");
+    owner_mismatch["identity"]["root_scope_id"] = json!("owner-a");
+
+    let mut turn_only = routing_request_json("remote-stage_router", "summary_only", None);
+    turn_only["identity"]["session_id"] = json!("turn-session");
+
+    for cold_request in [owner_mismatch, turn_only] {
+        let response = app
+            .clone()
+            .oneshot(request("POST", "/v1/routing/decision", Some(cold_request))?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let decision = json_body(response).await?;
+        assert_eq!(decision["route"]["backend_id"], "efficient");
+        assert_eq!(decision["reason_code"], "stage_router_feature_cold_default");
+        assert_eq!(decision["metadata"]["feature_state"], "cold");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_reconciles_all_session_header_aliases() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(random_decision_yaml())?);
+    let accepted: Vec<Vec<(&'static str, &'static [u8])>> = vec![
+        vec![(PROXY_SESSION_ID_HEADER, b"session-1")],
+        vec![(RELAY_SESSION_ID_HEADER, b"session-1")],
+        vec![
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+            (RELAY_SESSION_ID_HEADER, b"session-1"),
+        ],
+        vec![
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+        ],
+        vec![(RELAY_SESSION_ID_HEADER, b" session-1 ")],
+    ];
+
+    for headers in accepted {
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/v1/routing/decision",
+                Some(routing_request_json("remote-random", "none", None)),
+                &headers,
+            )?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK, "headers={headers:?}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_rejects_invalid_or_conflicting_session_headers() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(random_decision_yaml())?);
+    let rejected: Vec<Vec<(&'static str, &'static [u8])>> = vec![
+        vec![
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+            (RELAY_SESSION_ID_HEADER, b"session-2"),
+        ],
+        vec![
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+            (PROXY_SESSION_ID_HEADER, b"session-2"),
+        ],
+        vec![(PROXY_SESSION_ID_HEADER, b"")],
+        vec![(RELAY_SESSION_ID_HEADER, b"   ")],
+        vec![(PROXY_SESSION_ID_HEADER, b"different-session")],
+        vec![(RELAY_SESSION_ID_HEADER, b"\xff")],
+    ];
+
+    for headers in rejected {
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/v1/routing/decision",
+                Some(routing_request_json("remote-random", "none", None)),
+                &headers,
+            )?)
+            .await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "headers={headers:?}"
+        );
+        assert_eq!(
+            json_body(response).await?["error"]["code"],
+            "invalid_request_error"
+        );
+    }
     Ok(())
 }
 
@@ -153,12 +370,12 @@ async fn decision_endpoint_classifies_materialized_llm_request_without_target_di
     let app = build_switchyard_router(state_from_yaml(&format!(
         r#"
 targets:
-  strong:
-    model: upstream-strong
+  capable:
+    model: upstream-capable
     format: openai
     base_url: http://127.0.0.1:1/v1
-  weak:
-    model: upstream-weak
+  efficient:
+    model: upstream-efficient
     format: openai
     base_url: http://127.0.0.1:1/v1
   classifier:
@@ -168,10 +385,10 @@ targets:
 profiles:
   remote-llm:
     type: llm-routing
-    strong: strong
-    weak: weak
+    strong: capable
+    weak: efficient
     classifier: classifier
-    fallback_target_on_evict: strong
+    fallback_target_on_evict: capable
     profile_name: coding_agent
     classifier_min_confidence: 0.0
 "#,
@@ -198,7 +415,7 @@ profiles:
     assert_eq!(response.status(), StatusCode::OK);
     let decision = json_body(response).await?;
     assert_eq!(decision["router"]["name"], "llm-routing");
-    assert_eq!(decision["route"]["backend_id"], "strong");
+    assert_eq!(decision["route"]["backend_id"], "capable");
     assert_eq!(decision["confidence"], 0.95);
     assert_eq!(classifier.requests()?.len(), 1);
     Ok(())
@@ -321,17 +538,17 @@ async fn decision_endpoint_rejects_unknown_inbound_before_unknown_profile_lookup
     let app = build_switchyard_router(state_from_yaml(
         r#"
 targets:
-  strong:
-    model: upstream-strong
+  capable:
+    model: upstream-capable
     format: openai
-  weak:
-    model: upstream-weak
+  efficient:
+    model: upstream-efficient
     format: openai
 profiles:
   remote-random:
     type: random-routing
-    strong: strong
-    weak: weak
+    strong: capable
+    weak: efficient
     strong_probability: 1.0
 "#,
     )?);
@@ -356,11 +573,11 @@ async fn llm_decision_rejects_summary_only_materialization_before_classifier_cal
     let app = build_switchyard_router(state_from_yaml(
         r#"
 targets:
-  strong:
-    model: upstream-strong
+  capable:
+    model: upstream-capable
     format: openai
-  weak:
-    model: upstream-weak
+  efficient:
+    model: upstream-efficient
     format: openai
   classifier:
     model: classifier-model
@@ -369,10 +586,10 @@ targets:
 profiles:
   remote-llm:
     type: llm-routing
-    strong: strong
-    weak: weak
+    strong: capable
+    weak: efficient
     classifier: classifier
-    fallback_target_on_evict: strong
+    fallback_target_on_evict: capable
     profile_name: coding_agent
 "#,
     )?);
@@ -562,6 +779,63 @@ profiles:
         .oneshot(ndjson_request(&body, Some("bearer expected-token"))?)
         .await?;
     assert_eq!(accepted.status(), StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn decision_endpoint_enforces_relay_bearer_token_end_to_end() -> TestResult {
+    let state = state_from_yaml(
+        r#"
+targets:
+  capable:
+    model: upstream-capable
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  efficient:
+    model: upstream-efficient
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+profiles:
+  remote-random:
+    type: random-routing
+    strong: capable
+    weak: efficient
+    strong_probability: 1.0
+    rng_seed: 7
+"#,
+    )?
+    .with_atof_bearer_token(Some("expected-token".to_string()))?;
+    let app = build_switchyard_router(state);
+    let body = routing_request_json("remote-random", "none", None);
+
+    let missing = app
+        .clone()
+        .oneshot(request("POST", "/v1/routing/decision", Some(body.clone()))?)
+        .await?;
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(header(&missing, "www-authenticate"), Some("Bearer"));
+
+    let wrong = app
+        .clone()
+        .oneshot(request_with_headers(
+            "POST",
+            "/v1/routing/decision",
+            Some(body.clone()),
+            &[("authorization", b"Bearer wrong")],
+        )?)
+        .await?;
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+    let accepted = app
+        .oneshot(request_with_headers(
+            "POST",
+            "/v1/routing/decision",
+            Some(body),
+            &[("authorization", b"bearer expected-token")],
+        )?)
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    assert_eq!(json_body(accepted).await?["route"]["backend_id"], "capable");
     Ok(())
 }
 
@@ -873,19 +1147,19 @@ async fn random_routing_profile_reaches_selected_backend_path() -> TestResult {
     let app = build_switchyard_router(state_from_yaml(&format!(
         r#"
 targets:
-  strong:
-    model: upstream-strong
+  capable:
+    model: upstream-capable
     format: openai
     base_url: {base_url}
-  weak:
-    model: upstream-weak
+  efficient:
+    model: upstream-efficient
     format: openai
     base_url: {base_url}
 profiles:
   random:
     type: random-routing
-    strong: strong
-    weak: weak
+    strong: capable
+    weak: efficient
     strong_probability: 0.0000004
     rng_seed: 7
 "#,
@@ -904,8 +1178,8 @@ profiles:
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
     for (name, expected) in [
-        ("x-model-router-selected-model", "upstream-weak"),
-        ("x-model-router-selected-tier", "weak"),
+        ("x-model-router-selected-model", "upstream-efficient"),
+        ("x-model-router-selected-tier", "efficient"),
         ("x-model-router-version", "random-routing:v1"),
         ("x-model-router-tolerance", "0.0000004"),
     ] {
@@ -916,7 +1190,7 @@ profiles:
 
     let seen = stub.requests()?;
     assert_eq!(seen.len(), 1);
-    assert_eq!(seen[0]["model"], "upstream-weak");
+    assert_eq!(seen[0]["model"], "upstream-efficient");
     Ok(())
 }
 
@@ -988,7 +1262,7 @@ profiles:
 async fn stats_endpoints_use_components_v2_global_accumulator() -> TestResult {
     let _stats_guard = stats_guard().await;
     reset_stats()?;
-    profile_stats_accumulator().record_success("served-model", Some(12.0), Some("strong"))?;
+    profile_stats_accumulator().record_success("served-model", Some(12.0), Some("capable"))?;
     let app = build_switchyard_router(state_from_yaml(
         r#"
 profiles:
@@ -1055,7 +1329,7 @@ async fn openai_streams_include_routing_metadata_headers() -> TestResult {
             kind: StreamKind::OpenAi,
             routing_metadata: Some(RoutingMetadata {
                 selected_model: Some("served-model".to_string()),
-                selected_tier: Some("weak".to_string()),
+                selected_tier: Some("efficient".to_string()),
                 confidence: Some(0.0000004),
                 router_version: Some("test-router:v1".to_string()),
                 tolerance: Some(0.0000004),
@@ -1129,22 +1403,22 @@ async fn endpoint_metadata_is_passed_to_profiles() -> TestResult {
     )?);
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/messages")
-                .header("content-type", "application/json")
-                .header("X-Request-ID", "req-123")
-                .header("X-Switchyard-Trace", "trace-a")
-                .body(Body::from(
-                    json!({
-                        "model": "capture",
-                        "max_tokens": 16,
-                        "messages": [{"role": "user", "content": "hi"}],
-                    })
-                    .to_string(),
-                ))?,
-        )
+        .oneshot(request_with_headers(
+            "POST",
+            "/v1/messages",
+            Some(json!({
+                "model": "capture",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hi"}],
+            })),
+            &[
+                ("x-request-id", b"req-123"),
+                ("x-switchyard-trace", b"trace-a"),
+                (PROXY_SESSION_ID_HEADER, b" session-normal "),
+                (PROXY_SESSION_ID_HEADER, b"session-normal"),
+                (RELAY_SESSION_ID_HEADER, b"session-normal"),
+            ],
+        )?)
         .await?;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -1162,6 +1436,15 @@ async fn endpoint_metadata_is_passed_to_profiles() -> TestResult {
         input.metadata.inbound_format,
         Some(ChatRequestType::Anthropic)
     );
+    assert_eq!(input.metadata.session_id.as_deref(), Some("session-normal"));
+    assert_eq!(
+        input
+            .metadata
+            .headers
+            .get(PROXY_SESSION_ID_HEADER)
+            .map(Vec::as_slice),
+        Some(&[" session-normal ".to_string(), "session-normal".to_string()][..])
+    );
     assert_eq!(
         input
             .metadata
@@ -1170,6 +1453,50 @@ async fn endpoint_metadata_is_passed_to_profiles() -> TestResult {
             .map(Vec::as_slice),
         Some(&["trace-a".to_string()][..])
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn inference_endpoint_rejects_invalid_or_conflicting_session_headers() -> TestResult {
+    let app = build_switchyard_router(state_from_yaml(
+        r#"
+profiles:
+  bench:
+    type: noop
+"#,
+    )?);
+    let rejected: Vec<Vec<(&'static str, &'static [u8])>> = vec![
+        vec![
+            (PROXY_SESSION_ID_HEADER, b"session-1"),
+            (RELAY_SESSION_ID_HEADER, b"session-2"),
+        ],
+        vec![
+            (RELAY_SESSION_ID_HEADER, b"session-1"),
+            (RELAY_SESSION_ID_HEADER, b"session-2"),
+        ],
+        vec![(PROXY_SESSION_ID_HEADER, b"")],
+        vec![(RELAY_SESSION_ID_HEADER, b"\xff")],
+    ];
+
+    for headers in rejected {
+        let response = app
+            .clone()
+            .oneshot(request_with_headers(
+                "POST",
+                "/v1/chat/completions",
+                Some(json!({
+                    "model": "bench",
+                    "messages": [{"role": "user", "content": "hi"}],
+                })),
+                &headers,
+            )?)
+            .await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "headers={headers:?}"
+        );
+    }
     Ok(())
 }
 
@@ -1239,7 +1566,7 @@ impl Profile for BadTranslationProfile {
             ChatResponse::openai_completion(json!("not an OpenAI response object")),
             RoutingMetadata {
                 selected_model: Some("bad-upstream".to_string()),
-                selected_tier: Some("weak".to_string()),
+                selected_tier: Some("efficient".to_string()),
                 router_version: Some("test-router:v1".to_string()),
                 ..RoutingMetadata::default()
             },
@@ -1476,6 +1803,67 @@ fn tool_event(
     })
 }
 
+fn turn_event(uuid: &str, session_id: &str, owner_id: Option<&str>) -> Value {
+    let mut metadata = serde_json::Map::from_iter([
+        ("hermes_session_id".to_string(), json!(session_id)),
+        ("nemo_relay_scope_role".to_string(), json!("turn")),
+    ]);
+    if let Some(owner_id) = owner_id {
+        metadata.insert("switchyard_owner_id".to_string(), json!(owner_id));
+    }
+    json!({
+        "kind": "scope",
+        "uuid": uuid,
+        "scope_category": "start",
+        "name": "turn",
+        "category": "agent",
+        "metadata": metadata,
+    })
+}
+
+fn stage_router_decision_yaml() -> &'static str {
+    r#"
+targets:
+  capable:
+    model: provider/capable
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  efficient:
+    model: provider/efficient
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+profiles:
+  remote-stage_router:
+    type: stage_router
+    capable: capable
+    efficient: efficient
+    fallback_target_on_evict: capable
+    picker: efficient_first
+    confidence_threshold: 0.7
+"#
+}
+
+fn random_decision_yaml() -> &'static str {
+    r#"
+targets:
+  capable:
+    model: provider/capable
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+  efficient:
+    model: provider/efficient
+    format: openai
+    base_url: http://127.0.0.1:1/v1
+profiles:
+  remote-random:
+    type: random-routing
+    strong: capable
+    weak: efficient
+    strong_probability: 1.0
+    rng_seed: 7
+"#
+}
+
 fn state_from_yaml(input: &str) -> TestResult<ServerState> {
     let plan = parse_profile_config_str(input, ProfileConfigFormat::Yaml)?.resolve()?;
     Ok(ServerState::from_plan(&plan)?)
@@ -1497,6 +1885,22 @@ fn request(method: &str, uri: &str, body: Option<Value>) -> TestResult<Request<B
         .header("content-type", "application/json");
     let body = body.map_or_else(Body::empty, |body| Body::from(body.to_string()));
     Ok(builder.body(body)?)
+}
+
+fn request_with_headers(
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    headers: &[(&'static str, &[u8])],
+) -> TestResult<Request<Body>> {
+    let mut request = request(method, uri, body)?;
+    for (name, value) in headers {
+        request.headers_mut().append(
+            HeaderName::from_static(name),
+            HeaderValue::from_bytes(value)?,
+        );
+    }
+    Ok(request)
 }
 
 fn raw_request(method: &str, uri: &str, body: &str) -> TestResult<Request<Body>> {

--- a/switchyard_rust/profiles.pyi
+++ b/switchyard_rust/profiles.pyi
@@ -47,6 +47,7 @@ class ProfileInput:
     ) -> None: ...
 
 class ProfileRequestMetadata:
+    session_id: str | None
     request_id: str | None
     inbound_format: ChatRequestType | None
     headers: dict[str, list[str]]
@@ -56,6 +57,7 @@ class ProfileRequestMetadata:
         request_id: str | None = None,
         inbound_format: ChatRequestType | str | None = None,
         headers: dict[str, str | list[str]] | None = None,
+        session_id: str | None = None,
     ) -> None: ...
     @classmethod
     def from_headers(

--- a/tests/test_switchyard_rust_profile_bindings.py
+++ b/tests/test_switchyard_rust_profile_bindings.py
@@ -144,15 +144,15 @@ targets:
     format: openai
     base_url: "{base_url}/direct/v1"
     api_key: test-key
-  capable:
-    model: provider/capable
+  strong:
+    model: provider/strong
     format: openai
-    base_url: "{base_url}/capable/v1"
+    base_url: "{base_url}/strong/v1"
     api_key: test-key
-  efficient:
-    model: provider/efficient
+  weak:
+    model: provider/weak
     format: openai
-    base_url: "{base_url}/efficient/v1"
+    base_url: "{base_url}/weak/v1"
     api_key: test-key
   latency:
     model: provider/latency
@@ -171,9 +171,9 @@ profiles:
     target: direct
   random:
     type: random-routing
-    capable: capable
-    efficient: efficient
-    capable_probability: 1.0
+    strong: strong
+    weak: weak
+    strong_probability: 1.0
     rng_seed: 7
   latency:
     type: latency-service
@@ -182,15 +182,15 @@ profiles:
     max_retries: 0
   llm:
     type: llm-routing
-    capable: capable
-    efficient: efficient
+    strong: strong
+    weak: weak
     classifier: classifier
     profile_name: coding_agent
   stage_router:
     type: stage_router
-    capable: capable
-    efficient: efficient
-    fallback_target_on_evict: capable
+    capable: strong
+    efficient: weak
+    fallback_target_on_evict: strong
     picker: capable_first
     confidence_threshold: 0.7
     classifier:
@@ -234,9 +234,9 @@ def test_profile_config_plan_is_inspectable() -> None:
     ]
     assert document.profile_type("direct") == "passthrough"
     assert document.profile_body("random") == {
-        "capable": "capable",
-        "efficient": "efficient",
-        "capable_probability": 1.0,
+        "strong": "strong",
+        "weak": "weak",
+        "strong_probability": 1.0,
         "rng_seed": 7,
     }
     rust_document = document.without_profiles(["random"])
@@ -253,7 +253,7 @@ def test_profile_config_plan_is_inspectable() -> None:
         "random",
         "stage_router",
     ]
-    assert plan.target_ids() == ["classifier", "direct", "latency", "capable", "efficient"]
+    assert plan.target_ids() == ["classifier", "direct", "latency", "strong", "weak"]
     assert plan.profile_type("direct") == "passthrough"
     assert plan.profile_type("random") == "random-routing"
     assert plan.profile_type("latency") == "latency-service"
@@ -327,22 +327,22 @@ async def test_native_profiles_run_against_local_openai_mock(
 
     assert direct_response.body["model"] == "provider/direct"
     assert direct_response.body["mock_path"] == "/direct/v1/chat/completions"
-    assert random_response.body["model"] == "provider/capable"
-    assert random_response.body["mock_path"] == "/capable/v1/chat/completions"
+    assert random_response.body["model"] == "provider/strong"
+    assert random_response.body["mock_path"] == "/strong/v1/chat/completions"
     assert latency_response.body["model"] == "provider/latency"
     assert latency_response.body["mock_path"] == "/latency/v1/chat/completions"
-    assert llm_response.body["model"] == "provider/efficient"
-    assert llm_response.body["mock_path"] == "/efficient/v1/chat/completions"
-    assert stage_router_response.body["model"] == "provider/efficient"
-    assert stage_router_response.body["mock_path"] == "/efficient/v1/chat/completions"
+    assert llm_response.body["model"] == "provider/weak"
+    assert llm_response.body["mock_path"] == "/weak/v1/chat/completions"
+    assert stage_router_response.body["model"] == "provider/weak"
+    assert stage_router_response.body["mock_path"] == "/weak/v1/chat/completions"
     assert [call["body"]["model"] for call in mock_openai_server.calls] == [
         "provider/direct",
-        "provider/capable",
+        "provider/strong",
         "provider/latency",
         "provider/classifier",
-        "provider/efficient",
+        "provider/weak",
         "provider/classifier",
-        "provider/efficient",
+        "provider/weak",
     ]
     llm_classifier_body = mock_openai_server.calls[3]["body"]
     assert llm_classifier_body["tools"][0]["function"]["strict"] is True

--- a/tests/test_switchyard_rust_profile_bindings.py
+++ b/tests/test_switchyard_rust_profile_bindings.py
@@ -144,15 +144,15 @@ targets:
     format: openai
     base_url: "{base_url}/direct/v1"
     api_key: test-key
-  strong:
-    model: provider/strong
+  capable:
+    model: provider/capable
     format: openai
-    base_url: "{base_url}/strong/v1"
+    base_url: "{base_url}/capable/v1"
     api_key: test-key
-  weak:
-    model: provider/weak
+  efficient:
+    model: provider/efficient
     format: openai
-    base_url: "{base_url}/weak/v1"
+    base_url: "{base_url}/efficient/v1"
     api_key: test-key
   latency:
     model: provider/latency
@@ -171,9 +171,9 @@ profiles:
     target: direct
   random:
     type: random-routing
-    strong: strong
-    weak: weak
-    strong_probability: 1.0
+    capable: capable
+    efficient: efficient
+    capable_probability: 1.0
     rng_seed: 7
   latency:
     type: latency-service
@@ -182,15 +182,15 @@ profiles:
     max_retries: 0
   llm:
     type: llm-routing
-    strong: strong
-    weak: weak
+    capable: capable
+    efficient: efficient
     classifier: classifier
     profile_name: coding_agent
   stage_router:
     type: stage_router
-    capable: strong
-    efficient: weak
-    fallback_target_on_evict: strong
+    capable: capable
+    efficient: efficient
+    fallback_target_on_evict: capable
     picker: capable_first
     confidence_threshold: 0.7
     classifier:
@@ -234,9 +234,9 @@ def test_profile_config_plan_is_inspectable() -> None:
     ]
     assert document.profile_type("direct") == "passthrough"
     assert document.profile_body("random") == {
-        "strong": "strong",
-        "weak": "weak",
-        "strong_probability": 1.0,
+        "capable": "capable",
+        "efficient": "efficient",
+        "capable_probability": 1.0,
         "rng_seed": 7,
     }
     rust_document = document.without_profiles(["random"])
@@ -253,7 +253,7 @@ def test_profile_config_plan_is_inspectable() -> None:
         "random",
         "stage_router",
     ]
-    assert plan.target_ids() == ["classifier", "direct", "latency", "strong", "weak"]
+    assert plan.target_ids() == ["classifier", "direct", "latency", "capable", "efficient"]
     assert plan.profile_type("direct") == "passthrough"
     assert plan.profile_type("random") == "random-routing"
     assert plan.profile_type("latency") == "latency-service"
@@ -327,22 +327,22 @@ async def test_native_profiles_run_against_local_openai_mock(
 
     assert direct_response.body["model"] == "provider/direct"
     assert direct_response.body["mock_path"] == "/direct/v1/chat/completions"
-    assert random_response.body["model"] == "provider/strong"
-    assert random_response.body["mock_path"] == "/strong/v1/chat/completions"
+    assert random_response.body["model"] == "provider/capable"
+    assert random_response.body["mock_path"] == "/capable/v1/chat/completions"
     assert latency_response.body["model"] == "provider/latency"
     assert latency_response.body["mock_path"] == "/latency/v1/chat/completions"
-    assert llm_response.body["model"] == "provider/weak"
-    assert llm_response.body["mock_path"] == "/weak/v1/chat/completions"
-    assert stage_router_response.body["model"] == "provider/weak"
-    assert stage_router_response.body["mock_path"] == "/weak/v1/chat/completions"
+    assert llm_response.body["model"] == "provider/efficient"
+    assert llm_response.body["mock_path"] == "/efficient/v1/chat/completions"
+    assert stage_router_response.body["model"] == "provider/efficient"
+    assert stage_router_response.body["mock_path"] == "/efficient/v1/chat/completions"
     assert [call["body"]["model"] for call in mock_openai_server.calls] == [
         "provider/direct",
-        "provider/strong",
+        "provider/capable",
         "provider/latency",
         "provider/classifier",
-        "provider/weak",
+        "provider/efficient",
         "provider/classifier",
-        "provider/weak",
+        "provider/efficient",
     ]
     llm_classifier_body = mock_openai_server.calls[3]["body"]
     assert llm_classifier_body["tools"][0]["function"]["strict"] is True
@@ -386,6 +386,89 @@ def test_profile_request_metadata_normalizes_headers() -> None:
         "x-request-id": ["req-123"],
         "x-switchyard-trace": ["trace-a", "trace-b"],
     }
+    assert metadata.session_id is None
+
+
+def test_profile_request_metadata_reconciles_explicit_and_header_session_id() -> None:
+    metadata = ProfileRequestMetadata(
+        request_id="req-session",
+        headers={
+            "Proxy_X_Session_Id": [" session-1 ", "session-1"],
+            "X-Nemo-Relay-Session-Id": "session-1",
+        },
+        session_id=" session-1 ",
+    )
+
+    assert metadata.session_id == "session-1"
+    assert metadata.to_dict() == {
+        "request_id": "req-session",
+        "inbound_format": None,
+        "headers": {
+            "proxy_x_session_id": [" session-1 ", "session-1"],
+            "x-nemo-relay-session-id": ["session-1"],
+        },
+        "session_id": "session-1",
+    }
+    assert repr(metadata) == (
+        'ProfileRequestMetadata(request_id=Some("req-session"), session_id=Some("session-1"))'
+    )
+
+
+def test_profile_request_metadata_from_headers_accepts_equal_session_aliases() -> None:
+    metadata = ProfileRequestMetadata.from_headers(
+        {
+            "Proxy_X_Session_Id": [" session-1 ", "session-1"],
+            "X-Nemo-Relay-Session-Id": "session-1",
+        }
+    )
+
+    assert metadata.session_id == "session-1"
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"proxy_x_session_id": ["session-1", "session-2"]},
+        {
+            "proxy_x_session_id": "session-1",
+            "x-nemo-relay-session-id": "session-2",
+        },
+    ],
+)
+def test_profile_request_metadata_rejects_conflicting_session_headers(
+    headers: dict[str, str | list[str]],
+) -> None:
+    with pytest.raises(ValueError, match="conflicting session IDs"):
+        ProfileRequestMetadata.from_headers(headers)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"proxy_x_session_id": ""},
+        {"x-nemo-relay-session-id": "   "},
+        {"proxy_x_session_id": ["session-1", ""]},
+        {"x-nemo-relay-session-id": []},
+    ],
+)
+def test_profile_request_metadata_rejects_empty_session_headers(
+    headers: dict[str, str | list[str]],
+) -> None:
+    with pytest.raises(ValueError, match="non-empty session ID"):
+        ProfileRequestMetadata.from_headers(headers)
+
+
+def test_profile_request_metadata_rejects_explicit_header_session_conflict() -> None:
+    with pytest.raises(ValueError, match="conflicting session IDs"):
+        ProfileRequestMetadata(
+            headers={"x-nemo-relay-session-id": "session-from-header"},
+            session_id="session-explicit",
+        )
+
+
+def test_profile_request_metadata_rejects_empty_explicit_session_id() -> None:
+    with pytest.raises(ValueError, match="non-empty session ID"):
+        ProfileRequestMetadata(session_id="   ")
 
 
 def test_profile_input_binding_wraps_request_and_metadata() -> None:
@@ -393,12 +476,14 @@ def test_profile_input_binding_wraps_request_and_metadata() -> None:
         request_id="req-profile-input",
         inbound_format=ChatRequestType.OPENAI_CHAT,
         headers={"X-Switchyard-Trace": "trace-profile-input"},
+        session_id="session-profile-input",
     )
 
     input = ProfileInput(_request("client/profile-input"), metadata=metadata)
 
     assert input.request.model == "client/profile-input"
     assert input.metadata.request_id == "req-profile-input"
+    assert input.metadata.session_id == "session-profile-input"
     assert input.metadata.inbound_format == ChatRequestType.OPENAI_CHAT
     assert input.metadata.headers == {"x-switchyard-trace": ["trace-profile-input"]}
 


### PR DESCRIPTION
## What

### Summary

Adds the third [NeMo Relay](https://github.com/NVIDIA/NeMo-Relay) integration layer on top of [#8](https://github.com/NVIDIA-NeMo/Switchyard/pull/8) and [#9](https://github.com/NVIDIA-NeMo/Switchyard/pull/9):

- an owned `DecisionContext` that carries the typed request and one immutable, exact Relay snapshot through the existing profile registry;
- Relay-aware Cascade decisions with typed `FeatureFreshness`, explicit cold-default behavior, and no selected-target dispatch;
- exact, canonicalized `(session_id, owner_id)` lookup without parent, root, or session-only fallback;
- unified typed session metadata for Decision, normal Rust endpoints, and Python profile calls;
- strict reconciliation of `proxy_x_session_id` and `x-nemo-relay-session-id`, including repeated-value, conflict, empty-value, invalid-UTF-8, and body/header mismatch handling.

This is the Cascade and request-metadata slice of a previous end-to-end implementation, split into a focused public-repository change.

## Why

The Decision API and router-neutral ATOF snapshots become end-to-end useful when an existing router can consume them safely. This PR lets Cascade route from Relay history while preserving its normal inference path, the single configured profile runtime, strict tenant/session isolation, and Relay's current body-only Decision identity behavior.

## How tested

### Testing summary

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p switchyard-components-v2` (70 unit tests plus 51 profile integration tests)
- [x] `cargo test -p switchyard-server` (1 CLI, 10 migration, and 32 server tests)
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard` (160 source files)
- [x] `uv run pytest tests/ -q -o addopts=` (1,880 passed, 50 skipped)
- [x] One-record Relay `http_post` ATOF ingestion followed by a body-only Decision request warms Cascade and returns a strong route while both selected target URLs are unreachable.
- [x] Cold state, turn-only state, exact owner isolation, padded/blank owner canonicalization, no owner/session fallback, header alias reconciliation, invalid UTF-8, turn-depth saturation, and unchanged normal Cascade dispatch are covered.

`cargo test -p switchyard-py` reaches the known macOS PyO3 cdylib link limitation (`undefined _Py*` symbols); the crate passes workspace check/clippy, and the binding behavior passes in the full 1,880-test Python suite.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A: Rust/Python functional API change.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: Rust symbols are exported from the crate root; the existing Python module exposes the extended metadata type.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (`DESIGN.md` documents decision-scoped resources and session metadata.)
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

### Dependency and delta

This PR depends on [#8](https://github.com/NVIDIA-NeMo/Switchyard/pull/8) and [#9](https://github.com/NVIDIA-NeMo/Switchyard/pull/9). Because the author has read-only access to the upstream repository, this draft must target upstream `main` and temporarily contains both prerequisite commits.

Review the #11 delta commits `2bb2abc0` (Cascade integration), `8425e3ab` (Decision bearer auth and E2E coverage), `c5701405` (envelope-validation coverage), and `ae5a982a` (shared Relay auth documentation), plus the bounded-memory/reporting fixes inherited from #9. Use the [exact fork delta](https://github.com/bbednarski9/Switchyard/compare/feature/relay-atof-snapshots...feature/relay-cascade-integration). After #9 merges, this branch will be rebased onto updated `main` so the PR contains only the Cascade/auth delta.

### Review guidelines

Suggested review order:

1. `decision.rs`, `profile.rs`, and `registry.rs` for the owned `DecisionContext`, typed freshness/session metadata, and same-runtime dispatch.
2. `profiles/cascade.rs` for snapshot projection, cold/fresh behavior, source accounting, and the decision-only no-dispatch boundary.
3. `switchyard-server` for exact canonical identity lookup and session-header/body reconciliation.
4. The PyO3 binding and stub for the append-only `session_id` argument and matching alias semantics.
5. Component and server tests for one-record ATOF-to-Decision behavior, isolation, and unchanged normal Cascade inference.

Fresh snapshots use Cascade's existing override/scorer/classifier policy. Missing or turn-only snapshots select the configured picker default immediately, report `cascade_feature_cold_default`, retain the existing `fall_open` source, omit confidence, and do not call the classifier or selected target.

### Previous feedback addressed

- Completes the requested three-PR split: Decision API contracts/profiles, ATOF subscriptions/accumulation, then Cascade and request-metadata integration.
- Keeps one server-owned router-neutral accumulator and the same configured `Arc<dyn Profile>` for inference and decisions; no parallel registry, duplicate runtime, or Cascade-owned event state is introduced.
- Replaces string-based freshness control flow with `Option<FeatureFreshness>` and an exhaustive `Fresh` match.
- Uses exact canonical `(session_id, owner_id)` lookup only. Parent/root scopes and session-only state cannot satisfy an owner-specific miss; padded owners normalize and blank owners match ownerless ATOF state.
- Preserves the previous implementation's full ATOF identity compatibility order implemented in #9 while making request-side identity canonical.
- Accepts Decision requests without a session header because Relay currently sends body identity; when either supported header is present, every value must agree with the body and with the other alias.
- Keeps legacy Relay's additive `decision_profile.router` field compatible while `profile_id` remains authoritative.
- Makes cold Cascade behavior explicit and deterministic, records its routing source, and preserves the existing normal `run()` signal extraction and selected-target dispatch path.
- Adds typed Rust/Python session metadata with an append-only Python constructor argument and matching conflict/empty-value validation.
- Avoids new fallible `.expect()`, `.unwrap()`, or panic paths in the integration code.

### Follow-up fixes

- Applies the configured Relay bearer token consistently to both ATOF ingestion and the Decision endpoint.
- Adds an end-to-end server test covering missing, invalid, and accepted Decision authorization.