### PR TITLE
chore: support deterministic routing tiers

### DIFF
--- a/switchyard/cli/route_bundle.py
+++ b/switchyard/cli/route_bundle.py
@@ -35,6 +35,7 @@ from switchyard.lib.backends.llm_target import LlmTarget, coerce_llm_target
 from switchyard.lib.config import LatencyServiceBackendConfig, LatencyServiceEndpoint
 from switchyard.lib.processors.llm_classifier import DEFAULT_MAX_REQUEST_CHARS
 from switchyard.lib.processors.llm_classifier.presets import PROFILE_FACTORIES
+from switchyard.lib.processors.llm_classifier.signals import RouteTier
 from switchyard.lib.profiles import (
     CascadeProfileConfig,
     DeterministicRoutingProfileConfig,
@@ -222,6 +223,9 @@ _DETERMINISTIC_ROUTE_KEYS = (
         "classifier",
         "strong",
         "weak",
+        "tiers",
+        "tier_mapping",
+        "default_tier",
         "profile",
         "enable_stats",
         "fallback_target_on_evict",
@@ -398,6 +402,13 @@ def routing_profile_model_ids(
         _add(route_id)
         if not isinstance(route, Mapping):
             continue
+        tiers = route.get("tiers")
+        if isinstance(tiers, Mapping):
+            for tier in tiers.values():
+                if isinstance(tier, Mapping):
+                    _add(tier.get("model"))
+                elif isinstance(tier, str):
+                    _add(tier)
         for tier_field in _USER_FACING_TIER_FIELDS:
             tier = route.get(tier_field)
             if isinstance(tier, Mapping):
@@ -734,14 +745,19 @@ def _merge_multi_target_discovery(
         metadata=_route_metadata(model_id, route, route_type),
     )
 
-    strong = _target_value(
-        route.get("strong"), target_defaults, default_id="strong", where="strong",
-    )
-    weak = _target_value(
-        route.get("weak"), target_defaults, default_id="weak", where="weak",
-    )
+    if route_type == "deterministic":
+        passthrough_targets = tuple(_deterministic_tiers(model_id, route, target_defaults).values())
+    else:
+        passthrough_targets = (
+            _target_value(
+                route.get("strong"), target_defaults, default_id="strong", where="strong",
+            ),
+            _target_value(
+                route.get("weak"), target_defaults, default_id="weak", where="weak",
+            ),
+        )
     sub_table = build_passthrough_table(
-        (strong, weak),
+        passthrough_targets,
         stats,
         enable_stats=_optional_bool(route.get("enable_stats"), default=True),
         discovery_fn=_default_discovery_fn,
@@ -904,23 +920,22 @@ def _deterministic_switchyard(
         where=f"{model_id}.classifier",
     )
 
-    strong = _target_value(
-        route.get("strong"), target_defaults, default_id="strong", where="strong",
-    )
-    weak = _target_value(
-        route.get("weak"), target_defaults, default_id="weak", where="weak",
-    )
+    tiers = _deterministic_tiers(model_id, route, target_defaults)
+    tier_mapping = _deterministic_tier_mapping(model_id, route)
+    default_tier = _optional_str(route.get("default_tier"))
+    if default_tier is None and tiers:
+        default_tier = "strong" if "strong" in tiers else next(iter(tiers))
 
-    fallback_target_on_evict = _required_str(
-        route.get("fallback_target_on_evict"),
-        f"{model_id}.fallback_target_on_evict",
+    fallback_target_on_evict = (
+        _optional_str(route.get("fallback_target_on_evict"))
+        or default_tier
     )
-    valid_ids = {strong.id, weak.id}
+    valid_ids = {target.id for target in tiers.values()}
     if fallback_target_on_evict not in valid_ids:
         raise RouteBundleConfigError(
             f"route {model_id!r}: fallback_target_on_evict="
             f"{fallback_target_on_evict!r} must match one of {sorted(valid_ids)} "
-            f"(the configured strong/weak target ids)",
+            f"(the configured deterministic target ids)",
         )
 
     profile_name = _optional_str(route.get("profile")) or "general"
@@ -931,8 +946,7 @@ def _deterministic_switchyard(
         )
 
     config_data: dict[str, object] = {
-        "strong": strong,
-        "weak": weak,
+        "tiers": tiers,
         "classifier": {
             "id": "classifier",
             "model": _required_str(
@@ -970,6 +984,10 @@ def _deterministic_switchyard(
         ),
         "enable_stats": _optional_bool(route.get("enable_stats"), default=True),
     }
+    if tier_mapping is not None:
+        config_data["tier_mapping"] = tier_mapping
+    if default_tier is not None:
+        config_data["default_tier"] = default_tier
     if "tier_timeout_s" in route:
         config_data["tier_timeout_s"] = _optional_float(
             route.get("tier_timeout_s"),
@@ -999,6 +1017,66 @@ def _deterministic_switchyard(
             response_processors=extra_response_processors,
         )
     )
+
+
+def _deterministic_tiers(
+    model_id: str,
+    route: Mapping[str, object],
+    target_defaults: Mapping[str, object],
+) -> dict[str, LlmTarget]:
+    raw_tiers = route.get("tiers")
+    if raw_tiers is not None:
+        tiers_mapping = _require_mapping(raw_tiers, f"{model_id}.tiers")
+        if not tiers_mapping:
+            raise RouteBundleConfigError(f"route {model_id!r}: tiers must not be empty")
+        return {
+            str(label): _target_value(
+                raw_target,
+                target_defaults,
+                default_id=str(label),
+                where=f"{model_id}.tiers.{label}",
+            )
+            for label, raw_target in tiers_mapping.items()
+        }
+
+    return {
+        "strong": _target_value(
+            route.get("strong"),
+            target_defaults,
+            default_id="strong",
+            where="strong",
+        ),
+        "weak": _target_value(
+            route.get("weak"),
+            target_defaults,
+            default_id="weak",
+            where="weak",
+        ),
+    }
+
+
+def _deterministic_tier_mapping(
+    model_id: str,
+    route: Mapping[str, object],
+) -> dict[RouteTier, str] | None:
+    raw_mapping = route.get("tier_mapping")
+    if raw_mapping is None:
+        return None
+    mapping = _require_mapping(raw_mapping, f"{model_id}.tier_mapping")
+    if not mapping:
+        raise RouteBundleConfigError(f"route {model_id!r}: tier_mapping must not be empty")
+    parsed: dict[RouteTier, str] = {}
+    for raw_tier, raw_target in mapping.items():
+        try:
+            tier = RouteTier(str(raw_tier))
+        except ValueError as exc:
+            raise RouteBundleConfigError(
+                f"route {model_id!r}: tier_mapping key {raw_tier!r} must be one of "
+                f"{[tier.value for tier in RouteTier]}"
+            ) from exc
+        target = _required_str(raw_target, f"{model_id}.tier_mapping.{raw_tier}")
+        parsed[tier] = target
+    return parsed
 
 
 def _cascade_switchyard(

--- a/switchyard/lib/processors/llm_classifier/presets.py
+++ b/switchyard/lib/processors/llm_classifier/presets.py
@@ -290,6 +290,8 @@ class LLMClassifierProfile:
     def make_tier_selector_config(
         self,
         *,
+        tier_mapping: Mapping[RouteTier, str] | None = None,
+        default_tier: str | None = None,
         min_confidence: float | None = None,
         escalate_on_tool_planning: bool | None = None,
         align_with_llm_recommendation: bool | None = None,
@@ -297,8 +299,8 @@ class LLMClassifierProfile:
     ) -> SignalTierSelectorConfig:
         """Return a :class:`SignalTierSelectorConfig` with this profile's mapping."""
         return SignalTierSelectorConfig(
-            tier_mapping=self.tier_mapping,
-            default_tier=self.default_tier,
+            tier_mapping=self.tier_mapping if tier_mapping is None else tier_mapping,
+            default_tier=self.default_tier if default_tier is None else default_tier,
             min_confidence=self.min_confidence if min_confidence is None else min_confidence,
             escalate_on_tool_planning=(
                 self.escalate_on_tool_planning

--- a/switchyard/lib/profiles/deterministic_routing_config.py
+++ b/switchyard/lib/profiles/deterministic_routing_config.py
@@ -18,6 +18,7 @@ from pydantic import (
 
 from switchyard.lib.backends.llm_target import LlmTarget, coerce_llm_target
 from switchyard.lib.processors.llm_classifier import DEFAULT_MAX_REQUEST_CHARS
+from switchyard.lib.processors.llm_classifier.signals import RouteTier
 
 ProfileName = Literal["general", "coding_agent", "openclaw"]
 DEFAULT_DETERMINISTIC_TIER_TIMEOUT_S = 600.0
@@ -84,8 +85,11 @@ class DeterministicRoutingConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    strong: LlmTarget
-    weak: LlmTarget
+    strong: LlmTarget | None = None
+    weak: LlmTarget | None = None
+    tiers: dict[str, LlmTarget] | None = None
+    tier_mapping: dict[RouteTier, str] | None = None
+    default_tier: str | None = None
     classifier: LlmTarget
     #: Target id the chain executor reroutes to when the picked target is
     #: evicted (e.g. context-window overflow). Must match either
@@ -117,12 +121,36 @@ class DeterministicRoutingConfig(BaseModel):
     def _coerce_target(cls, value: object, info: ValidationInfo) -> LlmTarget:
         return coerce_llm_target(value, default_id=info.field_name or "target")
 
+    @field_validator("tiers", mode="before")
+    @classmethod
+    def _coerce_tiers(cls, value: object) -> object:
+        if value is None:
+            return None
+        if not isinstance(value, dict) or not value:
+            raise ValueError("tiers must be a non-empty mapping")
+        return {
+            str(label): coerce_llm_target(target, default_id=str(label))
+            for label, target in value.items()
+        }
+
     @field_validator("strong", "weak", "classifier")
     @classmethod
-    def _target_model_non_empty(cls, tier: LlmTarget) -> LlmTarget:
+    def _target_model_non_empty(cls, tier: LlmTarget | None) -> LlmTarget | None:
+        if tier is None:
+            return None
         if not tier.model:
             raise ValueError("target.model must be a non-empty string")
         return tier
+
+    @field_validator("tiers")
+    @classmethod
+    def _tier_models_non_empty(cls, tiers: dict[str, LlmTarget] | None) -> dict[str, LlmTarget] | None:
+        if tiers is None:
+            return None
+        empty = [label for label, target in tiers.items() if not label or not target.model]
+        if empty:
+            raise ValueError(f"tiers must have non-empty labels and models: {empty}")
+        return tiers
 
     @field_validator("classifier_system_prompt", mode="before")
     @classmethod
@@ -134,24 +162,57 @@ class DeterministicRoutingConfig(BaseModel):
     @field_validator("fallback_target_on_evict")
     @classmethod
     def _fallback_matches_existing_target(cls, value: str, info: ValidationInfo) -> str:
-        valid_ids = {info.data[key].id for key in ("strong", "weak") if key in info.data}
+        valid_ids: set[str] = set()
+        tiers = info.data.get("tiers")
+        if isinstance(tiers, dict):
+            valid_ids.update(tier.id for tier in tiers.values())
+        valid_ids.update(
+            tier.id
+            for key in ("strong", "weak")
+            if (tier := info.data.get(key)) is not None
+        )
         if value not in valid_ids:
             raise ValueError(
                 f"fallback_target_on_evict={value!r} must match one of "
-                f"{sorted(valid_ids)} (the configured strong/weak target ids; "
+                f"{sorted(valid_ids)} (the configured routing target ids; "
                 f"the classifier target is not a routing candidate)"
             )
         return value
 
     @model_validator(mode="after")
-    def _affinity_capacity_nonzero_when_enabled(self) -> DeterministicRoutingConfig:
+    def _validate_routing_tiers(self) -> DeterministicRoutingConfig:
         # A zero-capacity affinity store retains nothing, which would silently
         # disable stickiness while still paying the per-request key cost.
         if self.session_affinity and self.affinity_max_sessions == 0:
             raise ValueError(
                 "affinity_max_sessions must be > 0 when session_affinity is enabled"
             )
+        if self.tiers is None:
+            if self.strong is None or self.weak is None:
+                raise ValueError("deterministic routing requires either tiers or both strong and weak")
+            tiers = {"strong": self.strong, "weak": self.weak}
+        else:
+            tiers = self.tiers
+        labels = set(tiers)
+        if not labels:
+            raise ValueError("deterministic routing requires at least one tier")
+        if self.default_tier is not None and self.default_tier not in labels:
+            raise ValueError(
+                f"default_tier {self.default_tier!r} must match one of {sorted(labels)}"
+            )
+        if self.tier_mapping is not None:
+            unknown = sorted(set(self.tier_mapping.values()) - labels)
+            if unknown:
+                raise ValueError(
+                    f"tier_mapping target labels {unknown} must match one of {sorted(labels)}"
+                )
         return self
+
+    def resolved_tiers(self) -> dict[str, LlmTarget]:
+        if self.tiers is not None:
+            return dict(self.tiers)
+        assert self.strong is not None and self.weak is not None
+        return {"strong": self.strong, "weak": self.weak}
 
 
 __all__ = [

--- a/switchyard/lib/profiles/deterministic_routing_profile_config.py
+++ b/switchyard/lib/profiles/deterministic_routing_profile_config.py
@@ -12,6 +12,7 @@ from switchyard.lib.processors.llm_classifier.presets import (
     PROFILE_FACTORIES,
     resolve_classifier_prompt,
 )
+from switchyard.lib.processors.llm_classifier.signals import RouteTier
 from switchyard.lib.profiles.chain import ComponentChainProfile
 from switchyard.lib.profiles.deterministic_routing_config import (
     DEFAULT_DETERMINISTIC_TIER_TIMEOUT_S,
@@ -56,9 +57,19 @@ class DeterministicRoutingProfileConfig:
         from switchyard.lib.session_affinity import SessionAffinity
 
         config = self.config
+        tier_targets = config.resolved_tiers()
+        default_tier = (
+            config.default_tier
+            or (_TIER_STRONG if _TIER_STRONG in tier_targets else next(iter(tier_targets)))
+        )
+        weak_label = _TIER_WEAK
+        strong_label = default_tier
+        if config.tier_mapping:
+            weak_label = config.tier_mapping.get(RouteTier.SIMPLE, _TIER_WEAK)
+            strong_label = config.tier_mapping.get(RouteTier.REASONING, default_tier)
         profile = PROFILE_FACTORIES[config.profile_name](
-            weak=_TIER_WEAK,
-            strong=_TIER_STRONG,
+            weak=weak_label,
+            strong=strong_label,
         )
 
         request_processors: list[Any] = [ReasoningEffortNormalizer()]
@@ -95,6 +106,8 @@ class DeterministicRoutingProfileConfig:
         request_processors.append(
             SignalTierSelectorRequestProcessor(
                 profile.make_tier_selector_config(
+                    tier_mapping=config.tier_mapping,
+                    default_tier=default_tier,
                     min_confidence=config.classifier_min_confidence,
                 ),
                 affinity=affinity,
@@ -104,37 +117,27 @@ class DeterministicRoutingProfileConfig:
         # Resolve format='auto' once after deterministic tier defaults are
         # applied so backend selection and Anthropic cache wrapping see the
         # same concrete target.
-        strong_target = resolve_llm_target(
-            _apply_deepseek_overrides(
-                _apply_default_tier_timeout(
-                    config.strong,
-                    config.tier_timeout_s,
+        resolved_targets = {
+            label: resolve_llm_target(
+                _apply_deepseek_overrides(
+                    _apply_default_tier_timeout(target, config.tier_timeout_s),
                 ),
-            ),
-        )
-        weak_target = resolve_llm_target(
-            _apply_deepseek_overrides(
-                _apply_default_tier_timeout(
-                    config.weak,
-                    config.tier_timeout_s,
-                ),
-            ),
-        )
-        strong_backend = maybe_wrap_anthropic_cache(
-            build_native_backend(strong_target),
-            strong_target,
-        )
-        weak_backend = maybe_wrap_anthropic_cache(
-            build_native_backend(weak_target),
-            weak_target,
-        )
+            )
+            for label, target in tier_targets.items()
+        }
 
         backend = DeterministicRoutingLLMBackend(
             tiers={
-                _TIER_STRONG: (strong_backend, strong_target.model),
-                _TIER_WEAK: (weak_backend, weak_target.model),
+                label: (
+                    maybe_wrap_anthropic_cache(
+                        build_native_backend(target),
+                        target,
+                    ),
+                    target.model,
+                )
+                for label, target in resolved_targets.items()
             },
-            default_tier=_TIER_STRONG,
+            default_tier=default_tier,
         )
         return ComponentChainProfile(
             request_processors=request_processors,

--- a/tests/test_route_bundle.py
+++ b/tests/test_route_bundle.py
@@ -813,6 +813,78 @@ class TestDeterministicRouteType:
             "nvidia/nemotron-3-super",
         ]
 
+    def test_deterministic_route_accepts_custom_tiers_and_mapping(self):
+        from switchyard.cli.route_bundle import build_route_bundle_table
+        from switchyard.lib.backends.deterministic_routing_llm_backend import (
+            DeterministicRoutingLLMBackend,
+        )
+        from switchyard.lib.processors.llm_classifier.signals import RouteTier
+        from switchyard.lib.processors.llm_classifier.tier_selector_request_processor import (
+            SignalTierSelectorRequestProcessor,
+        )
+
+        bundle = self._bundle()
+        route = bundle["routes"]["myrouter/llm-classifier"]
+        route.pop("strong")
+        route.pop("weak")
+        route["fallback_target_on_evict"] = "frontier"
+        route["default_tier"] = "spark"
+        route["tiers"] = {
+            "gpu": {
+                "model": "local-qwen",
+                "api_key": "sk-gpu",
+                "base_url": "https://gpu.invalid/v1",
+            },
+            "spark": {
+                "model": "spark-qwen",
+                "api_key": "sk-spark",
+                "base_url": "https://spark.invalid/v1",
+            },
+            "nim": {
+                "model": "nim-qwen",
+                "api_key": "sk-nim",
+                "base_url": "https://nim.invalid/v1",
+            },
+            "frontier": {
+                "model": "frontier-qwen",
+                "api_key": "sk-frontier",
+                "base_url": "https://frontier.invalid/v1",
+            },
+        }
+        route["tier_mapping"] = {
+            "simple": "gpu",
+            "medium": "spark",
+            "complex": "nim",
+            "reasoning": "frontier",
+        }
+
+        table = build_route_bundle_table(bundle)
+        assert table.registered_models() == [
+            "myrouter/llm-classifier",
+            "local-qwen",
+            "spark-qwen",
+            "nim-qwen",
+            "frontier-qwen",
+        ]
+
+        switchyard = table.lookup_switchyard("myrouter/llm-classifier")
+        backend = next(
+            c for c in switchyard.iter_components()
+            if isinstance(c, DeterministicRoutingLLMBackend)
+        )
+        selector = next(
+            c for c in switchyard.iter_components()
+            if isinstance(c, SignalTierSelectorRequestProcessor)
+        )
+
+        assert set(backend._backends) == {"gpu", "spark", "nim", "frontier"}
+        assert backend._default_tier == "spark"
+        assert selector._config.default_tier == "spark"
+        assert selector._config.tier_mapping[RouteTier.SIMPLE] == "gpu"
+        assert selector._config.tier_mapping[RouteTier.MEDIUM] == "spark"
+        assert selector._config.tier_mapping[RouteTier.COMPLEX] == "nim"
+        assert selector._config.tier_mapping[RouteTier.REASONING] == "frontier"
+
     def test_anthropic_tier_is_cache_wrapped(self):
         """An Anthropic-format tier is wrapped for prompt caching via the YAML
         serve path, so an OpenAI-origin harness (Codex) routed onto a Claude


### PR DESCRIPTION
Adds configurable deterministic routing tiers beyond weak/strong while preserving the existing weak/strong configuration path. This lets downstream demos map classifier recommendations onto multiple backend tiers such as local GPU, Spark, NIM, and Frontier.