### PR TITLE
ci: add internal scan pipeline trigger

### DIFF
--- a/.agents/skills/publish-package/SKILL.md
+++ b/.agents/skills/publish-package/SKILL.md
@@ -12,6 +12,7 @@ wheels separate from official tag-gated release builds.
 |---|---|---|---|---|
 | Dev wheel artifact | Manual `publish.yml` dispatch with `build_dev_artifact=true` | GitHub Actions | One-day GitHub artifact | `docs/internal/release_workflow.md` |
 | Dev matrix artifact | Manual `publish.yml` dispatch with `build_dev_matrix=true` | GitHub Actions | Full matrix GitHub artifacts | `docs/internal/release_workflow.md` |
+| Internal scan trigger | Manual `publish.yml` dispatch with `trigger_internal_scan=true` and explicit wheel URLs | GitHub Actions → GitLab | NVIDIA GitLab nSpect/wheeltamer pipeline | `docs/internal/release_workflow.md` |
 | Official release build | Root `vMAJOR.MINOR.PATCH` tag | GitHub Actions `.github/workflows/publish.yml` | Full release artifact matrix + PyPI Trusted Publishing via `uv publish` | `.github/workflows/publish.yml` |
 
 Release publishing stays on the public GitHub/PyPI path. Manual branch builds only produce
@@ -25,6 +26,7 @@ artifacts; root release tags publish through PyPI Trusted Publishing.
 - Keep `.dev` artifacts public-safe because GitHub Actions artifacts may be shared for review.
 - Full wheel matrices may run manually for validation, but PyPI publishing belongs only on root
   `vMAJOR.MINOR.PATCH` tag releases.
+- Internal scan triggers must pass explicit wheel URLs; they do not publish or stage artifacts.
 - Manual dev builds should build exactly one Linux x86_64 wheel artifact with one-day retention.
 - Use PyPI Trusted Publishing with the GitHub environment named `pypi`; do not add long-lived PyPI tokens.
 
@@ -41,10 +43,16 @@ and `Version`.
 | `build_dev_artifact` | `false` | Set to `true` to build one temporary wheel artifact |
 | `build_dev_matrix` | `false` | Set to `true` to build the complete sdist and wheel matrix as artifacts |
 | `dev_version` | `0.0.1.dev0` | PEP 440 `.dev` version for wheel metadata |
+| `trigger_internal_scan` | `false` | Set to `true` to trigger the internal GitLab scan pipeline |
+| `internal_scan_wheel_urls` | `""` | Comma-separated HTTPS wheel URLs to scan/register |
+| `internal_scan_wheel_version` | `""` | Optional version label; defaults to `dev_version` |
 
 ## Required Secrets
 
 The artifact-only dev build does not require release secrets.
+
+The internal scan trigger requires `GITLAB_PIPELINE_URL` and `GITLAB_TRIGGER_TOKEN` in GitHub, plus
+nSpect credentials on the GitLab scan project.
 
 The official publish job uses `uv publish --trusted-publishing always`; no PyPI token is required.
 Manual dev builds never publish to PyPI.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,21 @@ on:
         required: true
         type: string
         default: "0.0.1.dev0"
+      trigger_internal_scan:
+        description: "Trigger the internal GitLab security scan pipeline for explicit wheel URLs."
+        required: true
+        type: boolean
+        default: false
+      internal_scan_wheel_urls:
+        description: "Comma-separated wheel URLs for nSpect/wheeltamer. Required when trigger_internal_scan=true."
+        required: false
+        type: string
+        default: ""
+      internal_scan_wheel_version:
+        description: "Wheel version label sent to the scan pipeline. Defaults to dev_version."
+        required: false
+        type: string
+        default: ""
 
 env:
   DEV_PACKAGE_NAME: "nemo-switchyard"
@@ -418,6 +433,83 @@ jobs:
           merge-multiple: true
       - name: List distributions
         run: ls -l dist
+
+  trigger-internal-scan:
+    name: Trigger internal security scan
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.trigger_internal_scan }}
+    needs: [validate-release-ref]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitLab scan pipeline
+        id: trigger
+        env:
+          GITLAB_TRIGGER_URL: ${{ secrets.GITLAB_PIPELINE_URL }}
+          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          WHEEL_URLS: ${{ inputs.internal_scan_wheel_urls }}
+          INPUT_WHEEL_VERSION: ${{ inputs.internal_scan_wheel_version }}
+          DEV_VERSION: ${{ inputs.dev_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GITLAB_TRIGGER_URL}" ]; then
+            echo "::error::GITLAB_PIPELINE_URL secret is required"
+            exit 1
+          fi
+          if [ -z "${GITLAB_TRIGGER_TOKEN}" ]; then
+            echo "::error::GITLAB_TRIGGER_TOKEN secret is required"
+            exit 1
+          fi
+          if [ -z "${WHEEL_URLS}" ]; then
+            echo "::error::internal_scan_wheel_urls is required when trigger_internal_scan=true"
+            exit 1
+          fi
+
+          WHEEL_VERSION="${INPUT_WHEEL_VERSION:-${DEV_VERSION}}"
+          if [ -z "${WHEEL_VERSION}" ]; then
+            echo "::error::internal_scan_wheel_version or dev_version is required"
+            exit 1
+          fi
+
+          TOKEN_FILE="$(mktemp)"
+          trap 'rm -f "${TOKEN_FILE}"' EXIT
+          chmod 600 "${TOKEN_FILE}"
+          printf '%s' "${GITLAB_TRIGGER_TOKEN}" > "${TOKEN_FILE}"
+
+          RESPONSE="$(curl -fsSL \
+            --request POST \
+            --form "token=<${TOKEN_FILE}" \
+            --form "ref=main" \
+            --form "variables[PROJECT]=switchyard" \
+            --form "variables[PIPELINE_TYPE]=security" \
+            --form "variables[RELEASE_TYPE]=ondemand" \
+            --form "variables[ARTIFACTS]=wheel" \
+            --form "variables[ENABLE_WHEEL_SCAN]=true" \
+            --form "variables[NSPECT_REGISTERED]=false" \
+            --form "variables[WHEEL_VERSION]=${WHEEL_VERSION}" \
+            --form "variables[COMMIT_SHA]=${GITHUB_SHA}" \
+            --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}" \
+            --form "variables[NSPECT_WHEEL_URLS]=${WHEEL_URLS}" \
+            "${GITLAB_TRIGGER_URL}")"
+
+          PIPELINE_ID="$(python -c 'import json, sys; print(json.load(sys.stdin).get("id", ""))' <<< "${RESPONSE}")"
+          PIPELINE_URL="$(python -c 'import json, sys; print(json.load(sys.stdin).get("web_url", ""))' <<< "${RESPONSE}")"
+          if [ -z "${PIPELINE_ID}" ]; then
+            ERROR="$(python -c 'import json, sys; data=json.load(sys.stdin); print(data.get("message") or data.get("error_description") or data.get("error") or "unparseable response")' <<< "${RESPONSE}" 2>/dev/null || echo "unparseable response")"
+            echo "::error::Failed to trigger GitLab scan pipeline: ${ERROR}"
+            exit 1
+          fi
+
+          echo "pipeline_id=${PIPELINE_ID}" >> "${GITHUB_OUTPUT}"
+          echo "pipeline_url=${PIPELINE_URL}" >> "${GITHUB_OUTPUT}"
+          echo "Triggered GitLab scan pipeline ${PIPELINE_ID}"
+
+          {
+            echo "## Internal GitLab Security Scan"
+            echo "- Pipeline: ${PIPELINE_URL}"
+            echo "- Wheel version: ${WHEEL_VERSION}"
+            echo "- Source commit: ${GITHUB_SHA}"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   publish:
     name: Publish distributions

--- a/docs/internal/release_workflow.md
+++ b/docs/internal/release_workflow.md
@@ -7,6 +7,7 @@ Switchyard currently follows the OSS-style NeMo path for GitHub builds:
 - regular CI runs tests, linting, type checks, Rust checks, and slim-install smoke checks;
 - manual dev builds create one Linux x86_64 wheel as a one-day GitHub Actions artifact;
 - manual dev matrix builds create the full sdist and wheel set as GitHub Actions artifacts;
+- manual internal scan triggers send explicit wheel URLs to the NVIDIA GitLab scan pipeline;
 - root `vMAJOR.MINOR.PATCH` tags run the complete release validation and wheel matrix;
 - public PyPI/GitHub publishing happens only from approved `vMAJOR.MINOR.PATCH` tag releases.
 
@@ -56,6 +57,33 @@ Use this to prove the complete release matrix before cutting an official tag:
 This path stamps the requested `.dev` version, runs the release checks, builds the sdist, builds the
 full abi3 wheel matrix, and uploads the distributions as GitHub Actions artifacts. It does not
 publish anything to PyPI.
+
+## Manual Internal Security Scan
+
+Use this to test the NVIDIA GitLab scan pipeline against already-accessible wheel URLs:
+
+| Input | Value |
+|---|---|
+| `trigger_internal_scan` | `true` |
+| `internal_scan_wheel_urls` | Comma-separated HTTPS wheel URLs |
+| `internal_scan_wheel_version` | Optional explicit version label |
+
+The scan trigger calls the internal GitLab project:
+
+```text
+https://gitlab-master.nvidia.com/aire/agents/nemo-switchyard-pipeline
+```
+
+The GitHub repository needs these secrets before the trigger can work:
+
+| Secret | Value |
+|---|---|
+| `GITLAB_PIPELINE_URL` | GitLab pipeline trigger endpoint for the internal scan project |
+| `GITLAB_TRIGGER_TOKEN` | GitLab pipeline trigger token for the scan project |
+
+The GitLab scan project also needs nSpect credentials and the Switchyard nSpect program id. This
+manual path is URL-based for the first pass; it does not stage GitHub artifacts into Artifactory and
+does not publish anything.
 
 ## Official Release Build
 


### PR DESCRIPTION
## What

Adds the GitHub-side trigger for the new internal Switchyard scan pipeline.

- Adds manual `publish.yml` inputs for `trigger_internal_scan`, explicit wheel URLs, and an optional wheel version label.
- Adds a `trigger-internal-scan` job that posts to the GitLab trigger endpoint stored in `GITLAB_PIPELINE_URL`.
- Keeps the trigger URL and token out of git; both are supplied as GitHub secrets.
- Documents the manual scan path in `docs/internal/release_workflow.md`.
- Updates the local `publish-package` skill so release workflow guidance stays in sync.

## Why

We need a minimal bridge from the OSS-style GitHub release workflow to an NVIDIA-internal GitLab pipeline so we can test nSpect/wheeltamer scanning without reintroducing Artifactory/Kitmaker publishing into the GitHub release path.

This first pass deliberately scans explicit wheel URLs only. It does not stage artifacts, publish packages, or change PyPI release behavior.

## GitLab side

Created the internal GitLab project `aire/agents/nemo-switchyard-pipeline` with a scan-only pipeline:

- preflight variable validation
- wheel URL download and wheeltamer scan
- nSpect version create/update for wheel URLs
- summary job

The concrete GitLab trigger endpoint is intentionally not written into this repo; it should live only in the `GITLAB_PIPELINE_URL` secret.

## How to test

1. Set GitHub secrets:
   - `GITLAB_PIPELINE_URL`
   - `GITLAB_TRIGGER_TOKEN`
2. Set GitLab scan project variables:
   - `SWITCHYARD_NSPECT_ID` or per-run `NSPECT_ID`
   - `NSPECT_API_URL`
   - `NSPECT_SSA_TOKEN_URL`
   - `NSPECT_SSA_CLIENT_ID`
   - `NSPECT_SSA_CLIENT_SECRET`
3. Run `Build and publish release distributions` manually with:
   - `trigger_internal_scan=true`
   - `internal_scan_wheel_urls=<comma-separated wheel URLs>`
   - optional `internal_scan_wheel_version=<version>`

## Validation

- `uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/publish.yml').read_text()); print('workflow yaml ok')"`
- `uv run python -c "from pathlib import Path; import yaml; text=Path('.agents/skills/publish-package/SKILL.md').read_text(); end=text.find('\\n---\\n',4); yaml.safe_load(text[4:end]); print('skill frontmatter ok')"`
- `uv run ruff check scripts/release/set_dev_wheel_version.py tests/test_dev_wheel_versioning.py`
- `uv run pytest tests/test_dev_wheel_versioning.py -v`
- `python scripts/release/set_dev_wheel_version.py 0.0.1.dev0 --print-version`
- `git diff --check`
- Verified no hardcoded GitLab trigger endpoint remains in the touched GitHub files.
