### PR TITLE
docs: clarify type-name conventions between route bundles and v2 profile configs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -50,6 +50,8 @@ switchyard --routing-profiles routes.yaml -- configure
 
 > **Format default and caching.** Omitting `format:` from a tier silently defaults to `OPENAI` (Chat Completions) — not `AUTO`. For Claude/Anthropic/Bedrock tiers this is wrong: set `format: anthropic` explicitly. The native `/v1/messages` path preserves `cache_control`, which is what enables prompt caching. `format: openai` routes Claude through OpenAI-format translation that strips `cache_control`: the request still succeeds, but caching silently never engages and you pay full input price. Always use `format: openai` for NIM/non-Claude models and `format: anthropic` for Claude and Bedrock models. Use `format: auto` only when the upstream is genuinely unknown.
 
+> **Type names differ between the two config formats.** The `routes.yaml` bundle above uses snake_case route types (`random_routing`). The v2 profile config used by `switchyard serve --config profiles.yaml` uses hyphenated profile types instead (`random-routing`, `llm-routing`). Copying a route type from this quickstart into a profile config fails with `unknown profile type` — see [Core Concepts](core_concepts.md) for the v2 format.
+
 Inspect what was saved:
 
 ```bash


### PR DESCRIPTION
### What

Adds a short note to the getting-started guide clarifying that legacy route bundles (`--routing-profiles routes.yaml`) use snake_case route types (`random_routing`) while v2 profile configs (`switchyard serve --config profiles.yaml`) use hyphenated profile types (`random-routing`, `llm-routing`).

### Why

Following the quickstart, we copied `type: random_routing` into a v2 profile config and hit `unknown profile type 'random_routing'`. The two formats are easy to conflate for new users, since the quickstart teaches the bundle format while `examples/profiles.yaml` and the serve docs use the v2 format. A one-paragraph note at the point of first contact avoids the confusion.

The note follows the existing blockquote style used by the adjacent "Format default and caching" note in the same file.

### Notes

- Docs-only change; no code affected.
