### PR TITLE
fix: record streaming token usage in v2 profile stats

### DIFF
--- a/crates/switchyard-components-v2/Cargo.toml
+++ b/crates/switchyard-components-v2/Cargo.toml
@@ -12,7 +12,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+async-stream = "0.3"
 async-trait = "0.1"
+futures-util = "0.3"
 parking_lot = "0.12"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }

--- a/crates/switchyard-components-v2/src/profiles/latency_service/mod.rs
+++ b/crates/switchyard-components-v2/src/profiles/latency_service/mod.rs
@@ -16,7 +16,6 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
-use switchyard_components::stats::usage_from_body;
 use switchyard_components::StatsAccumulator;
 use switchyard_core::{ChatResponse, LlmTarget, LlmTargetId, Result, SwitchyardError};
 
@@ -26,6 +25,7 @@ use self::selection::select_target;
 pub use self::selection::SelectedTarget;
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
+use crate::stats::{record_usage_or_tap_stream, UsageAttribution};
 use crate::{
     profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
     RoutingMetadata,
@@ -329,16 +329,16 @@ impl Profile for LatencyServiceProfile {
                         Some(backend_latency_ms),
                         None,
                     )?;
-                    let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-                    let routing_overhead_ms = (total_latency_ms - backend_latency_ms).max(0.0);
-                    let usage = response.body().map(usage_from_body).unwrap_or_default();
-                    self.stats.record_usage_after_success_attribution(
-                        stats_model,
-                        usage,
-                        Some(total_latency_ms),
-                        Some(routing_overhead_ms),
-                        None,
-                    )?;
+                    let response = record_usage_or_tap_stream(
+                        response,
+                        UsageAttribution::new(
+                            self.stats.clone(),
+                            stats_model,
+                            None,
+                            profile_started_at,
+                            backend_latency_ms,
+                        ),
+                    );
                     let processed = LatencyServiceProcessedRequest {
                         profile_input: input,
                         selected,

--- a/crates/switchyard-components-v2/src/profiles/latency_service/tests.rs
+++ b/crates/switchyard-components-v2/src/profiles/latency_service/tests.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use futures_core::Stream;
+use futures_util::StreamExt;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
 use switchyard_core::{BackendFormat, ChatRequest, LlmTargetId, ModelId, StreamEvent};
@@ -42,6 +43,7 @@ struct TestBackend {
 enum ResponseMode {
     Completion,
     OpenAiStream,
+    OpenAiStreamWithUsage,
 }
 
 struct OneEventStream {
@@ -83,6 +85,15 @@ impl ProfileBackend for TestBackend {
                     event: Some(Ok(StreamEvent::Json(json!({
                         "backend": self.name,
                         "model": request.model(),
+                    })))),
+                })))
+            }
+            ResponseMode::OpenAiStreamWithUsage => {
+                Ok(ChatResponse::OpenAiStream(Box::pin(OneEventStream {
+                    event: Some(Ok(StreamEvent::Json(json!({
+                        "backend": self.name,
+                        "model": request.model(),
+                        "usage": {"prompt_tokens": 21, "completion_tokens": 11},
                     })))),
                 })))
             }
@@ -590,6 +601,54 @@ fn unknown_target_health_update_is_rejected() -> Result<()> {
     assert!(error
         .to_string()
         .contains("target missing is not configured"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn streaming_response_records_usage_after_consumption() -> Result<()> {
+    let (profile, _calls) = profile_with_backend_modes(
+        vec![target("fast", "upstream-fast")?],
+        BTreeMap::new(),
+        BTreeMap::from([("fast", ResponseMode::OpenAiStreamWithUsage)]),
+        0,
+    )?;
+    profile.update_health(
+        LlmTargetId::from_static("fast"),
+        EndpointHealth::new(EndpointHealthStatus::Healthy),
+    )?;
+
+    let response = profile
+        .run(profile_input(ChatRequest::openai_chat(json!({
+            "model": "incoming-model",
+            "messages": [],
+        }))))
+        .await?;
+
+    // The call is attributed immediately; streaming usage is recorded lazily.
+    let before = profile.stats.snapshot()?;
+    assert_eq!(before.total_requests, 1);
+    assert_eq!(before.total_tokens.prompt, 0);
+
+    let mut stream = match response.response {
+        ChatResponse::OpenAiStream(stream) => stream,
+        _ => {
+            return Err(SwitchyardError::Other(
+                "expected OpenAI stream response".into(),
+            ))
+        }
+    };
+    while let Some(event) = stream.next().await {
+        event?;
+    }
+
+    let after = profile.stats.snapshot()?;
+    assert_eq!(after.total_tokens.prompt, 21);
+    assert_eq!(after.total_tokens.completion, 11);
+    let model = after
+        .models
+        .get("upstream-fast")
+        .ok_or_else(|| SwitchyardError::Other("model stats should be present".into()))?;
+    assert_eq!(model.calls, 1);
     Ok(())
 }
 

--- a/crates/switchyard-components-v2/src/profiles/llm_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/llm_routing.rs
@@ -17,6 +17,7 @@ use switchyard_core::{
 
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
+use crate::stats::{record_usage_or_tap_stream, UsageAttribution};
 use crate::{
     profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
     RoutingMetadata,
@@ -421,25 +422,25 @@ impl LlmRoutingProfile {
     fn record_success(
         &self,
         decision: &LlmRoutingDecision,
-        response: &ChatResponse,
-        total_latency_ms: f64,
+        response: ChatResponse,
+        started_at: Instant,
         backend_latency_ms: f64,
-    ) -> Result<()> {
+    ) -> Result<ChatResponse> {
         self.stats.record_success(
             decision.selected_model.as_str(),
             Some(backend_latency_ms),
             Some(decision.tier.as_str()),
         )?;
-        let routing_overhead_ms = (total_latency_ms - backend_latency_ms).max(0.0);
-        let usage = response.body().map(usage_from_body).unwrap_or_default();
-        self.stats.record_usage_after_success_attribution(
-            decision.selected_model.as_str(),
-            usage,
-            Some(total_latency_ms),
-            Some(routing_overhead_ms),
-            Some(decision.tier.as_str()),
-        )?;
-        Ok(())
+        Ok(record_usage_or_tap_stream(
+            response,
+            UsageAttribution::new(
+                self.stats.clone(),
+                decision.selected_model.as_str(),
+                Some(decision.tier.clone()),
+                started_at,
+                backend_latency_ms,
+            ),
+        ))
     }
 
     fn record_error(&self, decision: &LlmRoutingDecision) -> Result<()> {
@@ -489,11 +490,10 @@ impl Profile for LlmRoutingProfile {
         let (first_result, first_backend_latency_ms) = self.call_selected(&processed).await;
         match first_result {
             Ok(response) => {
-                let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-                self.record_success(
+                let response = self.record_success(
                     &processed.decision,
-                    &response,
-                    total_latency_ms,
+                    response,
+                    profile_started_at,
                     first_backend_latency_ms,
                 )?;
                 let response = self.rprocess(&processed, response).await?;
@@ -507,11 +507,10 @@ impl Profile for LlmRoutingProfile {
                 let (retry_result, retry_backend_latency_ms) = self.call_selected(&retry).await;
                 match retry_result {
                     Ok(response) => {
-                        let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-                        self.record_success(
+                        let response = self.record_success(
                             &retry.decision,
-                            &response,
-                            total_latency_ms,
+                            response,
+                            profile_started_at,
                             retry_backend_latency_ms,
                         )?;
                         let response = self.rprocess(&retry, response).await?;
@@ -1602,4 +1601,171 @@ fn normalize_reasoning_effort(request: &mut ChatRequest) {
         "reasoning_effort".to_string(),
         Value::String("high".to_string()),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use futures_util::StreamExt;
+    use serde_json::json;
+    use switchyard_core::{ModelId, StreamEvent};
+
+    use crate::backend::ProfileBackend;
+
+    use super::*;
+
+    // Stub backend used only to satisfy the profile struct; `record_success`
+    // never dispatches through it.
+    struct UnusedBackend;
+
+    #[async_trait]
+    impl ProfileBackend for UnusedBackend {
+        async fn call(&self, _request: &ChatRequest) -> Result<ChatResponse> {
+            Err(SwitchyardError::Other(
+                "backend should not be called".to_string(),
+            ))
+        }
+    }
+
+    fn target(id: &str, model: &str) -> Result<LlmTarget> {
+        let mut target = LlmTarget::new(LlmTargetId::new(id)?, ModelId::new(model)?);
+        target.format = BackendFormat::OpenAi;
+        Ok(target)
+    }
+
+    fn stub_backend(target: &LlmTarget) -> TargetBackend {
+        TargetBackend::new(target.clone(), Arc::new(UnusedBackend))
+    }
+
+    fn config(
+        strong: &LlmTarget,
+        weak: &LlmTarget,
+        classifier: &LlmTarget,
+    ) -> LlmRoutingProfileConfig {
+        LlmRoutingProfileConfig {
+            strong: strong.clone(),
+            weak: weak.clone(),
+            classifier: classifier.clone(),
+            fallback_target_on_evict: strong.id.clone(),
+            profile_name: PROFILE_GENERAL.to_string(),
+            classifier_min_confidence: 0.0,
+            classifier_fail_open: true,
+            classifier_recent_turn_window: 4,
+            classifier_max_tokens: 256,
+            alignment_min_confidence: DEFAULT_ALIGNMENT_MIN_CONFIDENCE,
+            default_tier: None,
+            tier_mapping: None,
+            classifier_system_prompt: None,
+            classifier_tool_name: None,
+            classifier_tool_description: None,
+            classifier_tool_parameters: None,
+        }
+    }
+
+    fn profile(stats: StatsAccumulator) -> Result<LlmRoutingProfile> {
+        let strong = target("strong", "frontier/model")?;
+        let weak = target("weak", "cheap/model")?;
+        let classifier = target("classifier", "cls/model")?;
+        let config = config(&strong, &weak, &classifier);
+        let policy = ClassifierPolicy::from_name(&config.profile_name)?;
+        Ok(LlmRoutingProfile {
+            policy,
+            strong_backend: stub_backend(&strong),
+            weak_backend: stub_backend(&weak),
+            classifier_backend: stub_backend(&classifier),
+            classifier_target: classifier,
+            fallback_target_on_evict: config.fallback_target_on_evict.clone(),
+            classifier_min_confidence: config.classifier_min_confidence,
+            classifier_fail_open: config.classifier_fail_open,
+            classifier_recent_turn_window: config.classifier_recent_turn_window,
+            classifier_max_tokens: config.classifier_max_tokens,
+            alignment_min_confidence: config.alignment_min_confidence,
+            default_tier: resolve_default_tier(config.default_tier.as_deref())?,
+            tier_mapping: config
+                .tier_mapping
+                .clone()
+                .unwrap_or_else(|| policy.default_tier_mapping()),
+            classifier_tool: LlmRoutingClassifierTool::from_config(policy, &config),
+            stats,
+        })
+    }
+
+    fn weak_decision() -> LlmRoutingDecision {
+        LlmRoutingDecision {
+            tier: TIER_WEAK.to_string(),
+            source: "unit_test".to_string(),
+            reason: "unit_test".to_string(),
+            policy_tier: None,
+            llm_recommended_tier: None,
+            confidence: None,
+            selected_target: "weak".to_string(),
+            selected_model: "cheap/model".to_string(),
+            signals: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn record_success_taps_streaming_usage_on_consumption() -> Result<()> {
+        let stats = StatsAccumulator::new();
+        let profile = profile(stats.clone())?;
+
+        let events: Vec<Result<StreamEvent>> = vec![
+            Ok(StreamEvent::Json(json!({
+                "choices": [{"delta": {"content": "hi"}}],
+            }))),
+            Ok(StreamEvent::Json(json!({
+                "choices": [],
+                "usage": {"prompt_tokens": 23, "completion_tokens": 12},
+            }))),
+        ];
+        let response = ChatResponse::OpenAiStream(Box::pin(futures_util::stream::iter(events)));
+
+        let response = profile.record_success(&weak_decision(), response, Instant::now(), 4.0)?;
+
+        // Success is attributed synchronously; streaming usage waits for consume.
+        let before = stats.snapshot()?;
+        assert_eq!(before.total_requests, 1);
+        assert_eq!(before.total_tokens.prompt, 0);
+
+        let mut stream = match response {
+            ChatResponse::OpenAiStream(stream) => stream,
+            _ => return Err(SwitchyardError::Other("expected stream response".into())),
+        };
+        let mut forwarded = 0;
+        while let Some(event) = stream.next().await {
+            event?;
+            forwarded += 1;
+        }
+        assert_eq!(forwarded, 2, "every event must still reach the client");
+
+        let after = stats.snapshot()?;
+        assert_eq!(after.total_tokens.prompt, 23);
+        assert_eq!(after.total_tokens.completion, 12);
+        let tier = after
+            .tiers
+            .get(TIER_WEAK)
+            .ok_or_else(|| SwitchyardError::Other("weak tier stats should be present".into()))?;
+        assert_eq!(tier.calls, 1);
+        assert_eq!(tier.model, "cheap/model");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn record_success_records_buffered_usage_immediately() -> Result<()> {
+        let stats = StatsAccumulator::new();
+        let profile = profile(stats.clone())?;
+
+        let response = ChatResponse::openai_completion(json!({
+            "usage": {"prompt_tokens": 7, "completion_tokens": 2},
+        }));
+        let _response = profile.record_success(&weak_decision(), response, Instant::now(), 4.0)?;
+
+        let snapshot = stats.snapshot()?;
+        assert_eq!(snapshot.total_requests, 1);
+        assert_eq!(snapshot.total_tokens.prompt, 7);
+        assert_eq!(snapshot.total_tokens.completion, 2);
+        Ok(())
+    }
 }

--- a/crates/switchyard-components-v2/src/profiles/passthrough.rs
+++ b/crates/switchyard-components-v2/src/profiles/passthrough.rs
@@ -6,12 +6,12 @@
 use std::time::Instant;
 
 use async_trait::async_trait;
-use switchyard_components::stats::usage_from_body;
 use switchyard_components::StatsAccumulator;
 use switchyard_core::{ChatResponse, LlmTarget, Result};
 
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
+use crate::stats::{record_usage_or_tap_stream, UsageAttribution};
 use crate::{profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse};
 
 /// Config for the flatter passthrough profile.
@@ -85,16 +85,16 @@ impl Profile for PassthroughProfile {
         let backend_latency_ms = backend_started_at.elapsed().as_secs_f64() * 1000.0;
         self.stats
             .record_success(target_model.to_string(), Some(backend_latency_ms), None)?;
-        let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-        let routing_overhead_ms = (total_latency_ms - backend_latency_ms).max(0.0);
-        let usage = response.body().map(usage_from_body).unwrap_or_default();
-        self.stats.record_usage_after_success_attribution(
-            target_model.to_string(),
-            usage,
-            Some(total_latency_ms),
-            Some(routing_overhead_ms),
-            None,
-        )?;
+        let response = record_usage_or_tap_stream(
+            response,
+            UsageAttribution::new(
+                self.stats.clone(),
+                target_model.as_str(),
+                None,
+                profile_started_at,
+                backend_latency_ms,
+            ),
+        );
         let response = self.rprocess(&processed, response).await?;
         Ok(ProfileResponse::from(response))
     }
@@ -105,8 +105,11 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use futures_util::StreamExt;
     use serde_json::{json, Value};
-    use switchyard_core::{BackendFormat, ChatRequest, LlmTargetId, ModelId, SwitchyardError};
+    use switchyard_core::{
+        BackendFormat, ChatRequest, LlmTargetId, ModelId, StreamEvent, SwitchyardError,
+    };
 
     use crate::backend::{ProfileBackend, TargetBackend};
     use crate::RequestMetadata;
@@ -270,6 +273,71 @@ mod tests {
         let calls = observed(&calls)?;
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].body, json!({"model": "provider/model"}));
+        Ok(())
+    }
+
+    struct StreamBackend;
+
+    #[async_trait]
+    impl ProfileBackend for StreamBackend {
+        async fn call(&self, _request: &ChatRequest) -> Result<ChatResponse> {
+            let events: Vec<Result<StreamEvent>> = vec![
+                Ok(StreamEvent::Json(json!({
+                    "choices": [{"delta": {"content": "hi"}}],
+                }))),
+                Ok(StreamEvent::Json(json!({
+                    "choices": [],
+                    "usage": {"prompt_tokens": 17, "completion_tokens": 9},
+                }))),
+            ];
+            Ok(ChatResponse::OpenAiStream(Box::pin(
+                futures_util::stream::iter(events),
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn run_records_streaming_usage_as_events_are_consumed() -> Result<()> {
+        let profile = PassthroughProfile {
+            backend: TargetBackend::new(
+                target("direct", "provider/model")?,
+                Arc::new(StreamBackend),
+            ),
+            stats: StatsAccumulator::new(),
+        };
+
+        let response = profile
+            .run(profile_input(ChatRequest::openai_chat(json!({
+                "model": "client/model",
+                "messages": [],
+            }))))
+            .await?;
+
+        // The call is counted right away, but streaming usage is not known until
+        // the stream is consumed.
+        let before = profile.stats.snapshot()?;
+        assert_eq!(before.total_requests, 1);
+        assert_eq!(before.total_tokens.prompt, 0);
+
+        let mut stream = match response.response {
+            ChatResponse::OpenAiStream(stream) => stream,
+            _ => return Err(SwitchyardError::Other("expected stream response".into())),
+        };
+        let mut forwarded = 0;
+        while let Some(event) = stream.next().await {
+            event?;
+            forwarded += 1;
+        }
+        assert_eq!(forwarded, 2, "every event must still reach the client");
+
+        let after = profile.stats.snapshot()?;
+        assert_eq!(after.total_tokens.prompt, 17);
+        assert_eq!(after.total_tokens.completion, 9);
+        let model = after
+            .models
+            .get("provider/model")
+            .ok_or_else(|| SwitchyardError::Other("model stats should be present".into()))?;
+        assert_eq!(model.calls, 1);
         Ok(())
     }
 }

--- a/crates/switchyard-components-v2/src/profiles/random_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/random_routing.rs
@@ -9,12 +9,12 @@ use async_trait::async_trait;
 use switchyard_components::request_processors::{
     RandomRoutingDecision, RandomRoutingEngine, RandomRoutingProcessorConfig, RandomRoutingTier,
 };
-use switchyard_components::stats::usage_from_body;
 use switchyard_components::StatsAccumulator;
 use switchyard_core::{ChatResponse, LlmTarget, Result, SwitchyardError};
 
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
+use crate::stats::{record_usage_or_tap_stream, UsageAttribution};
 use crate::{
     profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
     RoutingMetadata,
@@ -167,16 +167,16 @@ impl Profile for RandomRoutingProfile {
             Some(backend_latency_ms),
             Some(decision.tier.as_str()),
         )?;
-        let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-        let routing_overhead_ms = (total_latency_ms - backend_latency_ms).max(0.0);
-        let usage = response.body().map(usage_from_body).unwrap_or_default();
-        self.stats.record_usage_after_success_attribution(
-            decision.selected_model.as_str(),
-            usage,
-            Some(total_latency_ms),
-            Some(routing_overhead_ms),
-            Some(decision.tier.as_str()),
-        )?;
+        let response = record_usage_or_tap_stream(
+            response,
+            UsageAttribution::new(
+                self.stats.clone(),
+                decision.selected_model.as_str(),
+                Some(decision.tier.as_str().to_string()),
+                profile_started_at,
+                backend_latency_ms,
+            ),
+        );
         let response = self.rprocess(&processed, response).await?;
         Ok(ProfileResponse::with_routing_metadata(
             response,
@@ -195,8 +195,11 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use futures_util::StreamExt;
     use serde_json::{json, Value};
-    use switchyard_core::{BackendFormat, ChatRequest, LlmTargetId, ModelId, SwitchyardError};
+    use switchyard_core::{
+        BackendFormat, ChatRequest, LlmTargetId, ModelId, StreamEvent, SwitchyardError,
+    };
 
     use crate::backend::{ProfileBackend, TargetBackend};
     use crate::RequestMetadata;
@@ -476,6 +479,71 @@ mod tests {
             _ => return Err(SwitchyardError::Other("unexpected response shape".into())),
         }
         assert!(observed(&calls)?.is_empty());
+        Ok(())
+    }
+
+    struct StreamBackend;
+
+    #[async_trait]
+    impl ProfileBackend for StreamBackend {
+        async fn call(&self, _request: &ChatRequest) -> Result<ChatResponse> {
+            let events: Vec<Result<StreamEvent>> = vec![
+                Ok(StreamEvent::Json(json!({
+                    "choices": [{"delta": {"content": "hi"}}],
+                }))),
+                Ok(StreamEvent::Json(json!({
+                    "choices": [],
+                    "usage": {"prompt_tokens": 17, "completion_tokens": 9},
+                }))),
+            ];
+            Ok(ChatResponse::OpenAiStream(Box::pin(
+                futures_util::stream::iter(events),
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn run_records_streaming_usage_with_selected_tier() -> Result<()> {
+        let strong = target("strong", "frontier/model")?;
+        let weak = target("weak", "cheap/model")?;
+        let router_config = RandomRoutingProcessorConfig::new(strong.clone(), weak.clone())
+            .with_strong_probability(1.0)?
+            .with_rng_seed(Some(7));
+        let profile = RandomRoutingProfile {
+            router: RandomRoutingEngine::new(router_config)?,
+            strong_backend: TargetBackend::new(strong.clone(), Arc::new(StreamBackend)),
+            weak_backend: TargetBackend::new(weak, Arc::new(StreamBackend)),
+            stats: StatsAccumulator::new(),
+        };
+
+        let response = profile
+            .run(profile_input(ChatRequest::openai_chat(json!({
+                "model": "client/model",
+                "messages": [],
+            }))))
+            .await?;
+
+        let before = profile.stats.snapshot()?;
+        assert_eq!(before.total_requests, 1);
+        assert_eq!(before.total_tokens.prompt, 0);
+
+        let mut stream = match response.response {
+            ChatResponse::OpenAiStream(stream) => stream,
+            _ => return Err(SwitchyardError::Other("expected stream response".into())),
+        };
+        while let Some(event) = stream.next().await {
+            event?;
+        }
+
+        let after = profile.stats.snapshot()?;
+        assert_eq!(after.total_tokens.prompt, 17);
+        assert_eq!(after.total_tokens.completion, 9);
+        let tier = after
+            .tiers
+            .get("strong")
+            .ok_or_else(|| SwitchyardError::Other("strong tier stats should be present".into()))?;
+        assert_eq!(tier.calls, 1);
+        assert_eq!(tier.model, "frontier/model");
         Ok(())
     }
 }

--- a/crates/switchyard-components-v2/src/profiles/stage_router.rs
+++ b/crates/switchyard-components-v2/src/profiles/stage_router.rs
@@ -17,6 +17,7 @@ use switchyard_core::{ChatRequest, ChatResponse, LlmTarget, LlmTargetId, Result,
 
 use crate::backend::{native_target_backend, TargetBackend};
 use crate::profile_stats_accumulator;
+use crate::stats::{record_usage_or_tap_stream, UsageAttribution};
 use crate::{
     profile_config, Profile, ProfileConfig, ProfileHooks, ProfileInput, ProfileResponse,
     RoutingMetadata,
@@ -483,27 +484,28 @@ impl StageRouterProfile {
     fn record_success(
         &self,
         decision: &StageRouterDecision,
-        response: &ChatResponse,
-        total_latency_ms: f64,
+        response: ChatResponse,
+        started_at: Instant,
         backend_latency_ms: f64,
-    ) -> Result<()> {
-        if let Some(stats) = self.stats_handle() {
-            stats.record_success(
+    ) -> Result<ChatResponse> {
+        let Some(stats) = self.stats_handle() else {
+            return Ok(response);
+        };
+        stats.record_success(
+            decision.selected_model.as_str(),
+            Some(backend_latency_ms),
+            Some(decision.tier.as_str()),
+        )?;
+        Ok(record_usage_or_tap_stream(
+            response,
+            UsageAttribution::new(
+                stats.clone(),
                 decision.selected_model.as_str(),
-                Some(backend_latency_ms),
-                Some(decision.tier.as_str()),
-            )?;
-            let routing_overhead_ms = (total_latency_ms - backend_latency_ms).max(0.0);
-            let usage = response.body().map(usage_from_body).unwrap_or_default();
-            stats.record_usage_after_success_attribution(
-                decision.selected_model.as_str(),
-                usage,
-                Some(total_latency_ms),
-                Some(routing_overhead_ms),
-                Some(decision.tier.as_str()),
-            )?;
-        }
-        Ok(())
+                Some(decision.tier.as_str().to_string()),
+                started_at,
+                backend_latency_ms,
+            ),
+        ))
     }
 
     fn record_error(&self, decision: &StageRouterDecision) -> Result<()> {
@@ -561,11 +563,10 @@ impl Profile for StageRouterProfile {
         let (first_result, first_backend_latency_ms) = self.call_selected(&processed).await;
         match first_result {
             Ok(response) => {
-                let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-                self.record_success(
+                let response = self.record_success(
                     &processed.decision,
-                    &response,
-                    total_latency_ms,
+                    response,
+                    profile_started_at,
                     first_backend_latency_ms,
                 )?;
                 let response = self.rprocess(&processed, response).await?;
@@ -579,11 +580,10 @@ impl Profile for StageRouterProfile {
                 let (retry_result, retry_backend_latency_ms) = self.call_selected(&retry).await;
                 match retry_result {
                     Ok(response) => {
-                        let total_latency_ms = profile_started_at.elapsed().as_secs_f64() * 1000.0;
-                        self.record_success(
+                        let response = self.record_success(
                             &retry.decision,
-                            &response,
-                            total_latency_ms,
+                            response,
+                            profile_started_at,
                             retry_backend_latency_ms,
                         )?;
                         let response = self.rprocess(&retry, response).await?;
@@ -1017,8 +1017,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use futures_util::StreamExt;
     use serde_json::json;
-    use switchyard_core::{BackendFormat, ModelId};
+    use switchyard_core::{BackendFormat, ModelId, StreamEvent};
 
     use crate::backend::ProfileBackend;
     use crate::RequestMetadata;
@@ -1034,6 +1035,7 @@ mod tests {
     #[derive(Clone, Debug)]
     enum BackendAction {
         Ok,
+        OkStream,
         ContextOverflow,
     }
 
@@ -1069,6 +1071,20 @@ mod tests {
                         "completion_tokens": 5,
                     },
                 }))),
+                BackendAction::OkStream => {
+                    let events: Vec<Result<StreamEvent>> = vec![
+                        Ok(StreamEvent::Json(json!({
+                            "choices": [{"delta": {"content": "hi"}}],
+                        }))),
+                        Ok(StreamEvent::Json(json!({
+                            "choices": [],
+                            "usage": {"prompt_tokens": 19, "completion_tokens": 6},
+                        }))),
+                    ];
+                    Ok(ChatResponse::OpenAiStream(Box::pin(
+                        futures_util::stream::iter(events),
+                    )))
+                }
                 BackendAction::ContextOverflow => Err(SwitchyardError::ContextWindowExceeded {
                     target_id: self.target_id.clone(),
                     model: request.model().unwrap_or("").to_string(),
@@ -1148,6 +1164,43 @@ mod tests {
             enable_stats: true,
         };
         Ok((profile, calls))
+    }
+
+    #[tokio::test]
+    async fn stage_router_records_streaming_usage_after_consumption() -> Result<()> {
+        let (profile, _calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.7,
+            vec![BackendAction::OkStream],
+            vec![BackendAction::OkStream],
+        )?;
+
+        let response = profile
+            .run(profile_input(ChatRequest::openai_chat(json!({
+                "model": "smart-stage-router",
+                "messages": [{"role": "user", "content": "hi"}],
+            }))))
+            .await?;
+
+        // The call is attributed synchronously; streaming usage lands on consume.
+        let before = profile.stats.snapshot()?;
+        assert_eq!(before.total_requests, 1);
+        assert_eq!(before.total_tokens.prompt, 0);
+
+        let mut stream = match response.response {
+            ChatResponse::OpenAiStream(stream) => stream,
+            _ => return Err(SwitchyardError::Other("expected stream response".into())),
+        };
+        while let Some(event) = stream.next().await {
+            event?;
+        }
+
+        let after = profile.stats.snapshot()?;
+        assert_eq!(after.total_tokens.prompt, 19);
+        assert_eq!(after.total_tokens.completion, 6);
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/switchyard-components-v2/src/stats/mod.rs
+++ b/crates/switchyard-components-v2/src/stats/mod.rs
@@ -3,9 +3,13 @@
 
 //! Shared stats surface for profile-owned runtimes.
 
+mod stream_tap;
+
 use std::sync::OnceLock;
 
 use switchyard_components::StatsAccumulator;
+
+pub(crate) use stream_tap::{record_usage_or_tap_stream, UsageAttribution};
 
 /// Returns the process-wide stats accumulator used by v2 profiles.
 pub fn profile_stats_accumulator() -> StatsAccumulator {

--- a/crates/switchyard-components-v2/src/stats/stream_tap.rs
+++ b/crates/switchyard-components-v2/src/stats/stream_tap.rs
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native v2 stream tap that records token usage once a stream completes.
+//!
+//! v2 profiles record success synchronously, then read usage from the buffered
+//! response body. Streaming responses carry no buffered body, so their usage is
+//! only available while the stream is consumed. This module reuses the existing
+//! `switchyard-components` usage parsers and commits usage exactly once per
+//! stream, without depending on the v1 `ProxyContext` that
+//! `StatsResponseProcessor` needs.
+//!
+//! OpenAI-format taps keep the **last** usage frame observed and commit when
+//! the stream completes: spec-compliant upstreams send usage only on the final
+//! chunk, while cumulative emitters (e.g. vLLM with
+//! `stream_options.continuous_usage_stats`) update every chunk and must not be
+//! recorded from the first, partial frame. Streams that never carry a usage
+//! frame still commit zero usage so total-latency samples are not lost.
+
+use std::time::Instant;
+
+use async_stream::try_stream;
+use futures_util::StreamExt;
+use switchyard_components::stats::{
+    openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event, usage_from_body,
+    AnthropicStreamUsage, TokenUsage,
+};
+use switchyard_components::StatsAccumulator;
+use switchyard_core::{BoxResponseStream, ChatResponse, StreamEvent};
+
+/// Attribution captured before a response stream is consumed.
+///
+/// The matching `record_success` call has already counted the request against
+/// the model and tier, so usage is recorded with
+/// [`StatsAccumulator::record_usage_after_success_attribution`], which adds
+/// tokens and latency without double-counting the call.
+pub(crate) struct UsageAttribution {
+    accumulator: StatsAccumulator,
+    model: String,
+    tier: Option<String>,
+    started_at: Instant,
+    backend_latency_ms: f64,
+}
+
+impl UsageAttribution {
+    /// Captures the state needed to record usage once it becomes available.
+    pub(crate) fn new(
+        accumulator: StatsAccumulator,
+        model: impl Into<String>,
+        tier: Option<String>,
+        started_at: Instant,
+        backend_latency_ms: f64,
+    ) -> Self {
+        Self {
+            accumulator,
+            model: model.into(),
+            tier,
+            started_at,
+            backend_latency_ms,
+        }
+    }
+
+    /// Records the resolved usage, deriving total latency and routing overhead.
+    ///
+    /// For streams this runs on completion, so total latency spans the whole
+    /// response, matching the v1 stats processor semantics.
+    fn commit(&self, usage: TokenUsage) {
+        let total_latency_ms = self.started_at.elapsed().as_secs_f64() * 1000.0;
+        let routing_overhead_ms = (total_latency_ms - self.backend_latency_ms).max(0.0);
+        if let Err(error) = self.accumulator.record_usage_after_success_attribution(
+            self.model.clone(),
+            usage,
+            Some(total_latency_ms),
+            Some(routing_overhead_ms),
+            self.tier.as_deref(),
+        ) {
+            tracing::warn!(
+                error = %error,
+                model = %self.model,
+                "failed to record stream usage",
+            );
+        }
+    }
+}
+
+/// Records usage from a buffered body immediately, or taps a stream so usage is
+/// recorded once the stream completes.
+pub(crate) fn record_usage_or_tap_stream(
+    response: ChatResponse,
+    attribution: UsageAttribution,
+) -> ChatResponse {
+    match response {
+        ChatResponse::OpenAiStream(stream) => ChatResponse::OpenAiStream(tap_last_usage(
+            stream,
+            attribution,
+            openai_chat_usage_from_stream_event,
+        )),
+        ChatResponse::OpenAiResponsesStream(stream) => {
+            ChatResponse::OpenAiResponsesStream(tap_last_usage(
+                stream,
+                attribution,
+                openai_responses_usage_from_stream_event,
+            ))
+        }
+        ChatResponse::AnthropicStream(stream) => {
+            ChatResponse::AnthropicStream(tap_anthropic(stream, attribution))
+        }
+        buffered => {
+            let usage = buffered.body().map(usage_from_body).unwrap_or_default();
+            attribution.commit(usage);
+            buffered
+        }
+    }
+}
+
+/// Taps an OpenAI-format stream, committing the last usage frame on completion.
+///
+/// Keeping the last frame handles both spec-compliant upstreams (usage only on
+/// the final chunk) and cumulative emitters that update usage on every chunk.
+/// Committing on completion also records a latency sample for streams that
+/// never carry a usage frame. Abandoned streams commit nothing, matching the
+/// v1 stream taps.
+fn tap_last_usage(
+    mut stream: BoxResponseStream,
+    attribution: UsageAttribution,
+    extract: fn(&StreamEvent) -> Option<TokenUsage>,
+) -> BoxResponseStream {
+    Box::pin(try_stream! {
+        let mut latest = None;
+        while let Some(event) = stream.next().await {
+            let event = event?;
+            if let Some(usage) = extract(&event) {
+                latest = Some(usage);
+            }
+            yield event;
+        }
+        attribution.commit(latest.unwrap_or_default());
+    })
+}
+
+/// Taps an Anthropic stream, committing accumulated usage at `message_stop`.
+///
+/// If the stream ends without the observer committing (no usage frames seen),
+/// zero usage is committed so the total-latency sample is still recorded.
+fn tap_anthropic(
+    mut stream: BoxResponseStream,
+    attribution: UsageAttribution,
+) -> BoxResponseStream {
+    Box::pin(try_stream! {
+        let mut stream_usage = AnthropicStreamUsage::default();
+        let mut committed = false;
+        while let Some(event) = stream.next().await {
+            let event = event?;
+            if let Some(usage) = stream_usage.observe(&event) {
+                attribution.commit(usage);
+                committed = true;
+            }
+            yield event;
+        }
+        if !committed {
+            attribution.commit(TokenUsage::default());
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use switchyard_core::{Result, SwitchyardError};
+
+    use super::*;
+
+    fn attribution(accumulator: &StatsAccumulator) -> UsageAttribution {
+        UsageAttribution::new(
+            accumulator.clone(),
+            "provider/model",
+            Some("weak".to_string()),
+            Instant::now(),
+            5.0,
+        )
+    }
+
+    fn boxed_stream(events: Vec<StreamEvent>) -> BoxResponseStream {
+        let items: Vec<Result<StreamEvent>> = events.into_iter().map(Ok).collect();
+        Box::pin(futures_util::stream::iter(items))
+    }
+
+    async fn drain(response: ChatResponse) -> Result<usize> {
+        let mut stream = match response {
+            ChatResponse::OpenAiStream(stream)
+            | ChatResponse::OpenAiResponsesStream(stream)
+            | ChatResponse::AnthropicStream(stream) => stream,
+            other => {
+                return Err(SwitchyardError::Other(format!(
+                    "expected a stream response, got {other:?}"
+                )))
+            }
+        };
+        let mut count = 0;
+        while let Some(event) = stream.next().await {
+            event?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    #[tokio::test]
+    async fn buffered_response_records_usage_immediately() -> Result<()> {
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::openai_completion(json!({
+                "usage": {"prompt_tokens": 12, "completion_tokens": 4},
+            })),
+            attribution(&accumulator),
+        );
+
+        assert!(matches!(response, ChatResponse::OpenAiCompletion(_)));
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 12);
+        assert_eq!(snapshot.total_tokens.completion, 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openai_chat_stream_records_usage_only_after_consumption() -> Result<()> {
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::OpenAiStream(boxed_stream(vec![
+                StreamEvent::Json(json!({"choices": [{"delta": {"content": "hi"}}]})),
+                StreamEvent::Json(
+                    json!({"choices": [], "usage": {"prompt_tokens": 20, "completion_tokens": 8}}),
+                ),
+            ])),
+            attribution(&accumulator),
+        );
+
+        // The usage frame has not been consumed yet, so nothing is recorded.
+        assert_eq!(accumulator.snapshot()?.total_tokens.prompt, 0);
+
+        let forwarded = drain(response).await?;
+        assert_eq!(forwarded, 2, "every event must still reach the client");
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 20);
+        assert_eq!(snapshot.total_tokens.completion, 8);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openai_chat_cumulative_usage_frames_record_the_last_value() -> Result<()> {
+        // Cumulative emitters (e.g. vLLM continuous_usage_stats) put usage on
+        // every chunk; only the final cumulative value may be recorded.
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::OpenAiStream(boxed_stream(vec![
+                StreamEvent::Json(json!({
+                    "choices": [{"delta": {"content": "h"}}],
+                    "usage": {"prompt_tokens": 20, "completion_tokens": 1},
+                })),
+                StreamEvent::Json(json!({
+                    "choices": [{"delta": {"content": "i"}}],
+                    "usage": {"prompt_tokens": 20, "completion_tokens": 2},
+                })),
+                StreamEvent::Json(json!({
+                    "choices": [],
+                    "usage": {"prompt_tokens": 20, "completion_tokens": 8},
+                })),
+            ])),
+            attribution(&accumulator),
+        );
+
+        drain(response).await?;
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 20);
+        assert_eq!(
+            snapshot.total_tokens.completion, 8,
+            "the last cumulative frame must win, not the first"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stream_without_usage_frame_still_records_a_latency_sample() -> Result<()> {
+        // Clients that stream without stream_options.include_usage get no usage
+        // frame; the request already counted a call and must still contribute a
+        // total-latency sample (with zero tokens), as buffered paths do.
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::OpenAiStream(boxed_stream(vec![StreamEvent::Json(
+                json!({"choices": [{"delta": {"content": "hi"}}]}),
+            )])),
+            attribution(&accumulator),
+        );
+
+        drain(response).await?;
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 0);
+        assert_eq!(snapshot.total_tokens.completion, 0);
+        let model = snapshot
+            .models
+            .get("provider/model")
+            .ok_or_else(|| SwitchyardError::Other("model stats should be present".into()))?;
+        assert_eq!(
+            model.total_latency.count, 1,
+            "usage-less streams must still record a total-latency sample"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_records_usage_after_consumption() -> Result<()> {
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::OpenAiResponsesStream(boxed_stream(vec![StreamEvent::Json(json!({
+                "type": "response.completed",
+                "response": {"usage": {"input_tokens": 15, "output_tokens": 6}},
+            }))])),
+            attribution(&accumulator),
+        );
+
+        assert_eq!(accumulator.snapshot()?.total_tokens.prompt, 0);
+        drain(response).await?;
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 15);
+        assert_eq!(snapshot.total_tokens.completion, 6);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn anthropic_stream_records_usage_at_message_stop() -> Result<()> {
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::AnthropicStream(boxed_stream(vec![
+                StreamEvent::Json(json!({
+                    "type": "message_start",
+                    "message": {"usage": {"input_tokens": 30, "output_tokens": 0}},
+                })),
+                StreamEvent::Json(json!({
+                    "type": "message_delta",
+                    "usage": {"output_tokens": 9},
+                })),
+                StreamEvent::Json(json!({"type": "message_stop"})),
+            ])),
+            attribution(&accumulator),
+        );
+
+        assert_eq!(accumulator.snapshot()?.total_tokens.prompt, 0);
+        drain(response).await?;
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.prompt, 30);
+        assert_eq!(snapshot.total_tokens.completion, 9);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn anthropic_stream_without_usage_still_records_a_latency_sample() -> Result<()> {
+        let accumulator = StatsAccumulator::new();
+        let response = record_usage_or_tap_stream(
+            ChatResponse::AnthropicStream(boxed_stream(vec![StreamEvent::Json(
+                json!({"type": "content_block_delta", "delta": {"text": "hi"}}),
+            )])),
+            attribution(&accumulator),
+        );
+
+        drain(response).await?;
+
+        let snapshot = accumulator.snapshot()?;
+        assert_eq!(snapshot.total_tokens.completion, 0);
+        let model = snapshot
+            .models
+            .get("provider/model")
+            .ok_or_else(|| SwitchyardError::Other("model stats should be present".into()))?;
+        assert_eq!(model.total_latency.count, 1);
+        Ok(())
+    }
+}


### PR DESCRIPTION
### What

Adds a native v2 stream tap (`switchyard-components-v2/src/stats/stream_tap.rs`) and wires it into all five v2 profiles (passthrough, random-routing, llm-routing, cascade, latency-service), so `/v1/routing/stats` records token usage for streaming responses. Fixes the `108 calls / 0 tokens` shape reported in #18.

### Root cause

All v2 profiles read usage from the buffered body only:

```rust
let usage = response.body().map(usage_from_body).unwrap_or_default();
```

`ChatResponse::body()` returns `None` for the three stream variants, so streaming usage silently defaulted to zero while `record_success` still counted the call.

### Approach

Per the guidance in #18, this does **not** wire in the v1 `StatsResponseProcessor` (it depends on `ProxyContext` state that v2 doesn't have). Instead:

- `UsageAttribution` captures what v2 already holds locally before the stream is consumed: the stats accumulator, model, tier, request-start `Instant`, and backend latency.
- `record_usage_or_tap_stream(response, attribution)` records buffered bodies immediately and wraps the three stream variants so usage is committed once when the stream completes.
- Usage parsing reuses the existing `switchyard-components::stats` parsers (`openai_chat_usage_from_stream_event`, `openai_responses_usage_from_stream_event`, `AnthropicStreamUsage`).
- Usage is recorded via `record_usage_after_success_attribution`, so the tier call counted by `record_success` is not double-counted.

Profile wiring stays local: passthrough / random-routing / latency-service replace the inline usage read; llm-routing / cascade change `record_success` to take the response by value and return the (possibly wrapped) response. The cascade `enable_stats=false` guard is preserved (no tap when stats are disabled).

### Semantics notes (for review)

- **Last usage frame wins, committed at stream completion.** Spec-compliant upstreams send usage only on the final chunk; cumulative emitters (e.g. vLLM `stream_options.continuous_usage_stats`) update every chunk, so committing the first frame would under-count.
- **Usage-less streams still record latency.** Streams without a usage frame commit zero usage at completion, so total-latency samples aren't lost (matches the previous v2 behavior of recording zero usage).
- **Total latency spans until the stream completes**, matching the v1 stream taps. This includes client read time for streams — happy to change if you'd prefer header-time latency.
- **Client-disconnected streams commit nothing** — same limitation as the v1 taps.
- **Classifier-path usage is untouched** (llm-routing / cascade classifiers are always non-streaming, so `record_classifier_usage` still reads the buffered body).

### Testing

- Unit tests for the tap: buffered, OpenAI Chat / Responses / Anthropic streams, cumulative usage frames, usage-less streams (latency-sample preservation).
- Per-profile streaming tests for all five profiles, asserting usage is zero before the stream is consumed and recorded after.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass (toolchain 1.94.0).
- Live re-run of the #18 reproduction (passthrough profile → OpenRouter, Linux aarch64):

| Request | before (v0.1.0) | after this fix |
| --- | --- | --- |
| non-streaming | +49 | +43 |
| `"stream": true` | **+0** | **+50** |
| `"stream": true` + `stream_options.include_usage` | **+0** | **+50** |

(deltas are `total_tokens` in `/v1/routing/stats` per request; absolute counts vary with model output length)

Closes #18
