### PR TITLE
fix: accept both hyphen and underscore in v2 profile type names

### DIFF
--- a/crates/switchyard-components-v2/src/profiles/macros.rs
+++ b/crates/switchyard-components-v2/src/profiles/macros.rs
@@ -43,26 +43,43 @@ macro_rules! profile_types {
         }
 
         /// Parses a serialized profile body by dispatching to the owning config type.
+        ///
+        /// The `type` discriminator is matched with `-` and `_` treated as
+        /// equivalent, so a snake_case name copied from a legacy route bundle
+        /// (e.g. `random_routing`) resolves to its v2 profile, and a hyphenated
+        /// spelling of an underscore type (e.g. `stage-router`) resolves too.
         pub(crate) fn parse_profile_config(
             profile_type: &str,
             value: serde_json::Value,
             env: &crate::config::ProfileBuildEnv<'_>,
         ) -> switchyard_core::Result<ProfileConfigEntry> {
-            match profile_type {
-                $(
-                    <$config as crate::config::ProfileConfigDefinition>::PROFILE_TYPE => {
-                        let config =
-                            <$config as crate::config::ProfileConfigDefinition>::parse_profile_config(
-                                value,
-                                env,
-                            )?;
-                        Ok(ProfileConfigEntry::$config(Box::new(config)))
-                    }
-                )+
-                other => Err(switchyard_core::SwitchyardError::InvalidConfig(format!(
-                    "unknown profile type `{other}`"
-                ))),
+            // Compare treating `-` and `_` as equal without allocating. Profile
+            // type names are short ASCII, so an equal-length per-byte scan that
+            // folds the separators is enough. Registered names must stay unique
+            // under this folding (they are today) so dispatch is unambiguous.
+            fn eq_ignoring_separators(a: &str, b: &str) -> bool {
+                a.len() == b.len()
+                    && a.bytes().zip(b.bytes()).all(|(x, y)| {
+                        x == y || (matches!(x, b'-' | b'_') && matches!(y, b'-' | b'_'))
+                    })
             }
+
+            $(
+                if eq_ignoring_separators(
+                    profile_type,
+                    <$config as crate::config::ProfileConfigDefinition>::PROFILE_TYPE,
+                ) {
+                    let config =
+                        <$config as crate::config::ProfileConfigDefinition>::parse_profile_config(
+                            value,
+                            env,
+                        )?;
+                    return Ok(ProfileConfigEntry::$config(Box::new(config)));
+                }
+            )+
+            Err(switchyard_core::SwitchyardError::InvalidConfig(format!(
+                "unknown profile type `{profile_type}`"
+            )))
         }
     };
 }

--- a/crates/switchyard-components-v2/tests/config.rs
+++ b/crates/switchyard-components-v2/tests/config.rs
@@ -309,6 +309,73 @@ profiles:
     Ok(())
 }
 
+// `-` and `_` are equivalent in the `type` discriminator, so a name written with
+// either separator resolves to the same v2 profile: a legacy `random_routing`
+// spelling, and `stage-router` for the underscore-canonical stage router.
+#[test]
+fn profile_type_separators_are_normalized_during_resolution() -> Result<()> {
+    let input = r#"
+endpoints:
+  nvidia:
+    api_key: ${NVIDIA_API_KEY}
+    base_url: https://inference-api.nvidia.com/v1
+
+targets:
+  strong:
+    endpoint: nvidia
+    model: nvidia/moonshotai/kimi-k2.5
+    format: openai
+  weak:
+    endpoint: nvidia
+    model: nvidia/nvidia/nemotron-nano-9b-v2
+    format: openai
+  classifier:
+    endpoint: nvidia
+    model: nvidia/nvidia/nemotron-nano-9b-v2
+    format: openai
+
+profiles:
+  snake-llm:
+    type: llm_routing
+    strong: strong
+    weak: weak
+    classifier: classifier
+    profile_name: coding_agent
+  hyphen-stage:
+    type: stage-router
+    capable: strong
+    efficient: weak
+    fallback_target_on_evict: strong
+    picker: capable_first
+    confidence_threshold: 0.7
+  snake-latency:
+    type: latency_service
+    latency_service_url: http://latency.local
+    targets: [strong, weak]
+"#;
+
+    let plan = parse_yaml(input)?.resolve()?;
+
+    // Resolved profiles report the canonical type name regardless of the
+    // separator spelled in the config.
+    assert_eq!(
+        plan.profile_type(&ProfileId::new("snake-llm")?),
+        Some("llm-routing")
+    );
+    assert_eq!(
+        plan.profile_type(&ProfileId::new("hyphen-stage")?),
+        Some("stage_router")
+    );
+    assert_eq!(
+        plan.profile_type(&ProfileId::new("snake-latency")?),
+        Some("latency-service")
+    );
+
+    // The profiles build, not just parse.
+    assert_eq!(plan.build_profiles()?.len(), 3);
+    Ok(())
+}
+
 // Missing profile type discriminators should fail while parsing the document.
 #[test]
 fn missing_profile_type_is_rejected_during_document_parse() {


### PR DESCRIPTION
### What

Makes the v2 profile config (`switchyard serve --config profiles.yaml`) treat `-` and `_` as equivalent in the `type:` discriminator, so a profile type spelled with either separator resolves to the same profile.

### Why

The quickstart teaches the legacy route bundle with snake_case type names (`type: random_routing`), while v2 profile configs use hyphenated names (`random-routing`, `llm-routing`, `latency-service`). Copying `type: random_routing` into a `profiles.yaml` fails with `unknown profile type`. Since #20 the v2 names are themselves mixed (`random-routing` vs `stage_router`), so either separator is a reasonable spelling for any type.

This is the code-unification follow-up to #19 (a docs note), per the request there to fix it in code rather than documentation. #19 is closed in favor of this.

### How

`parse_profile_config` (the generated dispatch in `profiles/macros.rs`) now compares the requested `type` against each registered profile type treating `-` and `_` as equal, via a small non-allocating byte scan. Single dispatch point; no per-profile or macro-attribute changes. Unknown types still error with the user's original spelling.

- `random_routing` → `random-routing`
- `stage-router` → `stage_router`
- hyphenated/underscored spellings of `llm-routing`, `latency-service`, etc. all resolve

### Tests

- New `tests/config.rs::profile_type_separators_are_normalized_during_resolution`: `llm_routing`, `stage-router`, and `latency_service` resolve to their canonical types and build.
- Existing unknown-type / missing-type / empty-type tests unchanged.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass (toolchain 1.94.0).

### Notes

- Backward compatible: existing hyphenated (and `stage_router`) configs are unaffected.
- Scope is the v2 `--config` path (the failing side); the deprecated `--routing-profiles` bundle is unchanged.
- Registered profile type names must stay unique under separator folding (they are today), so dispatch is unambiguous.
- Normalization is applied at the config dispatch point (`parse_profile_config`). The resolved plan and runtime always report the canonical type name; `ProfileConfigDocument::profile_type()` still echoes the spelling written in the file. If you'd rather have the document accessor also report the canonical name, I can canonicalize at ingestion instead — let me know your preference.
- Docs are intentionally not touched (the confusion this documented is now removed in code).
