### PR TITLE
feat(stats): track max observed context tokens per model

### DIFF
--- a/crates/switchyard-components/src/stats/accumulator.rs
+++ b/crates/switchyard-components/src/stats/accumulator.rs
@@ -173,7 +173,9 @@ impl StatsAccumulator {
         {
             let stats = inner.model_stats_mut(model.clone());
             stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
-            stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
+            stats.max_observed_context_tokens = stats
+                .max_observed_context_tokens
+                .max(usage.prompt_tokens.saturating_add(usage.completion_tokens));
             stats.completion_tokens = stats
                 .completion_tokens
                 .saturating_add(usage.completion_tokens);
@@ -243,7 +245,9 @@ impl StatsAccumulator {
         let stats = inner.classifier_stats_mut(model.into());
         stats.calls = stats.calls.saturating_add(1);
         stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
-        stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
+        stats.max_observed_context_tokens = stats
+            .max_observed_context_tokens
+            .max(usage.prompt_tokens.saturating_add(usage.completion_tokens));
         stats.completion_tokens = stats
             .completion_tokens
             .saturating_add(usage.completion_tokens);
@@ -318,7 +322,9 @@ impl StatsAccumulator {
         let stats = inner.planner_stats_mut(model.into());
         stats.calls = stats.calls.saturating_add(1);
         stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
-        stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
+        stats.max_observed_context_tokens = stats
+            .max_observed_context_tokens
+            .max(usage.prompt_tokens.saturating_add(usage.completion_tokens));
         stats.completion_tokens = stats
             .completion_tokens
             .saturating_add(usage.completion_tokens);
@@ -557,7 +563,7 @@ fn build_model_snapshots(
                 errors: stats.errors,
                 request_pct,
                 prompt_tokens: stats.prompt_tokens,
-                max_prompt_tokens: stats.max_prompt_tokens,
+                max_observed_context_tokens: stats.max_observed_context_tokens,
                 completion_tokens: stats.completion_tokens,
                 total_tokens: token_total,
                 token_pct,
@@ -614,7 +620,7 @@ struct ModelStats {
     calls: u64,
     errors: u64,
     prompt_tokens: u64,
-    max_prompt_tokens: u64,
+    max_observed_context_tokens: u64,
     completion_tokens: u64,
     cached_tokens: u64,
     cache_creation_tokens: u64,
@@ -801,8 +807,8 @@ pub struct ModelStatsSnapshot {
     pub errors: u64,
     pub request_pct: f64,
     pub prompt_tokens: u64,
-    /// Largest prompt token count observed in one completed response.
-    pub max_prompt_tokens: u64,
+    /// Largest prompt-plus-completion token count observed in one completed response.
+    pub max_observed_context_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
     pub token_pct: f64,

--- a/crates/switchyard-components/src/stats/accumulator.rs
+++ b/crates/switchyard-components/src/stats/accumulator.rs
@@ -173,6 +173,7 @@ impl StatsAccumulator {
         {
             let stats = inner.model_stats_mut(model.clone());
             stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
+            stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
             stats.completion_tokens = stats
                 .completion_tokens
                 .saturating_add(usage.completion_tokens);
@@ -242,6 +243,7 @@ impl StatsAccumulator {
         let stats = inner.classifier_stats_mut(model.into());
         stats.calls = stats.calls.saturating_add(1);
         stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
+        stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
         stats.completion_tokens = stats
             .completion_tokens
             .saturating_add(usage.completion_tokens);
@@ -316,6 +318,7 @@ impl StatsAccumulator {
         let stats = inner.planner_stats_mut(model.into());
         stats.calls = stats.calls.saturating_add(1);
         stats.prompt_tokens = stats.prompt_tokens.saturating_add(usage.prompt_tokens);
+        stats.max_prompt_tokens = stats.max_prompt_tokens.max(usage.prompt_tokens);
         stats.completion_tokens = stats
             .completion_tokens
             .saturating_add(usage.completion_tokens);
@@ -554,6 +557,7 @@ fn build_model_snapshots(
                 errors: stats.errors,
                 request_pct,
                 prompt_tokens: stats.prompt_tokens,
+                max_prompt_tokens: stats.max_prompt_tokens,
                 completion_tokens: stats.completion_tokens,
                 total_tokens: token_total,
                 token_pct,
@@ -610,6 +614,7 @@ struct ModelStats {
     calls: u64,
     errors: u64,
     prompt_tokens: u64,
+    max_prompt_tokens: u64,
     completion_tokens: u64,
     cached_tokens: u64,
     cache_creation_tokens: u64,
@@ -796,6 +801,8 @@ pub struct ModelStatsSnapshot {
     pub errors: u64,
     pub request_pct: f64,
     pub prompt_tokens: u64,
+    /// Largest prompt token count observed in one completed response.
+    pub max_prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
     pub token_pct: f64,

--- a/crates/switchyard-components/tests/stats_accumulator.rs
+++ b/crates/switchyard-components/tests/stats_accumulator.rs
@@ -87,7 +87,7 @@ fn accumulator_matches_python_two_tier_snapshot_contract() -> Result<()> {
     assert_eq!(strong.tier.as_deref(), Some("strong"));
     assert_eq!(strong.request_pct, 50.0);
     assert_eq!(strong.token_pct, 73.53);
-    assert_eq!(strong.max_prompt_tokens, 100);
+    assert_eq!(strong.max_observed_context_tokens, 125);
     assert_eq!(strong.avg_prompt_tokens, 100.0);
     assert_eq!(strong.avg_completion_tokens, 25.0);
     assert_eq!(strong.cache_hit_rate, 0.1);
@@ -112,14 +112,15 @@ fn accumulator_matches_python_two_tier_snapshot_contract() -> Result<()> {
 }
 
 #[test]
-fn accumulator_tracks_max_prompt_tokens_per_model() -> Result<()> {
+fn accumulator_tracks_max_observed_context_tokens_per_model() -> Result<()> {
     let accumulator = StatsAccumulator::new();
-    for prompt_tokens in [100, 250, 175] {
+    for (prompt_tokens, completion_tokens) in [(100, 10), (90, 50), (120, 5)] {
         accumulator.record_success("model-a", None, None)?;
         accumulator.record_usage(
             "model-a",
             TokenUsage {
                 prompt_tokens,
+                completion_tokens,
                 ..TokenUsage::default()
             },
             None,
@@ -130,8 +131,9 @@ fn accumulator_tracks_max_prompt_tokens_per_model() -> Result<()> {
 
     let snapshot = accumulator.snapshot()?;
     let model = model_stats(&snapshot, "model-a")?;
-    assert_eq!(model.prompt_tokens, 525);
-    assert_eq!(model.max_prompt_tokens, 250);
+    assert_eq!(model.prompt_tokens, 310);
+    assert_eq!(model.completion_tokens, 65);
+    assert_eq!(model.max_observed_context_tokens, 140);
     Ok(())
 }
 
@@ -678,7 +680,7 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
         .get(model)
         .ok_or_else(|| SwitchyardError::Other("backend row missing".to_string()))?;
     assert_eq!(backend.prompt_tokens, 1_000_000);
-    assert_eq!(backend.max_prompt_tokens, 1_000_000);
+    assert_eq!(backend.max_observed_context_tokens, 1_000_000);
     assert_eq!(backend.calls, 1);
 
     // Classifier bucket: same model id, separate row, separate counts.
@@ -688,7 +690,7 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
         .get(model)
         .ok_or_else(|| SwitchyardError::Other("classifier row missing".to_string()))?;
     assert_eq!(classifier.prompt_tokens, 500_000);
-    assert_eq!(classifier.max_prompt_tokens, 500_000);
+    assert_eq!(classifier.max_observed_context_tokens, 500_000);
     assert_eq!(classifier.calls, 1);
     assert_eq!(snapshot.classifier.total_requests, 1);
 
@@ -701,13 +703,14 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
 }
 
 #[test]
-fn planner_bucket_tracks_max_prompt_tokens() -> Result<()> {
+fn planner_bucket_tracks_max_observed_context_tokens() -> Result<()> {
     let accumulator = StatsAccumulator::new();
-    for prompt_tokens in [120, 300, 200] {
+    for (prompt_tokens, completion_tokens) in [(120, 0), (300, 5), (200, 200)] {
         accumulator.record_planner_usage(
             "planner/model",
             TokenUsage {
                 prompt_tokens,
+                completion_tokens,
                 ..TokenUsage::default()
             },
             None,
@@ -721,20 +724,29 @@ fn planner_bucket_tracks_max_prompt_tokens() -> Result<()> {
         .get("planner/model")
         .ok_or_else(|| SwitchyardError::Other("planner row missing".to_string()))?;
     assert_eq!(planner.prompt_tokens, 620);
-    assert_eq!(planner.max_prompt_tokens, 300);
+    assert_eq!(planner.max_observed_context_tokens, 400);
     Ok(())
 }
 
 #[test]
 fn classifier_latency_lands_on_classifier_model_call_latency() -> Result<()> {
     let accumulator = StatsAccumulator::new();
-    accumulator.record_classifier_usage("claude-sonnet-4-6", TokenUsage::default(), Some(15.0))?;
+    accumulator.record_classifier_usage(
+        "claude-sonnet-4-6",
+        TokenUsage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            ..TokenUsage::default()
+        },
+        Some(15.0),
+    )?;
     let snapshot = accumulator.snapshot()?;
     let row = snapshot
         .classifier
         .models
         .get("claude-sonnet-4-6")
         .ok_or_else(|| SwitchyardError::Other("classifier row missing".to_string()))?;
+    assert_eq!(row.max_observed_context_tokens, 15);
     assert_eq!(row.model_call_latency.count, 1);
     assert_eq!(row.model_call_latency.total_ms, 15.0);
     Ok(())

--- a/crates/switchyard-components/tests/stats_accumulator.rs
+++ b/crates/switchyard-components/tests/stats_accumulator.rs
@@ -87,6 +87,7 @@ fn accumulator_matches_python_two_tier_snapshot_contract() -> Result<()> {
     assert_eq!(strong.tier.as_deref(), Some("strong"));
     assert_eq!(strong.request_pct, 50.0);
     assert_eq!(strong.token_pct, 73.53);
+    assert_eq!(strong.max_prompt_tokens, 100);
     assert_eq!(strong.avg_prompt_tokens, 100.0);
     assert_eq!(strong.avg_completion_tokens, 25.0);
     assert_eq!(strong.cache_hit_rate, 0.1);
@@ -107,6 +108,30 @@ fn accumulator_matches_python_two_tier_snapshot_contract() -> Result<()> {
     assert_eq!(weak_tier.model, "weak/model");
     assert_eq!(weak_tier.prompt_tokens, 40);
     assert_eq!(weak_tier.completion_tokens, 5);
+    Ok(())
+}
+
+#[test]
+fn accumulator_tracks_max_prompt_tokens_per_model() -> Result<()> {
+    let accumulator = StatsAccumulator::new();
+    for prompt_tokens in [100, 250, 175] {
+        accumulator.record_success("model-a", None, None)?;
+        accumulator.record_usage(
+            "model-a",
+            TokenUsage {
+                prompt_tokens,
+                ..TokenUsage::default()
+            },
+            None,
+            None,
+            None,
+        )?;
+    }
+
+    let snapshot = accumulator.snapshot()?;
+    let model = model_stats(&snapshot, "model-a")?;
+    assert_eq!(model.prompt_tokens, 525);
+    assert_eq!(model.max_prompt_tokens, 250);
     Ok(())
 }
 
@@ -653,6 +678,7 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
         .get(model)
         .ok_or_else(|| SwitchyardError::Other("backend row missing".to_string()))?;
     assert_eq!(backend.prompt_tokens, 1_000_000);
+    assert_eq!(backend.max_prompt_tokens, 1_000_000);
     assert_eq!(backend.calls, 1);
 
     // Classifier bucket: same model id, separate row, separate counts.
@@ -662,6 +688,7 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
         .get(model)
         .ok_or_else(|| SwitchyardError::Other("classifier row missing".to_string()))?;
     assert_eq!(classifier.prompt_tokens, 500_000);
+    assert_eq!(classifier.max_prompt_tokens, 500_000);
     assert_eq!(classifier.calls, 1);
     assert_eq!(snapshot.classifier.total_requests, 1);
 
@@ -670,6 +697,31 @@ fn classifier_bucket_keeps_same_model_separate_from_routed_traffic() -> Result<(
     assert_eq!(snapshot.cost_estimate.backend_cost, 3.0);
     assert_eq!(snapshot.cost_estimate.classifier_cost, 1.5);
     assert_eq!(snapshot.cost_estimate.total_cost, 4.5);
+    Ok(())
+}
+
+#[test]
+fn planner_bucket_tracks_max_prompt_tokens() -> Result<()> {
+    let accumulator = StatsAccumulator::new();
+    for prompt_tokens in [120, 300, 200] {
+        accumulator.record_planner_usage(
+            "planner/model",
+            TokenUsage {
+                prompt_tokens,
+                ..TokenUsage::default()
+            },
+            None,
+        )?;
+    }
+
+    let snapshot = accumulator.snapshot()?;
+    let planner = snapshot
+        .planner
+        .models
+        .get("planner/model")
+        .ok_or_else(|| SwitchyardError::Other("planner row missing".to_string()))?;
+    assert_eq!(planner.prompt_tokens, 620);
+    assert_eq!(planner.max_prompt_tokens, 300);
     Ok(())
 }
 

--- a/switchyard/lib/live_stats_collector.py
+++ b/switchyard/lib/live_stats_collector.py
@@ -93,8 +93,8 @@ class ModelStats:
       sum ``input_tokens + cache_creation_input_tokens +
       cache_read_input_tokens`` (Anthropic reports them as siblings, not
       parent/child).  For OpenAI it is ``usage.prompt_tokens``.
-    * ``max_prompt_tokens`` — largest input-token count observed in one
-      completed response.
+    * ``max_observed_context_tokens`` — largest prompt-plus-completion
+      token count observed in one completed response.
     * ``completion_tokens`` — total output tokens.
     * ``total_tokens`` — ``prompt_tokens + completion_tokens``.
     * ``reasoning_tokens`` — subset of ``completion_tokens`` for chain-of-
@@ -110,7 +110,7 @@ class ModelStats:
     tier: str = ""
     calls: int = 0
     prompt_tokens: int = 0
-    max_prompt_tokens: int = 0
+    max_observed_context_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
     reasoning_tokens: int = 0
@@ -160,7 +160,10 @@ class LiveStatsCollector:
                 self._models[model] = bucket
             bucket.calls += 1
             bucket.prompt_tokens += prompt_tokens
-            bucket.max_prompt_tokens = max(bucket.max_prompt_tokens, prompt_tokens)
+            bucket.max_observed_context_tokens = max(
+                bucket.max_observed_context_tokens,
+                prompt_tokens + completion_tokens,
+            )
             bucket.completion_tokens += completion_tokens
             bucket.total_tokens += prompt_tokens + completion_tokens
             bucket.reasoning_tokens += reasoning_tokens
@@ -218,7 +221,7 @@ class LiveStatsCollector:
                         "tier": str,
                         "calls": int,
                         "prompt_tokens": int,
-                        "max_prompt_tokens": int,
+                        "max_observed_context_tokens": int,
                         "completion_tokens": int,
                         "total_tokens": int,
                         "reasoning_tokens": int,
@@ -248,7 +251,7 @@ class LiveStatsCollector:
                 "tier": b.tier,
                 "calls": b.calls,
                 "prompt_tokens": b.prompt_tokens,
-                "max_prompt_tokens": b.max_prompt_tokens,
+                "max_observed_context_tokens": b.max_observed_context_tokens,
                 "completion_tokens": b.completion_tokens,
                 "total_tokens": b.total_tokens,
                 "reasoning_tokens": b.reasoning_tokens,

--- a/switchyard/lib/live_stats_collector.py
+++ b/switchyard/lib/live_stats_collector.py
@@ -93,6 +93,8 @@ class ModelStats:
       sum ``input_tokens + cache_creation_input_tokens +
       cache_read_input_tokens`` (Anthropic reports them as siblings, not
       parent/child).  For OpenAI it is ``usage.prompt_tokens``.
+    * ``max_prompt_tokens`` — largest input-token count observed in one
+      completed response.
     * ``completion_tokens`` — total output tokens.
     * ``total_tokens`` — ``prompt_tokens + completion_tokens``.
     * ``reasoning_tokens`` — subset of ``completion_tokens`` for chain-of-
@@ -108,6 +110,7 @@ class ModelStats:
     tier: str = ""
     calls: int = 0
     prompt_tokens: int = 0
+    max_prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
     reasoning_tokens: int = 0
@@ -157,6 +160,7 @@ class LiveStatsCollector:
                 self._models[model] = bucket
             bucket.calls += 1
             bucket.prompt_tokens += prompt_tokens
+            bucket.max_prompt_tokens = max(bucket.max_prompt_tokens, prompt_tokens)
             bucket.completion_tokens += completion_tokens
             bucket.total_tokens += prompt_tokens + completion_tokens
             bucket.reasoning_tokens += reasoning_tokens
@@ -214,6 +218,7 @@ class LiveStatsCollector:
                         "tier": str,
                         "calls": int,
                         "prompt_tokens": int,
+                        "max_prompt_tokens": int,
                         "completion_tokens": int,
                         "total_tokens": int,
                         "reasoning_tokens": int,
@@ -243,6 +248,7 @@ class LiveStatsCollector:
                 "tier": b.tier,
                 "calls": b.calls,
                 "prompt_tokens": b.prompt_tokens,
+                "max_prompt_tokens": b.max_prompt_tokens,
                 "completion_tokens": b.completion_tokens,
                 "total_tokens": b.total_tokens,
                 "reasoning_tokens": b.reasoning_tokens,

--- a/tests/test_live_stats_collector.py
+++ b/tests/test_live_stats_collector.py
@@ -54,7 +54,7 @@ def test_record_accumulates_across_calls():
     assert s.request_count == 2
     assert s.prompt_tokens == 30
     assert s.completion_tokens == 15
-    assert c.to_dict()["models"]["unknown"]["max_prompt_tokens"] == 20
+    assert c.to_dict()["models"]["unknown"]["max_observed_context_tokens"] == 30
 
 
 def test_snapshot_returns_copy():

--- a/tests/test_live_stats_collector.py
+++ b/tests/test_live_stats_collector.py
@@ -54,6 +54,7 @@ def test_record_accumulates_across_calls():
     assert s.request_count == 2
     assert s.prompt_tokens == 30
     assert s.completion_tokens == 15
+    assert c.to_dict()["models"]["unknown"]["max_prompt_tokens"] == 20
 
 
 def test_snapshot_returns_copy():

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -53,7 +53,7 @@ async def test_v1_stats_returns_existing_json_shape(
     assert body["total_requests"] == 1
     assert body["models"]["m"]["calls"] == 1
     assert body["models"]["m"]["prompt_tokens"] == 5
-    assert body["models"]["m"]["max_prompt_tokens"] == 5
+    assert body["models"]["m"]["max_observed_context_tokens"] == 8
     assert "cost_estimate" in body
 
 

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -53,6 +53,7 @@ async def test_v1_stats_returns_existing_json_shape(
     assert body["total_requests"] == 1
     assert body["models"]["m"]["calls"] == 1
     assert body["models"]["m"]["prompt_tokens"] == 5
+    assert body["models"]["m"]["max_prompt_tokens"] == 5
     assert "cost_estimate" in body
 
 


### PR DESCRIPTION
## Summary

- expose `max_observed_context_tokens` in each per-model row returned by `/v1/stats`
- calculate it as the largest `prompt_tokens + completion_tokens` observed for one completed call
- track the same high-water mark for backend, classifier, and planner calls
- keep the legacy Python collector and endpoint contract consistent

## Why

The cumulative token count and maximum prompt size do not describe the largest sequence processed by a model. The observed prompt-plus-completion high-water mark is a better input for estimating memory requirements when running agent workloads on smaller hardware or model combinations.

## Semantics

- values are grouped by model and retained for the current stats lifetime, until reset
- cached input is already included in normalized prompt usage, while reasoning is included in completion usage, so neither is counted twice
- this reports observed usage rather than the provider-advertised maximum context-window capacity

## Validation

- `uv run ruff check .`
- `uv run mypy switchyard`
- `pytest tests/ -m "not integration"`: 1,888 passed, 12 skipped
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes https://github.com/NVIDIA-NeMo/Switchyard/issues/23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-model “maximum observed context tokens” value to stats outputs, reflecting the largest prompt-plus-completion size seen for each model.
  * This value is now included in live stats and the `/v1/stats` response.

* **Bug Fixes**
  * Improved stats tracking so routed, classifier, and planner usage each contribute correctly to their own model totals.
  * Stats snapshots now preserve the new context-size value across reporting paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->