### PR TITLE
chore: Upgrade to Rust 1.96.1 (latest stable)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ authors = ["NVIDIA Corporation"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA-NeMo/Switchyard"
-rust-version = "1.94"
+rust-version = "1.96.1"

--- a/benchmark/switchyard-server.Dockerfile
+++ b/benchmark/switchyard-server.Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG RUST_VERSION=1.94
+ARG RUST_VERSION=1.96.1
 FROM rust:${RUST_VERSION}-bookworm
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.17 /uv /uvx /usr/local/bin/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.1"
 components = ["clippy", "rustfmt", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
From 1.94.0. We didn't trip any new clippy lints, so very simple.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Rust version to 1.96.1 across the workspace and build environment.
  * Aligned the pinned toolchain and container-based benchmark setup to use the same newer Rust release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->