### PR TITLE
chore: require switchyard_team code-owner review via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# PRs to main require review from the Switchyard core team.
+* @NVIDIA-NeMo/switchyard_team


### PR DESCRIPTION
Adds a root CODEOWNERS assigning `@NVIDIA-NeMo/switchyard_team` (14 members, write access) as default owners for the entire repo.

Pairs with flipping `require_code_owner_review: true` on the `main` branch ruleset, so every PR to main requires an approving review from a Switchyard core team member — today any collaborator with write access can approve.