### PR TITLE
fix(classifier): surface fail-open fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ LLM-classifier router, which you tune with `--weak-model`, `--classifier-model`,
 single-model passthrough. The `--routing-profiles FILE` path is deprecated and
 remains only for launcher-owned legacy bundles.
 
+Production LLM-classifier deployments should alert on
+`switchyard_classifier_fail_open_triggered_total`; successful fail-open responses
+include `x-switchyard-fallback: classifier_error`.
+
 ## Features
 
 - **Protocol Translation**: convert between OpenAI Chat, Anthropic Messages, and OpenAI Responses formats

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -135,6 +135,11 @@ LLM classifier routes can also enable
 [Session Affinity (Sticky Routing)](routing_algorithms/sticky_routing.md) to pin
 multi-turn conversations to one tier.
 
+For production LLM-classifier routes, alert on
+`switchyard_classifier_fail_open_triggered_total`. If the classifier fails and
+`classifier_fail_open` is enabled, successful responses include
+`x-switchyard-fallback: classifier_error`.
+
 A single YAML file can declare multiple routes. Each route becomes a model id on
 `GET /v1/models`; the first declared route is the launcher's initial model. See
 [Routing Overview](routing_algorithms/overview.md) for route selection and the

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -90,6 +90,32 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 Treat these as smoke checks, not fixed test vectors: the classifier model and
 prompt determine the verdict.
 
+## Production observability
+
+`classifier_fail_open: true` keeps traffic available when the classifier times
+out, returns a bad status, hits an SSL failure, or emits unparseable JSON. The
+client still receives HTTP 200 from the configured default tier, so production
+deployments must alert on the fallback path rather than on client errors.
+
+Switchyard exposes two first-class signals when fail-open is triggered:
+
+- Prometheus counter:
+  `switchyard_classifier_fail_open_triggered_total{reason="upstream_5xx"|"upstream_4xx"|"timeout"|"ssl"|"parse_error"|"low_confidence"|"other"}`
+- HTTP response header: `x-switchyard-fallback: classifier_error`
+
+Recommended alert:
+
+```yaml
+- alert: SwitchyardClassifierFailOpen
+  expr: sum(rate(switchyard_classifier_fail_open_triggered_total[5m])) > 0.05
+  for: 10m
+  annotations:
+    summary: Switchyard classifier failing; requests are falling back to the default tier
+```
+
+`/v1/routing/stats` still includes the lower-level
+`classifier.total_errors` counter for debugging the classifier bucket.
+
 ## Useful options
 
 | Option | Use it when |

--- a/switchyard/cli/launchers/launcher_runtime.py
+++ b/switchyard/cli/launchers/launcher_runtime.py
@@ -285,10 +285,15 @@ def _route_type_summary(route_type: str, route: object, route_key: str) -> str:
 
 def deterministic_strategy_summary(config: DeterministicRoutingConfig) -> str:
     """Return the strategy summary string for a deterministic (LLM-classifier) launch."""
+    alert = (
+        ", alert=switchyard_classifier_fail_open_triggered_total"
+        if getattr(config, "classifier_fail_open", True)
+        else ""
+    )
     return (
         f"llm-classifier: classifier={config.classifier.model}, "
         f"strong={config.strong.model}, weak={config.weak.model}, "
-        f"profile={config.profile_name}"
+        f"profile={config.profile_name}{alert}"
     )
 
 

--- a/switchyard/lib/endpoints/dispatch.py
+++ b/switchyard/lib/endpoints/dispatch.py
@@ -11,7 +11,10 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from switchyard.lib.endpoints.error_envelope import error_response
 from switchyard.lib.endpoints.route_selection import route_selection_headers
 from switchyard.lib.endpoints.upstream_error import record_upstream_attempt_success
-from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.proxy_context import (
+    CTX_SWITCHYARD_FALLBACK,
+    ProxyContext,
+)
 from switchyard.lib.roles import TranslatedResponse
 from switchyard.lib.route_table import RouteTable
 from switchyard_rust.core import ChatRequest
@@ -110,6 +113,11 @@ def serialize_chain_result(
     silently opt out of spend attribution.
     """
     headers = route_selection_headers(ctx)
+    fallback = ctx.metadata.get(CTX_SWITCHYARD_FALLBACK)
+    if isinstance(fallback, str) and fallback:
+        # Client-visible marker for availability-preserving fallback paths,
+        # stamped alongside the route-selection headers on every branch.
+        headers["x-switchyard-fallback"] = fallback
     if isinstance(result, Response):
         # Merge rather than pass through untouched: no current chain path
         # yields a pre-built Response after a billed upstream success, but if

--- a/switchyard/lib/endpoints/outcome_metrics.py
+++ b/switchyard/lib/endpoints/outcome_metrics.py
@@ -3,7 +3,7 @@
 
 """Outcome counters used to compute router-vs-direct error-rate ratios.
 
-Three process-wide counters published on ``/metrics``:
+Four process-wide counters published on ``/metrics``:
 
 * ``switchyard_client_responses_total{outcome}`` — every HTTP response
   returned to a client on an LLM-serving route. The denominator for the
@@ -20,6 +20,9 @@ Three process-wide counters published on ``/metrics``:
   incremented whenever a request's first upstream attempt failed and a
   subsequent attempt succeeded — direct evidence the steering logic
   rescued the request.
+* ``switchyard_classifier_fail_open_triggered_total{reason}`` — classifier
+  fallback events where routing used the default tier because the classifier
+  could not produce a usable verdict.
 
 Bucket semantics:
 
@@ -57,6 +60,16 @@ from threading import Lock
 from typing import Literal
 
 OutcomeBucket = Literal["success", "retryable_error", "other_error"]
+
+CLASSIFIER_FAIL_OPEN_REASONS = (
+    "upstream_5xx",
+    "upstream_4xx",
+    "timeout",
+    "ssl",
+    "parse_error",
+    "low_confidence",
+    "other",
+)
 
 #: HTTP status codes the success criterion counts as router-rescuable
 #: errors. 429 (rate limit), 500 (server error), 504 (gateway timeout).
@@ -104,6 +117,7 @@ def _seed_upstream() -> dict[tuple[str, str], int]:
 #: string, ``"none"`` for a non-HTTP failure, or a clamped ``"Nxx"`` class.
 _upstream_attempts: dict[tuple[str, str], int] = _seed_upstream()
 _retry_recovered: int = 0
+_classifier_fail_open: dict[str, int] = dict.fromkeys(CLASSIFIER_FAIL_OPEN_REASONS, 0)
 
 
 def classify(status_code: int) -> OutcomeBucket:
@@ -174,6 +188,49 @@ def record_retry_recovered() -> None:
         _retry_recovered += 1
 
 
+def classifier_fail_open_reason(exc: BaseException) -> str:
+    """Map classifier failures onto bounded Prometheus reasons."""
+    status = _status_code(exc)
+    if status is not None:
+        if 500 <= status < 600:
+            return "upstream_5xx"
+        if 400 <= status < 500:
+            return "upstream_4xx"
+    text = _exception_chain_text(exc)
+    if "ssl" in text or "certificate" in text:
+        return "ssl"
+    if "timeout" in text or "timed out" in text:
+        return "timeout"
+    return "other"
+
+
+def record_classifier_fail_open(reason: str) -> None:
+    """Record one classifier fallback-to-default event."""
+    if reason not in _classifier_fail_open:
+        reason = "other"
+    with _lock:
+        _classifier_fail_open[reason] += 1
+
+
+def _status_code(exc: BaseException) -> int | None:
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def _exception_chain_text(exc: BaseException) -> str:
+    parts: list[str] = []
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        parts.extend((type(current).__name__, str(current)))
+        current = current.__cause__ or current.__context__
+    return " ".join(parts).lower()
+
+
 def render_lines() -> list[str]:
     """Render the current counter state as Prometheus exposition lines.
 
@@ -184,6 +241,7 @@ def render_lines() -> list[str]:
         client = dict(_client_responses)
         upstream = dict(_upstream_attempts)
         recovered = _retry_recovered
+        fail_open = dict(_classifier_fail_open)
 
     lines: list[str] = []
     lines.append(
@@ -220,6 +278,17 @@ def render_lines() -> list[str]:
     lines.append("# TYPE switchyard_router_retry_recovered_total counter")
     lines.append(f"switchyard_router_retry_recovered_total {recovered}")
 
+    lines.append(
+        "# HELP switchyard_classifier_fail_open_triggered_total "
+        "Classifier fallbacks to the default tier after unusable classifier verdicts."
+    )
+    lines.append("# TYPE switchyard_classifier_fail_open_triggered_total counter")
+    for reason in CLASSIFIER_FAIL_OPEN_REASONS:
+        lines.append(
+            f'switchyard_classifier_fail_open_triggered_total{{reason="{reason}"}} '
+            f"{fail_open[reason]}"
+        )
+
     return lines
 
 
@@ -233,15 +302,20 @@ def _reset_for_tests() -> None:
         # each test starts from the same canonical seed.
         _upstream_attempts = _seed_upstream()
         _retry_recovered = 0
+        for reason in _classifier_fail_open:
+            _classifier_fail_open[reason] = 0
 
 
 __all__ = [
+    "CLASSIFIER_FAIL_OPEN_REASONS",
     "KNOWN_STATUS_CODES",
     "NO_STATUS_CODE",
     "RETRYABLE_STATUSES",
     "OutcomeBucket",
+    "classifier_fail_open_reason",
     "classify",
     "code_label",
+    "record_classifier_fail_open",
     "record_client_response",
     "record_retry_recovered",
     "record_upstream_attempt",

--- a/switchyard/lib/processors/llm_classifier/request_processor.py
+++ b/switchyard/lib/processors/llm_classifier/request_processor.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from switchyard.lib.endpoints import outcome_metrics
 from switchyard.lib.llm_client import OpenAILLMClient
 from switchyard.lib.processors._structured_output import build_response_format
 from switchyard.lib.processors.llm_classifier.signals import (
@@ -23,7 +24,7 @@ from switchyard.lib.processors.llm_classifier.signals import (
     RouteTier,
 )
 from switchyard.lib.processors.message_condensing import strip_markdown_fence, trim_messages
-from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.proxy_context import CTX_SWITCHYARD_FALLBACK, ProxyContext
 from switchyard.lib.session_affinity import SessionAffinity
 from switchyard.lib.stats_accumulator import StatsAccumulator
 from switchyard_rust.core import ChatRequest
@@ -381,6 +382,13 @@ class LLMClassifierRequestProcessor:
             signals = self._signal_schema.make_abstain(
                 self._config.fallback_recommended_tier,
             )
+            reason = (
+                "parse_error"
+                if isinstance(exc, LLMClassifierError)
+                else outcome_metrics.classifier_fail_open_reason(exc)
+            )
+            outcome_metrics.record_classifier_fail_open(reason)
+            ctx.metadata[CTX_SWITCHYARD_FALLBACK] = "classifier_error"
             _fail_open_exc: Exception | None = exc
         else:
             _fail_open_exc = None

--- a/switchyard/lib/processors/stage_router/classifier.py
+++ b/switchyard/lib/processors/stage_router/classifier.py
@@ -11,7 +11,9 @@ import time
 from importlib.resources import files
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from switchyard.lib.endpoints import outcome_metrics
 from switchyard.lib.llm_client import OpenAILLMClient
+from switchyard.lib.proxy_context import CTX_SWITCHYARD_FALLBACK
 
 if TYPE_CHECKING:
     from switchyard.lib.proxy_context import ProxyContext
@@ -221,8 +223,12 @@ class TierClassifier:
                 max_tokens=4096,
                 extra_body=extra_body,
             )
-        except Exception:
+        except Exception as exc:
             log.warning("classifier call failed; falling open", exc_info=True)
+            outcome_metrics.record_classifier_fail_open(
+                outcome_metrics.classifier_fail_open_reason(exc)
+            )
+            ctx.metadata[CTX_SWITCHYARD_FALLBACK] = "classifier_error"
             if self._stats is not None:
                 try:
                     await self._stats.record_classifier_error(self._model)
@@ -243,7 +249,11 @@ class TierClassifier:
                 )
             except Exception:
                 pass
-        return _parse_tier(response)
+        tier = _parse_tier(response)
+        if tier is None:
+            outcome_metrics.record_classifier_fail_open("parse_error")
+            ctx.metadata[CTX_SWITCHYARD_FALLBACK] = "classifier_error"
+        return tier
 
 
 __all__ = ["CAPABLE_TIER", "TierClassifier", "EFFICIENT_TIER"]

--- a/switchyard/lib/proxy_context.py
+++ b/switchyard/lib/proxy_context.py
@@ -102,6 +102,11 @@ CTX_UPSTREAM_MODEL = "_upstream_model"
 #: correlation id.
 CTX_ROUTE_SELECTION = "_route_selection"
 
+#: Client-visible successful fallback marker. Endpoints surface this as
+#: ``x-switchyard-fallback`` so callers can distinguish normal 200 responses
+#: from availability-preserving fallback paths.
+CTX_SWITCHYARD_FALLBACK = "_switchyard_fallback"
+
 
 __all__ = [
     "CTX_CALLER_API_KEY",
@@ -113,6 +118,7 @@ __all__ = [
     "CTX_ROUTE_SELECTION",
     "CTX_ROUTING",
     "CTX_TARGET_FORMAT",
+    "CTX_SWITCHYARD_FALLBACK",
     "CTX_UPSTREAM_ATTEMPTS_RECORDED",
     "CTX_UPSTREAM_HTTP_BODY",
     "CTX_UPSTREAM_HTTP_STATUS",

--- a/tests/test_llm_classifier_request_processor.py
+++ b/tests/test_llm_classifier_request_processor.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 
 import pytest
 
+from switchyard.lib.endpoints import outcome_metrics
 from switchyard.lib.processors.llm_classifier import (
     CTX_DETERMINISTIC_ROUTE_SIGNALS,
     ClassifierCompletion,
@@ -22,7 +23,7 @@ from switchyard.lib.processors.llm_classifier import (
     TaskType,
     parse_route_signals,
 )
-from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.proxy_context import CTX_SWITCHYARD_FALLBACK, ProxyContext
 from switchyard.lib.session_affinity import SessionAffinity
 from switchyard_rust.core import ChatRequest
 
@@ -67,6 +68,13 @@ class _FakeClassifierClient:
         if isinstance(self.response, Exception):
             raise self.response
         return ClassifierCompletion(content=self.response, usage=self.usage)
+
+
+@pytest.fixture(autouse=True)
+def _reset_classifier_fail_open_metrics() -> None:
+    outcome_metrics._reset_for_tests()
+    yield
+    outcome_metrics._reset_for_tests()
 
 
 def _messages_with_prior_assistant_turns(n: int) -> list[dict[str, str]]:
@@ -222,6 +230,11 @@ async def test_request_processor_fail_open_stamps_abstain_signals() -> None:
     assert signals.abstain is True
     assert signals.confidence == 0.0
     assert signals.reason_code is ReasonCode.AMBIGUOUS
+    assert ctx.metadata[CTX_SWITCHYARD_FALLBACK] == "classifier_error"
+
+    metrics = "\n".join(outcome_metrics.render_lines())
+    assert 'switchyard_classifier_fail_open_triggered_total{reason="parse_error"} 1' in metrics
+    assert 'switchyard_classifier_fail_open_triggered_total{reason="timeout"} 0' in metrics
 
 
 async def test_fail_open_annotates_signals_dump(capsys: pytest.CaptureFixture[str]) -> None:
@@ -240,6 +253,41 @@ async def test_fail_open_annotates_signals_dump(capsys: pytest.CaptureFixture[st
     assert payload["fail_open"] is True
     assert "upstream timeout" in payload["error"]
     assert payload["abstain"] is True
+    metrics = "\n".join(outcome_metrics.render_lines())
+    assert 'switchyard_classifier_fail_open_triggered_total{reason="timeout"} 1' in metrics
+
+
+class _StatusClassifierError(RuntimeError):
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"upstream returned {status_code}")
+        self.status_code = status_code
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (_StatusClassifierError(500), "upstream_5xx"),
+        (_StatusClassifierError(401), "upstream_4xx"),
+        (RuntimeError("SSL CERTIFICATE_VERIFY_FAILED"), "ssl"),
+    ],
+)
+async def test_fail_open_records_bounded_reason_metric(
+    error: Exception,
+    reason: str,
+) -> None:
+    fake = _FakeClassifierClient(error)
+    processor = LLMClassifierRequestProcessor(
+        LLMClassifierConfig(model="router-model"),
+        client=fake,
+    )
+
+    await processor.process(ProxyContext(), _request())
+
+    metrics = "\n".join(outcome_metrics.render_lines())
+    assert (
+        f'switchyard_classifier_fail_open_triggered_total{{reason="{reason}"}} 1'
+        in metrics
+    )
 
 
 async def test_request_processor_fail_closed_raises() -> None:

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import FastAPI
 from prometheus_client.parser import text_string_to_metric_families
 
+from switchyard.lib.endpoints import outcome_metrics
 from switchyard.lib.endpoints.stats_endpoint import PROMETHEUS_CONTENT_TYPE, StatsEndpoint
 from switchyard.lib.stats_accumulator import StatsAccumulator
 
@@ -26,6 +27,13 @@ from switchyard.lib.stats_accumulator import StatsAccumulator
 @pytest.fixture
 def stats() -> StatsAccumulator:
     return StatsAccumulator()
+
+
+@pytest.fixture(autouse=True)
+def _reset_classifier_fail_open_metrics() -> None:
+    outcome_metrics._reset_for_tests()
+    yield
+    outcome_metrics._reset_for_tests()
 
 
 @pytest.fixture
@@ -90,6 +98,21 @@ async def test_metrics_returns_prometheus_exposition(
     assert (
         'switchyard_model_call_latency_ms_count{model="strong/m",tier="strong"} 1'
         in body
+    )
+
+
+async def test_metrics_includes_classifier_fail_open_counter(
+    client: httpx.AsyncClient,
+) -> None:
+    outcome_metrics.record_classifier_fail_open("upstream_5xx")
+
+    resp = await client.get("/metrics")
+
+    assert resp.status_code == 200
+    assert "# TYPE switchyard_classifier_fail_open_triggered_total counter" in resp.text
+    assert (
+        'switchyard_classifier_fail_open_triggered_total{reason="upstream_5xx"} 1'
+        in resp.text
     )
 
 

--- a/tests/test_routing_banner.py
+++ b/tests/test_routing_banner.py
@@ -74,8 +74,9 @@ class TestStrategyHelpers:
         config.strong.model = "strong-model"
         config.weak.model = "weak-model"
         config.profile_name = "default"
+        config.classifier_fail_open = True
         result = deterministic_strategy_summary(config)
-        assert result == "llm-classifier: classifier=clf-model, strong=strong-model, weak=weak-model, profile=default"
+        assert result == "llm-classifier: classifier=clf-model, strong=strong-model, weak=weak-model, profile=default, alert=switchyard_classifier_fail_open_triggered_total"
 
 
 def _captured_strategy(captured: dict) -> str | None:

--- a/tests/test_stage_router_classifier.py
+++ b/tests/test_stage_router_classifier.py
@@ -16,12 +16,14 @@ from typing import Any
 
 import pytest
 
+from switchyard.lib.endpoints import outcome_metrics
 from switchyard.lib.processors.stage_router.classifier import (
     CAPABLE_TIER,
     EFFICIENT_TIER,
     RECENT_MESSAGES_KEY,
     TierClassifier,
 )
+from switchyard.lib.proxy_context import CTX_SWITCHYARD_FALLBACK
 from switchyard_rust.components import DimensionCollector, get_tool_result_signal
 from switchyard_rust.core import ChatRequest, ProxyContext
 
@@ -51,6 +53,13 @@ class _StubClient:
         if self._response.raise_exc is not None:
             raise self._response.raise_exc
         return self._response
+
+
+@pytest.fixture(autouse=True)
+def _reset_classifier_fail_open_metrics() -> None:
+    outcome_metrics._reset_for_tests()
+    yield
+    outcome_metrics._reset_for_tests()
 
 
 async def _build_signal() -> Any:
@@ -93,6 +102,9 @@ async def test_falls_open_on_malformed_json():
         client=_StubClient(_Resp(content="not json at all")),
     )
     assert await classifier.classify(ctx, signal) is None
+    metrics = "\n".join(outcome_metrics.render_lines())
+    assert 'switchyard_classifier_fail_open_triggered_total{reason="parse_error"} 1' in metrics
+    assert ctx.metadata[CTX_SWITCHYARD_FALLBACK] == "classifier_error"
 
 
 @pytest.mark.asyncio
@@ -113,6 +125,9 @@ async def test_falls_open_on_network_error():
         client=_StubClient(_Resp(raise_exc=TimeoutError("upstream slow"))),
     )
     assert await classifier.classify(ctx, signal) is None
+    metrics = "\n".join(outcome_metrics.render_lines())
+    assert 'switchyard_classifier_fail_open_triggered_total{reason="timeout"} 1' in metrics
+    assert ctx.metadata[CTX_SWITCHYARD_FALLBACK] == "classifier_error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_switchyard_app_factory.py
+++ b/tests/test_switchyard_app_factory.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from switchyard.lib.endpoints.base import Endpoint
+from switchyard.lib.proxy_context import CTX_SWITCHYARD_FALLBACK
 from switchyard.server.switchyard_app import build_switchyard_app
 
 
@@ -19,8 +20,9 @@ class _RequestWithBody(Protocol):
 
 
 class _RecordingSwitchyard:
-    def __init__(self) -> None:
+    def __init__(self, *, fallback: str | None = None) -> None:
         self.requests: list[_RequestWithBody] = []
+        self.fallback = fallback
 
     async def call(
         self,
@@ -29,6 +31,8 @@ class _RecordingSwitchyard:
         ctx: object | None = None,
     ) -> dict[str, object]:
         self.requests.append(request)
+        if self.fallback is not None and hasattr(ctx, "metadata"):
+            ctx.metadata[CTX_SWITCHYARD_FALLBACK] = self.fallback
         return {
             "id": "resp-test",
             "object": "response",
@@ -76,6 +80,21 @@ def test_responses_endpoint_uses_app_factory_switchyard() -> None:
     assert response.status_code == 200
     assert response.json()["model"] == "test-model"
     assert len(switchyard.requests) == 1
+
+
+def test_endpoint_surfaces_switchyard_fallback_header() -> None:
+    switchyard = _RecordingSwitchyard(fallback="classifier_error")
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1/responses",
+            json={"model": "test-model", "input": "ping"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-switchyard-fallback"] == "classifier_error"
+    assert response.json()["model"] == "test-model"
 
 
 def test_app_registers_component_contributed_endpoints() -> None:


### PR DESCRIPTION
## Summary

- Add a first-class `switchyard_classifier_fail_open_triggered_total{reason=...}` Prometheus counter for classifier fail-open fallbacks.
- Surface successful classifier fail-open responses with `x-switchyard-fallback: classifier_error`.
- Document production alerting requirements and show the fail-open metric in deterministic launcher banners.

## Changes

| File | What changed |
|---|---|
| `switchyard/lib/processors/llm_classifier/request_processor.py` | Record bounded fail-open reasons and stamp fallback metadata. |
| `switchyard/lib/endpoints/*` | Publish the metric on `/metrics` and attach fallback headers to serialized responses. |
| `README.md`, `docs/**` | Document the metric, header, and recommended alert. |
| `tests/**` | Cover metric emission, reason mapping, response header propagation, and banner text. |

## Validation

- `git diff --check`
- `uv run ruff check .`
- `uv run mypy switchyard`
- `uv run pytest tests/test_llm_classifier_request_processor.py tests/test_metrics_endpoint.py tests/test_switchyard_app_factory.py tests/test_routing_banner.py tests/readme/test_readme.py tests/getting_started/test_getting_started.py -v -o addopts=`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production observability for classifier fail-open behavior, including a new Prometheus metric and a response header that signals fallback responses.
  * Responses can now include fallback metadata when classifier failures are handled successfully.

* **Documentation**
  * Expanded getting-started and routing docs with alerting guidance, fallback behavior details, and recommended monitoring steps.

* **Bug Fixes**
  * Improved visibility into classifier failures by surfacing fallback status consistently in metrics and HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->