### PR TITLE
fix(route-bundle): remove public noop passthrough types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ write yourself.
 **Launcher routing is explicit.** By default, launchers use the built-in
 LLM-classifier router, which you tune with `--weak-model`, `--classifier-model`,
 `--profile`, and `--classifier-min-confidence`. Use `--model X` for
-single-model passthrough. The `--routing-profiles FILE` path is deprecated and
+single-model route. The `--routing-profiles FILE` path is deprecated and
 remains only for launcher-owned legacy bundles.
 
 ## Features
@@ -72,11 +72,11 @@ switchyard launch openclaw --model openai/gpt-4o-mini --api-key "$OPENROUTER_API
 ```
 
 Each launcher starts a local proxy, points the agent at it, and shuts the proxy
-down when the agent exits. Use `--model` for single-model passthrough. The
+down when the agent exits. Use `--model` for single-model route. The
 deprecated `--routing-profiles` flag remains for launcher-owned legacy bundles:
 
 ```bash
-switchyard launch claude --model openai/gpt-4o-mini --base-url https://openrouter.ai/api/v1       # single-model passthrough
+switchyard launch claude --model openai/gpt-4o-mini --base-url https://openrouter.ai/api/v1       # single-model route
 switchyard --routing-profiles routes.yaml -- launch claude                                        # legacy route bundle
 ```
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -67,12 +67,12 @@ launchers:
 
 | Flag | Purpose |
 |---|---|
-| `--model ID` | Single-model passthrough. Every request is rewritten to `model=ID` and forwarded to `--base-url`. |
-| `--routing-profiles PATH` | Deprecated path to a routing-profile YAML bundle. Each entry under `routes:` builds its own chain. Public route types are `model`, `passthrough`, `random_routing`, `stage_router`, and `deterministic`. Falls back to the path persisted by `switchyard --routing-profiles PATH -- configure` when omitted. |
+| `--model ID` | Single-model route. Every request is rewritten to `model=ID` and forwarded to `--base-url`. |
+| `--routing-profiles PATH` | Deprecated path to a routing-profile YAML bundle. Each entry under `routes:` builds its own chain. Public route types are `model`, `random_routing`, `routellm`, `latency_service`, `stage_router`, `deterministic`, and `plan_execute`; use `model` for standalone target execution. Falls back to the path persisted by `switchyard --routing-profiles PATH -- configure` when omitted. |
 
 On the launchers, the two flags are mutually exclusive: pass one or the other, not both.
 
-- `--model ID`: single-model passthrough. Any model id from `GET /v1/models` is accepted; every request is rewritten to `model=ID` and forwarded upstream.
+- `--model ID`: single-model route. Any model id from `GET /v1/models` is accepted; every request is rewritten to `model=ID` and forwarded upstream.
 - `--routing-profiles PATH`: loads a multi-chain YAML bundle; the first declared route becomes the initial model.
 
 For legacy route-bundle `type: deterministic` routes, the `classifier:` block also accepts:
@@ -277,7 +277,7 @@ switchyard [--routing-profiles PATH] launch claude [--model ID]
 ```
 
 When neither CLI routing flag is passed, `launch claude` uses a saved routing bundle
-first, then a saved `claude.model` as single-model passthrough. The built-in
+first, then a saved `claude.model` as single-model route. The built-in
 LLM-as-classifier route is the default only when neither a bundle nor a single-model
 default is resolved.
 
@@ -310,7 +310,7 @@ default is resolved.
 **Examples**
 
 ```bash
-# Single-model passthrough
+# Single-model route
 switchyard launch claude --model openai/gpt-4o-mini
 
 # Use a routing bundle
@@ -343,7 +343,7 @@ switchyard [--routing-profiles PATH] launch codex [--model ID]
 ```
 
 When neither CLI routing flag is passed, `launch codex` uses a saved routing bundle
-first, then a saved `codex.model` as single-model passthrough. The built-in
+first, then a saved `codex.model` as single-model route. The built-in
 LLM-as-classifier route is the default only when neither a bundle nor a single-model
 default is resolved. `--weak-model`, `--classifier-model`, `--profile`, and
 `--classifier-min-confidence` tune only that built-in route. `CODEX_ARGS` are forwarded
@@ -379,7 +379,7 @@ switchyard [--routing-profiles PATH] launch openclaw [--model ID]
 ```
 
 When neither CLI routing flag is passed, `launch openclaw` uses a saved routing bundle
-first, then a saved `openclaw.model` as single-model passthrough. The built-in
+first, then a saved `openclaw.model` as single-model route. The built-in
 LLM-as-classifier route is the default only when neither a bundle nor a single-model
 default is resolved. `--weak-model`, `--classifier-model`, `--profile`, and
 `--classifier-min-confidence` tune only that built-in route.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -61,19 +61,16 @@ faster. A tier is a role you hand to a target rather than a fixed property of it
 so the same target can be the strong tier in one profile and the weak tier in
 another.
 
-A profile's `type` sets the strategy. `passthrough` sends everything to one
-target with no routing. `random-routing` splits traffic on a fixed probability.
-`llm-routing` asks a classifier model to pick a tier for each turn. `stage_router`
-escalates from weak to strong when request signals call for it. The
-[Routing Overview](routing_algorithms/overview.md) covers when to use each and
-how to tune it.
+A profile's `type` sets the strategy. `random-routing` splits traffic on a
+fixed probability. `llm-routing` asks a classifier model to pick a tier for each
+turn. `stage_router` escalates from weak to strong when request signals call for
+it. The [Routing Overview](routing_algorithms/overview.md) covers when to use
+each and how to tune it.
 
-!!! warning "There is no `type: model`"
-    The current profile config does not have a `type: model`. To expose a single
-    model, point clients at a target ID directly, or add a `passthrough` profile
-    when you want a second name for it. `type: model` survives only in the
-    deprecated `--routing-profiles` bundles used by the launcher compatibility
-    path.
+!!! note "Single-model routes"
+    In profile configs, target IDs are directly addressable model IDs. In the
+    deprecated `--routing-profiles` route-bundle format, use `type: model` for a
+    standalone target alias.
 
 Session affinity, or sticky routing, pins a conversation to one tier so later
 turns reuse it instead of being classified again. It belongs to `llm-routing`

--- a/docs/guides/agent_launchers.md
+++ b/docs/guides/agent_launchers.md
@@ -51,7 +51,7 @@ single model.
 
 ## Override the default route
 
-Use `--model` for a single-model passthrough session:
+Use `--model` for a single-model route session:
 
 ```bash
 switchyard launch claude --model openai/gpt-4o-mini
@@ -100,8 +100,9 @@ simultaneously.
 2. Switch back to the validated default route. If that works, the issue is
    model-specific.
 
-In passthrough mode, Switchyard forwards the empty response as-is. Multi-target
-routing profiles treat empty completions as errors and surface them explicitly.
+For a single-model route, Switchyard forwards the empty response as-is.
+Multi-target routing profiles treat empty completions as errors and surface them
+explicitly.
 
 ### Claude Code with MCP tools
 

--- a/docs/operations/context_window.md
+++ b/docs/operations/context_window.md
@@ -7,8 +7,7 @@ also overflows, the request fails with a 400 in the client's inbound wire
 format.
 
 Any multi-target route (stage-router, random_routing, or deterministic) supports
-this. Set `fallback_target_on_evict` on the route. Single-target routes
-(`type: passthrough`, `type: model`) have no alternative target, so the original
+this. Set `fallback_target_on_evict` on the route. Single-target `type: model` routes have no alternative target, so the original
 overflow propagates unchanged.
 
 ## Configuration

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -71,10 +71,6 @@ profile and target appears on `GET /v1/models`:
 
 ```yaml
 profiles:
-  fast:
-    type: passthrough
-    target: weak
-
   smart:
     type: random-routing
     strong: strong
@@ -82,26 +78,17 @@ profiles:
     strong_probability: 0.3
 ```
 
-Use the profile ID to select policy behavior (`fast` or `smart`) and a target ID
-to bypass routing (`weak` or `strong`).
+Use the profile ID to select policy behavior (`smart`) and a target ID to bypass
+routing (`weak` or `strong`).
 
-## Direct targets and passthrough aliases
+## Direct targets and model routes
 
-For new profile configs, use one public model concept:
+For new profile configs, select a target ID directly when you want to call one
+upstream model without a routing policy. The target ID is already a public model
+ID on `GET /v1/models`.
 
-- Select a target ID directly when its configured name is the client-facing
-  name you want.
-- Add a `type: passthrough` profile only when you need another stable alias for
-  that target, such as `fast` above.
-
-Both choices call the same single target. There is no `type: model` profile in
-the current profile schema.
-
-The deprecated `--routing-profiles` route-bundle format has a separate legacy
-distinction: `type: model` registers one explicit alias without model discovery,
-while `type: passthrough` queries the upstream model catalog and registers the
-discovered models too. That distinction applies only to legacy `routes:`
-bundles used by the launcher compatibility path.
+The deprecated `--routing-profiles` route-bundle format uses `type: model` for
+standalone target aliases.
 
 ## Self-hosted targets
 
@@ -126,15 +113,12 @@ targets:
     model: my-rl-qwen
     format: openai
 
-profiles:
-  fast-local:
-    type: passthrough
-    target: local-weak
 ```
 
-Reference `local-weak` from any routing profile field that accepts a target ID,
-including `strong`, `weak`, `target`, or `targets`. Switchyard does not start or
-manage the model server; it only sends requests to the configured endpoint.
+Clients can select `local-weak` directly as a model ID, or reference it from any
+routing profile field that accepts a target ID, including `strong`, `weak`,
+`target`, or `targets`. Switchyard does not start or manage the model server; it
+only sends requests to the configured endpoint.
 
 ## How session affinity composes
 

--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -295,7 +295,7 @@ curl -s http://localhost:4000/v1/stats > routing_stats_final.json
 
 ## When *not* to use stage-router
 
-- **Single-model deployments.** Use a plain passthrough profile instead.
+- **Single-model deployments.** Select a target ID directly instead.
 - **Probabilistic A/B splits.** Use
   [Random Routing](random_routing.md) (`type: random-routing` in profile configs).
   The stage-router's signals are wasted on a fixed traffic ratio.

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -38,7 +38,7 @@ async def main():
         print("Set it with: export OPENAI_API_KEY='sk-...'")
         return
 
-    # Create a passthrough proxy that forwards to OpenAI
+    # Create a single-model route that forwards to OpenAI
     switchyard = SwitchyardRecipes.passthrough_recipe(
         api_key=api_key,
         base_url="https://api.openai.com/v1",

--- a/examples/profiles.yaml
+++ b/examples/profiles.yaml
@@ -4,7 +4,7 @@
 #
 # Each profile id and each target id is exposed as a model on GET /v1/models, so
 # a client (or `switchyard launch claude --model <id>`) selects a profile by id:
-#   fast                 passthrough to the efficient model
+#   target ids           direct single-model routes
 #   smart-stage-router   signal-based stage-router routing between the efficient and capable models
 #   the model ids        the targets, addressable directly
 #
@@ -30,10 +30,6 @@ targets:
     format: openai
 
 profiles:
-  fast:
-    type: passthrough
-    target: moonshotai/kimi-k2.6
-
   smart-stage-router:
     type: stage_router
     capable: anthropic/claude-opus-4.7

--- a/examples/python_profile.yaml
+++ b/examples/python_profile.yaml
@@ -10,8 +10,8 @@
 #
 #   switchyard serve --config examples/python_profile.yaml
 #
-# `direct` is a Rust passthrough; `smart` is the shipped Python `header-routing`
-# profile (switchyard/lib/profiles/header_routing.py), which picks a tier from the
+# `smart` is the shipped Python `header-routing` profile
+# (switchyard/lib/profiles/header_routing.py), which picks a tier from the
 # x-switchyard-tier request header and delegates the call to a Rust target
 # backend. Both share the same resolved targets.
 
@@ -31,10 +31,6 @@ targets:
     format: openai
 
 profiles:
-  direct:
-    type: passthrough
-    target: weak
-
   smart:
     type: header-routing
     strong: strong

--- a/examples/route.yaml
+++ b/examples/route.yaml
@@ -8,18 +8,12 @@ routes:
     type: model
     target: moonshotai/kimi-k2.6
 
-  openrouter-catalog:               # `type: passthrough` — auto-discovers available models via GET /v1/models
-    type: passthrough
-
   random-router:                    # `type: random_routing` — weighted coin
     type: random_routing
     strong: anthropic/claude-opus-4.7
     weak: moonshotai/kimi-k2.6
     strong_probability: 0.3
     fallback_target_on_evict: strong
-
-  bench:                            # `type: noop` — for benchmarking
-    type: noop
 
   llm-classifier:                   # `type: deterministic` — LLM-as-classifier
     type: deterministic

--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -104,7 +104,7 @@ def _is_deterministic_launch(
     """Return ``True`` when the resolved launch will use deterministic routing.
 
     For ``claude`` / ``codex``: deterministic is the implicit default when
-    no single-model passthrough (CLI ``--model`` or saved
+    no single-model route (CLI ``--model`` or saved
     ``configured_route.model``) and no routing-profiles bundle (CLI
     ``--routing-profiles`` or saved bundle) is in play. Pass
     ``route=None`` to check before the route is resolved (e.g. inside
@@ -474,7 +474,7 @@ def cmd_launch_claude(args: argparse.Namespace) -> None:
         validated coding-agent trio (Claude Opus 4.7 + Nemotron-3 Super
         + DeepSeek V4 Flash classifier). Override individual tiers with
         ``--weak-model`` / ``--classifier-model`` / ``--profile``.
-      * ``--model X`` — single-tier passthrough to X.
+      * ``--model X`` — single-model route to X.
       * ``--routing-profiles FILE`` (global flag) — YAML-driven multi-chain table.
         ``--model`` is optional; falls back to the first YAML route.
 
@@ -536,7 +536,7 @@ def cmd_launch_claude(args: argparse.Namespace) -> None:
         configured_route = LaunchRouteConfig()
     route = route_from_launch_args(args, configured_route)
     # Deterministic LLM-classifier routing is the implicit default for
-    # ``launch claude`` when neither single-model passthrough nor a
+    # ``launch claude`` when neither single-model route nor a
     # routing-profiles bundle is in play.
     deterministic = _is_deterministic_launch(
         target="claude", args=args, route=route, routing_profiles=routing_profiles,
@@ -735,7 +735,7 @@ def cmd_launch_codex(args: argparse.Namespace) -> None:
         configured_route = LaunchRouteConfig()
     route = route_from_launch_args(args, configured_route)
     # Deterministic LLM-classifier routing is the implicit default for
-    # ``launch codex`` when neither single-model passthrough nor a
+    # ``launch codex`` when neither single-model route nor a
     # routing-profiles bundle is in play.
     deterministic = _is_deterministic_launch(
         target="codex", args=args, route=route, routing_profiles=routing_profiles,
@@ -938,7 +938,7 @@ def cmd_launch_openclaw(args: argparse.Namespace) -> None:
         configured_route = LaunchRouteConfig()
     route = route_from_launch_args(args, configured_route)
     # LLM-classifier routing is the implicit default for ``launch openclaw``
-    # when neither single-model passthrough nor a routing-profiles bundle is
+    # when neither single-model route nor a routing-profiles bundle is
     # in play.
     deterministic = _is_deterministic_launch(
         target="openclaw", args=args, route=route, routing_profiles=routing_profiles,

--- a/switchyard/cli/launchers/claude_code_launcher.py
+++ b/switchyard/cli/launchers/claude_code_launcher.py
@@ -5,8 +5,8 @@
 
 Implements two UXes on top of a single chain-agnostic runner:
 
-* ``switchyard launch claude --model <name>`` — single-model
-  passthrough.  Spin up an in-process V2 passthrough proxy on a free
+* ``switchyard launch claude --model <name>`` — single-model route.
+  Spin up an in-process V2 proxy on a free
   local port, probe the backend for native ``POST /v1/messages``
   support, build the matching chain
   (:class:`AnthropicNativeBackend` or :class:`OpenAiNativeBackend`
@@ -297,7 +297,7 @@ def _run_claude_with_switchyard(
 
     Takes a pre-built :class:`Switchyard` and a display-only model
     name.  The caller decides what's in the chain (single-model
-    passthrough, random routing across a preset, latency-service
+    single-model routing, random routing across a preset, latency-service
     pool, …) — this function owns only the uvicorn-in-a-thread +
     ``claude`` supervision + env-var injection boilerplate that is
     identical across those modes.
@@ -419,7 +419,7 @@ def launch_claude(
     routing_profiles: str | None = None,
     rl_log_dir: Path | None = None,
 ) -> int:
-    """Start a passthrough proxy and run ``claude`` against it.
+    """Start a single-model proxy and run ``claude`` against it.
 
     Single-model UX — ``model`` seeds Claude Code's session, while the
     proxy preserves any model Claude Code sends later so ``/model``
@@ -427,7 +427,7 @@ def launch_claude(
 
     When ``routing_profiles`` is given, the launcher builds a
     :class:`RouteTable` instead of a single chain: ``model`` is
-    registered as a tier passthrough, then every entry from the YAML file
+    registered as a direct tier route, then every entry from the YAML file
     is merged on top via :meth:`RouteTable.register`. YAML routes
     win on id conflict. The launcher's stats accumulator is threaded into
     both the launcher's chain and the YAML loader so all traffic records
@@ -498,7 +498,7 @@ def launch_claude_deterministic_routing(
     The LLM-classifier chain (classifier → tier selector → per-tier dispatch)
     is wrapped in a :class:`RouteTable` whose virtual model is the
     deterministic routing target. Configured strong + weak models register
-    as direct passthrough chains so the Claude Code ``/model`` picker can
+    as direct model-route chains so the Claude Code ``/model`` picker can
     override the routing policy. The classifier is not user-selectable.
     """
     from switchyard.cli.model_catalog.model_discovery import fetch_model_ids

--- a/switchyard/cli/launchers/codex_cli_launcher.py
+++ b/switchyard/cli/launchers/codex_cli_launcher.py
@@ -6,8 +6,8 @@
 Sibling of :mod:`switchyard.cli.launchers.claude_code_launcher`, but
 spawns the OpenAI Codex CLI instead of Claude Code:
 
-* ``switchyard launch codex --model <name>`` — single-model
-  passthrough.  Spin up an in-process V2 passthrough proxy on a free
+* ``switchyard launch codex --model <name>`` — single-model route.
+  Spin up an in-process V2 proxy on a free
   local port, wire up a Responses-native OpenAI backend through the generic
   ``LlmTarget`` recipe, then spawn ``codex`` against the proxy.
 
@@ -214,7 +214,7 @@ def _codex_catalog_entry_for_registered_model(
     return (
         model_id,
         f"{_codex_model_display_name(model_id)} (Switchyard)",
-        f"Direct Switchyard passthrough to discovered model {model_id}.",
+        f"Direct Switchyard model route to discovered model {model_id}.",
     )
 
 
@@ -443,7 +443,7 @@ def launch_codex(
     routing_profiles: str | None = None,
     rl_log_dir: Path | None = None,
 ) -> int:
-    """Start a passthrough proxy and run ``codex`` against it.
+    """Start a single-model proxy and run ``codex`` against it.
 
     Single-model UX — ``model`` seeds the Codex session, while the proxy
     preserves any model Codex sends later so client-side model selection
@@ -451,7 +451,7 @@ def launch_codex(
 
     When ``routing_profiles`` is given, the launcher builds a
     :class:`RouteTable` instead of a single chain: ``model`` is
-    registered as a tier passthrough, then every entry from the YAML file
+    registered as a direct tier route, then every entry from the YAML file
     is merged on top (including each tier's ``GET /v1/models`` catalog
     hydration). Codex's ``/model`` picker is populated from the merged
     table, so YAML-declared models appear alongside the launcher-
@@ -482,7 +482,7 @@ def launch_codex(
     if routing_profiles is not None:
         # Wrap the single chain in a RouteTable so YAML routes can
         # merge on top. The launcher's `model` registers as a tier
-        # passthrough; YAML entries land alongside (override on id conflict).
+        # model route; YAML entries land alongside (override on id conflict).
         # Codex's /model picker iterates the table, so YAML-declared
         # models surface in the picker automatically.
         from switchyard.lib.route_table import RouteTable
@@ -565,7 +565,7 @@ def _codex_catalog_entry_for_deterministic_model(
     return (
         model_id,
         f"{_codex_model_display_name(model_id)} (Switchyard)",
-        f"Direct Switchyard passthrough to discovered model {model_id}.",
+        f"Direct Switchyard model route to discovered model {model_id}.",
     )
 
 
@@ -630,7 +630,7 @@ def launch_codex_deterministic_routing(
         model_table,
         # Boot codex on the virtual routing model so the LLM classifier runs by
         # default — matches launch_claude_deterministic_routing. Pinning the
-        # strong model id here would hit its direct passthrough and silently
+        # strong model id here would hit its direct model route and silently
         # bypass routing.
         display_model=routing_model,
         port=port,

--- a/switchyard/cli/launchers/launcher_runtime.py
+++ b/switchyard/cli/launchers/launcher_runtime.py
@@ -220,8 +220,8 @@ def stdin_is_tty() -> bool:
 
 
 def passthrough_strategy_summary(model: str) -> str:
-    """Return the strategy summary string for a single-model passthrough."""
-    return f"passthrough → {model}"
+    """Return the strategy summary string for a single-model route."""
+    return f"model → {model}"
 
 
 def routing_profiles_strategy_summary(routing_profiles: str, default_model: str) -> str:
@@ -277,9 +277,9 @@ def _route_type_summary(route_type: str, route: object, route_key: str) -> str:
     if route_type == "random_routing":
         p = r.get("strong_probability", "")
         return f"random-routing: strong={_model(r.get('strong'))}, weak={_model(r.get('weak'))}, p_strong={p}"
-    if route_type in ("model", "passthrough"):
+    if route_type == "model":
         target = r.get("model") or r.get("target") or route_key
-        return f"passthrough → {target}"
+        return f"model → {target}"
     return f"{route_type}: {route_key}"
 
 
@@ -307,7 +307,7 @@ def _format_strategy_lines(summary: str) -> list[str]:
     """Expand a strategy summary string into one or more banner lines.
 
     ``type: k1=v1, k2=v2`` → type on first line, each k=v pair indented.
-    ``passthrough → model`` → single line (no key=value pairs to split).
+    ``model → target`` → single line (no key=value pairs to split).
     """
     col = "  routing   "  # label column: 2 indent + 7 label + 3 gap = 12 chars
     pad = " " * len(col)

--- a/switchyard/cli/launchers/openclaw_launcher.py
+++ b/switchyard/cli/launchers/openclaw_launcher.py
@@ -8,8 +8,8 @@ Sibling of :mod:`switchyard.cli.launchers.claude_code_launcher` and
 `OpenClaw <https://github.com/openclaw/openclaw>`_ personal-agent CLI
 instead of Claude Code / Codex:
 
-* ``switchyard launch openclaw --model <name>`` — single-model
-  passthrough.  Spin up an in-process V2 passthrough proxy on a free
+* ``switchyard launch openclaw --model <name>`` — single-model route.
+  Spin up an in-process V2 proxy on a free
   local port, wire up an OpenAI Chat backend through the generic
   ``LlmTarget`` recipe, then spawn ``openclaw chat`` against the proxy.
 
@@ -506,7 +506,7 @@ def launch_openclaw(
     routing_profiles: str | None = None,
     rl_log_dir: Path | None = None,
 ) -> int:
-    """Start a passthrough proxy and run ``openclaw chat`` against it.
+    """Start a single-model proxy and run ``openclaw chat`` against it.
 
     Single-model UX — ``model`` seeds the OpenClaw session, while the
     proxy preserves any model OpenClaw sends later so a client-side
@@ -514,7 +514,7 @@ def launch_openclaw(
 
     When ``routing_profiles`` is given, the launcher builds a
     :class:`RouteTable` instead of a single chain: ``model`` is
-    registered as a tier passthrough, then every entry from the YAML
+    registered as a direct tier route, then every entry from the YAML
     file is merged on top (including each tier's ``GET /v1/models``
     catalog hydration). OpenClaw's ``/model`` picker is populated from
     the merged table via ``agents.defaults.models``, so YAML-declared
@@ -545,7 +545,7 @@ def launch_openclaw(
     if routing_profiles is not None:
         # Wrap the single chain in a RouteTable so YAML routes
         # can merge on top. The launcher's `model` registers as a tier
-        # passthrough; YAML entries land alongside (override on id
+        # model route; YAML entries land alongside (override on id
         # conflict). OpenClaw's /model picker iterates the catalog, so
         # YAML-declared models surface there automatically.
         from switchyard.lib.route_table import RouteTable
@@ -625,7 +625,7 @@ def _openclaw_catalog_entry_for_deterministic_model(
     return (
         model_id,
         f"{display} (Switchyard)",
-        f"Direct Switchyard passthrough to discovered model {model_id}.",
+        f"Direct Switchyard model route to discovered model {model_id}.",
     )
 
 

--- a/switchyard/cli/route_bundle.py
+++ b/switchyard/cli/route_bundle.py
@@ -176,17 +176,6 @@ _RANDOM_ROUTING_ROUTE_KEYS = _ROUTE_METADATA_KEYS | _TARGET_DEFAULT_ROUTE_KEYS |
     "preset",
     "fallback_target_on_evict",
 })
-_PASSTHROUGH_SETTING_KEYS = frozenset({
-    "api_key",
-    "base_url",
-    "timeout",
-    "timeout_secs",
-})
-_PASSTHROUGH_ROUTE_KEYS = (
-    _ROUTE_METADATA_KEYS
-    | frozenset({"defaults", "enable_stats"})
-    | _PASSTHROUGH_SETTING_KEYS
-)
 _LATENCY_ENDPOINT_DEFAULT_KEYS = frozenset({
     "api_key",
     "base_url",
@@ -213,7 +202,6 @@ _LATENCY_SERVICE_ROUTE_KEYS = _ROUTE_METADATA_KEYS | frozenset({
     "affinity_store_ttl_seconds",
     "affinity_key_prefix",
 }) | _LATENCY_ENDPOINT_DEFAULT_KEYS
-_NOOP_ROUTE_KEYS = _ROUTE_METADATA_KEYS
 _DETERMINISTIC_ROUTE_KEYS = (
     _ROUTE_METADATA_KEYS
     | _TARGET_DEFAULT_ROUTE_KEYS
@@ -323,8 +311,6 @@ _ROUTE_KEYS_BY_TYPE: Mapping[str, frozenset[str]] = {
     "model": _MODEL_ROUTE_KEYS,
     "random_routing": _RANDOM_ROUTING_ROUTE_KEYS,
     "latency_service": _LATENCY_SERVICE_ROUTE_KEYS,
-    "noop": _NOOP_ROUTE_KEYS,
-    "passthrough": _PASSTHROUGH_ROUTE_KEYS,
     "deterministic": _DETERMINISTIC_ROUTE_KEYS,
     "escalation_router": _ESCALATION_ROUTE_KEYS,
     "stage_router": _STAGE_ROUTER_ROUTE_KEYS,
@@ -334,8 +320,6 @@ _DEFAULT_KEYS_BY_TYPE: Mapping[str, frozenset[str]] = {
     "model": _TARGET_DEFAULT_KEYS,
     "random_routing": _TARGET_DEFAULT_KEYS,
     "latency_service": _LATENCY_ENDPOINT_DEFAULT_KEYS,
-    "passthrough": _PASSTHROUGH_SETTING_KEYS,
-    "noop": frozenset(),
     "deterministic": _TARGET_DEFAULT_KEYS,
     "escalation_router": _TARGET_DEFAULT_KEYS,
     "stage_router": _TARGET_DEFAULT_KEYS,
@@ -409,7 +393,7 @@ def routing_profile_model_ids(
     Returns each route's YAML key followed by its tier ``model`` fields
     (``strong`` / ``weak`` for stage_router/deterministic/random_routing,
     ``planner`` / ``executor`` for plan_execute, ``target`` for
-    ``model`` / ``passthrough``). Declaration order, later duplicates dropped.
+    ``model``). Declaration order, later duplicates dropped.
     Returns ``[]`` for a ``None`` or empty bundle.
 
     Used by both the configure wizard (preview the picker) and the launchers
@@ -557,22 +541,6 @@ def build_table_from_bundle(
             )
             continue
 
-        # `passthrough` routes hydrate their single tier's catalog into the
-        # table alongside the configured target model. (`model` routes are
-        # pure aliases — they register under the route key only, no catalog.)
-        if route_type == "passthrough":
-            _merge_discovered_single_tier(
-                table,
-                model_id,
-                route,
-                route_type=route_type,
-                target_defaults=route_defaults,
-                stats=stats,
-                pre_routing_request_processors=pre_routing_request_processors,
-                extra_response_processors=extra_response_processors,
-            )
-            continue
-
         # `stage_router` and `deterministic` routes register the routing-policy chain
         # at the route key AND hydrate each tier's catalog (`strong` + `weak`)
         # into the table as direct passthroughs — same client-facing
@@ -664,69 +632,6 @@ def _merge_random_routing_route(
             table.set_default_model(default_model)
 
 
-def _merge_discovered_single_tier(
-    table: RouteTable,
-    model_id: str,
-    route: Mapping[str, object],
-    route_type: str,
-    target_defaults: Mapping[str, object],
-    stats: StatsAccumulator,
-    pre_routing_request_processors: Sequence[Any] = (),
-    extra_response_processors: Sequence[Any] = (),
-) -> None:
-    """Expand a ``passthrough`` route with catalog discovery.
-
-    Builds a single ``LlmTarget`` from the route's fields, then goes through
-    :func:`build_passthrough_table` with the shared
-    :func:`_default_discovery_fn` — the same path the launcher's per-tier
-    passthrough registration takes. Follows the unified ordering rule:
-
-      - The YAML route key registered first (aliasing the tier's chain when
-        the key differs from ``tier.model``).
-      - The tier's configured model registered next.
-      - Every catalog entry from the tier's ``GET /v1/models`` after that.
-    """
-    tier = _passthrough_target(model_id, route, target_defaults, route_type)
-    sub_table = build_passthrough_table(
-        (tier,),
-        stats,
-        enable_stats=_optional_bool(route.get("enable_stats"), default=True),
-        discovery_fn=_default_discovery_fn,
-        pre_routing_request_processors=pre_routing_request_processors,
-        extra_response_processors=extra_response_processors,
-    )
-    was_empty = not table.registered_models()
-    items = list(sub_table.items())
-    alias_registered = False
-    if model_id != tier.model:
-        tier_chain, tier_metadata = next(
-            ((ch, md) for mid, ch, md in items if mid == tier.model),
-            (None, {}),
-        )
-        if tier_chain is not None:
-            # YAML key first as an alias to the tier's chain so
-            # `registered_models()[0]` is always the user-declared route key.
-            table.register(
-                model_id,
-                tier_chain,
-                metadata={**dict(tier_metadata), "display_name": model_id},
-            )
-            alias_registered = True
-    for sub_model, sub_chain, sub_metadata in items:
-        if sub_model == model_id:
-            if alias_registered:
-                continue
-            # When YAML key == tier.model this entry is the route key itself;
-            # let it register here so it lands at position 0 of the table.
-            table.register(sub_model, sub_chain, metadata=sub_metadata)
-            continue
-        table.register(sub_model, sub_chain, metadata=sub_metadata)
-    for warning in sub_table.model_listing_warnings():
-        table.add_model_listing_warning(warning)
-    if was_empty and model_id in table.registered_models():
-        table.set_default_model(model_id)
-
-
 def _merge_multi_target_discovery(
     table: RouteTable,
     model_id: str,
@@ -803,12 +708,8 @@ def _build_switchyard_for_route(
     pre_routing_request_processors: Sequence[Any] = (),
     extra_response_processors: Sequence[Any] = (),
 ) -> ChainRuntime:
-    if route_type in ("model", "passthrough"):
-        # Both kinds resolve to a single-tier passthrough chain — same shape the
-        # launcher produces via build_passthrough_table's per-tier registration.
-        # The "passthrough" kind synthesizes a target whose model defaults to the
-        # route's table key when no explicit target/model is given.
-        target = _passthrough_target(model_id, route, target_defaults, route_type)
+    if route_type == "model":
+        target = _model_target(model_id, route, target_defaults)
         return build_tier_passthrough_switchyard(
             target,
             stats,
@@ -825,19 +726,6 @@ def _build_switchyard_for_route(
             stats=stats,
             extra_request_processors=pre_routing_request_processors,
             extra_response_processors=extra_response_processors,
-        )
-
-    if route_type == "noop":
-        from switchyard.lib.profiles.noop import NoopProfileConfig
-
-        return ProfileSwitchyard(
-            NoopProfileConfig()
-            .build()
-            .with_runtime_components(
-                stats_accumulator=stats,
-                pre_request_processors=pre_routing_request_processors,
-                response_processors=extra_response_processors,
-            )
         )
 
     if route_type == "deterministic":
@@ -1280,24 +1168,15 @@ def _plan_execute_switchyard(
     )
 
 
-def _passthrough_target(
+def _model_target(
     model_id: str,
     route: Mapping[str, object],
     target_defaults: Mapping[str, object],
-    route_type: str,
 ) -> LlmTarget:
-    """Resolve the LlmTarget for a ``model`` or ``passthrough`` route.
-
-    ``model`` routes require an explicit ``target`` or ``model`` field. The
-    ``passthrough`` kind is permissive: if no target is given, the route's
-    table key becomes the model name and the rest of the target is
-    populated from defaults plus inline route fields.
-    """
+    """Resolve the target for a public ``type: model`` route."""
     target_raw = route.get("target", route.get("model"))
     if target_raw is None:
-        if route_type == "model":
-            raise RouteBundleConfigError(f"route {model_id!r} requires target or model")
-        target_raw = model_id
+        raise RouteBundleConfigError(f"route {model_id!r} requires target or model")
     return coerce_llm_target(
         _target_mapping(target_raw, target_defaults, default_id=model_id, where="target"),
         default_id=model_id,
@@ -1489,8 +1368,6 @@ def _normalize_route(model_id: str, raw: object) -> Mapping[str, object]:
 def _route_type(model_id: str, route: Mapping[str, object]) -> str:
     raw_type = route.get("type", route.get("kind"))
     if raw_type is None:
-        if not route:
-            return "noop"
         if "latency_service_url" in route or "latency_url" in route:
             return "latency_service"
         if "strong" in route and "weak" in route:
@@ -1505,17 +1382,11 @@ def _route_type(model_id: str, route: Mapping[str, object]) -> str:
 
     normalized = raw_type.lower().replace("-", "_")
     aliases = {
-        "direct": "model",
-        "llm_target": "model",
         "model": "model",
-        "target": "model",
         "random": "random_routing",
         "random_routing": "random_routing",
         "latency": "latency_service",
         "latency_service": "latency_service",
-        "noop": "noop",
-        "no_op": "noop",
-        "passthrough": "passthrough",
         "deterministic": "deterministic",
         "llm_classifier": "deterministic",
         "llm_classifier_routing": "deterministic",

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -37,7 +37,7 @@ Examples::
     switchyard --routing-profiles profiles.yaml -- launch claude
     switchyard --routing-profiles profiles.yaml -- launch codex
 
-    # Single-model passthrough (--model stays on the launcher subcommand)
+    # Single-model route (--model stays on the launcher subcommand)
     switchyard launch claude --model openai/gpt-5.2
     switchyard launch claude --smoke --model openai/gpt-5.2
     switchyard launch codex  --model openai/gpt-5.2
@@ -49,8 +49,8 @@ Examples::
     # Forwarding args to the launched tool (second -- after the subcommand)
     switchyard --routing-profiles profiles.yaml -- launch claude -- --no-auto-approve
 
-Legacy routing policies that used to be top-level CLI verbs (``passthrough``,
-``random-routing``, ``latency-service``) and launcher flags
+Legacy routing policies that used to be top-level CLI verbs
+(``random-routing``, ``latency-service``) and launcher flags
 (``--routing``, ``--weak-model``, ``--strong-probability``, ``--preset``)
 are expressed in deprecated routing-profile YAML files. ``serve`` and
 launchers still parse the YAML into profile-backed runtimes.
@@ -1098,10 +1098,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "spawns `claude` with ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, "
             "and ANTHROPIC_MODEL preset.  Proxy shuts down when claude exits.\n\n"
             "Route selection (mutually exclusive — pick one or neither):\n"
-            "  --model X               single-model passthrough — every request "
+            "  --model X               single-model route — every request "
             "is rewritten to model=X. Falls back to the saved configure default.\n"
             "  --routing-profiles PATH serve a YAML bundle of routes (random, "
-            "stage_router, plan_execute, passthrough, …); the first declared route "
+            "stage_router, plan_execute, model, …); the first declared route "
             "is the initial model.\n\n"
             "With neither flag, the saved routing bundle from "
             "`switchyard configure` is used."
@@ -1111,7 +1111,7 @@ def _build_parser() -> argparse.ArgumentParser:
     lc.add_argument(
         "--model", type=str, default=None,
         help=(
-            "Single-model passthrough: model id from GET /v1/models "
+            "Single-model route: model id from GET /v1/models "
             "(e.g. openai/gpt-5.2). Falls back to the saved "
             "`configure` default when omitted. Mutually exclusive with "
             "--routing-profiles (pass that as a global switchyard flag before "
@@ -1189,10 +1189,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "Completions for the upstream backend.  Proxy shuts down when "
             "codex exits.\n\n"
             "Route selection (mutually exclusive — pick one or neither):\n"
-            "  --model X               single-model passthrough — every request "
+            "  --model X               single-model route — every request "
             "is rewritten to model=X. Falls back to the saved configure default.\n"
             "  --routing-profiles PATH serve a YAML bundle of routes (random, "
-            "stage_router, plan_execute, passthrough, …); the first declared route "
+            "stage_router, plan_execute, model, …); the first declared route "
             "is the initial model.\n\n"
             "With neither flag, the saved routing bundle from "
             "`switchyard configure` is used."
@@ -1202,7 +1202,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cx.add_argument(
         "--model", type=str, default=None,
         help=(
-            "Single-model passthrough: model id from GET /v1/models "
+            "Single-model route: model id from GET /v1/models "
             "(e.g. openai/gpt-5.2). Falls back to the saved "
             "`configure` default when omitted. Mutually exclusive with "
             "--routing-profiles (pass that as a global switchyard flag before "
@@ -1284,10 +1284,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "the upstream backend. Proxy and the transient workspace "
             "are torn down when openclaw exits.\n\n"
             "Route selection (mutually exclusive — pick one or neither):\n"
-            "  --model X               single-model passthrough — every request "
+            "  --model X               single-model route — every request "
             "is rewritten to model=X. Falls back to the saved configure default.\n"
             "  --routing-profiles PATH serve a YAML bundle of routes (random, "
-            "stage_router, plan_execute, passthrough, …); the first declared route "
+            "stage_router, plan_execute, model, …); the first declared route "
             "is the initial model.\n\n"
             "With neither flag, the saved routing bundle from "
             "`switchyard configure` is used."
@@ -1297,7 +1297,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ow.add_argument(
         "--model", type=str, default=None,
         help=(
-            "Single-model passthrough: model id from GET /v1/models "
+            "Single-model route: model id from GET /v1/models "
             "(e.g. openai/gpt-5.2). Falls back to the saved "
             "`configure` default when omitted. Mutually exclusive with "
             "--routing-profiles (pass that as a global switchyard flag before "

--- a/tests/getting_started/test_getting_started.py
+++ b/tests/getting_started/test_getting_started.py
@@ -6,11 +6,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 import textwrap
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import httpx
@@ -157,43 +160,43 @@ def test_all_yaml_blocks_in_guide_validate_as_route_bundles(
             ) from exc
 
 
-@pytest.fixture
-def noop_routes_yaml(tmp_path: Path) -> Path:
-    # Same shape as the guide's Step 3 YAML (defaults + a single named route),
-    # but `type: noop` so the lifecycle test runs without an upstream.
+def _model_routes_yaml(tmp_path: Path, base_url: str) -> Path:
     path = tmp_path / "routes.yaml"
     path.write_text(
-        textwrap.dedent("""\
+        textwrap.dedent(f"""\
         defaults:
           api_key: dummy
-          base_url: https://upstream.invalid/v1
+          base_url: {base_url}
           format: openai
 
         routes:
           gpt-4o:
-            type: noop
+            type: model
+            target: gpt-4o
         """)
     )
     return path
 
 
-def test_step3_and_step4_serve_lifecycle_with_noop(noop_routes_yaml: Path) -> None:
+def test_step3_and_step4_serve_lifecycle_with_model_route(tmp_path: Path) -> None:
     port = find_free_port()
-    with _serve_in_background(noop_routes_yaml, port):
-        health_status, health_body = _http_get(f"http://127.0.0.1:{port}/health")
-        assert health_status == 200, f"GET /health → {health_status}: {health_body!r}"
+    with _openai_stub_server() as base_url:
+        routes_yaml = _model_routes_yaml(tmp_path, base_url)
+        with _serve_in_background(routes_yaml, port):
+            health_status, health_body = _http_get(f"http://127.0.0.1:{port}/health")
+            assert health_status == 200, f"GET /health → {health_status}: {health_body!r}"
 
-        status, body = _http_post_json(
-            f"http://127.0.0.1:{port}/v1/chat/completions",
-            {
-                "model": "gpt-4o",
-                "messages": [{"role": "user", "content": "What is 2+2?"}],
-            },
-        )
-        assert status == 200, (
-            f"POST /v1/chat/completions → {status}: {body!r}"
-        )
-        assert b'"choices"' in body, f"Response missing 'choices': {body!r}"
+            status, body = _http_post_json(
+                f"http://127.0.0.1:{port}/v1/chat/completions",
+                {
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "What is 2+2?"}],
+                },
+            )
+            assert status == 200, (
+                f"POST /v1/chat/completions → {status}: {body!r}"
+            )
+            assert b'"choices"' in body, f"Response missing 'choices': {body!r}"
 
 
 # Snippet execution lives in pytest-markdown-docs; this tripwire guards the
@@ -211,6 +214,48 @@ def test_python_snippet_tripwire(guide_text: str) -> None:
         "Python snippet no longer builds a passthrough profile — update the "
         "markdown-docs fixture in conftest.py."
     )
+
+
+class _OpenAIStubHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        body = json.dumps({
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "gpt-4o",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "4"},
+                "finish_reason": "stop",
+            }],
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+@contextmanager
+def _openai_stub_server() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAIStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=TEARDOWN_GRACE_S)
+        server.server_close()
 
 
 @contextmanager

--- a/tests/test_launch_claude.py
+++ b/tests/test_launch_claude.py
@@ -1049,10 +1049,10 @@ class TestResolveInitialFromProfiles:
     def test_empty_bundle_raises(self, tmp_path):
         from switchyard.cli.launch_command import _resolve_initial_from_profiles
         yaml_path = tmp_path / "empty.yaml"
-        yaml_path.write_text("routes:\n  noop:\n    type: noop\n")
+        yaml_path.write_text("routes:\n  single-model:\n    type: model\n    target: upstream/model\n")
         assert (
             _resolve_initial_from_profiles(target="codex", routing_profiles=str(yaml_path))
-            == "noop"
+            == "single-model"
         )
 
     def test_model_and_profiles_mutually_exclusive(self):

--- a/tests/test_launch_claude_deterministic.py
+++ b/tests/test_launch_claude_deterministic.py
@@ -141,7 +141,7 @@ class TestDispatch:
     def test_model_flag_opts_out_of_deterministic(
         self, monkeypatch, tmp_path,
     ) -> None:
-        """Passing --model X falls through to single-model passthrough."""
+        """Passing --model X falls through to single-model route."""
         from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_claude
 
         parser = _build_parser()

--- a/tests/test_launch_openclaw.py
+++ b/tests/test_launch_openclaw.py
@@ -587,7 +587,7 @@ class TestLaunchOpenclaw:
         def fake_passthrough(**_kwargs):
             raise AssertionError(
                 "no --model should default to the classifier launcher, "
-                "not single-model passthrough",
+                "not single-model route",
             )
 
         def fake_classifier(**_kwargs):

--- a/tests/test_launch_openclaw_deterministic.py
+++ b/tests/test_launch_openclaw_deterministic.py
@@ -67,8 +67,9 @@ class TestMutualExclusion:
             "  base_url: https://upstream.invalid/v1\n"
             "  format: openai\n"
             "routes:\n"
-            "  bench:\n"
-            "    type: noop\n"
+            "  single-model:\n"
+            "    type: model\n"
+            "    target: upstream/model\n"
         )
         parser = _build_parser()
         args = parser.parse_args([
@@ -140,7 +141,7 @@ class TestDispatch:
     def test_model_flag_opts_out_of_classifier(
         self, monkeypatch, tmp_path,
     ) -> None:
-        """Passing --model X falls through to single-model passthrough."""
+        """Passing --model X falls through to single-model route."""
         from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_openclaw
 
         parser = _build_parser()

--- a/tests/test_resolve_classifier_prompts.py
+++ b/tests/test_resolve_classifier_prompts.py
@@ -107,7 +107,7 @@ def test_non_deterministic_routes_are_skipped(tmp_path: Path) -> None:
     module = _load_resolver_module()
     bundle = {
         "routes": {
-            "r/pass": {"type": "passthrough"},
+            "r/model": {"type": "model", "target": "m"},
             "r/rand": {"type": "random_routing"},
         },
     }

--- a/tests/test_route_bundle.py
+++ b/tests/test_route_bundle.py
@@ -152,7 +152,8 @@ def test_route_bundle_rejects_missing_environment_variable() -> None:
             },
             "strong_probablity",
         ),
-        ({"type": "passthrough", "model": "gpt-4o"}, "model"),
+        ({"type": "passthrough", "target": "gpt-4o"}, "unsupported route type"),
+        ({"type": "noop"}, "unsupported route type"),
         ({"type": "model", "target": {"modle": "gpt-4o"}}, "modle"),
     ],
 )
@@ -164,11 +165,9 @@ def test_route_bundle_rejects_unknown_route_keys(
         build_route_bundle_table({"routes": {"bad": route}})
 
 
-def test_empty_route_mapping_registers_noop() -> None:
-    table = build_route_bundle_table({"routes": {"noop": {}}})
-
-    assert table.registered_models() == ["noop"]
-    assert table.registered_model_entries()[0]["switchyard"]["profile"] == "noop"
+def test_empty_route_mapping_is_rejected() -> None:
+    with pytest.raises(RouteBundleConfigError, match="recognizable route shape"):
+        build_route_bundle_table({"routes": {"empty": {}}})
 
 
 def test_random_routing_hydrates_tier_and_catalog_models(
@@ -253,86 +252,6 @@ def test_model_route_aliases_under_route_key(
     assert table.default_model() == "configured-route"
 
 
-def test_passthrough_route_hydrates_catalog(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A ``passthrough`` route hydrates the catalog under the route id.
-
-    The route's YAML key becomes the tier's configured model name (passthrough
-    routes don't take an explicit target); catalog entries register alongside.
-    """
-    monkeypatch.setattr(
-        "switchyard.cli.route_bundle.fetch_model_ids",
-        lambda base_url, api_key: ["catalog/x", "catalog/y"],
-    )
-
-    table = build_route_bundle_table({
-        "routes": {
-            "openai-passthrough": {
-                "type": "passthrough",
-                "api_key": "k",
-                "base_url": "https://example/v1",
-            },
-        },
-    })
-
-    assert table.registered_models() == [
-        "openai-passthrough",
-        "catalog/x",
-        "catalog/y",
-    ]
-    assert table.default_model() == "openai-passthrough"
-
-
-def test_route_bundle_keeps_first_passthrough_route_as_default() -> None:
-    """Later discovered-route merges must not override the advertised default."""
-    table = build_route_bundle_table({
-        "routes": {
-            "first-route": {
-                "type": "passthrough",
-                "api_key": "k-first",
-                "base_url": "https://first.example/v1",
-            },
-            "second-route": {
-                "type": "passthrough",
-                "api_key": "k-second",
-                "base_url": "https://second.example/v1",
-            },
-        },
-    })
-
-    assert table.registered_models() == ["first-route", "second-route"]
-    assert table.default_model() == "first-route"
-
-
-def test_passthrough_route_preserves_warning_when_catalog_fetch_fails(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fail_catalog(_base_url: str, _api_key: str) -> list[str]:
-        raise RuntimeError("catalog timed out")
-
-    monkeypatch.setattr(
-        "switchyard.cli.route_bundle.fetch_model_ids",
-        fail_catalog,
-    )
-
-    table = build_route_bundle_table({
-        "routes": {
-            "configured-route": {
-                "type": "passthrough",
-                "api_key": "k",
-                "base_url": "https://primary.example/v1",
-            },
-        },
-    })
-
-    assert table.registered_models() == ["configured-route"]
-    assert table.default_model() == "configured-route"
-    assert table.model_listing_warnings() == [
-        "Model discovery failed for https://primary.example/v1: catalog timed out"
-    ]
-
-
 def test_random_routing_with_empty_catalog_registers_only_tier_passthroughs() -> None:
     """When discovery yields an empty catalog, only tier passthroughs register.
 
@@ -374,12 +293,12 @@ def test_route_bundle_threads_extra_processors_through_routes() -> None:
     response_processor = _NoopResponseProcessor()
 
     table = build_route_bundle_table(
-        {"routes": {"noop": {"type": "noop"}}},
+        {"routes": {"single-model": {"type": "model", "target": "upstream/model"}}},
         pre_routing_request_processors=[request_processor],
         extra_response_processors=[response_processor],
     )
 
-    components = table.lookup_switchyard("noop").iter_components()
+    components = table.lookup_switchyard("single-model").iter_components()
     assert request_processor in components
     assert response_processor in components
 
@@ -391,7 +310,7 @@ def test_serve_subcommand_hands_table_to_server(
     import switchyard.cli.switchyard_cli as cli
 
     yaml_path = tmp_path / "routes.yaml"
-    yaml_path.write_text("routes:\n  noop:\n    type: noop\n")
+    yaml_path.write_text("routes:\n  single-model:\n    type: model\n    target: upstream/model\n")
     captured: dict[str, Any] = {}
 
     def _fake_serve(
@@ -416,7 +335,7 @@ def test_serve_subcommand_hands_table_to_server(
     args.func(args)
 
     assert isinstance(captured["switchyard"], RouteTable)
-    assert captured["switchyard"].registered_models() == ["noop"]
+    assert captured["switchyard"].registered_models() == ["single-model"]
     assert captured["args"].port == 4555
     assert captured["inbound_default"] == "both"
 
@@ -494,7 +413,7 @@ def test_serve_config_and_routing_profiles_are_mutually_exclusive(
     config_path = tmp_path / "profiles.yaml"
     routes_path = tmp_path / "routes.yaml"
     config_path.write_text("profiles:\n  bench:\n    type: noop\n")
-    routes_path.write_text("routes:\n  bench:\n    type: noop\n")
+    routes_path.write_text("routes:\n  bench:\n    type: model\n    target: upstream/model\n")
 
     args = cli._build_parser().parse_args([
         "--routing-profiles",
@@ -627,7 +546,7 @@ def test_main_warns_when_routing_profiles_flag_is_used(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     yaml_path = tmp_path / "routes.yaml"
-    yaml_path.write_text("routes:\n  noop:\n    type: noop\n")
+    yaml_path.write_text("routes:\n  single-model:\n    type: model\n    target: upstream/model\n")
 
     monkeypatch.setattr(
         sys, "argv", ["switchyard", "--routing-profiles", str(yaml_path), "serve"]
@@ -659,7 +578,7 @@ def test_serve_warns_when_saved_route_bundle_is_used(
     from switchyard.cli.config.user_config import UserConfig, save_user_config
 
     monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
-    save_user_config(UserConfig(routing_profiles={"routes": {"noop": {"type": "noop"}}}))
+    save_user_config(UserConfig(routing_profiles={"routes": {"single-model": {"type": "model", "target": "upstream/model"}}}))
 
     def _fake_serve(
         args: argparse.Namespace,
@@ -693,8 +612,9 @@ def test_serve_subcommand_enables_intake_from_cli_args(
     yaml_path = tmp_path / "routes.yaml"
     yaml_path.write_text(
         "routes:\n"
-        "  noop:\n"
-        "    type: noop\n"
+        "  single-model:\n"
+        "    type: model\n"
+        "    target: upstream/model\n"
     )
     captured: dict[str, Any] = {}
 
@@ -722,7 +642,7 @@ def test_serve_subcommand_enables_intake_from_cli_args(
     ])
     args.func(args)
 
-    components = captured["switchyard"].lookup_switchyard("noop").iter_components()
+    components = captured["switchyard"].lookup_switchyard("single-model").iter_components()
     assert any(isinstance(component, IntakeRequestProcessor) for component in components)
     assert any(isinstance(component, IntakeResponseProcessor) for component in components)
 

--- a/tests/test_routing_banner.py
+++ b/tests/test_routing_banner.py
@@ -35,18 +35,18 @@ _STAGE_ROUTER_YAML = textwrap.dedent("""\
           model: clf-model/v1
 """)
 
-_PASSTHROUGH_YAML = textwrap.dedent("""\
+_MODEL_YAML = textwrap.dedent("""\
     routes:
       my_route:
-        type: passthrough
-        model: some/model
+        type: model
+        target: some/model
 """)
 
 
 class TestStrategyHelpers:
     def test_passthrough_summary(self):
-        """passthrough_strategy_summary returns 'passthrough → <model>'."""
-        assert passthrough_strategy_summary("my/model") == "passthrough → my/model"
+        """passthrough_strategy_summary returns 'model → <model>'."""
+        assert passthrough_strategy_summary("my/model") == "model → my/model"
 
     def test_routing_profiles_stage_router(self, tmp_path):
         """routing_profiles_strategy_summary describes the default stage_router route."""
@@ -55,12 +55,12 @@ class TestStrategyHelpers:
         result = routing_profiles_strategy_summary(str(p), "my_route")
         assert result == "stage_router: strong=strong-model/v1, weak=weak-model/v1, llm-classifier=clf-model/v1, confidence_threshold=0.7"
 
-    def test_routing_profiles_passthrough_type(self, tmp_path):
-        """routing_profiles_strategy_summary describes a passthrough-type route."""
+    def test_routing_profiles_model_type(self, tmp_path):
+        """routing_profiles_strategy_summary describes a model-type route."""
         p = tmp_path / "profiles.yaml"
-        p.write_text(_PASSTHROUGH_YAML)
+        p.write_text(_MODEL_YAML)
         result = routing_profiles_strategy_summary(str(p), "my_route")
-        assert result == "passthrough → some/model"
+        assert result == "model → some/model"
 
     def test_routing_profiles_fallback_on_missing_file(self):
         """Falls back to default_model when the profiles file cannot be read."""
@@ -137,7 +137,7 @@ def _patch_build_deps(monkeypatch):
 
 class TestCodexRoutingBanner:
     def test_passthrough_banner(self):
-        """launch_codex produces passthrough → <model> for single-model launch."""
+        """launch_codex produces model → <model> for single-model launch."""
         captured: dict = {}
         with _patch_codex_runner(captured):
             launch_codex(
@@ -148,7 +148,7 @@ class TestCodexRoutingBanner:
                 timeout=None,
                 codex_args=[],
             )
-        assert _captured_strategy(captured) == "passthrough → nvidia/moonshotai/kimi-k2.6"
+        assert _captured_strategy(captured) == "model → nvidia/moonshotai/kimi-k2.6"
 
     def test_routing_profiles_banner(self, tmp_path):
         """launch_codex describes the default route type for routing-profiles launch."""
@@ -176,7 +176,7 @@ class TestCodexRoutingBanner:
 
 class TestOpenclawRoutingBanner:
     def test_passthrough_banner(self):
-        """launch_openclaw produces passthrough → <model> for single-model launch."""
+        """launch_openclaw produces model → <model> for single-model launch."""
         captured: dict = {}
         with _patch_openclaw_runner(captured):
             launch_openclaw(
@@ -187,7 +187,7 @@ class TestOpenclawRoutingBanner:
                 timeout=None,
                 openclaw_args=[],
             )
-        assert _captured_strategy(captured) == "passthrough → nvidia/moonshotai/kimi-k2.6"
+        assert _captured_strategy(captured) == "model → nvidia/moonshotai/kimi-k2.6"
 
     def test_routing_profiles_banner(self, tmp_path):
         """launch_openclaw describes the default route type for routing-profiles launch."""
@@ -215,7 +215,7 @@ class TestOpenclawRoutingBanner:
 
 class TestClaudeRoutingBanner:
     def test_passthrough_banner(self):
-        """launch_claude produces passthrough → <model> for single-model launch."""
+        """launch_claude produces model → <model> for single-model launch."""
         captured: dict = {}
         with _patch_claude_runner(captured):
             launch_claude(
@@ -226,7 +226,7 @@ class TestClaudeRoutingBanner:
                 timeout=None,
                 claude_args=[],
             )
-        assert _captured_strategy(captured) == "passthrough → nvidia/moonshotai/kimi-k2.6"
+        assert _captured_strategy(captured) == "model → nvidia/moonshotai/kimi-k2.6"
 
     def test_routing_profiles_banner(self, tmp_path):
         """launch_claude describes the default route type for routing-profiles launch."""

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -122,7 +122,7 @@ def test_cli_write_records_routing_profile_digest(tmp_path: Path) -> None:
     out = tmp_path / "run_manifest.json"
     run_dir = tmp_path / "run"
     profile = tmp_path / "routes.yaml"
-    profile.write_text("routes:\n  tb-lite-random-routing:\n    type: noop\n")
+    profile.write_text("routes:\n  tb-lite-random-routing:\n    type: model\n    target: upstream/model\n")
     dataset = tmp_path / "dataset"
     dataset.mkdir()
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -339,7 +339,7 @@ def test_redacted_snapshot_surfaces_only_route_ids(tmp_path):
     save_user_config(
         UserConfig(routing_profiles={"routes": {
             "alpha/model": {"type": "model"},
-            "beta/model": {"type": "passthrough"},
+            "beta/model": {"type": "model"},
         }}),
         config_dir=tmp_path,
     )


### PR DESCRIPTION
## Summary
- Remove public route-bundle support for `type: noop` and `type: passthrough`
- Keep standalone route-bundle target execution on the single public `type: model` path
- Update README/docs/examples/launcher wording so public docs and banners say “model route” instead of exposing the older standalone route names
- Replace test-only `noop` route-bundle fixtures with explicit `type: model` routes, including a local OpenAI-compatible stub for the getting-started lifecycle test
- Refresh `.secrets.baseline` so CI secret scan stays stable after the line shifts

## Validation
- `uv run ruff check .`
- `uv run mypy switchyard`
- `env -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u OPENROUTER_API_KEY -u NVIDIA_BASE_URL -u OPENAI_BASE_URL -u ANTHROPIC_BASE_URL -u OPENROUTER_BASE_URL XDG_CONFIG_HOME=/tmp/switchyard-empty-config uv run pytest tests/ -v -m "not integration" -o addopts=`
- `env -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u OPENROUTER_API_KEY -u NVIDIA_BASE_URL -u OPENAI_BASE_URL -u ANTHROPIC_BASE_URL -u OPENROUTER_BASE_URL XDG_CONFIG_HOME=/tmp/switchyard-empty-config uv run pytest tests/test_routing_banner.py tests/test_launch_claude.py tests/test_launch_claude_deterministic.py tests/test_launch_openclaw.py tests/test_launch_openclaw_deterministic.py -v -o addopts=`
- `uv run --isolated --no-project --with pre-commit pre-commit run detect-secrets --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified and expanded support for explicit single-model routing across launch flows and examples.
  * Updated routing banners to show `model → target` for single-model setups.

* **Bug Fixes**
  * Tightened route configuration handling and validation for routing profiles.
  * Improved behavior for empty or invalid route configurations.

* **Documentation**
  * Refreshed docs and CLI help to replace “passthrough” wording with clearer “route” terminology.
  * Updated getting-started and example configs to match the new routing model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->