### PR TITLE
feat(translation): add gemini generateContent wire format support

### DIFF
--- a/.agents/skills/switchyard-codebase-exploration/SKILL.md
+++ b/.agents/skills/switchyard-codebase-exploration/SKILL.md
@@ -42,7 +42,7 @@ Before making a code change, be able to name:
 
 - the client ingress path: CLI, FastAPI endpoint, Python API, or route-table host
 - the chain slot touched: request-side component, `LLMBackend`, response-side component, `TranslationEngine`, or wiring only
-- the wire formats involved: OpenAI Chat, Anthropic Messages, OpenAI Responses, streaming/non-streaming
+- the wire formats involved: OpenAI Chat, Anthropic Messages, OpenAI Responses, Gemini generateContent, streaming/non-streaming
 - the profile/route-table/export path that exposes the behavior
 - the focused tests and the broad validation gate to run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,11 +162,13 @@ switchyard/
 │   │   ├── base.py                 # ChatResponse, ChatResponseType compatibility re-export
 │   │   ├── openai_chat.py          # ResponseStream
 │   │   ├── openai_responses.py     # ResponsesApiStream
-│   │   └── anthropic.py            # AnthropicResponseStream
+│   │   ├── anthropic.py            # AnthropicResponseStream
+│   │   └── gemini.py               # GeminiResponseStream
 │   ├── backends/                   # LLMBackend implementations
 │   │   ├── openai_llm_backend.py           # OpenAiPassthroughBackend
 │   │   ├── openai_native_backend.py        # OpenAiNativeBackend
 │   │   ├── anthropic_native_llm_backend.py # AnthropicNativeBackend
+│   │   ├── gemini_native_llm_backend.py    # GeminiNativeBackend
 │   │   ├── latency_service_llm_backend.py  # LatencyServiceLLMBackend
 │   │   ├── llm_target.py                   # LlmTarget, BackendFormat
 │   │   ├── multi_llm_backend.py            # MultiLlmBackend helpers
@@ -187,6 +189,7 @@ switchyard/
 │   ├── endpoints/                  # FastAPI endpoint wrappers (require `nemo-switchyard[server]`)
 │   │   ├── openai_chat_endpoint.py         # OpenAIChatEndpoint
 │   │   ├── anthropic_messages_endpoint.py  # AnthropicMessagesEndpoint
+│   │   ├── gemini_endpoint.py              # GeminiEndpoint
 │   │   ├── responses_endpoint.py           # ResponsesEndpoint
 │   │   ├── stats_endpoint.py               # StatsEndpoint
 │   │   ├── sse_helpers.py
@@ -330,6 +333,7 @@ uvicorn.run(build_switchyard_app(switchyard), port=4000)
 | `OPENAI_API_KEY` | API key for OpenAI-compatible backends |
 | `OPENAI_BASE_URL` | Base URL for OpenAI-compatible API |
 | `ANTHROPIC_API_KEY` | API key for Anthropic Claude |
+| `GEMINI_API_KEY` | API key for Google Gemini generateContent backends |
 | `NVIDIA_API_KEY` | API key for NVIDIA NIM / Inference Hub |
 | `OPENROUTER_API_KEY` | OpenRouter key for examples and saved provider setup; pass via `--api-key` or `switchyard configure` |
 | `SWITCHYARD_INTAKE_CAPTURE_CONTENT` | Set truthy to include prompt/response text in intake; default off (metadata-only) |

--- a/crates/switchyard-components-v2/src/backend.rs
+++ b/crates/switchyard-components-v2/src/backend.rs
@@ -6,7 +6,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use switchyard_components::backends::{AnthropicNativeBackend, OpenAiNativeBackend};
+use switchyard_components::backends::{
+    AnthropicNativeBackend, GeminiNativeBackend, OpenAiNativeBackend,
+};
 use switchyard_core::{
     BackendFormat, ChatRequest, ChatResponse, LlmTarget, Result, SwitchyardError,
 };
@@ -49,6 +51,7 @@ pub(crate) fn native_target_backend(target: LlmTarget) -> Result<TargetBackend> 
             Arc::new(OpenAiNativeBackend::new(target.clone())?)
         }
         BackendFormat::Anthropic => Arc::new(AnthropicNativeBackend::new(target.clone())?),
+        BackendFormat::Gemini => Arc::new(GeminiNativeBackend::new(target.clone())?),
         BackendFormat::Auto => {
             return Err(SwitchyardError::InvalidConfig(format!(
                 "target {} must have a resolved backend format",
@@ -68,6 +71,13 @@ impl ProfileBackend for OpenAiNativeBackend {
 
 #[async_trait]
 impl ProfileBackend for AnthropicNativeBackend {
+    async fn call(&self, request: &ChatRequest) -> Result<ChatResponse> {
+        self.call_without_context(request).await
+    }
+}
+
+#[async_trait]
+impl ProfileBackend for GeminiNativeBackend {
     async fn call(&self, request: &ChatRequest) -> Result<ChatResponse> {
         self.call_without_context(request).await
     }

--- a/crates/switchyard-components/src/backends/anthropic.rs
+++ b/crates/switchyard-components/src/backends/anthropic.rs
@@ -273,12 +273,13 @@ impl AnthropicTransport for ReqwestAnthropicTransport {
 fn validate_target_format(target: &LlmTarget) -> Result<()> {
     match target.format {
         BackendFormat::Anthropic => Ok(()),
-        BackendFormat::Auto | BackendFormat::OpenAi | BackendFormat::Responses => {
-            Err(SwitchyardError::InvalidConfig(format!(
-                "AnthropicNativeBackend requires a target with resolved Anthropic format, got {:?} for {}",
-                target.format, target.id
-            )))
-        }
+        BackendFormat::Auto
+        | BackendFormat::OpenAi
+        | BackendFormat::Responses
+        | BackendFormat::Gemini => Err(SwitchyardError::InvalidConfig(format!(
+            "AnthropicNativeBackend requires a target with resolved Anthropic format, got {:?} for {}",
+            target.format, target.id
+        ))),
     }
 }
 

--- a/crates/switchyard-components/src/backends/common.rs
+++ b/crates/switchyard-components/src/backends/common.rs
@@ -60,6 +60,7 @@ pub(crate) fn request_wire_format(request_type: ChatRequestType) -> WireFormat {
         ChatRequestType::OpenAiChat => WireFormat::OpenAiChat,
         ChatRequestType::OpenAiResponses => WireFormat::OpenAiResponses,
         ChatRequestType::Anthropic => WireFormat::AnthropicMessages,
+        ChatRequestType::Gemini => WireFormat::GeminiGenerateContent,
     }
 }
 

--- a/crates/switchyard-components/src/backends/gemini.rs
+++ b/crates/switchyard-components/src/backends/gemini.rs
@@ -1,0 +1,543 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gemini-compatible generateContent backend.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fmt;
+use std::sync::Arc;
+
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::Value;
+use switchyard_core::{
+    merge_target_extra_body, BackendFormat, BoxResponseStream, ChatRequest, ChatRequestType,
+    ChatResponse, LlmBackend, LlmTarget, LlmTargetId, ProxyContext, Result, StreamEvent,
+    SwitchyardError,
+};
+use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
+
+use super::common::{
+    build_reqwest_client, decode_sse_frame, drain_next_sse_frame, has_non_whitespace_bytes,
+    parse_json_sse_frame, request_wire_format, set_json_model, shared_translation_engine,
+    ParsedSseFrame,
+};
+use super::BackendSelection;
+use crate::telemetry::{telemetry_header_value, SWITCHYARD_VERSION_HEADER};
+
+const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+const GEMINI_API_KEY_ENV: &str = "GEMINI_API_KEY";
+static GEMINI_ONLY: [ChatRequestType; 1] = [ChatRequestType::Gemini];
+
+/// Backend that calls a Gemini-compatible generateContent API.
+pub struct GeminiNativeBackend {
+    /// Resolved target used for endpoint credentials and model rewriting.
+    target: LlmTarget,
+    /// HTTP transport, injectable for deterministic tests.
+    transport: Arc<dyn GeminiTransport>,
+    /// Shared request translator for non-Gemini inbound payloads.
+    translation: Arc<TranslationEngine>,
+    /// Translation policy kept explicit so backend behavior is inspectable.
+    translation_policy: TranslationPolicy,
+}
+
+impl fmt::Debug for GeminiNativeBackend {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GeminiNativeBackend")
+            .field("target", &self.target)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GeminiNativeBackend {
+    /// Creates a Gemini-compatible backend for one target.
+    pub fn new(target: LlmTarget) -> Result<Self> {
+        let transport = Arc::new(ReqwestGeminiTransport::new(target.endpoint.timeout_secs)?);
+        Self::with_transport(target, transport)
+    }
+
+    /// Returns the configured upstream target.
+    pub fn target(&self) -> &LlmTarget {
+        &self.target
+    }
+
+    fn with_transport(target: LlmTarget, transport: Arc<dyn GeminiTransport>) -> Result<Self> {
+        validate_target_format(&target)?;
+        Ok(Self {
+            target,
+            transport,
+            translation: shared_translation_engine(),
+            translation_policy: TranslationPolicy::default(),
+        })
+    }
+
+    fn outbound_body(&self, request: &ChatRequest) -> Result<Value> {
+        let mut body = match request.request_type() {
+            ChatRequestType::Gemini => request.body().clone(),
+            source => {
+                self.translation
+                    .translate_request(
+                        request_wire_format(source),
+                        WireFormat::GeminiGenerateContent,
+                        request.body(),
+                        &self.translation_policy,
+                    )
+                    .map_err(|error| {
+                        SwitchyardError::Backend(format!(
+                        "failed to translate {source:?} request to Gemini generateContent: {error}"
+                    ))
+                    })?
+                    .body
+            }
+        };
+        set_json_model(&mut body, self.target.model.as_str());
+        // Per-target ``extra_body`` merged last; caller wins on key
+        // conflicts (see :func:`merge_target_extra_body`).
+        merge_target_extra_body(&mut body, self.target.extra_body.as_ref());
+        Ok(body)
+    }
+
+    /// Calls this target without requiring chain-local `ProxyContext` state.
+    pub async fn call_without_context(&self, request: &ChatRequest) -> Result<ChatResponse> {
+        let http_request = self.http_request(request)?;
+        self.send_http_request(http_request).await
+    }
+
+    // Builds the upstream HTTP request before any context observations are recorded.
+    //
+    // The internal Gemini wire body carries synthetic `model` and `stream`
+    // fields because the real API encodes both in the URL; they are popped
+    // here so the upstream body only contains generateContent fields.
+    fn http_request(&self, request: &ChatRequest) -> Result<GeminiHttpRequest> {
+        let mut body = self.outbound_body(request)?;
+        let stream = take_body_field(&mut body, "stream")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let model = take_body_field(&mut body, "model")
+            .and_then(|value| value.as_str().map(str::to_string))
+            .unwrap_or_else(|| self.target.model.as_str().to_string());
+        Ok(GeminiHttpRequest {
+            target_id: self.target.id.clone(),
+            url: generate_content_url(self.target.endpoint.base_url.as_deref(), &model, stream),
+            api_key: gemini_api_key(self.target.endpoint.api_key.as_deref()),
+            body,
+            model,
+            stream,
+            extra_headers: self.target.extra_headers.clone(),
+        })
+    }
+
+    // Sends an already-normalized upstream request.
+    async fn send_http_request(&self, request: GeminiHttpRequest) -> Result<ChatResponse> {
+        match self.transport.send(request).await? {
+            GeminiHttpResponse::Buffered(body) => Ok(ChatResponse::gemini_completion(body)),
+            GeminiHttpResponse::Stream(stream) => Ok(ChatResponse::GeminiStream(stream)),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmBackend for GeminiNativeBackend {
+    fn supported_request_types(&self) -> &[ChatRequestType] {
+        &GEMINI_ONLY
+    }
+
+    async fn call(&self, ctx: &mut ProxyContext, request: &ChatRequest) -> Result<ChatResponse> {
+        let http_request = self.http_request(request)?;
+
+        ctx.inbound_format = ctx.inbound_format.or(Some(request.request_type()));
+        let previous_selection = ctx.get::<BackendSelection>().cloned();
+        ctx.insert(BackendSelection::native_target_observation(
+            previous_selection.as_ref(),
+            self.target.id.clone(),
+            self.target.model.clone(),
+            request.model().map(str::to_string),
+        ));
+
+        self.send_http_request(http_request).await
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct GeminiHttpRequest {
+    /// Target ID used only for logging and diagnostics.
+    target_id: LlmTargetId,
+    /// Fully resolved generateContent or streamGenerateContent URL.
+    url: String,
+    /// Per-target API key or process environment fallback.
+    api_key: Option<String>,
+    /// Already-normalized Gemini request body without synthetic fields.
+    body: Value,
+    /// Model resolved into the URL, kept for error reporting.
+    model: String,
+    /// Whether the upstream call should be treated as SSE.
+    stream: bool,
+    /// Per-target headers merged onto the outbound request.
+    extra_headers: BTreeMap<String, String>,
+}
+
+enum GeminiHttpResponse {
+    /// Complete JSON response from a non-streaming upstream call.
+    Buffered(Value),
+    /// Streamed SSE response converted into Switchyard stream events.
+    Stream(BoxResponseStream),
+}
+
+#[async_trait]
+trait GeminiTransport: Send + Sync {
+    /// Sends one already-normalized Gemini generateContent request.
+    async fn send(&self, request: GeminiHttpRequest) -> Result<GeminiHttpResponse>;
+}
+
+struct ReqwestGeminiTransport {
+    /// Reused async HTTP client with configured timeout behavior.
+    client: reqwest::Client,
+}
+
+impl ReqwestGeminiTransport {
+    fn new(timeout_secs: Option<f64>) -> Result<Self> {
+        let client = build_reqwest_client("Gemini", timeout_secs)?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl GeminiTransport for ReqwestGeminiTransport {
+    async fn send(&self, request: GeminiHttpRequest) -> Result<GeminiHttpResponse> {
+        let target_id = request.target_id.clone();
+        let mut builder = self.client.post(&request.url).json(&request.body);
+        if let Some(api_key) = request.api_key {
+            builder = builder.header("x-goog-api-key", api_key);
+        }
+        if let Some(version) = telemetry_header_value() {
+            builder = builder.header(SWITCHYARD_VERSION_HEADER, version);
+        }
+        for (name, value) in &request.extra_headers {
+            builder = builder.header(name, value);
+        }
+
+        let response = builder.send().await.map_err(|error| {
+            tracing::warn!(
+                target_id = %target_id,
+                error = %error,
+                "Gemini generateContent request failed"
+            );
+            SwitchyardError::Upstream(format!("Gemini generateContent request failed: {error}"))
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+            tracing::warn!(
+                target_id = %target_id,
+                status = %status,
+                "Gemini generateContent returned error status"
+            );
+            if status == reqwest::StatusCode::BAD_REQUEST && is_context_overflow(&body) {
+                return Err(SwitchyardError::ContextWindowExceeded {
+                    target_id: target_id.to_string(),
+                    model: request.model,
+                    message: body,
+                });
+            }
+            return Err(SwitchyardError::UpstreamHttp {
+                provider: "Gemini generateContent".to_string(),
+                status_code: status.as_u16(),
+                body,
+            });
+        }
+
+        if request.stream {
+            return Ok(GeminiHttpResponse::Stream(gemini_sse_stream(response)));
+        }
+
+        let body = response.json::<Value>().await.map_err(|error| {
+            SwitchyardError::Upstream(format!(
+                "Gemini generateContent returned invalid JSON: {error}"
+            ))
+        })?;
+        Ok(GeminiHttpResponse::Buffered(body))
+    }
+}
+
+fn validate_target_format(target: &LlmTarget) -> Result<()> {
+    match target.format {
+        BackendFormat::Gemini => Ok(()),
+        BackendFormat::Auto
+        | BackendFormat::OpenAi
+        | BackendFormat::Responses
+        | BackendFormat::Anthropic => Err(SwitchyardError::InvalidConfig(format!(
+            "GeminiNativeBackend requires a target with resolved Gemini format, got {:?} for {}",
+            target.format, target.id
+        ))),
+    }
+}
+
+// Removes a top-level field from an object body, returning its value.
+fn take_body_field(body: &mut Value, key: &str) -> Option<Value> {
+    body.as_object_mut().and_then(|object| object.remove(key))
+}
+
+// Builds the generateContent URL; the verb and `alt=sse` encode streaming.
+fn generate_content_url(base_url: Option<&str>, model: &str, stream: bool) -> String {
+    let base_url = base_url
+        .unwrap_or(DEFAULT_GEMINI_BASE_URL)
+        .trim_end_matches('/');
+    let base_url = if base_url.ends_with("/v1beta") {
+        base_url.to_string()
+    } else {
+        format!("{base_url}/v1beta")
+    };
+    if stream {
+        format!("{base_url}/models/{model}:streamGenerateContent?alt=sse")
+    } else {
+        format!("{base_url}/models/{model}:generateContent")
+    }
+}
+
+fn gemini_api_key(configured: Option<&str>) -> Option<String> {
+    // Resolve per call so long-lived backends can pick up rotated environment credentials.
+    configured
+        .map(str::to_string)
+        .or_else(|| env::var(GEMINI_API_KEY_ENV).ok())
+        .filter(|value| !value.trim().is_empty())
+}
+
+// Canonical Gemini overflow 400 looks like
+// `{"error":{"code":400,"message":"The input token count (N) exceeds the maximum
+// number of tokens allowed (M).","status":"INVALID_ARGUMENT"}}`. The status is a
+// generic INVALID_ARGUMENT, so detection is phrase-based only.
+const GEMINI_OVERFLOW_PHRASES: &[&str] = &[
+    "input token count",
+    "exceeds the maximum number of tokens",
+    "context window",
+];
+
+fn is_context_overflow(body: &str) -> bool {
+    super::context_overflow::is_overflow_body(body, |_| false, GEMINI_OVERFLOW_PHRASES)
+}
+
+fn gemini_sse_stream(response: reqwest::Response) -> BoxResponseStream {
+    Box::pin(try_stream! {
+        let mut chunks = response.bytes_stream();
+        let mut buffer = Vec::new();
+
+        while let Some(chunk) = chunks.next().await {
+            let chunk = chunk.map_err(|error| {
+                SwitchyardError::Upstream(format!("Gemini stream read failed: {error}"))
+            })?;
+            buffer.extend_from_slice(&chunk);
+
+            // Gemini SSE frames are unnamed `data:` lines, each carrying one
+            // complete GenerateContentResponse chunk; there is no done marker.
+            while let Some(frame) = drain_next_sse_frame(&mut buffer, "Gemini")? {
+                match parse_json_sse_frame(&frame, "Gemini", None)? {
+                    ParsedSseFrame::Json(value) => yield StreamEvent::Json(value),
+                    ParsedSseFrame::Done | ParsedSseFrame::Empty => {}
+                }
+            }
+        }
+
+        // Preserve the last frame when an upstream closes without a final SSE
+        // separator.
+        if has_non_whitespace_bytes(&buffer) {
+            let frame = decode_sse_frame(&buffer, "Gemini")?;
+            match parse_json_sse_frame(&frame, "Gemini", None)? {
+                ParsedSseFrame::Json(value) => yield StreamEvent::Json(value),
+                ParsedSseFrame::Done | ParsedSseFrame::Empty => {}
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use serde_json::json;
+    use switchyard_core::{EndpointConfig, LlmTargetId, ModelId};
+
+    use super::*;
+
+    struct FakeGeminiTransport {
+        requests: Mutex<Vec<GeminiHttpRequest>>,
+        response: Mutex<Option<Result<GeminiHttpResponse>>>,
+    }
+
+    impl FakeGeminiTransport {
+        fn with_response(response: GeminiHttpResponse) -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                response: Mutex::new(Some(Ok(response))),
+            }
+        }
+
+        fn with_error(message: &str) -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                response: Mutex::new(Some(Err(SwitchyardError::Upstream(message.to_string())))),
+            }
+        }
+
+        fn recorded_requests(&self) -> Result<Vec<GeminiHttpRequest>> {
+            Ok(self
+                .requests
+                .lock()
+                .map_err(|_| {
+                    SwitchyardError::Other("fake transport request mutex poisoned".to_string())
+                })?
+                .clone())
+        }
+    }
+
+    #[async_trait]
+    impl GeminiTransport for FakeGeminiTransport {
+        async fn send(&self, request: GeminiHttpRequest) -> Result<GeminiHttpResponse> {
+            self.requests
+                .lock()
+                .map_err(|_| {
+                    SwitchyardError::Other("fake transport request mutex poisoned".to_string())
+                })?
+                .push(request);
+            self.response
+                .lock()
+                .map_err(|_| {
+                    SwitchyardError::Other("fake transport response mutex poisoned".to_string())
+                })?
+                .take()
+                .ok_or_else(|| {
+                    SwitchyardError::Other("fake transport response already consumed".to_string())
+                })?
+        }
+    }
+
+    fn gemini_target() -> LlmTarget {
+        LlmTarget {
+            id: LlmTargetId::from_static("primary"),
+            model: ModelId::from_static("gemini-2.5-flash"),
+            format: BackendFormat::Gemini,
+            endpoint: EndpointConfig {
+                base_url: Some("https://example.test".to_string()),
+                api_key: Some("secret".to_string()),
+                timeout_secs: None,
+            },
+            extra_body: None,
+            extra_headers: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn transport_errors_are_backend_errors() -> Result<()> {
+        let transport = Arc::new(FakeGeminiTransport::with_error("upstream exploded"));
+        let backend = GeminiNativeBackend::with_transport(gemini_target(), transport)?;
+        let request = ChatRequest::gemini(json!({
+            "model": "client-model",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        }));
+        let mut ctx = ProxyContext::new();
+
+        let Err(error) = backend.call(&mut ctx, &request).await else {
+            return Err(SwitchyardError::Other(
+                "backend call should fail".to_string(),
+            ));
+        };
+
+        assert!(matches!(error, SwitchyardError::Upstream(_)));
+        assert!(error.to_string().contains("upstream exploded"));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_openai_targets() -> Result<()> {
+        let mut target = gemini_target();
+        target.format = BackendFormat::OpenAi;
+
+        let Err(error) = GeminiNativeBackend::new(target) else {
+            return Err(SwitchyardError::Other(
+                "OpenAI target should be rejected".to_string(),
+            ));
+        };
+
+        assert!(matches!(error, SwitchyardError::InvalidConfig(_)));
+        Ok(())
+    }
+
+    // Synthetic model/stream fields must move into the URL, not the body.
+    #[tokio::test]
+    async fn moves_model_and_stream_into_the_url() -> Result<()> {
+        let transport = Arc::new(FakeGeminiTransport::with_response(
+            GeminiHttpResponse::Buffered(json!({"candidates": []})),
+        ));
+        let backend = GeminiNativeBackend::with_transport(gemini_target(), transport.clone())?;
+        let request = ChatRequest::gemini(json!({
+            "model": "client-model",
+            "stream": true,
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        }));
+
+        backend.call_without_context(&request).await?;
+
+        let requests = transport.recorded_requests()?;
+        let sent = requests.first().ok_or_else(|| {
+            SwitchyardError::Other("transport should record one request".to_string())
+        })?;
+        assert_eq!(
+            sent.url,
+            "https://example.test/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+        );
+        assert!(sent.stream);
+        assert!(sent.body.get("model").is_none());
+        assert!(sent.body.get("stream").is_none());
+        assert!(sent.body.get("contents").is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn formats_generate_content_urls_for_root_and_versioned_bases() {
+        assert_eq!(
+            generate_content_url(None, "gemini-2.5-flash", false),
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+        );
+        assert_eq!(
+            generate_content_url(Some("https://example.test/"), "m", false),
+            "https://example.test/v1beta/models/m:generateContent"
+        );
+        assert_eq!(
+            generate_content_url(Some("https://example.test/v1beta"), "m", true),
+            "https://example.test/v1beta/models/m:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn gemini_context_overflow_canonical_shape_matches() {
+        let body = r#"{"error":{"code":400,"message":"The input token count (1189926) exceeds the maximum number of tokens allowed (1048576).","status":"INVALID_ARGUMENT"}}"#;
+        assert!(is_context_overflow(body));
+    }
+
+    #[test]
+    fn gemini_context_overflow_unrelated_400_does_not_match() {
+        let body = r#"{"error":{"code":400,"message":"Invalid JSON payload received.","status":"INVALID_ARGUMENT"}}"#;
+        assert!(!is_context_overflow(body));
+    }
+
+    #[test]
+    fn parses_gemini_sse_json_frames() -> Result<()> {
+        let ParsedSseFrame::Json(value) = parse_json_sse_frame(
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]}}]}\n",
+            "Gemini",
+            None,
+        )?
+        else {
+            return Err(SwitchyardError::Other(
+                "JSON frame should produce a JSON value".to_string(),
+            ));
+        };
+        assert!(value["candidates"].is_array());
+        Ok(())
+    }
+}

--- a/crates/switchyard-components/src/backends/gemini.rs
+++ b/crates/switchyard-components/src/backends/gemini.rs
@@ -161,7 +161,7 @@ impl LlmBackend for GeminiNativeBackend {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 struct GeminiHttpRequest {
     /// Target ID used only for logging and diagnostics.
     target_id: LlmTargetId,
@@ -177,6 +177,20 @@ struct GeminiHttpRequest {
     stream: bool,
     /// Per-target headers merged onto the outbound request.
     extra_headers: BTreeMap<String, String>,
+}
+
+// Manual impl so the raw API key never reaches logs via `{:?}` formatting.
+impl fmt::Debug for GeminiHttpRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GeminiHttpRequest")
+            .field("target_id", &self.target_id)
+            .field("url", &self.url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .field("model", &self.model)
+            .field("stream", &self.stream)
+            .finish_non_exhaustive()
+    }
 }
 
 enum GeminiHttpResponse {

--- a/crates/switchyard-components/src/backends/mod.rs
+++ b/crates/switchyard-components/src/backends/mod.rs
@@ -6,12 +6,14 @@
 pub mod anthropic;
 mod common;
 mod context_overflow;
+pub mod gemini;
 pub mod multi;
 pub mod openai;
 mod selection;
 pub mod stats;
 
 pub use anthropic::AnthropicNativeBackend;
+pub use gemini::GeminiNativeBackend;
 pub use multi::{LlmTargetBackend, MultiLlmBackend};
 pub use openai::{OpenAiNativeBackend, OpenAiPassthroughBackend};
 pub use selection::{BackendSelection, BackendSelectionReason};

--- a/crates/switchyard-components/src/backends/multi.rs
+++ b/crates/switchyard-components/src/backends/multi.rs
@@ -20,10 +20,11 @@ use switchyard_core::{
 
 use super::{BackendSelection, BackendSelectionReason};
 
-const DEFAULT_SUPPORTED_REQUEST_TYPES: [ChatRequestType; 3] = [
+const DEFAULT_SUPPORTED_REQUEST_TYPES: [ChatRequestType; 4] = [
     ChatRequestType::OpenAiChat,
     ChatRequestType::OpenAiResponses,
     ChatRequestType::Anthropic,
+    ChatRequestType::Gemini,
 ];
 
 /// One configured upstream target and the backend that can call it.

--- a/crates/switchyard-components/src/backends/openai.rs
+++ b/crates/switchyard-components/src/backends/openai.rs
@@ -80,7 +80,7 @@ impl OpenAiNativeBackend {
         match self.target.format {
             BackendFormat::OpenAi => ChatRequestType::OpenAiChat,
             BackendFormat::Responses => ChatRequestType::OpenAiResponses,
-            BackendFormat::Auto | BackendFormat::Anthropic => {
+            BackendFormat::Auto | BackendFormat::Anthropic | BackendFormat::Gemini => {
                 unreachable!("OpenAiNativeBackend target format is validated at construction")
             }
         }
@@ -90,7 +90,7 @@ impl OpenAiNativeBackend {
         match self.target_request_type() {
             ChatRequestType::OpenAiChat => WireFormat::OpenAiChat,
             ChatRequestType::OpenAiResponses => WireFormat::OpenAiResponses,
-            ChatRequestType::Anthropic => {
+            ChatRequestType::Anthropic | ChatRequestType::Gemini => {
                 unreachable!("OpenAiNativeBackend only targets OpenAI wire formats")
             }
         }
@@ -243,7 +243,7 @@ impl LlmBackend for OpenAiNativeBackend {
         match self.target.format {
             BackendFormat::OpenAi => &OPENAI_CHAT_ONLY,
             BackendFormat::Responses => &OPENAI_RESPONSES_ONLY,
-            BackendFormat::Auto | BackendFormat::Anthropic => {
+            BackendFormat::Auto | BackendFormat::Anthropic | BackendFormat::Gemini => {
                 unreachable!("OpenAiNativeBackend target format is validated at construction")
             }
         }
@@ -444,7 +444,7 @@ impl OpenAiTransport for ReqwestOpenAiTransport {
 fn validate_target_format(target: &LlmTarget) -> Result<()> {
     match target.format {
         BackendFormat::OpenAi | BackendFormat::Responses => Ok(()),
-        BackendFormat::Auto | BackendFormat::Anthropic => {
+        BackendFormat::Auto | BackendFormat::Anthropic | BackendFormat::Gemini => {
             Err(SwitchyardError::InvalidConfig(format!(
                 "OpenAiNativeBackend requires a target with resolved OpenAI format, got {:?} for {}",
                 target.format, target.id
@@ -457,9 +457,11 @@ fn endpoint_for_backend_format(format: BackendFormat) -> Result<OpenAiEndpoint> 
     match format {
         BackendFormat::OpenAi => Ok(OpenAiEndpoint::ChatCompletions),
         BackendFormat::Responses => Ok(OpenAiEndpoint::Responses),
-        BackendFormat::Auto | BackendFormat::Anthropic => Err(SwitchyardError::InvalidConfig(
-            format!("OpenAiNativeBackend cannot dispatch target format {format:?}"),
-        )),
+        BackendFormat::Auto | BackendFormat::Anthropic | BackendFormat::Gemini => {
+            Err(SwitchyardError::InvalidConfig(format!(
+                "OpenAiNativeBackend cannot dispatch target format {format:?}"
+            )))
+        }
     }
 }
 

--- a/crates/switchyard-components/src/dimension_collector/tool_signals.rs
+++ b/crates/switchyard-components/src/dimension_collector/tool_signals.rs
@@ -320,6 +320,14 @@ pub fn extract_tool_signals_with_window(
                 .unwrap_or(&[]);
             extract_from_messages_openai_chat(messages, recent_window)
         }
+        ChatRequestType::Gemini => {
+            let contents = obj
+                .get("contents")
+                .and_then(Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            extract_from_contents_gemini(contents, recent_window)
+        }
     }
 }
 
@@ -509,6 +517,68 @@ fn extract_from_input_responses(items: &[Value], recent_window: usize) -> ToolRe
         tool_texts,
         tool_calls,
         items.len() as u32,
+        prompt_char_count,
+        recent_window,
+    )
+}
+
+fn extract_from_contents_gemini(contents: &[Value], recent_window: usize) -> ToolResultSignal {
+    let mut tool_texts: Vec<String> = Vec::new();
+    let mut tool_calls: Vec<ObservedToolCall> = Vec::new();
+    let mut prompt_char_count: u32 = 0;
+
+    for content in contents {
+        let Some(obj) = content.as_object() else {
+            continue;
+        };
+        let role = obj.get("role").and_then(Value::as_str).unwrap_or("");
+        let Some(parts) = obj.get("parts").and_then(Value::as_array) else {
+            continue;
+        };
+        for part in parts {
+            let Some(p) = part.as_object() else { continue };
+            if let Some(response) = p.get("functionResponse").and_then(|fr| fr.get("response")) {
+                // Function responses carry arbitrary JSON; classify the
+                // serialized form so error markers inside it are visible.
+                tool_texts.push(
+                    response
+                        .as_str()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| response.to_string()),
+                );
+                continue;
+            }
+            if role == "model" {
+                if let Some(call) = p.get("functionCall").and_then(Value::as_object) {
+                    let Some(name) = call.get("name").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    // Gemini delivers `args` as a parsed object.
+                    let command = call
+                        .get("args")
+                        .and_then(Value::as_object)
+                        .and_then(|args| args.get("command"))
+                        .and_then(Value::as_str)
+                        .map(|s| s.to_lowercase());
+                    tool_calls.push(ObservedToolCall {
+                        name: name.to_string(),
+                        command,
+                    });
+                }
+                continue;
+            }
+            if role == "user" {
+                if let Some(text) = p.get("text").and_then(Value::as_str) {
+                    prompt_char_count = text.len() as u32;
+                }
+            }
+        }
+    }
+
+    build_signal(
+        tool_texts,
+        tool_calls,
+        contents.len() as u32,
         prompt_char_count,
         recent_window,
     )

--- a/crates/switchyard-components/src/intake.rs
+++ b/crates/switchyard-components/src/intake.rs
@@ -15,8 +15,8 @@ pub use context::{
     INTAKE_ENABLED_HEADER, INTAKE_TASK_HEADER, PROXY_SESSION_ID_HEADER,
 };
 pub use payload::{
-    anthropic_response_from_stream, now_millis, openai_chat_response_from_stream,
-    request_type_value, responses_response_from_stream, to_nvdataflow_document,
-    IntakePayloadBuilder, IntakePayloadContext, IntakeStreamCapture, IntakeStreamFormat,
-    SYNTHETIC_STREAM_RESPONSE_IDS, UNKNOWN_MODEL,
+    anthropic_response_from_stream, gemini_response_from_stream, now_millis,
+    openai_chat_response_from_stream, request_type_value, responses_response_from_stream,
+    to_nvdataflow_document, IntakePayloadBuilder, IntakePayloadContext, IntakeStreamCapture,
+    IntakeStreamFormat, SYNTHETIC_STREAM_RESPONSE_IDS, UNKNOWN_MODEL,
 };

--- a/crates/switchyard-components/src/intake/payload.rs
+++ b/crates/switchyard-components/src/intake/payload.rs
@@ -248,9 +248,24 @@ impl IntakePayloadBuilder {
                         "failed to translate Anthropic intake response to OpenAI Chat: {error}"
                     ))
                 }),
+            ChatResponseType::GeminiCompletion => self
+                .translation
+                .translate_response(
+                    WireFormat::GeminiGenerateContent,
+                    WireFormat::OpenAiChat,
+                    body,
+                    &self.policy,
+                )
+                .map(|output| output.body)
+                .map_err(|error| {
+                    SwitchyardError::Processor(format!(
+                        "failed to translate Gemini intake response to OpenAI Chat: {error}"
+                    ))
+                }),
             ChatResponseType::OpenAiStream
             | ChatResponseType::OpenAiResponsesStream
-            | ChatResponseType::AnthropicStream => Err(SwitchyardError::Processor(
+            | ChatResponseType::AnthropicStream
+            | ChatResponseType::GeminiStream => Err(SwitchyardError::Processor(
                 "intake payload builder requires a buffered response".to_string(),
             )),
         }
@@ -356,6 +371,7 @@ pub fn request_type_value(request_type: ChatRequestType) -> &'static str {
         ChatRequestType::OpenAiChat => "openai_chat",
         ChatRequestType::OpenAiResponses => "openai_responses",
         ChatRequestType::Anthropic => "anthropic",
+        ChatRequestType::Gemini => "gemini",
     }
 }
 
@@ -368,6 +384,8 @@ pub enum IntakeStreamFormat {
     OpenAiResponses,
     /// Anthropic Messages stream.
     Anthropic,
+    /// Gemini generateContent stream.
+    Gemini,
 }
 
 /// Format-specific stream capture state.
@@ -378,6 +396,8 @@ pub enum IntakeStreamCapture {
     OpenAiResponses(ResponsesStreamCapture),
     /// Anthropic stream capture.
     Anthropic(AnthropicStreamCapture),
+    /// Gemini stream capture.
+    Gemini(GeminiStreamCapture),
 }
 
 impl IntakeStreamCapture {
@@ -393,6 +413,7 @@ impl IntakeStreamCapture {
             IntakeStreamFormat::Anthropic => {
                 Self::Anthropic(AnthropicStreamCapture::new(served_model))
             }
+            IntakeStreamFormat::Gemini => Self::Gemini(GeminiStreamCapture::new(served_model)),
         }
     }
 
@@ -402,6 +423,7 @@ impl IntakeStreamCapture {
             Self::OpenAiChat(capture) => capture.observe(event),
             Self::OpenAiResponses(capture) => capture.observe(event),
             Self::Anthropic(capture) => capture.observe(event),
+            Self::Gemini(capture) => capture.observe(event),
         }
     }
 
@@ -411,6 +433,7 @@ impl IntakeStreamCapture {
             Self::OpenAiChat(capture) => Ok(capture.finish()),
             Self::OpenAiResponses(capture) => capture.finish(),
             Self::Anthropic(capture) => Ok(capture.finish()),
+            Self::Gemini(capture) => Ok(capture.finish()),
         }
     }
 }
@@ -442,6 +465,15 @@ pub fn responses_response_from_stream(
     served_model: Option<&str>,
 ) -> Result<Value> {
     let mut capture = ResponsesStreamCapture::new(served_model);
+    for event in events {
+        capture.observe(event);
+    }
+    capture.finish()
+}
+
+/// Reconstructs an OpenAI Chat completion from Gemini stream chunks.
+pub fn gemini_response_from_stream(events: &[StreamEvent], served_model: Option<&str>) -> Value {
+    let mut capture = GeminiStreamCapture::new(served_model);
     for event in events {
         capture.observe(event);
     }
@@ -664,6 +696,7 @@ fn request_wire_format(request_type: ChatRequestType) -> WireFormat {
         ChatRequestType::OpenAiChat => WireFormat::OpenAiChat,
         ChatRequestType::OpenAiResponses => WireFormat::OpenAiResponses,
         ChatRequestType::Anthropic => WireFormat::AnthropicMessages,
+        ChatRequestType::Gemini => WireFormat::GeminiGenerateContent,
     }
 }
 
@@ -1510,6 +1543,179 @@ impl AnthropicStreamCapture {
         }
         response
     }
+}
+
+/// Capture state for Gemini generateContent streaming.
+///
+/// Gemini stream chunks are complete `GenerateContentResponse` objects:
+/// text arrives as incremental `parts`, function calls arrive whole in a
+/// single chunk, and the terminal chunk carries `finishReason` plus the
+/// authoritative `usageMetadata`. Only `candidates[0]` is captured.
+pub struct GeminiStreamCapture {
+    /// Backend-selected model fallback.
+    served_model: Option<String>,
+    /// Response ID from the stream.
+    id: Option<String>,
+    /// Model version reported by the stream.
+    model: Option<String>,
+    /// Accumulated non-thought text content.
+    content: String,
+    /// Completed OpenAI-shaped tool calls.
+    tool_calls: Vec<Value>,
+    /// Gemini finish reason from the terminal chunk.
+    finish_reason: Option<String>,
+    /// Latest usageMetadata object observed on the stream.
+    usage: Option<Value>,
+}
+
+impl GeminiStreamCapture {
+    /// Creates empty Gemini stream capture state.
+    fn new(served_model: Option<&str>) -> Self {
+        Self {
+            served_model: served_model.map(str::to_string),
+            id: None,
+            model: None,
+            content: String::new(),
+            tool_calls: Vec::new(),
+            finish_reason: None,
+            usage: None,
+        }
+    }
+
+    /// Merges one Gemini stream chunk into the capture state.
+    fn observe(&mut self, event: &StreamEvent) {
+        let StreamEvent::Json(value) = event else {
+            return;
+        };
+        if self.id.is_none() {
+            self.id = value
+                .get("responseId")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if self.model.is_none() {
+            self.model = value
+                .get("modelVersion")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if let Some(usage) = value.get("usageMetadata").filter(|usage| usage.is_object()) {
+            self.usage = Some(usage.clone());
+        }
+        let Some(candidate) = value
+            .get("candidates")
+            .and_then(Value::as_array)
+            .and_then(|candidates| candidates.first())
+        else {
+            return;
+        };
+        if let Some(reason) = candidate.get("finishReason").and_then(Value::as_str) {
+            self.finish_reason = Some(reason.to_string());
+        }
+        let Some(parts) = candidate
+            .get("content")
+            .and_then(|content| content.get("parts"))
+            .and_then(Value::as_array)
+        else {
+            return;
+        };
+        for part in parts {
+            // Thought parts are private reasoning; keep them out of content.
+            if part.get("thought").and_then(Value::as_bool) == Some(true) {
+                continue;
+            }
+            if let Some(text) = part.get("text").and_then(Value::as_str) {
+                self.content.push_str(text);
+                continue;
+            }
+            if let Some(call) = part.get("functionCall").and_then(Value::as_object) {
+                let index = self.tool_calls.len();
+                self.tool_calls.push(json!({
+                    "id": format!("call_switchyard_{index}"),
+                    "type": "function",
+                    "function": {
+                        "name": call.get("name").and_then(Value::as_str).unwrap_or_default(),
+                        "arguments": json_argument_string(call.get("args")),
+                    },
+                }));
+            }
+        }
+    }
+
+    /// Builds a buffered OpenAI Chat completion from captured Gemini state.
+    fn finish(self) -> Value {
+        let has_tool_calls = !self.tool_calls.is_empty();
+        let mut message = json!({
+            "role": "assistant",
+            "content": if self.content.is_empty() { Value::Null } else { Value::String(self.content) },
+        });
+        if has_tool_calls {
+            if let Value::Object(object) = &mut message {
+                object.insert("tool_calls".to_string(), Value::Array(self.tool_calls));
+            }
+        }
+        let mut response = json!({
+            "id": self.id.unwrap_or_else(|| "gemini_switchyard_stream".to_string()),
+            "object": "chat.completion",
+            "model": self
+                .model
+                .or(self.served_model)
+                .unwrap_or_else(|| UNKNOWN_MODEL.to_string()),
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": self
+                    .finish_reason
+                    .map(|reason| gemini_finish_reason_to_openai(&reason, has_tool_calls))
+                    .unwrap_or_else(|| default_openai_finish_reason(has_tool_calls)),
+            }],
+        });
+        if let Some(usage) = self.usage {
+            let prompt_tokens = coerce_i64(usage.get("promptTokenCount")).unwrap_or(0);
+            let completion_tokens = coerce_i64(usage.get("candidatesTokenCount"))
+                .unwrap_or(0)
+                .saturating_add(coerce_i64(usage.get("thoughtsTokenCount")).unwrap_or(0));
+            let cached_tokens = coerce_i64(usage.get("cachedContentTokenCount")).unwrap_or(0);
+            let mut usage_object = Map::new();
+            usage_object.insert("prompt_tokens".to_string(), Value::from(prompt_tokens));
+            usage_object.insert(
+                "completion_tokens".to_string(),
+                Value::from(completion_tokens),
+            );
+            usage_object.insert(
+                "total_tokens".to_string(),
+                Value::from(prompt_tokens.saturating_add(completion_tokens)),
+            );
+            if cached_tokens != 0 {
+                usage_object.insert(
+                    "prompt_tokens_details".to_string(),
+                    json!({"cached_tokens": cached_tokens}),
+                );
+            }
+            if let Value::Object(object) = &mut response {
+                object.insert("usage".to_string(), Value::Object(usage_object));
+            }
+        }
+        response
+    }
+}
+
+/// Maps Gemini finish reasons onto OpenAI Chat finish reasons.
+///
+/// Gemini reports `STOP` even for function-call turns, so tool-call presence
+/// takes precedence over the raw reason.
+fn gemini_finish_reason_to_openai(reason: &str, has_tool_calls: bool) -> Value {
+    Value::String(
+        match reason {
+            "STOP" if has_tool_calls => "tool_calls",
+            "STOP" => "stop",
+            "MAX_TOKENS" => "length",
+            "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII"
+            | "IMAGE_SAFETY" => "content_filter",
+            other => other,
+        }
+        .to_string(),
+    )
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/crates/switchyard-components/src/lib.rs
+++ b/crates/switchyard-components/src/lib.rs
@@ -16,8 +16,9 @@ pub mod stats;
 mod telemetry;
 
 pub use backends::{
-    AnthropicNativeBackend, BackendSelection, BackendSelectionReason, LlmTargetBackend,
-    MultiLlmBackend, OpenAiNativeBackend, OpenAiPassthroughBackend, StatsLlmBackend,
+    AnthropicNativeBackend, BackendSelection, BackendSelectionReason, GeminiNativeBackend,
+    LlmTargetBackend, MultiLlmBackend, OpenAiNativeBackend, OpenAiPassthroughBackend,
+    StatsLlmBackend,
 };
 pub use dimension_collector::{
     extract_tool_signals, ContextSignals, DimensionScore, Keywords, ResponseFlag, ResponseSignals,

--- a/crates/switchyard-components/src/response_processors/intake.rs
+++ b/crates/switchyard-components/src/response_processors/intake.rs
@@ -60,7 +60,8 @@ impl IntakeResponseProcessor {
         match response {
             ChatResponse::OpenAiCompletion(_)
             | ChatResponse::OpenAiResponsesCompletion(_)
-            | ChatResponse::AnthropicCompletion(_) => {
+            | ChatResponse::AnthropicCompletion(_)
+            | ChatResponse::GeminiCompletion(_) => {
                 let payload = self.buffered_payload(ctx, &response);
                 enqueue_payload(Arc::clone(&self.sink), payload).await;
                 Ok(response)
@@ -90,6 +91,13 @@ impl IntakeResponseProcessor {
                     IntakeStreamFormat::Anthropic,
                 )))
             }
+            ChatResponse::GeminiStream(stream) => Ok(ChatResponse::GeminiStream(wrap_stream(
+                stream,
+                self.builder.clone(),
+                Arc::clone(&self.sink),
+                IntakePayloadContext::from_proxy_context(ctx, None),
+                IntakeStreamFormat::Gemini,
+            ))),
         }
     }
 

--- a/crates/switchyard-components/src/response_processors/stats.rs
+++ b/crates/switchyard-components/src/response_processors/stats.rs
@@ -8,9 +8,10 @@ use futures_util::StreamExt;
 use switchyard_core::{BoxResponseStream, ChatResponse, ProxyContext, Result};
 
 use crate::stats::{
-    openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event,
-    selected_stats_model, selected_stats_tier, usage_from_body, AnthropicStreamUsage, PrefixProbe,
-    StatsAccumulator, StatsBackendLatency, StatsRequestStart, TokenUsage,
+    gemini_usage_from_body, openai_chat_usage_from_stream_event,
+    openai_responses_usage_from_stream_event, selected_stats_model, selected_stats_tier,
+    usage_from_body, AnthropicStreamUsage, GeminiStreamUsage, PrefixProbe, StatsAccumulator,
+    StatsBackendLatency, StatsRequestStart, TokenUsage,
 };
 
 /// Records token usage, total latency, and routing overhead.
@@ -83,6 +84,18 @@ impl StatsResponseProcessor {
                 )?;
                 Ok(ChatResponse::AnthropicCompletion(response))
             }
+            ChatResponse::GeminiCompletion(response) => {
+                record_usage(
+                    &self.accumulator,
+                    &model,
+                    gemini_usage_from_body(response.body()),
+                    started_at,
+                    backend_latency,
+                    tier.as_deref(),
+                    cache_eligible,
+                )?;
+                Ok(ChatResponse::GeminiCompletion(response))
+            }
             ChatResponse::OpenAiStream(stream) => {
                 Ok(ChatResponse::OpenAiStream(wrap_openai_chat_stream(
                     stream,
@@ -107,6 +120,17 @@ impl StatsResponseProcessor {
             )),
             ChatResponse::AnthropicStream(stream) => {
                 Ok(ChatResponse::AnthropicStream(wrap_anthropic_stream(
+                    stream,
+                    self.accumulator.clone(),
+                    model,
+                    started_at,
+                    backend_latency,
+                    tier,
+                    cache_eligible,
+                )))
+            }
+            ChatResponse::GeminiStream(stream) => {
+                Ok(ChatResponse::GeminiStream(wrap_gemini_stream(
                     stream,
                     self.accumulator.clone(),
                     model,
@@ -195,6 +219,35 @@ fn wrap_anthropic_stream(
 ) -> BoxResponseStream {
     Box::pin(try_stream! {
         let mut stream_usage = AnthropicStreamUsage::default();
+        while let Some(event) = stream.next().await {
+            let event = event?;
+            if let Some(usage) = stream_usage.observe(&event) {
+                log_stream_record_result(record_usage(
+                    &accumulator,
+                    &model,
+                    usage,
+                    started_at,
+                    backend_latency,
+                    tier.as_deref(),
+                    cache_eligible,
+                ), &model);
+            }
+            yield event;
+        }
+    })
+}
+
+fn wrap_gemini_stream(
+    mut stream: BoxResponseStream,
+    accumulator: StatsAccumulator,
+    model: String,
+    started_at: Option<StatsRequestStart>,
+    backend_latency: Option<StatsBackendLatency>,
+    tier: Option<String>,
+    cache_eligible: f64,
+) -> BoxResponseStream {
+    Box::pin(try_stream! {
+        let mut stream_usage = GeminiStreamUsage::default();
         while let Some(event) = stream.next().await {
             let event = event?;
             if let Some(usage) = stream_usage.observe(&event) {

--- a/crates/switchyard-components/src/stats/mod.rs
+++ b/crates/switchyard-components/src/stats/mod.rs
@@ -20,6 +20,7 @@ pub use context::{
 };
 pub use cost::{estimate_model_cost, has_model_price, CostBreakdown, CostEstimate};
 pub use usage::{
-    openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event, usage_from_body,
-    AnthropicStreamUsage, TokenUsage,
+    gemini_usage_from_body, openai_chat_usage_from_stream_event,
+    openai_responses_usage_from_stream_event, usage_from_body, AnthropicStreamUsage,
+    GeminiStreamUsage, TokenUsage,
 };

--- a/crates/switchyard-components/src/stats/usage.rs
+++ b/crates/switchyard-components/src/stats/usage.rs
@@ -38,6 +38,13 @@ pub fn usage_from_body(body: &Value) -> TokenUsage {
         .unwrap_or_default()
 }
 
+/// Extracts usage from a buffered Gemini generateContent response body.
+pub fn gemini_usage_from_body(body: &Value) -> TokenUsage {
+    body.get("usageMetadata")
+        .map(token_usage_from_gemini_metadata)
+        .unwrap_or_default()
+}
+
 /// Extracts OpenAI Chat streaming usage from an event.
 pub fn openai_chat_usage_from_stream_event(event: &StreamEvent) -> Option<TokenUsage> {
     let StreamEvent::Json(value) = event else {
@@ -167,6 +174,88 @@ impl AnthropicStreamUsage {
         if let Some(value) = int_field(usage, "cache_creation_input_tokens") {
             self.cache_creation_input_tokens = value;
         }
+    }
+}
+
+/// Accumulates Gemini streaming usage and commits once on the terminal chunk.
+///
+/// Gemini streams have no explicit stop event; the final chunk carries both
+/// `candidates[].finishReason` and the authoritative `usageMetadata`. A
+/// finish-reason chunk before any usage frame is a known no-op, matching the
+/// Anthropic stream tap behavior.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GeminiStreamUsage {
+    prompt_tokens: u64,
+    candidates_tokens: u64,
+    thoughts_tokens: u64,
+    cached_tokens: u64,
+    saw_usage: bool,
+    committed: bool,
+}
+
+impl GeminiStreamUsage {
+    /// Observes one stream chunk and returns usage exactly once at the finish chunk.
+    pub fn observe(&mut self, event: &StreamEvent) -> Option<TokenUsage> {
+        let StreamEvent::Json(value) = event else {
+            return None;
+        };
+        if let Some(usage) = value.get("usageMetadata") {
+            self.merge(usage);
+        }
+        let finished = value
+            .get("candidates")
+            .and_then(Value::as_array)
+            .and_then(|candidates| candidates.first())
+            .and_then(|candidate| candidate.get("finishReason"))
+            .and_then(Value::as_str)
+            .is_some();
+        if finished && self.saw_usage && !self.committed {
+            self.committed = true;
+            return Some(TokenUsage {
+                prompt_tokens: self.prompt_tokens,
+                // Gemini bills thinking tokens as output but reports them
+                // outside candidatesTokenCount; fold them back in.
+                completion_tokens: self.candidates_tokens.saturating_add(self.thoughts_tokens),
+                cached_tokens: self.cached_tokens,
+                cache_creation_tokens: 0,
+                reasoning_tokens: self.thoughts_tokens,
+                cacheable_prompt_tokens: 0,
+            });
+        }
+        None
+    }
+
+    fn merge(&mut self, usage: &Value) {
+        if !usage.is_object() {
+            return;
+        }
+        self.saw_usage = true;
+        if let Some(value) = int_field(usage, "promptTokenCount") {
+            self.prompt_tokens = value;
+        }
+        if let Some(value) = int_field(usage, "candidatesTokenCount") {
+            self.candidates_tokens = value;
+        }
+        if let Some(value) = int_field(usage, "thoughtsTokenCount") {
+            self.thoughts_tokens = value;
+        }
+        if let Some(value) = int_field(usage, "cachedContentTokenCount") {
+            self.cached_tokens = value;
+        }
+    }
+}
+
+// Converts Gemini `usageMetadata` counters into normalized token usage.
+fn token_usage_from_gemini_metadata(usage: &Value) -> TokenUsage {
+    let candidates = int_field(usage, "candidatesTokenCount").unwrap_or(0);
+    let thoughts = int_field(usage, "thoughtsTokenCount").unwrap_or(0);
+    TokenUsage {
+        prompt_tokens: int_field(usage, "promptTokenCount").unwrap_or(0),
+        completion_tokens: candidates.saturating_add(thoughts),
+        cached_tokens: int_field(usage, "cachedContentTokenCount").unwrap_or(0),
+        cache_creation_tokens: 0,
+        reasoning_tokens: thoughts,
+        cacheable_prompt_tokens: 0,
     }
 }
 

--- a/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
+++ b/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
@@ -254,6 +254,7 @@ fn default_supported_request_types_are_all_wire_formats_in_stable_order() -> Res
             ChatRequestType::OpenAiChat,
             ChatRequestType::OpenAiResponses,
             ChatRequestType::Anthropic,
+            ChatRequestType::Gemini,
         ]
     );
     Ok(())

--- a/crates/switchyard-core/src/backend.rs
+++ b/crates/switchyard-core/src/backend.rs
@@ -24,6 +24,8 @@ pub enum BackendFormat {
     Responses,
     /// Anthropic Messages wire format.
     Anthropic,
+    /// Gemini generateContent wire format.
+    Gemini,
 }
 
 /// Optional endpoint overrides for an LLM target.

--- a/crates/switchyard-core/src/types.rs
+++ b/crates/switchyard-core/src/types.rs
@@ -21,6 +21,8 @@ pub enum ChatRequestType {
     OpenAiResponses,
     #[serde(rename = "anthropic")]
     Anthropic,
+    #[serde(rename = "gemini")]
+    Gemini,
 }
 
 /// JSON request body wrapper shared by all request variants.
@@ -61,6 +63,8 @@ pub enum ChatRequest {
     OpenAiResponses(WireRequest),
     #[serde(rename = "anthropic")]
     Anthropic(WireRequest),
+    #[serde(rename = "gemini")]
+    Gemini(WireRequest),
 }
 
 impl ChatRequest {
@@ -79,13 +83,19 @@ impl ChatRequest {
         Self::Anthropic(WireRequest::new(body))
     }
 
+    /// Creates a Gemini generateContent request.
+    pub fn gemini(body: Value) -> Self {
+        Self::Gemini(WireRequest::new(body))
+    }
+
     /// Validates the request body before it enters the chain.
     ///
     /// Catches structurally valid but semantically invalid input so it
     /// fails fast with a 4xx instead of reaching the backend and surfacing
     /// as an opaque upstream 5xx. Currently rejects a present-but-empty
     /// `messages` array on the message-based formats (OpenAI Chat,
-    /// Anthropic). Absent or non-array `messages` are left for the backend
+    /// Anthropic) and a present-but-empty `contents` array on Gemini.
+    /// Absent or non-array conversation fields are left for the backend
     /// to interpret; the Responses format carries `input`, not `messages`,
     /// and is exempt.
     pub fn validate(&self) -> Result<()> {
@@ -99,6 +109,15 @@ impl ChatRequest {
                 }
             }
         }
+        if matches!(self, Self::Gemini(_)) {
+            if let Some(contents) = self.body().get("contents").and_then(Value::as_array) {
+                if contents.is_empty() {
+                    return Err(SwitchyardError::InvalidRequest(
+                        "contents must be a non-empty array".to_string(),
+                    ));
+                }
+            }
+        }
         Ok(())
     }
 
@@ -108,6 +127,7 @@ impl ChatRequest {
             Self::OpenAiChat(_) => ChatRequestType::OpenAiChat,
             Self::OpenAiResponses(_) => ChatRequestType::OpenAiResponses,
             Self::Anthropic(_) => ChatRequestType::Anthropic,
+            Self::Gemini(_) => ChatRequestType::Gemini,
         }
     }
 
@@ -116,7 +136,8 @@ impl ChatRequest {
         match self {
             Self::OpenAiChat(request)
             | Self::OpenAiResponses(request)
-            | Self::Anthropic(request) => request.body(),
+            | Self::Anthropic(request)
+            | Self::Gemini(request) => request.body(),
         }
     }
 
@@ -125,7 +146,8 @@ impl ChatRequest {
         match self {
             Self::OpenAiChat(request)
             | Self::OpenAiResponses(request)
-            | Self::Anthropic(request) => request.body_mut(),
+            | Self::Anthropic(request)
+            | Self::Gemini(request) => request.body_mut(),
         }
     }
 
@@ -164,6 +186,10 @@ pub enum ChatResponseType {
     AnthropicCompletion,
     #[serde(rename = "anthropic_stream")]
     AnthropicStream,
+    #[serde(rename = "gemini_completion")]
+    GeminiCompletion,
+    #[serde(rename = "gemini_stream")]
+    GeminiStream,
 }
 
 /// JSON response body wrapper shared by buffered response variants.
@@ -208,6 +234,8 @@ pub enum ChatResponse {
     OpenAiResponsesStream(BoxResponseStream),
     AnthropicCompletion(WireResponse),
     AnthropicStream(BoxResponseStream),
+    GeminiCompletion(WireResponse),
+    GeminiStream(BoxResponseStream),
 }
 
 impl ChatResponse {
@@ -226,6 +254,11 @@ impl ChatResponse {
         Self::AnthropicCompletion(WireResponse::new(body))
     }
 
+    /// Creates a buffered Gemini generateContent response.
+    pub fn gemini_completion(body: Value) -> Self {
+        Self::GeminiCompletion(WireResponse::new(body))
+    }
+
     /// Returns the response's tagged wire shape.
     pub fn response_type(&self) -> ChatResponseType {
         match self {
@@ -235,6 +268,8 @@ impl ChatResponse {
             Self::OpenAiResponsesStream(_) => ChatResponseType::OpenAiResponsesStream,
             Self::AnthropicCompletion(_) => ChatResponseType::AnthropicCompletion,
             Self::AnthropicStream(_) => ChatResponseType::AnthropicStream,
+            Self::GeminiCompletion(_) => ChatResponseType::GeminiCompletion,
+            Self::GeminiStream(_) => ChatResponseType::GeminiStream,
         }
     }
 
@@ -243,10 +278,12 @@ impl ChatResponse {
         match self {
             Self::OpenAiCompletion(response)
             | Self::OpenAiResponsesCompletion(response)
-            | Self::AnthropicCompletion(response) => Some(response.body()),
-            Self::OpenAiStream(_) | Self::OpenAiResponsesStream(_) | Self::AnthropicStream(_) => {
-                None
-            }
+            | Self::AnthropicCompletion(response)
+            | Self::GeminiCompletion(response) => Some(response.body()),
+            Self::OpenAiStream(_)
+            | Self::OpenAiResponsesStream(_)
+            | Self::AnthropicStream(_)
+            | Self::GeminiStream(_) => None,
         }
     }
 }
@@ -274,6 +311,11 @@ impl fmt::Debug for ChatResponse {
             Self::AnthropicStream(_) => {
                 f.debug_tuple("AnthropicStream").field(&"<stream>").finish()
             }
+            Self::GeminiCompletion(response) => f
+                .debug_tuple("GeminiCompletion")
+                .field(response.body())
+                .finish(),
+            Self::GeminiStream(_) => f.debug_tuple("GeminiStream").field(&"<stream>").finish(),
         }
     }
 }

--- a/crates/switchyard-py/src/component_bindings/backends.rs
+++ b/crates/switchyard-py/src/component_bindings/backends.rs
@@ -9,8 +9,8 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyIterator, PyTuple};
 use switchyard_components::{
-    AnthropicNativeBackend, LlmTargetBackend, MultiLlmBackend, OpenAiNativeBackend,
-    OpenAiPassthroughBackend, StatsLlmBackend,
+    AnthropicNativeBackend, GeminiNativeBackend, LlmTargetBackend, MultiLlmBackend,
+    OpenAiNativeBackend, OpenAiPassthroughBackend, StatsLlmBackend,
 };
 use switchyard_core::{ChatRequestType, EndpointConfig, LlmBackend, LlmTargetId};
 
@@ -185,6 +185,41 @@ impl PyAnthropicNativeBackend {
 }
 
 #[pyclass(
+    name = "GeminiNativeBackend",
+    extends = PyLlmBackend,
+    skip_from_py_object
+)]
+#[derive(Clone, Debug)]
+pub(crate) struct PyGeminiNativeBackend {
+    inner: Arc<GeminiNativeBackend>,
+}
+
+#[pymethods]
+impl PyGeminiNativeBackend {
+    #[new]
+    fn py_new(target: PyRef<'_, PyLlmTarget>) -> PyResult<PyClassInitializer<Self>> {
+        let backend = GeminiNativeBackend::new(target.clone_core()).map_err(py_core_error)?;
+        let backend = Arc::new(backend);
+        let base: Arc<dyn LlmBackend> = backend.clone();
+        Ok(PyClassInitializer::from(PyLlmBackend::from_native(base))
+            .add_subclass(Self { inner: backend }))
+    }
+
+    #[getter]
+    fn target(&self) -> PyLlmTarget {
+        PyLlmTarget::from_core(self.inner.target().clone())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "GeminiNativeBackend(target_id={:?}, model={:?})",
+            self.inner.target().id.as_str(),
+            self.inner.target().model.as_str(),
+        )
+    }
+}
+
+#[pyclass(
     name = "MultiLlmBackend",
     extends = PyLlmBackend,
     skip_from_py_object
@@ -344,6 +379,7 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyOpenAiNativeBackend>()?;
     module.add_class::<PyOpenAiPassthroughBackend>()?;
     module.add_class::<PyAnthropicNativeBackend>()?;
+    module.add_class::<PyGeminiNativeBackend>()?;
     module.add_class::<PyMultiLlmBackend>()?;
     module.add_class::<PyStatsLlmBackend>()?;
     Ok(())

--- a/crates/switchyard-py/src/component_bindings/config.rs
+++ b/crates/switchyard-py/src/component_bindings/config.rs
@@ -50,6 +50,9 @@ impl PyBackendFormat {
     #[classattr]
     const ANTHROPIC: Self = Self::new_inner(BackendFormat::Anthropic);
 
+    #[classattr]
+    const GEMINI: Self = Self::new_inner(BackendFormat::Gemini);
+
     #[getter]
     fn value(&self) -> &'static str {
         backend_format_name(self.inner)
@@ -69,6 +72,7 @@ impl PyBackendFormat {
             BackendFormat::OpenAi => 2,
             BackendFormat::Responses => 3,
             BackendFormat::Anthropic => 4,
+            BackendFormat::Gemini => 5,
         }
     }
 
@@ -679,6 +683,7 @@ fn backend_format_from_str(value: &str) -> PyResult<BackendFormat> {
         "openai" => Ok(BackendFormat::OpenAi),
         "responses" => Ok(BackendFormat::Responses),
         "anthropic" => Ok(BackendFormat::Anthropic),
+        "gemini" => Ok(BackendFormat::Gemini),
         _ => Err(PyValueError::new_err(format!(
             "Unknown backend format: {value:?}"
         ))),
@@ -691,6 +696,7 @@ fn backend_format_name(format: BackendFormat) -> &'static str {
         BackendFormat::OpenAi => "openai",
         BackendFormat::Responses => "responses",
         BackendFormat::Anthropic => "anthropic",
+        BackendFormat::Gemini => "gemini",
     }
 }
 
@@ -700,6 +706,7 @@ fn backend_format_variant_name(format: BackendFormat) -> &'static str {
         BackendFormat::OpenAi => "OPENAI",
         BackendFormat::Responses => "RESPONSES",
         BackendFormat::Anthropic => "ANTHROPIC",
+        BackendFormat::Gemini => "GEMINI",
     }
 }
 

--- a/crates/switchyard-py/src/core_bindings/request.rs
+++ b/crates/switchyard-py/src/core_bindings/request.rs
@@ -34,6 +34,9 @@ impl PyChatRequestType {
     #[classattr]
     const ANTHROPIC: Self = Self::new(ChatRequestType::Anthropic);
 
+    #[classattr]
+    const GEMINI: Self = Self::new(ChatRequestType::Gemini);
+
     #[getter]
     fn value(&self) -> &'static str {
         request_type_name(self.inner)
@@ -52,6 +55,7 @@ impl PyChatRequestType {
             ChatRequestType::OpenAiChat => 1,
             ChatRequestType::OpenAiResponses => 2,
             ChatRequestType::Anthropic => 3,
+            ChatRequestType::Gemini => 4,
         }
     }
 }
@@ -95,6 +99,13 @@ impl PyChatRequest {
         })
     }
 
+    #[classmethod]
+    fn gemini(_cls: &Bound<'_, PyType>, body: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            inner: ChatRequest::gemini(value_from_python(body)?),
+        })
+    }
+
     /// Validates the request at the inbound trust boundary.
     ///
     /// Kept separate from construction so internal re-wraps (e.g. the
@@ -131,6 +142,7 @@ impl PyChatRequest {
             ChatRequestType::OpenAiChat => ChatRequest::openai_chat(body),
             ChatRequestType::OpenAiResponses => ChatRequest::openai_responses(body),
             ChatRequestType::Anthropic => ChatRequest::anthropic(body),
+            ChatRequestType::Gemini => ChatRequest::gemini(body),
         };
         Ok(())
     }
@@ -164,6 +176,7 @@ pub(crate) fn request_type_from_python(value: &Bound<'_, PyAny>) -> PyResult<Cha
         "openai_chat" => Ok(ChatRequestType::OpenAiChat),
         "openai_responses" => Ok(ChatRequestType::OpenAiResponses),
         "anthropic" | "anthropic_messages" => Ok(ChatRequestType::Anthropic),
+        "gemini" | "gemini_generate_content" => Ok(ChatRequestType::Gemini),
         _ => Err(PyValueError::new_err(format!(
             "Unknown request type: {raw:?}"
         ))),
@@ -175,6 +188,7 @@ pub(crate) fn request_type_name(request_type: ChatRequestType) -> &'static str {
         ChatRequestType::OpenAiChat => "openai_chat",
         ChatRequestType::OpenAiResponses => "openai_responses",
         ChatRequestType::Anthropic => "anthropic",
+        ChatRequestType::Gemini => "gemini",
     }
 }
 
@@ -183,6 +197,7 @@ pub(crate) fn request_type_variant_name(request_type: ChatRequestType) -> &'stat
         ChatRequestType::OpenAiChat => "OPENAI_CHAT",
         ChatRequestType::OpenAiResponses => "OPENAI_RESPONSES",
         ChatRequestType::Anthropic => "ANTHROPIC",
+        ChatRequestType::Gemini => "GEMINI",
     }
 }
 

--- a/crates/switchyard-py/src/core_bindings/response.rs
+++ b/crates/switchyard-py/src/core_bindings/response.rs
@@ -51,6 +51,12 @@ impl PyChatResponseType {
     #[classattr]
     const ANTHROPIC_STREAM: Self = Self::new(ChatResponseType::AnthropicStream);
 
+    #[classattr]
+    const GEMINI_COMPLETION: Self = Self::new(ChatResponseType::GeminiCompletion);
+
+    #[classattr]
+    const GEMINI_STREAM: Self = Self::new(ChatResponseType::GeminiStream);
+
     #[getter]
     fn value(&self) -> &'static str {
         response_type_name(self.inner)
@@ -75,6 +81,8 @@ impl PyChatResponseType {
             ChatResponseType::OpenAiResponsesStream => 4,
             ChatResponseType::AnthropicCompletion => 5,
             ChatResponseType::AnthropicStream => 6,
+            ChatResponseType::GeminiCompletion => 7,
+            ChatResponseType::GeminiStream => 8,
         }
     }
 }
@@ -148,6 +156,21 @@ impl PyChatResponse {
         Self::stream_response(stream.py(), ChatResponseType::AnthropicStream, stream)
     }
 
+    #[classmethod]
+    fn gemini_completion(_cls: &Bound<'_, PyType>, body: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            inner: PyChatResponseInner::Buffered {
+                response_type: ChatResponseType::GeminiCompletion,
+                body: value_from_python(body)?,
+            },
+        })
+    }
+
+    #[classmethod]
+    fn gemini_stream(_cls: &Bound<'_, PyType>, stream: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Self::stream_response(stream.py(), ChatResponseType::GeminiStream, stream)
+    }
+
     #[getter]
     fn response_type(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         response_type_object(py, self.response_type_inner())
@@ -191,9 +214,17 @@ impl PyChatResponse {
                     body,
                 }
             }
+            ChatResponseType::GeminiCompletion => {
+                let body = value_from_python(body)?;
+                PyChatResponseInner::Buffered {
+                    response_type: ChatResponseType::GeminiCompletion,
+                    body,
+                }
+            }
             ChatResponseType::OpenAiStream
             | ChatResponseType::OpenAiResponsesStream
-            | ChatResponseType::AnthropicStream => {
+            | ChatResponseType::AnthropicStream
+            | ChatResponseType::GeminiStream => {
                 return Err(PyValueError::new_err(
                     "streaming ChatResponse values do not have a replaceable body",
                 ));
@@ -246,6 +277,14 @@ impl PyChatResponse {
                 response_type: ChatResponseType::AnthropicStream,
                 stream: Py::new(py, PyResponseStream::from_core_stream(stream))?,
             },
+            ChatResponse::GeminiCompletion(response) => PyChatResponseInner::Buffered {
+                response_type: ChatResponseType::GeminiCompletion,
+                body: response.into_body(),
+            },
+            ChatResponse::GeminiStream(stream) => PyChatResponseInner::Stream {
+                response_type: ChatResponseType::GeminiStream,
+                stream: Py::new(py, PyResponseStream::from_core_stream(stream))?,
+            },
         };
         Ok(Self { inner })
     }
@@ -263,9 +302,11 @@ impl PyChatResponse {
                 ChatResponseType::AnthropicCompletion => {
                     ChatResponse::anthropic_completion(body.clone())
                 }
+                ChatResponseType::GeminiCompletion => ChatResponse::gemini_completion(body.clone()),
                 ChatResponseType::OpenAiStream
                 | ChatResponseType::OpenAiResponsesStream
-                | ChatResponseType::AnthropicStream => {
+                | ChatResponseType::AnthropicStream
+                | ChatResponseType::GeminiStream => {
                     return Err(PyRuntimeError::new_err(
                         "streaming response type stored without a stream",
                     ));
@@ -282,9 +323,11 @@ impl PyChatResponse {
                         ChatResponse::OpenAiResponsesStream(stream)
                     }
                     ChatResponseType::AnthropicStream => ChatResponse::AnthropicStream(stream),
+                    ChatResponseType::GeminiStream => ChatResponse::GeminiStream(stream),
                     ChatResponseType::OpenAiCompletion
                     | ChatResponseType::OpenAiResponsesCompletion
-                    | ChatResponseType::AnthropicCompletion => {
+                    | ChatResponseType::AnthropicCompletion
+                    | ChatResponseType::GeminiCompletion => {
                         return Err(PyRuntimeError::new_err(
                             "buffered response type stored with a stream",
                         ));
@@ -828,6 +871,8 @@ fn response_type_name(response_type: ChatResponseType) -> &'static str {
         ChatResponseType::OpenAiResponsesStream => "openai_responses_stream",
         ChatResponseType::AnthropicCompletion => "anthropic_completion",
         ChatResponseType::AnthropicStream => "anthropic_stream",
+        ChatResponseType::GeminiCompletion => "gemini_completion",
+        ChatResponseType::GeminiStream => "gemini_stream",
     }
 }
 
@@ -839,6 +884,8 @@ fn response_type_variant_name(response_type: ChatResponseType) -> &'static str {
         ChatResponseType::OpenAiResponsesStream => "OPENAI_RESPONSES_STREAM",
         ChatResponseType::AnthropicCompletion => "ANTHROPIC_COMPLETION",
         ChatResponseType::AnthropicStream => "ANTHROPIC_STREAM",
+        ChatResponseType::GeminiCompletion => "GEMINI_COMPLETION",
+        ChatResponseType::GeminiStream => "GEMINI_STREAM",
     }
 }
 

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -124,6 +124,12 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
         .route("/v1/chat/completions", post(openai_chat_completions))
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/responses", post(openai_responses))
+        // Gemini encodes the model and verb in one path segment, e.g.
+        // `/v1beta/models/gemini-2.5-flash:generateContent`.
+        .route(
+            "/v1beta/models/{model_action}",
+            post(gemini_generate_content),
+        )
         .route("/v1/models", get(models))
         // Keep the legacy routing stats aliases wired to the same handlers.
         .route("/v1/stats", get(stats))
@@ -235,6 +241,45 @@ async fn openai_responses(
         ChatRequest::openai_responses(body),
         WireFormat::OpenAiResponses,
         metadata_from_headers(&headers, ChatRequestType::OpenAiResponses),
+    )
+    .await
+}
+
+async fn gemini_generate_content(
+    State(state): State<ServerState>,
+    axum::extract::Path(model_action): axum::extract::Path<String>,
+    headers: HeaderMap,
+    body: std::result::Result<Json<Value>, JsonRejection>,
+) -> Response {
+    // The URL encodes what other formats carry in the body: the model and,
+    // via the verb, whether the response streams.
+    let Some((model, verb)) = model_action.rsplit_once(':') else {
+        return *Box::new(invalid_body_error(
+            "Gemini requests must use models/{model}:generateContent or :streamGenerateContent",
+        ));
+    };
+    let stream = match verb {
+        "generateContent" => false,
+        "streamGenerateContent" => true,
+        _ => {
+            return *Box::new(invalid_body_error(format!(
+                "Unsupported Gemini action {verb:?}; expected generateContent or streamGenerateContent"
+            )));
+        }
+    };
+    let mut body = match llm_json_body(body) {
+        Ok(body) => body,
+        Err(response) => return *response,
+    };
+    if let Some(object) = body.as_object_mut() {
+        object.insert("model".to_string(), Value::String(model.to_string()));
+        object.insert("stream".to_string(), Value::Bool(stream));
+    }
+    handle_llm_request(
+        state,
+        ChatRequest::gemini(body),
+        WireFormat::GeminiGenerateContent,
+        metadata_from_headers(&headers, ChatRequestType::Gemini),
     )
     .await
 }
@@ -506,6 +551,7 @@ fn model_entry_json(entry: &ServedModel) -> Value {
                 "openai-chat-completions",
                 "openai-responses",
                 "anthropic-messages",
+                "gemini-generate-content",
             ],
         },
     })
@@ -533,6 +579,10 @@ fn startup_banner(options: &ServerRunOptions, registry: &ProfileRegistry) -> Str
     push_line(&mut output, "    POST /v1/chat/completions");
     push_line(&mut output, "    POST /v1/messages");
     push_line(&mut output, "    POST /v1/responses");
+    push_line(
+        &mut output,
+        "    POST /v1beta/models/{model}:generateContent",
+    );
     push_line(&mut output, "    GET  /v1/routing/stats");
     push_line(&mut output, "    POST /v1/routing/stats/reset");
     push_line(&mut output, "");

--- a/crates/switchyard-server/src/response.rs
+++ b/crates/switchyard-server/src/response.rs
@@ -50,6 +50,13 @@ pub(crate) fn translate_chain_response(
             translation,
             &policy,
         ),
+        ChatResponse::GeminiCompletion(response) => translate_buffered_response(
+            response.into_body(),
+            WireFormat::GeminiGenerateContent,
+            target_format,
+            translation,
+            &policy,
+        ),
         ChatResponse::OpenAiStream(stream) => Ok(TranslatedResponse::Stream(
             translate_stream_response(stream, WireFormat::OpenAiChat, target_format, translation),
         )),
@@ -65,6 +72,14 @@ pub(crate) fn translate_chain_response(
             Ok(TranslatedResponse::Stream(translate_stream_response(
                 stream,
                 WireFormat::AnthropicMessages,
+                target_format,
+                translation,
+            )))
+        }
+        ChatResponse::GeminiStream(stream) => {
+            Ok(TranslatedResponse::Stream(translate_stream_response(
+                stream,
+                WireFormat::GeminiGenerateContent,
                 target_format,
                 translation,
             )))

--- a/crates/switchyard-server/src/sse.rs
+++ b/crates/switchyard-server/src/sse.rs
@@ -44,7 +44,9 @@ fn frame_event(
     value: Value,
 ) -> std::result::Result<Event, SwitchyardError> {
     match target_format {
-        WireFormat::OpenAiChat => Event::default()
+        // Gemini streams are unnamed `data:` frames like OpenAI Chat, but
+        // without the terminal `[DONE]` marker (see `frame_stream`).
+        WireFormat::OpenAiChat | WireFormat::GeminiGenerateContent => Event::default()
             .json_data(value)
             .map_err(|error| SwitchyardError::Other(error.to_string())),
         WireFormat::AnthropicMessages | WireFormat::OpenAiResponses => {
@@ -68,6 +70,16 @@ fn error_event(target_format: WireFormat, message: String) -> Event {
                 "error": {
                     "message": message,
                     "type": "SwitchyardError",
+                }
+            })
+            .to_string(),
+        ),
+        WireFormat::GeminiGenerateContent => Event::default().data(
+            json!({
+                "error": {
+                    "code": 500,
+                    "message": message,
+                    "status": "INTERNAL",
                 }
             })
             .to_string(),

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -481,7 +481,9 @@ fn decode_anthropic_content_block(
             .map(|source| vec![ContentBlock::Image { source }])
             .unwrap_or_default(),
         Some("document") => vec![ContentBlock::File {
-            source: decode_anthropic_document_source(block.get("source").unwrap_or(&Value::Null)),
+            source: decode_anthropic_document_source(
+                block.get("source").unwrap_or(&Value::Object(block.clone())),
+            ),
         }],
         Some("input_file") | Some("file") => vec![ContentBlock::File {
             source: decode_file_source(block),
@@ -515,7 +517,7 @@ fn decode_tool_result_content(value: &Value) -> Vec<ContentBlock> {
                     }),
                     Some("image") => content.push(ContentBlock::Image {
                         source: decode_anthropic_image_source(
-                            block.get("source").unwrap_or(&Value::Null),
+                            block.get("source").unwrap_or(&Value::Object(block.clone())),
                         ),
                     }),
                     _ => content.push(ContentBlock::Text {

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -472,17 +472,17 @@ fn decode_anthropic_content_block(
             content: decode_tool_result_content(block.get("content").unwrap_or(&Value::Null)),
             is_error: block.get("is_error").and_then(Value::as_bool),
         })],
-        Some("image") => {
-            let source = block
-                .get("source")
-                .cloned()
-                .map(ImageSource::Raw)
-                .unwrap_or_else(|| ImageSource::Raw(Value::Object(block.clone())));
-            vec![ContentBlock::Image { source }]
-        }
+        Some("image") => vec![ContentBlock::Image {
+            source: decode_anthropic_image_source(
+                block.get("source").unwrap_or(&Value::Object(block.clone())),
+            ),
+        }],
         Some("input_image") | Some("image_url") => decode_image_source(block)
             .map(|source| vec![ContentBlock::Image { source }])
             .unwrap_or_default(),
+        Some("document") => vec![ContentBlock::File {
+            source: decode_anthropic_document_source(block.get("source").unwrap_or(&Value::Null)),
+        }],
         Some("input_file") | Some("file") => vec![ContentBlock::File {
             source: decode_file_source(block),
         }],
@@ -493,30 +493,42 @@ fn decode_anthropic_content_block(
     })
 }
 
-// Converts Anthropic tool-result content into text-like IR blocks.
+// Converts Anthropic tool-result content into IR blocks, keeping image
+// attachments typed so target codecs can re-encode them instead of leaking
+// base64 payloads into prompt text.
 fn decode_tool_result_content(value: &Value) -> Vec<ContentBlock> {
     match value {
         Value::String(text) => vec![ContentBlock::Text { text: text.clone() }],
         Value::Array(blocks) => {
-            let mut text = Vec::new();
+            let mut content = Vec::new();
             for block in blocks {
-                if let Some(block) = block.as_object() {
-                    if block.get("type").and_then(Value::as_str) == Some("text") {
-                        text.push(
-                            block
-                                .get("text")
-                                .and_then(Value::as_str)
-                                .unwrap_or_default()
-                                .to_string(),
-                        );
-                    } else {
-                        text.push(json_string(&Value::Object(block.clone())));
-                    }
+                let Some(block) = block.as_object() else {
+                    continue;
+                };
+                match block.get("type").and_then(Value::as_str) {
+                    Some("text") => content.push(ContentBlock::Text {
+                        text: block
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                    }),
+                    Some("image") => content.push(ContentBlock::Image {
+                        source: decode_anthropic_image_source(
+                            block.get("source").unwrap_or(&Value::Null),
+                        ),
+                    }),
+                    _ => content.push(ContentBlock::Text {
+                        text: json_string(&Value::Object(block.clone())),
+                    }),
                 }
             }
-            vec![ContentBlock::Text {
-                text: text.join(" "),
-            }]
+            if content.is_empty() {
+                content.push(ContentBlock::Text {
+                    text: String::new(),
+                });
+            }
+            content
         }
         Value::Null => vec![ContentBlock::Text {
             text: String::new(),
@@ -524,6 +536,63 @@ fn decode_tool_result_content(value: &Value) -> Vec<ContentBlock> {
         other => vec![ContentBlock::Text {
             text: json_string(other),
         }],
+    }
+}
+
+// Parses an Anthropic image `source` into a typed IR image source so
+// cross-provider encoders can carry the payload; unknown shapes stay raw.
+fn decode_anthropic_image_source(source: &Value) -> ImageSource {
+    let Some(object) = source.as_object() else {
+        return ImageSource::Raw(source.clone());
+    };
+    match object.get("type").and_then(Value::as_str) {
+        Some("base64") => ImageSource::Base64 {
+            media_type: object
+                .get("media_type")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            data: object
+                .get("data")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        },
+        Some("url") => ImageSource::Url {
+            url: object
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            detail: None,
+        },
+        _ => ImageSource::Raw(source.clone()),
+    }
+}
+
+// Parses an Anthropic document `source` into a typed IR file source; only
+// base64 payloads have a cross-provider representation.
+fn decode_anthropic_document_source(source: &Value) -> FileSource {
+    let Some(object) = source.as_object() else {
+        return FileSource::Raw(source.clone());
+    };
+    match object.get("type").and_then(Value::as_str) {
+        Some("base64") => FileSource::FileData {
+            data: object
+                .get("data")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            filename: object
+                .get("filename")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+        },
+        Some("file") => object
+            .get("file_id")
+            .and_then(Value::as_str)
+            .map(|file_id| FileSource::FileId(file_id.to_string()))
+            .unwrap_or_else(|| FileSource::Raw(source.clone())),
+        _ => FileSource::Raw(source.clone()),
     }
 }
 
@@ -736,7 +805,7 @@ fn encode_one_anthropic_block(block: &ContentBlock) -> Vec<Value> {
         ContentBlock::ToolResult(result) => vec![json!({
             "type": "tool_result",
             "tool_use_id": sanitize_anthropic_tool_use_id(&result.tool_call_id),
-            "content": text_from_blocks(&result.content, " "),
+            "content": anthropic_tool_result_content(&result.content),
         })],
         ContentBlock::Image { source } => vec![match source {
             ImageSource::Url { url, .. } => {
@@ -798,6 +867,42 @@ fn encode_one_anthropic_block(block: &ContentBlock) -> Vec<Value> {
     }
 }
 
+// Tool results stay plain strings for text-only content (the common wire
+// shape) and become block arrays when image attachments must survive.
+fn anthropic_tool_result_content(content: &[ContentBlock]) -> Value {
+    let has_images = content
+        .iter()
+        .any(|block| matches!(block, ContentBlock::Image { .. }));
+    if !has_images {
+        return Value::String(text_from_blocks(content, " "));
+    }
+    let blocks = content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(json!({"type": "text", "text": text})),
+            ContentBlock::Image { source } => Some(match source {
+                ImageSource::Base64 { media_type, data } => json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
+                        "data": data,
+                    },
+                }),
+                ImageSource::Url { url, .. } => {
+                    json!({"type": "image", "source": {"type": "url", "url": url}})
+                }
+                ImageSource::Raw(raw) => json!({"type": "image", "source": raw.clone()}),
+            }),
+            other => {
+                let text = text_from_blocks(std::slice::from_ref(other), " ");
+                (!text.is_empty()).then(|| json!({"type": "text", "text": text}))
+            }
+        })
+        .collect::<Vec<_>>();
+    Value::Array(blocks)
+}
+
 // Anthropic requires `tool_use.input` to be object-shaped, while OpenAI and
 // Responses commonly carry function-call arguments as JSON strings.
 fn anthropic_tool_input(arguments: &Value) -> Value {
@@ -829,11 +934,26 @@ fn encode_anthropic_tools(tools: &[ToolDefinition]) -> Value {
                 json!({
                     "name": tool.name,
                     "description": tool.description.clone().unwrap_or_default(),
-                    "input_schema": tool.parameters,
+                    "input_schema": anthropic_input_schema(&tool.parameters),
                 })
             })
             .collect(),
     )
+}
+
+// Anthropic requires `input_schema.type`; parameterless tools arrive from
+// other providers as empty (or typeless) schemas and default to `object`.
+fn anthropic_input_schema(parameters: &Value) -> Value {
+    match parameters {
+        Value::Object(schema) => {
+            let mut schema = schema.clone();
+            schema
+                .entry("type".to_string())
+                .or_insert_with(|| Value::String("object".to_string()));
+            Value::Object(schema)
+        }
+        _ => json!({"type": "object"}),
+    }
 }
 
 // Encodes normalized tool choice into Anthropic tool-choice JSON.

--- a/crates/switchyard-translation/src/codecs/common.rs
+++ b/crates/switchyard-translation/src/codecs/common.rs
@@ -33,6 +33,19 @@ pub(crate) fn reasoning_text_from_blocks(content: &[ContentBlock], separator: &s
         .join(separator)
 }
 
+/// Splits a `data:<media type>;base64,<data>` URL into its components.
+///
+/// Provider APIs disagree on inline-image encoding: OpenAI embeds base64
+/// payloads in data URLs while Anthropic and Gemini carry explicit media-type
+/// plus data fields, so decoders normalize data URLs into base64 sources.
+pub(crate) fn parse_data_url(url: &str) -> Option<(Option<String>, String)> {
+    let rest = url.strip_prefix("data:")?;
+    let (header, data) = rest.split_once(',')?;
+    let header = header.strip_suffix(";base64")?;
+    let media_type = (!header.is_empty()).then(|| header.to_string());
+    Some((media_type, data.to_string()))
+}
+
 /// Copies unknown provider fields into the IR extension map.
 pub(crate) fn provider_extensions(
     object: &Map<String, Value>,

--- a/crates/switchyard-translation/src/codecs/gemini/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/gemini/buffered.rs
@@ -1,0 +1,1396 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Buffered codec for Gemini generateContent request and response JSON.
+//!
+//! The internal Gemini wire body carries synthetic top-level `model` and
+//! `stream` fields because the real API encodes both in the URL path
+//! (`/v1beta/models/{model}:generateContent` vs `:streamGenerateContent`).
+//! Endpoints inject them on decode and the Gemini backend moves them back
+//! into the URL before the upstream call.
+
+use serde_json::{json, Map, Value};
+
+use crate::codecs::common::provider_extensions;
+use crate::codecs::{
+    DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
+};
+use crate::diagnostic::TranslationDiagnostic;
+use crate::error::{Result, TranslationError};
+use crate::format::{FormatId, WireFormat};
+use crate::ir::{
+    is_known_role_name, ContentBlock, ConversationRequest, ConversationResponse, FileSource,
+    ImageSource, InstructionBlock, MediaSource, Message, OutputParams, ProviderExtensions,
+    ReasoningParams, ResponseOutput, Role, SamplingParams, StopReason, ToolCall, ToolChoice,
+    ToolDefinition, ToolResult, Usage,
+};
+use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
+use crate::util::{
+    capture_request_preservation, capture_response_preservation, embed_preservation,
+    exact_preserved_request, exact_preserved_response,
+};
+use crate::util::{json_string, push_lossy, stable_id, validate_request_capabilities};
+
+/// Format codec for Gemini generateContent payloads.
+pub struct GeminiGenerateContentCodec;
+
+impl FormatCodec for GeminiGenerateContentCodec {
+    fn format(&self) -> FormatId {
+        WireFormat::GeminiGenerateContent.into()
+    }
+
+    fn decode_request(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedRequest> {
+        let body = crate::util::object(body, "$")?;
+        let mut diagnostics = Vec::new();
+        let generation = camel_or_snake(body, "generationConfig", "generation_config")
+            .and_then(Value::as_object);
+        let mut request = ConversationRequest {
+            model: body
+                .get("model")
+                .and_then(Value::as_str)
+                .filter(|model| !model.is_empty())
+                .map(ToOwned::to_owned),
+            output: OutputParams {
+                max_output_tokens: generation
+                    .and_then(|config| config.get("maxOutputTokens"))
+                    .and_then(Value::as_u64),
+                response_format: generation.and_then(decode_gemini_response_format),
+            },
+            sampling: SamplingParams {
+                temperature: generation
+                    .and_then(|config| config.get("temperature"))
+                    .and_then(Value::as_f64),
+                top_p: generation
+                    .and_then(|config| config.get("topP"))
+                    .and_then(Value::as_f64),
+                top_k: generation
+                    .and_then(|config| config.get("topK"))
+                    .and_then(Value::as_i64),
+            },
+            reasoning: ReasoningParams {
+                effort: None,
+                raw: generation
+                    .and_then(|config| config.get("thinkingConfig"))
+                    .cloned(),
+            },
+            stream: body.get("stream").and_then(Value::as_bool).unwrap_or(false),
+            preservation: capture_request_preservation(
+                WireFormat::GeminiGenerateContent,
+                &Value::Object(body.clone()),
+                policy,
+            ),
+            ..ConversationRequest::default()
+        };
+        if let Some(stop) = generation
+            .and_then(|config| config.get("stopSequences"))
+            .filter(|stop| stop.is_array())
+        {
+            // Stored under both raw keys: the Anthropic encoder reads the
+            // OpenAI-style `stop` extension and the OpenAI encoder reads the
+            // Anthropic-style `stop_sequences` extension.
+            request
+                .extensions
+                .fields
+                .insert("stop".to_string(), stop.clone());
+            request
+                .extensions
+                .fields
+                .insert("stop_sequences".to_string(), stop.clone());
+        }
+        if let Some(system) = camel_or_snake(body, "systemInstruction", "system_instruction") {
+            if let Some(content) = decode_gemini_system(system) {
+                request.instructions.push(InstructionBlock {
+                    role: Role::System,
+                    content,
+                });
+            }
+        }
+        if let Some(contents) = body.get("contents").and_then(Value::as_array) {
+            request.messages = decode_gemini_contents(contents, &mut diagnostics, policy)?;
+        }
+        request.tools = decode_gemini_tools(body.get("tools"), &mut diagnostics, policy)?;
+        request.tool_choice =
+            camel_or_snake(body, "toolConfig", "tool_config").map(decode_gemini_tool_choice);
+        request.extensions.fields.extend(provider_extensions(
+            body,
+            &[
+                "model",
+                "stream",
+                "contents",
+                "systemInstruction",
+                "system_instruction",
+                "tools",
+                "toolConfig",
+                "tool_config",
+                "generationConfig",
+                "generation_config",
+                "safetySettings",
+                "safety_settings",
+            ],
+        ));
+
+        Ok(DecodedRequest {
+            request,
+            diagnostics,
+        })
+    }
+
+    fn encode_request(
+        &self,
+        request: &ConversationRequest,
+        policy: &TranslationPolicy,
+    ) -> Result<EncodedRequest> {
+        if let Some(body) = exact_preserved_request(
+            &request.preservation,
+            WireFormat::GeminiGenerateContent,
+            policy,
+        ) {
+            return Ok(EncodedRequest {
+                body,
+                diagnostics: Vec::new(),
+            });
+        }
+        let mut diagnostics = Vec::new();
+        validate_request_capabilities(request, &mut diagnostics, policy)?;
+        let mut body = Map::new();
+        if let Some(model) = &request.model {
+            body.insert("model".to_string(), Value::String(model.clone()));
+        }
+        if request.stream {
+            body.insert("stream".to_string(), Value::Bool(true));
+        }
+        let system_text = request
+            .instructions
+            .iter()
+            .flat_map(|instruction| instruction.content.iter())
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } | ContentBlock::Refusal { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if !system_text.is_empty() {
+            body.insert(
+                "systemInstruction".to_string(),
+                json!({"parts": [{"text": system_text}]}),
+            );
+        }
+
+        body.insert(
+            "contents".to_string(),
+            Value::Array(encode_gemini_contents(
+                &request.messages,
+                &mut diagnostics,
+                policy,
+            )?),
+        );
+
+        if !request.tools.is_empty() {
+            body.insert("tools".to_string(), encode_gemini_tools(&request.tools));
+        }
+        if let Some(config) = request
+            .tool_choice
+            .as_ref()
+            .and_then(encode_gemini_tool_choice)
+        {
+            body.insert("toolConfig".to_string(), config);
+        }
+
+        let generation = encode_generation_config(request);
+        if !generation.is_empty() {
+            body.insert("generationConfig".to_string(), Value::Object(generation));
+        }
+
+        let body = embed_preservation(Value::Object(body), &request.preservation, policy);
+        Ok(EncodedRequest { body, diagnostics })
+    }
+
+    fn decode_response(
+        &self,
+        body: &Value,
+        _policy: &TranslationPolicy,
+    ) -> Result<DecodedResponse> {
+        let body = crate::util::object(body, "$")?;
+        let candidate = body
+            .get("candidates")
+            .and_then(Value::as_array)
+            .and_then(|candidates| candidates.first())
+            .and_then(Value::as_object);
+        let mut content = Vec::new();
+        if let Some(parts) = candidate
+            .and_then(|candidate| candidate.get("content"))
+            .and_then(|value| value.get("parts"))
+            .and_then(Value::as_array)
+        {
+            let mut generated_id = 0;
+            for part in parts {
+                if let Some(part) = part.as_object() {
+                    generated_id += 1;
+                    content.extend(decode_gemini_part(
+                        part,
+                        generated_id,
+                        &mut Vec::new(),
+                        &TranslationPolicy::default(),
+                    )?);
+                }
+            }
+        }
+        let has_tool_calls = content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::ToolCall(_)));
+        if content.is_empty() {
+            content.push(ContentBlock::Text {
+                text: String::new(),
+            });
+        }
+        let finish_reason = candidate
+            .and_then(|candidate| candidate.get("finishReason"))
+            .and_then(Value::as_str);
+        // A fully blocked prompt has no candidates but carries a block reason.
+        let blocked = candidate.is_none()
+            && body
+                .get("promptFeedback")
+                .and_then(|feedback| feedback.get("blockReason"))
+                .is_some();
+        let stop_reason = if blocked {
+            StopReason::ContentFilter
+        } else {
+            map_gemini_finish_reason(finish_reason, has_tool_calls)
+        };
+        let response = ConversationResponse {
+            id: body
+                .get("responseId")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            model: body
+                .get("modelVersion")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            outputs: vec![ResponseOutput {
+                role: Role::Assistant,
+                content,
+                stop_reason: Some(stop_reason),
+            }],
+            usage: decode_gemini_usage(body.get("usageMetadata")),
+            extensions: ProviderExtensions {
+                fields: provider_extensions(
+                    body,
+                    &["candidates", "usageMetadata", "modelVersion", "responseId"],
+                ),
+            },
+            preservation: capture_response_preservation(
+                WireFormat::GeminiGenerateContent,
+                &Value::Object(body.clone()),
+                _policy,
+            ),
+        };
+        Ok(DecodedResponse {
+            response,
+            diagnostics: Vec::new(),
+        })
+    }
+
+    fn encode_response(
+        &self,
+        response: &ConversationResponse,
+        _policy: &TranslationPolicy,
+    ) -> Result<EncodedResponse> {
+        if let Some(body) = exact_preserved_response(
+            &response.preservation,
+            WireFormat::GeminiGenerateContent,
+            _policy,
+        ) {
+            return Ok(EncodedResponse {
+                body,
+                diagnostics: Vec::new(),
+            });
+        }
+        let output = response.first_output();
+        let parts = output
+            .map(|output| encode_gemini_response_parts(&output.content))
+            .unwrap_or_else(|| vec![json!({"text": ""})]);
+        let body = json!({
+            "candidates": [{
+                "content": {"parts": parts, "role": "model"},
+                "finishReason": output
+                    .and_then(|output| output.stop_reason)
+                    .map(gemini_finish_reason)
+                    .unwrap_or("STOP"),
+                "index": 0,
+            }],
+            "usageMetadata": encode_gemini_usage(&response.usage),
+            "modelVersion": response.model.clone().unwrap_or_else(|| "unknown".to_string()),
+            "responseId": response
+                .id
+                .clone()
+                .unwrap_or_else(|| "gemini_switchyard".to_string()),
+        });
+        Ok(EncodedResponse {
+            body: embed_preservation(body, &response.preservation, _policy),
+            diagnostics: Vec::new(),
+        })
+    }
+}
+
+// Reads a field that Gemini clients may spell in camelCase or snake_case.
+fn camel_or_snake<'a>(
+    object: &'a Map<String, Value>,
+    camel: &str,
+    snake: &str,
+) -> Option<&'a Value> {
+    object.get(camel).or_else(|| object.get(snake))
+}
+
+// Decodes Gemini's `systemInstruction` content into instruction blocks.
+fn decode_gemini_system(value: &Value) -> Option<Vec<ContentBlock>> {
+    let text = match value {
+        Value::String(text) => text.clone(),
+        Value::Object(object) => object
+            .get("parts")
+            .and_then(Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|part| part.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("\n\n")
+            })
+            .unwrap_or_default(),
+        _ => String::new(),
+    };
+    (!text.is_empty()).then(|| vec![ContentBlock::Text { text }])
+}
+
+// Decodes `contents[]` while pairing functionResponse parts with the
+// functionCall that produced them. Gemini has no tool-call IDs on the wire;
+// calls and responses pair by function name and order, so decoding assigns
+// stable synthetic IDs and lets each response consume the earliest
+// unconsumed call with a matching name.
+fn decode_gemini_contents(
+    contents: &[Value],
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<Message>> {
+    let mut messages = Vec::new();
+    let mut open_calls: Vec<(String, String, bool)> = Vec::new();
+    let mut generated_id = 0;
+    for (index, content) in contents.iter().enumerate() {
+        let Some(content) = content.as_object() else {
+            push_lossy(
+                diagnostics,
+                policy,
+                format!("Gemini content at index {index} is not an object"),
+            )?;
+            continue;
+        };
+        // Gemini only defines `user`/`model`; other known role names stay
+        // lenient (mapped to `user`) to match cross-format decode behavior,
+        // while genuinely unknown roles are rejected.
+        let role = match content.get("role").and_then(Value::as_str) {
+            Some("model") => Role::Assistant,
+            Some("user") | None => Role::User,
+            Some(other) if is_known_role_name(other) => Role::User,
+            Some(other) => {
+                return Err(TranslationError::unsupported_role(
+                    format!("$.contents[{index}].role"),
+                    other,
+                ));
+            }
+        };
+        let mut blocks = Vec::new();
+        if let Some(parts) = content.get("parts").and_then(Value::as_array) {
+            for part in parts {
+                let Some(part) = part.as_object() else {
+                    push_lossy(diagnostics, policy, "Gemini part is not an object")?;
+                    continue;
+                };
+                if let Some(call) = part.get("functionCall").and_then(Value::as_object) {
+                    generated_id += 1;
+                    let decoded = decode_gemini_function_call(part, call, generated_id, policy);
+                    if let Some(ContentBlock::ToolCall(call)) = decoded.last() {
+                        open_calls.push((call.name.clone(), call.id.clone(), false));
+                    }
+                    blocks.extend(decoded);
+                    continue;
+                }
+                if let Some(response) = part.get("functionResponse").and_then(Value::as_object) {
+                    generated_id += 1;
+                    blocks.push(decode_gemini_function_response(
+                        response,
+                        &mut open_calls,
+                        generated_id,
+                        policy,
+                    ));
+                    continue;
+                }
+                generated_id += 1;
+                blocks.extend(decode_gemini_part(part, generated_id, diagnostics, policy)?);
+            }
+        }
+        if blocks.is_empty() {
+            blocks.push(ContentBlock::Text {
+                text: String::new(),
+            });
+        }
+        messages.push(Message {
+            role,
+            content: blocks,
+        });
+    }
+    Ok(messages)
+}
+
+// Decodes one non-tool Gemini part into zero or more IR blocks.
+fn decode_gemini_part(
+    part: &Map<String, Value>,
+    generated_counter: usize,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<ContentBlock>> {
+    if let Some(call) = part.get("functionCall").and_then(Value::as_object) {
+        return Ok(decode_gemini_function_call(
+            part,
+            call,
+            generated_counter,
+            policy,
+        ));
+    }
+    if let Some(text) = part.get("text").and_then(Value::as_str) {
+        if part.get("thought").and_then(Value::as_bool) == Some(true) {
+            return Ok(vec![ContentBlock::Reasoning {
+                text: text.to_string(),
+                signature: part_thought_signature(part),
+            }]);
+        }
+        return Ok(vec![ContentBlock::Text {
+            text: text.to_string(),
+        }]);
+    }
+    if let Some(inline) = part.get("inlineData").and_then(Value::as_object) {
+        let media_type = inline
+            .get("mimeType")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let data = inline
+            .get("data")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        return Ok(vec![
+            match media_type.as_deref().unwrap_or("").split('/').next() {
+                Some("image") => ContentBlock::Image {
+                    source: ImageSource::Base64 { media_type, data },
+                },
+                Some("audio") => ContentBlock::Audio {
+                    source: MediaSource::Base64 { media_type, data },
+                },
+                Some("video") => ContentBlock::Video {
+                    source: MediaSource::Base64 { media_type, data },
+                },
+                _ => ContentBlock::File {
+                    source: FileSource::FileData {
+                        data,
+                        filename: None,
+                    },
+                },
+            },
+        ]);
+    }
+    if let Some(file) = part.get("fileData").and_then(Value::as_object) {
+        let url = file
+            .get("fileUri")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let media_type = file
+            .get("mimeType")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        return Ok(vec![
+            match media_type.as_deref().unwrap_or("").split('/').next() {
+                Some("image") => ContentBlock::Image {
+                    source: ImageSource::Url { url, detail: None },
+                },
+                Some("audio") => ContentBlock::Audio {
+                    source: MediaSource::Url { url, media_type },
+                },
+                Some("video") => ContentBlock::Video {
+                    source: MediaSource::Url { url, media_type },
+                },
+                _ => ContentBlock::Unknown {
+                    provider: WireFormat::GeminiGenerateContent.into(),
+                    raw: Value::Object(part.clone()),
+                },
+            },
+        ]);
+    }
+    push_lossy(diagnostics, policy, "unsupported Gemini part kind")?;
+    Ok(vec![ContentBlock::Unknown {
+        provider: WireFormat::GeminiGenerateContent.into(),
+        raw: Value::Object(part.clone()),
+    }])
+}
+
+// Decodes a functionCall part; a thought signature rides along as a
+// signature-only reasoning block so it can be replayed on encode.
+fn decode_gemini_function_call(
+    part: &Map<String, Value>,
+    call: &Map<String, Value>,
+    generated_counter: usize,
+    policy: &TranslationPolicy,
+) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
+    if let Some(signature) = part_thought_signature(part) {
+        blocks.push(ContentBlock::Reasoning {
+            text: String::new(),
+            signature: Some(signature),
+        });
+    }
+    blocks.push(ContentBlock::ToolCall(ToolCall {
+        id: generated_tool_id(generated_counter, policy),
+        name: call
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        arguments: call.get("args").cloned().unwrap_or_else(|| json!({})),
+    }));
+    blocks
+}
+
+// Decodes a functionResponse part, consuming the matching open call ID.
+fn decode_gemini_function_response(
+    response: &Map<String, Value>,
+    open_calls: &mut [(String, String, bool)],
+    generated_counter: usize,
+    policy: &TranslationPolicy,
+) -> ContentBlock {
+    let name = response
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let tool_call_id = open_calls
+        .iter_mut()
+        .find(|(call_name, _, consumed)| !consumed && call_name == name)
+        .map(|entry| {
+            entry.2 = true;
+            entry.1.clone()
+        })
+        .unwrap_or_else(|| generated_tool_id(generated_counter, policy));
+    ContentBlock::ToolResult(ToolResult {
+        tool_call_id,
+        content: decode_function_response_content(response.get("response")),
+        is_error: None,
+    })
+}
+
+// Converts a functionResponse `response` payload into IR content blocks.
+fn decode_function_response_content(value: Option<&Value>) -> Vec<ContentBlock> {
+    match value {
+        Some(Value::String(text)) => vec![ContentBlock::Text { text: text.clone() }],
+        Some(Value::Object(object)) => {
+            // Accept the `{parts: [...]}` shape this codec emits, so tool
+            // results round-trip; any other object is preserved as JSON text.
+            if let Some(parts) = object.get("parts").and_then(Value::as_array) {
+                let mut blocks = Vec::new();
+                for part in parts {
+                    let Some(part) = part.as_object() else {
+                        continue;
+                    };
+                    if let Some(text) = part.get("text").and_then(Value::as_str) {
+                        blocks.push(ContentBlock::Text {
+                            text: text.to_string(),
+                        });
+                    } else if let Some(inline) = part.get("inlineData").and_then(Value::as_object) {
+                        blocks.push(ContentBlock::Image {
+                            source: ImageSource::Base64 {
+                                media_type: inline
+                                    .get("mimeType")
+                                    .and_then(Value::as_str)
+                                    .map(ToOwned::to_owned),
+                                data: inline
+                                    .get("data")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            },
+                        });
+                    }
+                }
+                if !blocks.is_empty() {
+                    return blocks;
+                }
+            }
+            vec![ContentBlock::Text {
+                text: json_string(&Value::Object(object.clone())),
+            }]
+        }
+        Some(other) => vec![ContentBlock::Text {
+            text: json_string(other),
+        }],
+        None => vec![ContentBlock::Text {
+            text: String::new(),
+        }],
+    }
+}
+
+// Reads a non-empty thoughtSignature from a Gemini part.
+fn part_thought_signature(part: &Map<String, Value>) -> Option<String> {
+    part.get("thoughtSignature")
+        .and_then(Value::as_str)
+        .filter(|signature| !signature.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+// Generates a tool-call ID for Gemini's ID-less function calls.
+fn generated_tool_id(counter: usize, policy: &TranslationPolicy) -> String {
+    match &policy.deterministic_ids {
+        DeterministicIdPolicy::GenerateStable { prefix } => stable_id(prefix, counter),
+        DeterministicIdPolicy::Preserve => String::new(),
+    }
+}
+
+// Decodes Gemini tool declarations into normalized tool definitions.
+fn decode_gemini_tools(
+    value: Option<&Value>,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<ToolDefinition>> {
+    let mut tools = Vec::new();
+    for entry in value.and_then(Value::as_array).into_iter().flatten() {
+        let Some(entry) = entry.as_object() else {
+            continue;
+        };
+        let Some(declarations) =
+            camel_or_snake(entry, "functionDeclarations", "function_declarations")
+                .and_then(Value::as_array)
+        else {
+            // Built-in tools such as googleSearch or codeExecution have no
+            // cross-provider equivalent.
+            push_lossy(
+                diagnostics,
+                policy,
+                "unsupported non-function Gemini tool entry",
+            )?;
+            continue;
+        };
+        for declaration in declarations.iter().filter_map(Value::as_object) {
+            let Some(name) = declaration
+                .get("name")
+                .and_then(Value::as_str)
+                .filter(|name| !name.is_empty())
+            else {
+                continue;
+            };
+            tools.push(ToolDefinition {
+                name: name.to_string(),
+                description: declaration
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                parameters: declaration
+                    .get("parameters")
+                    .or_else(|| declaration.get("parametersJsonSchema"))
+                    .map(schema_from_gemini)
+                    .unwrap_or_else(|| json!({})),
+                strict: None,
+            });
+        }
+    }
+    Ok(tools)
+}
+
+// Decodes Gemini toolConfig into normalized tool-choice policy.
+fn decode_gemini_tool_choice(value: &Value) -> ToolChoice {
+    let Some(config) = value
+        .as_object()
+        .and_then(|object| {
+            camel_or_snake(object, "functionCallingConfig", "function_calling_config")
+        })
+        .and_then(Value::as_object)
+    else {
+        return ToolChoice::Raw(value.clone());
+    };
+    let allowed = config
+        .get("allowedFunctionNames")
+        .and_then(Value::as_array)
+        .map(|names| {
+            names
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    match config.get("mode").and_then(Value::as_str) {
+        Some("AUTO") | None => ToolChoice::Auto,
+        Some("NONE") => ToolChoice::None,
+        Some("ANY") if allowed.len() == 1 => ToolChoice::Tool {
+            name: allowed.into_iter().next().unwrap_or_default(),
+        },
+        Some("ANY") => ToolChoice::Required,
+        _ => ToolChoice::Raw(value.clone()),
+    }
+}
+
+// Maps generationConfig JSON-mode fields onto OpenAI-style response_format.
+fn decode_gemini_response_format(generation: &Map<String, Value>) -> Option<Value> {
+    if generation.get("responseMimeType").and_then(Value::as_str) != Some("application/json") {
+        return None;
+    }
+    let schema = generation
+        .get("responseSchema")
+        .or_else(|| generation.get("responseJsonSchema"));
+    Some(match schema {
+        Some(schema) => json!({
+            "type": "json_schema",
+            "json_schema": {"name": "response", "schema": schema_from_gemini(schema)},
+        }),
+        None => json!({"type": "json_object"}),
+    })
+}
+
+// Encodes normalized messages into Gemini `contents[]`.
+fn encode_gemini_contents(
+    messages: &[Message],
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<Value>> {
+    let mut contents = Vec::new();
+    for message in messages {
+        let role = match message.role {
+            Role::Assistant => "model",
+            Role::User | Role::Tool | Role::System | Role::Developer => "user",
+        };
+        // Thought signatures echoed by the client (or produced by response
+        // decode) attach back onto functionCall parts in order; Gemini
+        // requires them when replaying thinking-model tool calls.
+        let signatures = message
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Reasoning {
+                    signature: Some(signature),
+                    ..
+                } if !signature.is_empty() => Some(signature.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let mut signature_index = 0;
+        let mut parts = Vec::new();
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } | ContentBlock::Refusal { text } => {
+                    if !text.is_empty() {
+                        parts.push(json!({"text": text}));
+                    }
+                }
+                // Reasoning text is never replayed in requests; only its
+                // signature matters (attached to functionCall parts above).
+                ContentBlock::Reasoning { .. } => {}
+                ContentBlock::ToolCall(call) => {
+                    let mut part = Map::new();
+                    part.insert(
+                        "functionCall".to_string(),
+                        json!({"name": call.name, "args": gemini_tool_args(&call.arguments)}),
+                    );
+                    let signature = signatures
+                        .get(signature_index)
+                        .or_else(|| signatures.last());
+                    if let Some(signature) = signature {
+                        part.insert(
+                            "thoughtSignature".to_string(),
+                            Value::String(signature.clone()),
+                        );
+                    }
+                    signature_index += 1;
+                    parts.push(Value::Object(part));
+                }
+                ContentBlock::ToolResult(result) => {
+                    parts.push(encode_gemini_function_response(result, messages));
+                }
+                ContentBlock::Image { source } => match source {
+                    ImageSource::Base64 { media_type, data } => parts.push(json!({
+                        "inlineData": {
+                            "mimeType": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
+                            "data": data,
+                        },
+                    })),
+                    ImageSource::Url { .. } | ImageSource::Raw(_) => {
+                        push_lossy(
+                            diagnostics,
+                            policy,
+                            "Gemini does not accept URL or raw image sources; image dropped",
+                        )?;
+                    }
+                },
+                ContentBlock::Audio { source } => {
+                    encode_gemini_media(source, "audio/mpeg", &mut parts, diagnostics, policy)?;
+                }
+                ContentBlock::Video { source } => {
+                    encode_gemini_media(source, "video/mp4", &mut parts, diagnostics, policy)?;
+                }
+                ContentBlock::File { source } => match source {
+                    // The IR file source has no media type; PDF is the
+                    // dominant cross-provider document payload.
+                    FileSource::FileData { data, .. } => parts.push(json!({
+                        "inlineData": {"mimeType": "application/pdf", "data": data},
+                    })),
+                    FileSource::FileId(_) | FileSource::Raw(_) => {
+                        push_lossy(
+                            diagnostics,
+                            policy,
+                            "Gemini cannot reference foreign file IDs; file dropped",
+                        )?;
+                    }
+                },
+                ContentBlock::Unknown { raw, .. } => {
+                    push_lossy(
+                        diagnostics,
+                        policy,
+                        "unknown content block encoded as text for Gemini",
+                    )?;
+                    parts.push(json!({"text": json_string(raw)}));
+                }
+            }
+        }
+        // Gemini rejects contents with an empty parts array.
+        if parts.is_empty() {
+            continue;
+        }
+        contents.push(json!({"role": role, "parts": parts}));
+    }
+    Ok(contents)
+}
+
+// Encodes base64 and URL media sources into Gemini parts.
+fn encode_gemini_media(
+    source: &MediaSource,
+    default_media_type: &str,
+    parts: &mut Vec<Value>,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<()> {
+    match source {
+        MediaSource::Base64 { media_type, data } => parts.push(json!({
+            "inlineData": {
+                "mimeType": media_type.clone().unwrap_or_else(|| default_media_type.to_string()),
+                "data": data,
+            },
+        })),
+        MediaSource::Url { url, media_type } => {
+            let mut file = Map::new();
+            file.insert("fileUri".to_string(), Value::String(url.clone()));
+            if let Some(media_type) = media_type {
+                file.insert("mimeType".to_string(), Value::String(media_type.clone()));
+            }
+            parts.push(json!({"fileData": Value::Object(file)}));
+        }
+        MediaSource::Raw(_) => {
+            push_lossy(diagnostics, policy, "raw media source dropped for Gemini")?;
+        }
+    }
+    Ok(())
+}
+
+// Encodes a tool result as a functionResponse part, recovering the function
+// name from the tool call it answers (Gemini pairs by name, not ID).
+fn encode_gemini_function_response(result: &ToolResult, messages: &[Message]) -> Value {
+    let name = find_tool_name(messages, &result.tool_call_id).unwrap_or_else(|| "tool".to_string());
+    let mut parts = Vec::new();
+    for block in &result.content {
+        match block {
+            ContentBlock::Text { text } => parts.push(json!({"text": text})),
+            ContentBlock::Image {
+                source: ImageSource::Base64 { media_type, data },
+            } => parts.push(json!({
+                "inlineData": {
+                    "mimeType": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
+                    "data": data,
+                },
+            })),
+            other => parts.push(json!({"text": json_string(&json!(other))})),
+        }
+    }
+    if parts.is_empty() {
+        parts.push(json!({"text": ""}));
+    }
+    json!({
+        "functionResponse": {"name": name, "response": {"parts": parts}},
+    })
+}
+
+// Finds the function name for a tool-call ID anywhere in the conversation.
+fn find_tool_name(messages: &[Message], tool_call_id: &str) -> Option<String> {
+    messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .find_map(|block| match block {
+            ContentBlock::ToolCall(call) if call.id == tool_call_id => Some(call.name.clone()),
+            _ => None,
+        })
+}
+
+// Gemini requires `functionCall.args` to be object-shaped, while OpenAI and
+// Responses commonly carry function-call arguments as JSON strings.
+fn gemini_tool_args(arguments: &Value) -> Value {
+    match arguments {
+        Value::Object(object) => Value::Object(object.clone()),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| json!({"raw": text})),
+        Value::Null => json!({}),
+        other => json!({"value": other}),
+    }
+}
+
+// Encodes normalized tool definitions into a single Gemini tool entry.
+fn encode_gemini_tools(tools: &[ToolDefinition]) -> Value {
+    json!([{
+        "functionDeclarations": tools
+            .iter()
+            .map(|tool| {
+                let mut declaration = Map::new();
+                declaration.insert("name".to_string(), Value::String(tool.name.clone()));
+                if let Some(description) = &tool.description {
+                    declaration.insert(
+                        "description".to_string(),
+                        Value::String(description.clone()),
+                    );
+                }
+                declaration.insert("parameters".to_string(), schema_to_gemini(&tool.parameters));
+                Value::Object(declaration)
+            })
+            .collect::<Vec<_>>(),
+    }])
+}
+
+// Encodes normalized tool choice into Gemini toolConfig JSON.
+fn encode_gemini_tool_choice(choice: &ToolChoice) -> Option<Value> {
+    let config = match choice {
+        ToolChoice::Auto => json!({"mode": "AUTO"}),
+        ToolChoice::Required => json!({"mode": "ANY"}),
+        ToolChoice::None => json!({"mode": "NONE"}),
+        ToolChoice::Tool { name } => json!({"mode": "ANY", "allowedFunctionNames": [name]}),
+        ToolChoice::Raw(value) => {
+            // Only replay raw values that are already Gemini-shaped; foreign
+            // provider shapes would be rejected with a 400.
+            return value
+                .as_object()
+                .is_some_and(|object| object.contains_key("functionCallingConfig"))
+                .then(|| value.clone());
+        }
+    };
+    Some(json!({"functionCallingConfig": config}))
+}
+
+// Builds generationConfig from IR sampling, output, and reasoning params.
+fn encode_generation_config(request: &ConversationRequest) -> Map<String, Value> {
+    let mut generation = Map::new();
+    if let Some(max_tokens) = request.output.max_output_tokens {
+        generation.insert("maxOutputTokens".to_string(), json!(max_tokens));
+    }
+    if let Some(value) = request.sampling.temperature {
+        generation.insert("temperature".to_string(), json!(value));
+    }
+    if let Some(value) = request.sampling.top_p {
+        generation.insert("topP".to_string(), json!(value));
+    }
+    if let Some(value) = request.sampling.top_k {
+        generation.insert("topK".to_string(), json!(value));
+    }
+    // OpenAI sources preserve `stop`; Anthropic sources preserve `stop_sequences`.
+    let stop = request
+        .extensions
+        .fields
+        .get("stop")
+        .or_else(|| request.extensions.fields.get("stop_sequences"));
+    match stop {
+        Some(Value::String(stop)) => {
+            generation.insert("stopSequences".to_string(), json!([stop]));
+        }
+        Some(Value::Array(stops)) => {
+            generation.insert("stopSequences".to_string(), Value::Array(stops.clone()));
+        }
+        _ => {}
+    }
+    if let Some(format) = &request.output.response_format {
+        encode_gemini_response_format(format, &mut generation);
+    }
+    if let Some(config) = thinking_config(&request.reasoning) {
+        generation.insert("thinkingConfig".to_string(), config);
+    }
+    generation
+}
+
+// Maps OpenAI-style response_format onto Gemini JSON-mode fields.
+fn encode_gemini_response_format(format: &Value, generation: &mut Map<String, Value>) {
+    match format.get("type").and_then(Value::as_str) {
+        Some("json_object") => {
+            generation.insert(
+                "responseMimeType".to_string(),
+                Value::String("application/json".to_string()),
+            );
+        }
+        Some("json_schema") => {
+            generation.insert(
+                "responseMimeType".to_string(),
+                Value::String("application/json".to_string()),
+            );
+            if let Some(schema) = format
+                .get("json_schema")
+                .and_then(|json_schema| json_schema.get("schema"))
+            {
+                generation.insert("responseSchema".to_string(), schema_to_gemini(schema));
+            }
+        }
+        _ => {}
+    }
+}
+
+// Builds thinkingConfig from preserved Gemini config or a reasoning effort.
+fn thinking_config(reasoning: &ReasoningParams) -> Option<Value> {
+    if let Some(raw) = &reasoning.raw {
+        if raw.as_object().is_some_and(|config| {
+            config.contains_key("thinkingBudget") || config.contains_key("includeThoughts")
+        }) {
+            return Some(raw.clone());
+        }
+    }
+    let budget = match reasoning.effort.as_deref() {
+        Some("minimal") | Some("low") => 1024,
+        Some("medium") => 8192,
+        Some("high") => 24576,
+        _ => return None,
+    };
+    Some(json!({"thinkingBudget": budget}))
+}
+
+// JSON-Schema keywords Gemini's OpenAPI-style schema subset rejects with
+// `400 Unknown name`; they are stripped rather than forwarded.
+const GEMINI_DROPPED_SCHEMA_KEYS: &[&str] = &[
+    "$schema",
+    "$id",
+    "$ref",
+    "$defs",
+    "definitions",
+    "additionalProperties",
+    "unevaluatedProperties",
+    "patternProperties",
+    "propertyNames",
+    "dependentRequired",
+    "dependentSchemas",
+    "if",
+    "then",
+    "else",
+    "allOf",
+    "not",
+    "const",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "uniqueItems",
+    "contentEncoding",
+    "contentMediaType",
+    "contentSchema",
+    "readOnly",
+    "writeOnly",
+    "deprecated",
+    "examples",
+    "default",
+];
+
+const GEMINI_SCHEMA_TYPES: &[&str] = &[
+    "string", "number", "integer", "boolean", "array", "object", "null",
+];
+
+// Sanitizes a JSON Schema into Gemini's OpenAPI-style subset: uppercase
+// `type`, dropped unsupported keywords, union types collapsed to a single
+// type plus `nullable`, and enums coerced to STRING values.
+fn schema_to_gemini(schema: &Value) -> Value {
+    let Some(object) = schema.as_object() else {
+        // Boolean schemas (`true`) have no Gemini equivalent; accept anything.
+        return json!({});
+    };
+    let mut sanitized = Map::new();
+    let has_enum = object.get("enum").and_then(Value::as_array).is_some();
+    for (key, value) in object {
+        if GEMINI_DROPPED_SCHEMA_KEYS.contains(&key.as_str())
+            || key.starts_with("x-")
+            || key.starts_with("x_")
+        {
+            continue;
+        }
+        match key.as_str() {
+            "type" => {
+                let (schema_type, nullable) = gemini_schema_type(value, has_enum);
+                sanitized.insert("type".to_string(), Value::String(schema_type));
+                if nullable {
+                    sanitized.insert("nullable".to_string(), Value::Bool(true));
+                }
+            }
+            "enum" => {
+                let values = value
+                    .as_array()
+                    .map(|values| {
+                        values
+                            .iter()
+                            .map(|value| match value {
+                                Value::String(text) => Value::String(text.clone()),
+                                Value::Null => Value::String(String::new()),
+                                other => Value::String(json_string(other)),
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                sanitized.insert("enum".to_string(), Value::Array(values));
+                // Gemini only allows enums on STRING-typed schemas.
+                sanitized.insert("type".to_string(), Value::String("STRING".to_string()));
+            }
+            "properties" => {
+                let properties = value
+                    .as_object()
+                    .map(|properties| {
+                        properties
+                            .iter()
+                            .map(|(name, schema)| (name.clone(), schema_to_gemini(schema)))
+                            .collect::<Map<_, _>>()
+                    })
+                    .unwrap_or_default();
+                sanitized.insert("properties".to_string(), Value::Object(properties));
+            }
+            "items" => {
+                sanitized.insert("items".to_string(), schema_to_gemini(value));
+            }
+            "anyOf" | "oneOf" => {
+                let members = value
+                    .as_array()
+                    .map(|members| members.iter().map(schema_to_gemini).collect::<Vec<_>>())
+                    .unwrap_or_default();
+                sanitized.insert("anyOf".to_string(), Value::Array(members));
+            }
+            _ => {
+                sanitized.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    Value::Object(sanitized)
+}
+
+// Resolves a JSON Schema `type` value into Gemini's single uppercase type
+// plus a nullable flag, collapsing Draft-2020 union arrays.
+fn gemini_schema_type(value: &Value, has_enum: bool) -> (String, bool) {
+    match value {
+        Value::String(schema_type) => (uppercase_schema_type(schema_type, has_enum), false),
+        Value::Array(members) => {
+            let nullable = members.iter().any(|member| member.as_str() == Some("null"));
+            let concrete = members
+                .iter()
+                .filter_map(Value::as_str)
+                .find(|member| *member != "null");
+            match concrete {
+                Some(schema_type) => (uppercase_schema_type(schema_type, has_enum), nullable),
+                None => ("STRING".to_string(), nullable),
+            }
+        }
+        _ => ("STRING".to_string(), false),
+    }
+}
+
+fn uppercase_schema_type(schema_type: &str, has_enum: bool) -> String {
+    if has_enum {
+        return "STRING".to_string();
+    }
+    if GEMINI_SCHEMA_TYPES.contains(&schema_type) {
+        schema_type.to_ascii_uppercase()
+    } else {
+        "STRING".to_string()
+    }
+}
+
+// Lowercases Gemini's uppercase schema types back into JSON Schema form so
+// declarations survive translation toward OpenAI or Anthropic targets.
+fn schema_from_gemini(schema: &Value) -> Value {
+    let Some(object) = schema.as_object() else {
+        return schema.clone();
+    };
+    let mut restored = Map::new();
+    for (key, value) in object {
+        match key.as_str() {
+            "type" => {
+                let lowered = value
+                    .as_str()
+                    .map(|schema_type| Value::String(schema_type.to_ascii_lowercase()))
+                    .unwrap_or_else(|| value.clone());
+                restored.insert("type".to_string(), lowered);
+            }
+            "properties" => {
+                let properties = value
+                    .as_object()
+                    .map(|properties| {
+                        properties
+                            .iter()
+                            .map(|(name, schema)| (name.clone(), schema_from_gemini(schema)))
+                            .collect::<Map<_, _>>()
+                    })
+                    .unwrap_or_default();
+                restored.insert("properties".to_string(), Value::Object(properties));
+            }
+            "items" => {
+                restored.insert("items".to_string(), schema_from_gemini(value));
+            }
+            "anyOf" => {
+                let members = value
+                    .as_array()
+                    .map(|members| members.iter().map(schema_from_gemini).collect::<Vec<_>>())
+                    .unwrap_or_default();
+                restored.insert("anyOf".to_string(), Value::Array(members));
+            }
+            _ => {
+                restored.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    Value::Object(restored)
+}
+
+// Encodes assistant output blocks into Gemini response parts.
+fn encode_gemini_response_parts(content: &[ContentBlock]) -> Vec<Value> {
+    let mut parts = Vec::new();
+    let mut pending_signature: Option<String> = None;
+    for block in content {
+        match block {
+            ContentBlock::Text { text } | ContentBlock::Refusal { text } => {
+                parts.push(json!({"text": text}));
+            }
+            ContentBlock::Reasoning { text, signature } => {
+                if text.is_empty() {
+                    // Signature-only reasoning pairs with the next tool call.
+                    if signature.is_some() {
+                        pending_signature = signature.clone();
+                    }
+                    continue;
+                }
+                let mut part = Map::new();
+                part.insert("text".to_string(), Value::String(text.clone()));
+                part.insert("thought".to_string(), Value::Bool(true));
+                if let Some(signature) = signature.as_ref().filter(|value| !value.is_empty()) {
+                    part.insert(
+                        "thoughtSignature".to_string(),
+                        Value::String(signature.clone()),
+                    );
+                }
+                parts.push(Value::Object(part));
+            }
+            ContentBlock::ToolCall(call) => {
+                let mut part = Map::new();
+                part.insert(
+                    "functionCall".to_string(),
+                    json!({"name": call.name, "args": gemini_tool_args(&call.arguments)}),
+                );
+                if let Some(signature) = pending_signature.take() {
+                    part.insert("thoughtSignature".to_string(), Value::String(signature));
+                }
+                parts.push(Value::Object(part));
+            }
+            ContentBlock::Image {
+                source: ImageSource::Base64 { media_type, data },
+            } => parts.push(json!({
+                "inlineData": {
+                    "mimeType": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
+                    "data": data,
+                },
+            })),
+            other => parts.push(json!({"text": json_string(&json!(other))})),
+        }
+    }
+    if parts.is_empty() {
+        parts.push(json!({"text": ""}));
+    }
+    parts
+}
+
+// Maps Gemini finish reasons to normalized stop reasons. Gemini reports
+// `STOP` even for function-call turns, so tool-call presence wins.
+fn map_gemini_finish_reason(reason: Option<&str>, has_tool_calls: bool) -> StopReason {
+    match reason {
+        Some("STOP") | Some("FINISH_REASON_UNSPECIFIED") | None if has_tool_calls => {
+            StopReason::ToolUse
+        }
+        Some("STOP") | Some("FINISH_REASON_UNSPECIFIED") | None => StopReason::EndTurn,
+        Some("MAX_TOKENS") => StopReason::MaxTokens,
+        Some("SAFETY")
+        | Some("RECITATION")
+        | Some("BLOCKLIST")
+        | Some("PROHIBITED_CONTENT")
+        | Some("SPII")
+        | Some("IMAGE_SAFETY") => StopReason::ContentFilter,
+        Some("MALFORMED_FUNCTION_CALL") => StopReason::Error,
+        _ => StopReason::Unknown,
+    }
+}
+
+// Maps normalized stop reasons back to Gemini's vocabulary.
+fn gemini_finish_reason(reason: StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn | StopReason::ToolUse => "STOP",
+        StopReason::MaxTokens => "MAX_TOKENS",
+        StopReason::ContentFilter => "SAFETY",
+        StopReason::Error | StopReason::Unknown => "OTHER",
+    }
+}
+
+// Normalizes Gemini usageMetadata counters. Gemini reports thinking tokens
+// outside candidatesTokenCount, so they are folded back into output tokens
+// to match the other providers' accounting.
+fn decode_gemini_usage(value: Option<&Value>) -> Usage {
+    let Some(value) = value.and_then(Value::as_object) else {
+        return Usage::default();
+    };
+    let input_tokens = value.get("promptTokenCount").and_then(Value::as_u64);
+    let candidates_tokens = value.get("candidatesTokenCount").and_then(Value::as_u64);
+    let thoughts_tokens = value.get("thoughtsTokenCount").and_then(Value::as_u64);
+    let output_tokens = match (candidates_tokens, thoughts_tokens) {
+        (None, None) => None,
+        (candidates, thoughts) => Some(
+            candidates
+                .unwrap_or(0)
+                .saturating_add(thoughts.unwrap_or(0)),
+        ),
+    };
+    Usage {
+        input_tokens,
+        output_tokens,
+        total_tokens: value
+            .get("totalTokenCount")
+            .and_then(Value::as_u64)
+            .or_else(|| {
+                input_tokens
+                    .zip(output_tokens)
+                    .map(|(input, output)| input + output)
+            }),
+        reasoning_tokens: thoughts_tokens,
+    }
+}
+
+// Encodes normalized usage into Gemini usageMetadata JSON.
+fn encode_gemini_usage(usage: &Usage) -> Value {
+    let input = usage.input_tokens.unwrap_or(0);
+    let output = usage.output_tokens.unwrap_or(0);
+    let thoughts = usage.reasoning_tokens.unwrap_or(0);
+    let mut metadata = Map::new();
+    metadata.insert("promptTokenCount".to_string(), json!(input));
+    metadata.insert(
+        "candidatesTokenCount".to_string(),
+        json!(output.saturating_sub(thoughts)),
+    );
+    if thoughts > 0 {
+        metadata.insert("thoughtsTokenCount".to_string(), json!(thoughts));
+    }
+    metadata.insert(
+        "totalTokenCount".to_string(),
+        json!(usage.total_tokens.unwrap_or(input + output)),
+    );
+    Value::Object(metadata)
+}

--- a/crates/switchyard-translation/src/codecs/gemini/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/gemini/buffered.rs
@@ -205,11 +205,7 @@ impl FormatCodec for GeminiGenerateContentCodec {
         Ok(EncodedRequest { body, diagnostics })
     }
 
-    fn decode_response(
-        &self,
-        body: &Value,
-        _policy: &TranslationPolicy,
-    ) -> Result<DecodedResponse> {
+    fn decode_response(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedResponse> {
         let body = crate::util::object(body, "$")?;
         let candidate = body
             .get("candidates")
@@ -217,6 +213,7 @@ impl FormatCodec for GeminiGenerateContentCodec {
             .and_then(|candidates| candidates.first())
             .and_then(Value::as_object);
         let mut content = Vec::new();
+        let mut diagnostics = Vec::new();
         if let Some(parts) = candidate
             .and_then(|candidate| candidate.get("content"))
             .and_then(|value| value.get("parts"))
@@ -229,8 +226,8 @@ impl FormatCodec for GeminiGenerateContentCodec {
                     content.extend(decode_gemini_part(
                         part,
                         generated_id,
-                        &mut Vec::new(),
-                        &TranslationPolicy::default(),
+                        &mut diagnostics,
+                        policy,
                     )?);
                 }
             }
@@ -281,12 +278,12 @@ impl FormatCodec for GeminiGenerateContentCodec {
             preservation: capture_response_preservation(
                 WireFormat::GeminiGenerateContent,
                 &Value::Object(body.clone()),
-                _policy,
+                policy,
             ),
         };
         Ok(DecodedResponse {
             response,
-            diagnostics: Vec::new(),
+            diagnostics,
         })
     }
 
@@ -814,10 +811,36 @@ fn encode_gemini_contents(
                     // sibling parts of the same user turn where they are
                     // fully visible.
                     for block in &result.content {
-                        if let ContentBlock::Image { source } = block {
-                            if let Some(part) = gemini_inline_image(source) {
-                                parts.push(part);
+                        match block {
+                            ContentBlock::Image { source } => {
+                                if let Some(part) = gemini_inline_image(source) {
+                                    parts.push(part);
+                                }
                             }
+                            ContentBlock::Audio { source } => {
+                                encode_gemini_media(
+                                    source,
+                                    "audio/mpeg",
+                                    &mut parts,
+                                    diagnostics,
+                                    policy,
+                                )?;
+                            }
+                            ContentBlock::Video { source } => {
+                                encode_gemini_media(
+                                    source,
+                                    "video/mp4",
+                                    &mut parts,
+                                    diagnostics,
+                                    policy,
+                                )?;
+                            }
+                            ContentBlock::File {
+                                source: FileSource::FileData { data, .. },
+                            } => parts.push(json!({
+                                "inlineData": {"mimeType": "application/pdf", "data": data},
+                            })),
+                            _ => {}
                         }
                     }
                 }
@@ -932,13 +955,18 @@ fn encode_gemini_media(
 // name from the tool call it answers (Gemini pairs by name, not ID).
 fn encode_gemini_function_response(result: &ToolResult, messages: &[Message]) -> Value {
     let name = find_tool_name(messages, &result.tool_call_id).unwrap_or_else(|| "tool".to_string());
-    // Image attachments are hoisted to sibling parts by the caller; the
+    // Media attachments are hoisted to sibling parts by the caller; the
     // response payload itself carries the text-shaped content.
     let mut parts = Vec::new();
     for block in &result.content {
         match block {
             ContentBlock::Text { text } => parts.push(json!({"text": text})),
-            ContentBlock::Image { .. } => {}
+            ContentBlock::Image { .. }
+            | ContentBlock::Audio { .. }
+            | ContentBlock::Video { .. }
+            | ContentBlock::File {
+                source: FileSource::FileData { .. },
+            } => {}
             other => parts.push(json!({"text": json_string(&json!(other))})),
         }
     }

--- a/crates/switchyard-translation/src/codecs/gemini/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/gemini/buffered.rs
@@ -808,19 +808,26 @@ fn encode_gemini_contents(
                 }
                 ContentBlock::ToolResult(result) => {
                     parts.push(encode_gemini_function_response(result, messages));
+                    // Gemini models do not read media nested inside the
+                    // functionResponse payload (and 2.5 rejects the dedicated
+                    // multimodal field), so attachments are hoisted to
+                    // sibling parts of the same user turn where they are
+                    // fully visible.
+                    for block in &result.content {
+                        if let ContentBlock::Image { source } = block {
+                            if let Some(part) = gemini_inline_image(source) {
+                                parts.push(part);
+                            }
+                        }
+                    }
                 }
-                ContentBlock::Image { source } => match source {
-                    ImageSource::Base64 { media_type, data } => parts.push(json!({
-                        "inlineData": {
-                            "mimeType": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
-                            "data": data,
-                        },
-                    })),
-                    ImageSource::Url { .. } | ImageSource::Raw(_) => {
+                ContentBlock::Image { source } => match gemini_inline_image(source) {
+                    Some(part) => parts.push(part),
+                    None => {
                         push_lossy(
                             diagnostics,
                             policy,
-                            "Gemini does not accept URL or raw image sources; image dropped",
+                            "Gemini does not accept remote image URLs; image dropped",
                         )?;
                     }
                 },
@@ -863,6 +870,34 @@ fn encode_gemini_contents(
     Ok(contents)
 }
 
+// Maps IR image sources to Gemini inlineData parts when a payload exists.
+// Remote URLs return None: Gemini cannot fetch arbitrary web images.
+fn gemini_inline_image(source: &ImageSource) -> Option<Value> {
+    let (media_type, data) = match source {
+        ImageSource::Base64 { media_type, data } => (media_type.clone(), data.clone()),
+        ImageSource::Url { url, .. } => crate::codecs::common::parse_data_url(url)?,
+        ImageSource::Raw(raw) => {
+            // Recognize the flattened media_type/data shape other providers use.
+            let object = raw.as_object()?;
+            let data = object.get("data").and_then(Value::as_str)?.to_string();
+            (
+                object
+                    .get("media_type")
+                    .or_else(|| object.get("mimeType"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                data,
+            )
+        }
+    };
+    Some(json!({
+        "inlineData": {
+            "mimeType": media_type.unwrap_or_else(|| "image/png".to_string()),
+            "data": data,
+        },
+    }))
+}
+
 // Encodes base64 and URL media sources into Gemini parts.
 fn encode_gemini_media(
     source: &MediaSource,
@@ -897,18 +932,13 @@ fn encode_gemini_media(
 // name from the tool call it answers (Gemini pairs by name, not ID).
 fn encode_gemini_function_response(result: &ToolResult, messages: &[Message]) -> Value {
     let name = find_tool_name(messages, &result.tool_call_id).unwrap_or_else(|| "tool".to_string());
+    // Image attachments are hoisted to sibling parts by the caller; the
+    // response payload itself carries the text-shaped content.
     let mut parts = Vec::new();
     for block in &result.content {
         match block {
             ContentBlock::Text { text } => parts.push(json!({"text": text})),
-            ContentBlock::Image {
-                source: ImageSource::Base64 { media_type, data },
-            } => parts.push(json!({
-                "inlineData": {
-                    "mimeType": media_type.clone().unwrap_or_else(|| "image/png".to_string()),
-                    "data": data,
-                },
-            })),
+            ContentBlock::Image { .. } => {}
             other => parts.push(json!({"text": json_string(&json!(other))})),
         }
     }

--- a/crates/switchyard-translation/src/codecs/gemini/mod.rs
+++ b/crates/switchyard-translation/src/codecs/gemini/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Codec pair for the Gemini generateContent wire format.
+
+mod buffered;
+mod stream;
+
+pub use buffered::GeminiGenerateContentCodec;
+pub use stream::GeminiGenerateContentStreamCodec;

--- a/crates/switchyard-translation/src/codecs/gemini/stream.rs
+++ b/crates/switchyard-translation/src/codecs/gemini/stream.rs
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Streaming codec for Gemini streamGenerateContent chunks.
+//!
+//! Each Gemini SSE `data:` line carries a complete `GenerateContentResponse`
+//! chunk: text arrives as incremental parts, function calls arrive whole in a
+//! single chunk, and the terminal chunk carries `finishReason` plus the
+//! authoritative `usageMetadata`. There are no named events and no `[DONE]`
+//! marker.
+
+use serde_json::{json, Map, Value};
+
+use crate::codecs::stream::{
+    record_source_identity, target_message_id_or_source_message_id, target_model_or_source_model,
+    ConversationStreamEvent, StreamCodec, StreamTranslationState,
+};
+use crate::format::{FormatId, WireFormat};
+
+/// Stream codec for Gemini streamGenerateContent chunks.
+pub struct GeminiGenerateContentStreamCodec;
+
+impl StreamCodec for GeminiGenerateContentStreamCodec {
+    fn format(&self) -> FormatId {
+        WireFormat::GeminiGenerateContent.into()
+    }
+
+    fn decode_event(
+        &self,
+        state: &mut StreamTranslationState,
+        event: &Value,
+    ) -> Vec<ConversationStreamEvent> {
+        decode_gemini_stream(state, event)
+    }
+
+    fn encode_event(
+        &self,
+        state: &mut StreamTranslationState,
+        event: ConversationStreamEvent,
+    ) -> Vec<Value> {
+        encode_gemini_stream(state, event)
+    }
+
+    fn finish(&self, state: &mut StreamTranslationState) -> Vec<Value> {
+        finish_gemini_stream(state)
+    }
+}
+
+// Decodes one Gemini chunk into neutral streaming events.
+fn decode_gemini_stream(
+    state: &mut StreamTranslationState,
+    event: &Value,
+) -> Vec<ConversationStreamEvent> {
+    let Some(object) = event.as_object() else {
+        return vec![ConversationStreamEvent::Error {
+            message: "Gemini stream chunk is not an object".to_string(),
+        }];
+    };
+    if let Some(error) = object.get("error") {
+        return vec![ConversationStreamEvent::Error {
+            message: error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown Gemini stream error")
+                .to_string(),
+        }];
+    }
+
+    let mut out = Vec::new();
+    if !state.saw_message_start {
+        state.saw_message_start = true;
+        state.message_id = object
+            .get("responseId")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        state.model = object
+            .get("modelVersion")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        out.push(ConversationStreamEvent::MessageStart {
+            id: state.message_id.clone(),
+            model: state.model.clone(),
+        });
+    }
+
+    if let Some(usage) = object.get("usageMetadata") {
+        capture_gemini_usage(state, usage);
+        out.push(ConversationStreamEvent::Usage(state.usage.clone()));
+    }
+
+    let candidate = object
+        .get("candidates")
+        .and_then(Value::as_array)
+        .and_then(|candidates| candidates.first())
+        .and_then(Value::as_object);
+    if let Some(parts) = candidate
+        .and_then(|candidate| candidate.get("content"))
+        .and_then(|content| content.get("parts"))
+        .and_then(Value::as_array)
+    {
+        for part in parts.iter().filter_map(Value::as_object) {
+            out.extend(decode_gemini_stream_part(state, part));
+        }
+    }
+
+    if let Some(reason) = candidate
+        .and_then(|candidate| candidate.get("finishReason"))
+        .and_then(Value::as_str)
+    {
+        out.push(ConversationStreamEvent::MessageStop {
+            reason: Some(neutral_stop_reason(
+                reason,
+                state.source_tool_calls_seen > 0,
+            )),
+        });
+    }
+    out
+}
+
+// Decodes one Gemini part into neutral text, reasoning, or tool-call events.
+fn decode_gemini_stream_part(
+    state: &mut StreamTranslationState,
+    part: &Map<String, Value>,
+) -> Vec<ConversationStreamEvent> {
+    if let Some(call) = part.get("functionCall").and_then(Value::as_object) {
+        // Gemini delivers complete function calls in one chunk; emit a single
+        // delta carrying the full arguments. Wire-format calls have no index,
+        // so each call gets the next per-stream slot.
+        let index = state.source_tool_calls_seen;
+        state.source_tool_calls_seen += 1;
+        return vec![ConversationStreamEvent::ToolCallDelta {
+            index,
+            id: Some(format!("call_{}", index + 1)),
+            name: call
+                .get("name")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            arguments_delta: Some(
+                call.get("args")
+                    .cloned()
+                    .unwrap_or_else(|| json!({}))
+                    .to_string(),
+            ),
+        }];
+    }
+    if let Some(text) = part.get("text").and_then(Value::as_str) {
+        if text.is_empty() {
+            return Vec::new();
+        }
+        if part.get("thought").and_then(Value::as_bool) == Some(true) {
+            return vec![ConversationStreamEvent::ReasoningDelta {
+                index: 0,
+                text: text.to_string(),
+            }];
+        }
+        return vec![ConversationStreamEvent::TextDelta {
+            index: 0,
+            text: text.to_string(),
+        }];
+    }
+    Vec::new()
+}
+
+// Encodes neutral streaming events into Gemini chunks.
+fn encode_gemini_stream(
+    state: &mut StreamTranslationState,
+    event: ConversationStreamEvent,
+) -> Vec<Value> {
+    match event {
+        ConversationStreamEvent::MessageStart { id, model } => {
+            // Gemini has no dedicated start frame; identity rides on every
+            // content chunk instead.
+            record_source_identity(state, id, model);
+            state.emitted_message_start = true;
+            Vec::new()
+        }
+        ConversationStreamEvent::TextDelta { text, .. } => {
+            state.output_tokens_seen += 1;
+            state.emitted_content_block = true;
+            vec![gemini_chunk(state, json!({"text": text}), None)]
+        }
+        ConversationStreamEvent::ReasoningDelta { text, .. } => {
+            state.emitted_content_block = true;
+            vec![gemini_chunk(
+                state,
+                json!({"text": text, "thought": true}),
+                None,
+            )]
+        }
+        ConversationStreamEvent::ToolCallDelta {
+            index,
+            id,
+            name,
+            arguments_delta,
+        } => {
+            // Buffer partial tool calls; Gemini emits complete functionCall
+            // parts, so buffered calls flush in the terminal chunk.
+            let tool = state.tool_states.entry(index).or_default();
+            if id.is_some() {
+                tool.id = id;
+            }
+            if name.is_some() {
+                tool.name = name;
+            }
+            if let Some(delta) = arguments_delta {
+                tool.arguments.push_str(&delta);
+            }
+            Vec::new()
+        }
+        ConversationStreamEvent::Usage(usage) => {
+            state.usage = usage;
+            state.saw_backend_usage = true;
+            Vec::new()
+        }
+        ConversationStreamEvent::MessageStop { reason } => {
+            state.stop_reason = reason.or_else(|| state.stop_reason.clone());
+            Vec::new()
+        }
+        ConversationStreamEvent::Error { message } => {
+            vec![json!({
+                "error": {"code": 500, "message": message, "status": "INTERNAL"},
+            })]
+        }
+    }
+}
+
+// Emits the terminal Gemini chunk with buffered tool calls, the finish
+// reason, and usage metadata.
+fn finish_gemini_stream(state: &mut StreamTranslationState) -> Vec<Value> {
+    let mut parts = Vec::new();
+    for tool in state.tool_states.values() {
+        let Some(name) = tool.name.clone() else {
+            continue;
+        };
+        let args = serde_json::from_str::<Value>(&tool.arguments)
+            .ok()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| json!({}));
+        parts.push(json!({"functionCall": {"name": name, "args": args}}));
+    }
+    let has_tool_calls = !parts.is_empty();
+    if parts.is_empty() && !state.emitted_content_block {
+        parts.push(json!({"text": ""}));
+    }
+
+    let mut candidate = Map::new();
+    if !parts.is_empty() {
+        candidate.insert(
+            "content".to_string(),
+            json!({"parts": parts, "role": "model"}),
+        );
+    }
+    candidate.insert(
+        "finishReason".to_string(),
+        Value::String(gemini_stream_finish_reason(
+            state.stop_reason.as_deref(),
+            has_tool_calls || !state.tool_states.is_empty(),
+        )),
+    );
+    candidate.insert("index".to_string(), json!(0));
+
+    let mut chunk = Map::new();
+    chunk.insert(
+        "candidates".to_string(),
+        Value::Array(vec![Value::Object(candidate)]),
+    );
+    chunk.insert("usageMetadata".to_string(), gemini_stream_usage(state));
+    insert_gemini_identity(state, &mut chunk);
+    state.finished = true;
+    vec![Value::Object(chunk)]
+}
+
+// Builds one streaming content chunk around a single part.
+fn gemini_chunk(state: &StreamTranslationState, part: Value, finish_reason: Option<&str>) -> Value {
+    let mut candidate = Map::new();
+    candidate.insert(
+        "content".to_string(),
+        json!({"parts": [part], "role": "model"}),
+    );
+    if let Some(reason) = finish_reason {
+        candidate.insert(
+            "finishReason".to_string(),
+            Value::String(reason.to_string()),
+        );
+    }
+    candidate.insert("index".to_string(), json!(0));
+    let mut chunk = Map::new();
+    chunk.insert(
+        "candidates".to_string(),
+        Value::Array(vec![Value::Object(candidate)]),
+    );
+    insert_gemini_identity(state, &mut chunk);
+    Value::Object(chunk)
+}
+
+// Stamps the response identity Gemini clients expect on every chunk.
+fn insert_gemini_identity(state: &StreamTranslationState, chunk: &mut Map<String, Value>) {
+    chunk.insert(
+        "modelVersion".to_string(),
+        Value::String(target_model_or_source_model(state)),
+    );
+    if let Some(id) = target_message_id_or_source_message_id(state) {
+        chunk.insert("responseId".to_string(), Value::String(id.to_string()));
+    }
+}
+
+// Maps Gemini finish reasons into the neutral stop-reason vocabulary shared
+// by the other stream encoders. Gemini reports STOP for function-call turns,
+// so calls seen on this stream win over the raw reason.
+fn neutral_stop_reason(reason: &str, saw_tool_calls: bool) -> String {
+    match reason {
+        "STOP" | "FINISH_REASON_UNSPECIFIED" if saw_tool_calls => "tool_use".to_string(),
+        "STOP" | "FINISH_REASON_UNSPECIFIED" => "end_turn".to_string(),
+        "MAX_TOKENS" => "max_tokens".to_string(),
+        "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII" | "IMAGE_SAFETY" => {
+            "content_filter".to_string()
+        }
+        other => other.to_string(),
+    }
+}
+
+// Maps neutral stop reasons back to Gemini's finish-reason vocabulary.
+fn gemini_stream_finish_reason(reason: Option<&str>, has_tool_calls: bool) -> String {
+    match reason {
+        Some("max_tokens") | Some("length") => "MAX_TOKENS".to_string(),
+        Some("content_filter") => "SAFETY".to_string(),
+        // Gemini reports STOP even for tool-call turns.
+        Some("tool_use")
+        | Some("tool_calls")
+        | Some("function_call")
+        | Some("end_turn")
+        | Some("stop")
+        | Some("stop_sequence")
+        | None => "STOP".to_string(),
+        Some(_) if has_tool_calls => "STOP".to_string(),
+        Some(_) => "OTHER".to_string(),
+    }
+}
+
+// Preserves Gemini usage counters and updates normalized token counts.
+fn capture_gemini_usage(state: &mut StreamTranslationState, usage: &Value) {
+    let Some(usage) = usage.as_object() else {
+        return;
+    };
+    for (key, target) in [
+        ("promptTokenCount", "input_tokens"),
+        ("candidatesTokenCount", "candidates_tokens"),
+        ("thoughtsTokenCount", "thoughts_tokens"),
+        ("totalTokenCount", "total_tokens"),
+    ] {
+        if let Some(value) = usage.get(key).and_then(Value::as_u64) {
+            state.usage_extras.insert(target.to_string(), value);
+        }
+    }
+    let candidates = state.usage_extras.get("candidates_tokens").copied();
+    let thoughts = state.usage_extras.get("thoughts_tokens").copied();
+    state.usage.input_tokens = state.usage_extras.get("input_tokens").copied();
+    // Thinking tokens fold into output tokens to match other providers.
+    state.usage.output_tokens = match (candidates, thoughts) {
+        (None, None) => None,
+        (candidates, thoughts) => Some(
+            candidates
+                .unwrap_or(0)
+                .saturating_add(thoughts.unwrap_or(0)),
+        ),
+    };
+    state.usage.total_tokens = state.usage_extras.get("total_tokens").copied();
+    state.usage.reasoning_tokens = thoughts;
+}
+
+// Builds the terminal usageMetadata payload from accumulated stream state.
+fn gemini_stream_usage(state: &StreamTranslationState) -> Value {
+    let mut usage = Map::new();
+    if state.saw_backend_usage {
+        let input = state.usage.input_tokens.unwrap_or(0);
+        let output = state.usage.output_tokens.unwrap_or(0);
+        let thoughts = state.usage.reasoning_tokens.unwrap_or(0);
+        usage.insert("promptTokenCount".to_string(), json!(input));
+        usage.insert(
+            "candidatesTokenCount".to_string(),
+            json!(output.saturating_sub(thoughts)),
+        );
+        if thoughts > 0 {
+            usage.insert("thoughtsTokenCount".to_string(), json!(thoughts));
+        }
+        usage.insert(
+            "totalTokenCount".to_string(),
+            json!(state.usage.total_tokens.unwrap_or(input + output)),
+        );
+    } else {
+        usage.insert(
+            "candidatesTokenCount".to_string(),
+            json!(state.output_tokens_seen),
+        );
+        usage.insert(
+            "totalTokenCount".to_string(),
+            json!(state.output_tokens_seen),
+        );
+    }
+    Value::Object(usage)
+}

--- a/crates/switchyard-translation/src/codecs/mod.rs
+++ b/crates/switchyard-translation/src/codecs/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod anthropic;
 pub(crate) mod common;
+pub mod gemini;
 pub mod openai_chat;
 pub mod responses;
 pub mod stream;

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -503,38 +503,49 @@ pub(crate) fn decode_openai_content(
 pub(crate) fn decode_image_source(block: &Map<String, Value>) -> Option<ImageSource> {
     if let Some(image_url) = block.get("image_url") {
         if let Some(url) = image_url.as_str() {
-            return Some(ImageSource::Url {
-                url: url.to_string(),
-                detail: block
+            return Some(image_source_from_url(
+                url,
+                block
                     .get("detail")
                     .and_then(Value::as_str)
                     .map(ToOwned::to_owned),
-            });
+            ));
         }
         if let Some(payload) = image_url.as_object() {
-            return payload
-                .get("url")
-                .and_then(Value::as_str)
-                .map(|url| ImageSource::Url {
-                    url: url.to_string(),
-                    detail: payload
+            return payload.get("url").and_then(Value::as_str).map(|url| {
+                image_source_from_url(
+                    url,
+                    payload
                         .get("detail")
                         .or_else(|| block.get("detail"))
                         .and_then(Value::as_str)
                         .map(ToOwned::to_owned),
-                });
+                )
+            });
         }
     }
     if let Some(image_url) = block.get("image_url").and_then(Value::as_str) {
-        return Some(ImageSource::Url {
-            url: image_url.to_string(),
-            detail: block
+        return Some(image_source_from_url(
+            image_url,
+            block
                 .get("detail")
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned),
-        });
+        ));
     }
     None
+}
+
+// Normalizes data URLs into base64 sources so every target codec can carry
+// the payload; remote URLs stay URL sources (and keep their detail hint).
+fn image_source_from_url(url: &str, detail: Option<String>) -> ImageSource {
+    match crate::codecs::common::parse_data_url(url) {
+        Some((media_type, data)) => ImageSource::Base64 { media_type, data },
+        None => ImageSource::Url {
+            url: url.to_string(),
+            detail,
+        },
+    }
 }
 
 /// Decodes OpenAI file block shapes into normalized file sources.
@@ -697,6 +708,7 @@ fn encode_message_with_tool_results_to_openai(
     let mut out = Vec::new();
     let mut pending_content = Vec::new();
 
+    let mut hoisted_images = Vec::new();
     for block in &message.content {
         if let ContentBlock::ToolResult(result) = block {
             push_pending_openai_message(
@@ -706,6 +718,13 @@ fn encode_message_with_tool_results_to_openai(
                 diagnostics,
                 policy,
             )?;
+            // OpenAI tool messages are text-only; image attachments inside
+            // tool results are hoisted into a user message that follows the
+            // tool messages, where vision models can actually read them.
+            hoisted_images.extend(result.content.iter().filter_map(|block| match block {
+                ContentBlock::Image { source } => openai_image_part(source),
+                _ => None,
+            }));
             out.push(json!({
                 "role": "tool",
                 "tool_call_id": result.tool_call_id,
@@ -723,6 +742,9 @@ fn encode_message_with_tool_results_to_openai(
         diagnostics,
         policy,
     )?;
+    if !hoisted_images.is_empty() {
+        out.push(json!({"role": "user", "content": hoisted_images}));
+    }
     Ok(out)
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -524,15 +524,6 @@ pub(crate) fn decode_image_source(block: &Map<String, Value>) -> Option<ImageSou
             });
         }
     }
-    if let Some(image_url) = block.get("image_url").and_then(Value::as_str) {
-        return Some(image_source_from_url(
-            image_url,
-            block
-                .get("detail")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned),
-        ));
-    }
     None
 }
 
@@ -964,12 +955,15 @@ fn openai_image_part(source: &ImageSource) -> Option<Value> {
             }
             Some(json!({"type": "image_url", "image_url": image_url}))
         }
-        ImageSource::Base64 { media_type, data } => media_type.as_ref().map(|media_type| {
-            json!({
+        ImageSource::Base64 { media_type, data } => {
+            // Data URLs need a media type; default like the other codecs do
+            // rather than dropping the payload.
+            let media_type = media_type.as_deref().unwrap_or("image/png");
+            Some(json!({
                 "type": "image_url",
                 "image_url": {"url": format!("data:{media_type};base64,{data}")},
-            })
-        }),
+            }))
+        }
         ImageSource::Raw(raw) => openai_raw_image_part(raw),
     }
 }

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::codecs::anthropic::AnthropicMessagesStreamCodec;
+use crate::codecs::gemini::GeminiGenerateContentStreamCodec;
 use crate::codecs::openai_chat::OpenAiChatStreamCodec;
 use crate::codecs::responses::OpenAiResponsesStreamCodec;
 use crate::engine::{FormatRegistry, TranslationEngine};
@@ -57,6 +58,10 @@ pub struct StreamTranslationState {
 
     pub(crate) reasoning_block_index: Option<usize>,
     pub(crate) reasoning_block_started: bool,
+
+    /// Count of tool calls decoded from the source stream, used by decoders
+    /// whose wire format has no per-call index (for example Gemini).
+    pub(crate) source_tool_calls_seen: usize,
 }
 
 // Tracks an in-progress streamed tool call across provider-specific deltas.
@@ -167,6 +172,7 @@ impl StreamCodecRegistry {
         registry.register(OpenAiChatStreamCodec);
         registry.register(AnthropicMessagesStreamCodec);
         registry.register(OpenAiResponsesStreamCodec);
+        registry.register(GeminiGenerateContentStreamCodec);
         registry
     }
 

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use serde_json::Value;
 
 use crate::codecs::anthropic::AnthropicMessagesCodec;
+use crate::codecs::gemini::GeminiGenerateContentCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
 use crate::codecs::responses::OpenAiResponsesCodec;
 use crate::codecs::stream::{StreamCodecRegistry, StreamTranslationState};
@@ -58,6 +59,7 @@ impl FormatRegistry {
         registry.register(OpenAiChatCodec);
         registry.register(AnthropicMessagesCodec);
         registry.register(OpenAiResponsesCodec);
+        registry.register(GeminiGenerateContentCodec);
         registry
     }
 

--- a/crates/switchyard-translation/src/format.rs
+++ b/crates/switchyard-translation/src/format.rs
@@ -16,6 +16,8 @@ pub enum WireFormat {
     AnthropicMessages,
     #[serde(rename = "openai_responses")]
     OpenAiResponses,
+    #[serde(rename = "gemini_generate_content")]
+    GeminiGenerateContent,
 }
 
 impl WireFormat {
@@ -25,6 +27,7 @@ impl WireFormat {
             Self::OpenAiChat => "openai_chat",
             Self::AnthropicMessages => "anthropic_messages",
             Self::OpenAiResponses => "openai_responses",
+            Self::GeminiGenerateContent => "gemini_generate_content",
         }
     }
 }

--- a/crates/switchyard-translation/tests/lossless_roundtrip.rs
+++ b/crates/switchyard-translation/tests/lossless_roundtrip.rs
@@ -9,10 +9,11 @@ use switchyard_translation::{
     PreservationPolicy, TranslationEngine, TranslationPolicy, WireFormat, PRESERVATION_METADATA_KEY,
 };
 
-const FORMATS: [WireFormat; 3] = [
+const FORMATS: [WireFormat; 4] = [
     WireFormat::OpenAiChat,
     WireFormat::AnthropicMessages,
     WireFormat::OpenAiResponses,
+    WireFormat::GeminiGenerateContent,
 ];
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -283,6 +284,7 @@ fn format_key(format: WireFormat) -> &'static str {
         WireFormat::OpenAiChat => "openai_chat",
         WireFormat::AnthropicMessages => "anthropic_messages",
         WireFormat::OpenAiResponses => "openai_responses",
+        WireFormat::GeminiGenerateContent => "gemini_generate_content",
     }
 }
 
@@ -537,6 +539,85 @@ fn request_fixture(format: WireFormat) -> Value {
             "store": false,
             "truncation": "auto"
         }),
+        WireFormat::GeminiGenerateContent => json!({
+            "model": "gemini-2.5-flash",
+            "stream": true,
+            "systemInstruction": {
+                "parts": [{"text": "Follow exact instructions."}]
+            },
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": "Inspect this payload."},
+                        {
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": "iVBORw0KGgo="
+                            }
+                        },
+                        {
+                            "fileData": {
+                                "mimeType": "video/mp4",
+                                "fileUri": "https://example.test/clip.mp4"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "model",
+                    "parts": [
+                        {"text": "Planning the lookup.", "thought": true},
+                        {
+                            "functionCall": {
+                                "name": "lookup",
+                                "args": {"query": "rust", "limit": 2}
+                            },
+                            "thoughtSignature": "c2lnbmF0dXJl"
+                        }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "parts": [{
+                        "functionResponse": {
+                            "name": "lookup",
+                            "response": {"parts": [{"text": "found"}]}
+                        }
+                    }]
+                }
+            ],
+            "tools": [{
+                "functionDeclarations": [{
+                    "name": "lookup",
+                    "description": "Lookup data",
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {"query": {"type": "STRING"}},
+                        "required": ["query"]
+                    }
+                }]
+            }],
+            "toolConfig": {
+                "functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["lookup"]}
+            },
+            "generationConfig": {
+                "maxOutputTokens": 888,
+                "temperature": 0.2,
+                "topP": 0.91,
+                "topK": 40,
+                "stopSequences": ["END"],
+                "responseMimeType": "application/json",
+                "responseSchema": {"type": "OBJECT"},
+                "thinkingConfig": {"thinkingBudget": 1024, "includeThoughts": true}
+            },
+            "safetySettings": [{
+                "category": "HARM_CATEGORY_HARASSMENT",
+                "threshold": "BLOCK_NONE"
+            }],
+            "cachedContent": "cachedContents/example",
+            "labels": {"trace": "gemini-request"}
+        }),
     }
 }
 
@@ -675,6 +756,38 @@ fn response_fixture(format: WireFormat) -> Value {
             "tools": [{"type": "web_search_preview"}],
             "metadata": {"trace": "responses-response", "kept": {"nested": true}},
             "service_tier": "default"
+        }),
+        WireFormat::GeminiGenerateContent => json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {"text": "Planning the lookup.", "thought": true},
+                        {"text": "Here is the answer."},
+                        {
+                            "functionCall": {
+                                "name": "lookup",
+                                "args": {"query": "rust"}
+                            },
+                            "thoughtSignature": "c2lnbmF0dXJl"
+                        }
+                    ],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0,
+                "finishMessage": "Model generated function call(s)."
+            }],
+            "promptFeedback": {"safetyRatings": []},
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "thoughtsTokenCount": 2,
+                "totalTokenCount": 17,
+                "cachedContentTokenCount": 4,
+                "serviceTier": "standard"
+            },
+            "modelVersion": "gemini-2.5-flash",
+            "responseId": "resp_adversarial"
         }),
     }
 }

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1101,3 +1101,175 @@ fn responses_to_chat_preserves_tool_choice_when_tools_survive() -> TestResult {
     );
     Ok(())
 }
+
+// Verifies OpenAI Chat requests map to Gemini generateContent shape.
+#[test]
+fn openai_chat_request_translates_to_gemini_generate_content() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gemini-2.5-flash",
+        "messages": [
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"Paris\"}"}
+                }]
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "22C"}
+        ],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {"city": {"type": "string", "default": "Paris"}},
+                    "required": ["city"]
+                }
+            }
+        }],
+        "tool_choice": "required",
+        "max_tokens": 128,
+        "temperature": 0.3,
+        "stop": ["END"],
+        "stream": true
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["model"], "gemini-2.5-flash");
+    assert_eq!(output["stream"], true);
+    assert_eq!(
+        output["systemInstruction"],
+        json!({"parts": [{"text": "Be terse."}]})
+    );
+    assert_eq!(
+        output["contents"][0],
+        json!({"role": "user", "parts": [{"text": "Weather in Paris?"}]})
+    );
+    assert_eq!(
+        output["contents"][1]["parts"][0]["functionCall"],
+        json!({"name": "get_weather", "args": {"city": "Paris"}})
+    );
+    let function_response = &output["contents"][2]["parts"][0]["functionResponse"];
+    assert_eq!(function_response["name"], "get_weather");
+    assert_eq!(function_response["response"]["parts"][0]["text"], "22C");
+    // The declaration schema is sanitized into Gemini's OpenAPI subset.
+    let parameters = &output["tools"][0]["functionDeclarations"][0]["parameters"];
+    assert_eq!(parameters["type"], "OBJECT");
+    assert_eq!(parameters["properties"]["city"]["type"], "STRING");
+    assert!(parameters["properties"]["city"].get("default").is_none());
+    assert!(parameters.get("additionalProperties").is_none());
+    assert_eq!(output["toolConfig"]["functionCallingConfig"]["mode"], "ANY");
+    let generation = &output["generationConfig"];
+    assert_eq!(generation["maxOutputTokens"], 128);
+    assert_eq!(generation["temperature"], 0.3);
+    assert_eq!(generation["stopSequences"], json!(["END"]));
+    Ok(())
+}
+
+// Verifies Gemini requests translate to OpenAI Chat with paired tool-call IDs.
+#[test]
+fn gemini_request_translates_to_openai_chat_with_paired_tool_ids() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gemini-2.5-flash",
+        "systemInstruction": {"parts": [{"text": "Be terse."}]},
+        "contents": [
+            {"role": "user", "parts": [{"text": "Weather?"}]},
+            {"role": "model", "parts": [
+                {"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}}
+            ]},
+            {"role": "user", "parts": [
+                {"functionResponse": {"name": "get_weather", "response": {"result": "22C"}}}
+            ]}
+        ],
+        "tools": [{
+            "functionDeclarations": [{
+                "name": "get_weather",
+                "parameters": {"type": "OBJECT", "properties": {"city": {"type": "STRING"}}}
+            }]
+        }],
+        "generationConfig": {"maxOutputTokens": 64, "stopSequences": ["END"]}
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::GeminiGenerateContent,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["messages"][0],
+        json!({"role": "system", "content": "Be terse."})
+    );
+    let call_id = output["messages"][2]["tool_calls"][0]["id"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(!call_id.is_empty());
+    assert_eq!(output["messages"][3]["role"], "tool");
+    assert_eq!(
+        output["messages"][3]["tool_call_id"],
+        Value::String(call_id)
+    );
+    // Gemini's uppercase schema types are restored to JSON Schema form.
+    assert_eq!(
+        output["tools"][0]["function"]["parameters"]["properties"]["city"]["type"],
+        "string"
+    );
+    assert_eq!(output["max_completion_tokens"], 64);
+    assert_eq!(output["stop"], json!(["END"]));
+    Ok(())
+}
+
+// Verifies signed thinking blocks replay as Gemini thought signatures.
+#[test]
+fn anthropic_signed_thinking_replays_as_gemini_thought_signature() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gemini-2.5-flash",
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": "Weather?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "checking", "signature": "sig-1"},
+                    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {}}
+                ]
+            }
+        ]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let call_part = &output["contents"][1]["parts"][0];
+    assert_eq!(call_part["functionCall"]["name"], "get_weather");
+    assert_eq!(call_part["thoughtSignature"], "sig-1");
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1273,3 +1273,196 @@ fn anthropic_signed_thinking_replays_as_gemini_thought_signature() -> TestResult
     assert_eq!(call_part["thoughtSignature"], "sig-1");
     Ok(())
 }
+
+// Verifies OpenAI data-URL images become typed base64 payloads that both
+// Anthropic and Gemini can carry natively.
+#[test]
+fn openai_data_url_image_translates_to_anthropic_and_gemini_base64() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "m",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,aW1n"}
+                }
+            ]
+        }]
+    });
+
+    let anthropic = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    let image = &anthropic["messages"][0]["content"][1];
+    assert_eq!(image["source"]["type"], "base64");
+    assert_eq!(image["source"]["media_type"], "image/png");
+    assert_eq!(image["source"]["data"], "aW1n");
+
+    let gemini = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    let part = &gemini["contents"][0]["parts"][1];
+    assert_eq!(part["inlineData"]["mimeType"], "image/png");
+    assert_eq!(part["inlineData"]["data"], "aW1n");
+    Ok(())
+}
+
+// Verifies Anthropic base64 images survive translation toward every target
+// instead of degrading to raw passthrough shapes.
+#[test]
+fn anthropic_image_translates_to_openai_data_url_and_gemini_inline_data() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "m",
+        "max_tokens": 128,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": "aW1n"}
+            }]
+        }]
+    });
+
+    let openai = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(
+        openai["messages"][0]["content"][0]["image_url"]["url"],
+        "data:image/jpeg;base64,aW1n"
+    );
+
+    let gemini = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(
+        gemini["contents"][0]["parts"][0]["inlineData"]["data"],
+        "aW1n"
+    );
+    Ok(())
+}
+
+// Verifies tool-result image attachments stay typed blocks toward Anthropic
+// and Gemini, and are dropped (not leaked as text) toward OpenAI.
+#[test]
+fn tool_result_image_attachment_translates_per_target_capability() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "m",
+        "max_tokens": 128,
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "take_screenshot",
+                    "input": {}
+                }]
+            },
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": [
+                        {"type": "text", "text": "screenshot captured"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "c2NyZWVuc2hvdA=="
+                            }
+                        }
+                    ]
+                }]
+            }
+        ]
+    });
+
+    // Anthropic round trip keeps the typed image block inside the result.
+    let anthropic = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy {
+                preservation: switchyard_translation::PreservationPolicy::Disabled,
+                ..TranslationPolicy::default()
+            },
+        )?
+        .body;
+    let result_content = &anthropic["messages"][1]["content"][0]["content"];
+    assert!(result_content.is_array());
+    assert_eq!(result_content[1]["type"], "image");
+    assert_eq!(result_content[1]["source"]["data"], "c2NyZWVuc2hvdA==");
+
+    // Gemini cannot read media nested inside the functionResponse payload,
+    // so the image is hoisted to a sibling part of the same user turn.
+    let gemini = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    let result_parts = &gemini["contents"][1]["parts"];
+    assert_eq!(
+        result_parts[0]["functionResponse"]["response"]["parts"][0]["text"],
+        "screenshot captured"
+    );
+    assert_eq!(result_parts[1]["inlineData"]["data"], "c2NyZWVuc2hvdA==");
+
+    // OpenAI tool messages are text-only: text survives, and the payload is
+    // hoisted into a following user message instead of leaking as text.
+    let openai = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    let messages = openai["messages"]
+        .as_array()
+        .ok_or("translated body should carry messages")?;
+    let tool_index = messages
+        .iter()
+        .position(|message| message["role"] == "tool")
+        .ok_or("translated body should contain a tool message")?;
+    let content = messages[tool_index]["content"].as_str().unwrap_or_default();
+    assert!(content.contains("screenshot captured"));
+    assert!(!content.contains("c2NyZWVuc2hvdA=="));
+    let hoisted = &messages[tool_index + 1];
+    assert_eq!(hoisted["role"], "user");
+    assert_eq!(
+        hoisted["content"][0]["image_url"]["url"],
+        "data:image/png;base64,c2NyZWVuc2hvdA=="
+    );
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -320,3 +320,120 @@ fn openai_chat_response_with_text_and_tool_call_translates_both_to_responses() -
     assert_eq!(output["output"][1]["call_id"], "call_1");
     Ok(())
 }
+
+// Verifies Gemini function-call responses surface as OpenAI tool calls, with
+// thinking tokens folded into completion tokens.
+#[test]
+fn gemini_function_call_response_translates_to_openai_tool_calls() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "candidates": [{
+            "content": {
+                "parts": [{
+                    "functionCall": {"name": "get_weather", "args": {"city": "Paris"}}
+                }],
+                "role": "model"
+            },
+            // Gemini reports STOP even for function-call turns.
+            "finishReason": "STOP",
+            "index": 0
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "thoughtsTokenCount": 7,
+            "totalTokenCount": 22
+        },
+        "modelVersion": "gemini-2.5-flash",
+        "responseId": "resp-1"
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::GeminiGenerateContent,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let choice = &output["choices"][0];
+    assert_eq!(choice["finish_reason"], "tool_calls");
+    assert_eq!(
+        choice["message"]["tool_calls"][0]["function"]["name"],
+        "get_weather"
+    );
+    assert_eq!(output["usage"]["prompt_tokens"], 10);
+    assert_eq!(output["usage"]["completion_tokens"], 12);
+    assert_eq!(output["model"], "gemini-2.5-flash");
+    Ok(())
+}
+
+// Verifies OpenAI completions map onto the Gemini candidates shape.
+#[test]
+fn openai_chat_response_translates_to_gemini_candidates() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "chatcmpl-1",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hello"},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6}
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::OpenAiChat,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let candidate = &output["candidates"][0];
+    assert_eq!(candidate["content"]["parts"], json!([{"text": "Hello"}]));
+    assert_eq!(candidate["content"]["role"], "model");
+    assert_eq!(candidate["finishReason"], "STOP");
+    assert_eq!(output["usageMetadata"]["promptTokenCount"], 4);
+    assert_eq!(output["usageMetadata"]["candidatesTokenCount"], 2);
+    assert_eq!(output["responseId"], "chatcmpl-1");
+    Ok(())
+}
+
+// Verifies Anthropic tool-use responses map to Gemini function-call parts.
+#[test]
+fn anthropic_tool_use_response_translates_to_gemini_function_call() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-x",
+        "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Paris"}}
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 3, "output_tokens": 2}
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::AnthropicMessages,
+            WireFormat::GeminiGenerateContent,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let candidate = &output["candidates"][0];
+    assert_eq!(
+        candidate["content"]["parts"][0]["functionCall"],
+        json!({"name": "get_weather", "args": {"city": "Paris"}})
+    );
+    // Gemini reports STOP for tool-call turns.
+    assert_eq!(candidate["finishReason"], "STOP");
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -416,3 +416,132 @@ fn anthropic_thinking_stream_deltas_do_not_become_openai_chat_content() -> TestR
         .any(|event| { event["choices"][0]["delta"]["content"] == "private chain of thought" }));
     Ok(())
 }
+
+// Verifies Gemini chunks translate to OpenAI Chat chunks with tool calls
+// delivered whole and thinking tokens folded into usage.
+#[test]
+fn gemini_stream_translates_to_openai_chat_chunks() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::GeminiGenerateContent, WireFormat::OpenAiChat);
+
+    let text_chunk = json!({
+        "candidates": [{
+            "content": {"parts": [{"text": "Hi"}], "role": "model"},
+            "index": 0
+        }],
+        "modelVersion": "gemini-2.5-flash",
+        "responseId": "resp-1"
+    });
+    let events = engine.translate_event(
+        &mut state,
+        WireFormat::GeminiGenerateContent,
+        WireFormat::OpenAiChat,
+        &text_chunk,
+    )?;
+    assert_eq!(events[0]["model"], "gemini-2.5-flash");
+    assert_eq!(events[0]["choices"][0]["delta"]["content"], "Hi");
+
+    let final_chunk = json!({
+        "candidates": [{
+            "content": {
+                "parts": [{"functionCall": {"name": "run", "args": {"cmd": "ls"}}}],
+                "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 2,
+            "candidatesTokenCount": 1,
+            "thoughtsTokenCount": 4
+        }
+    });
+    let events = engine.translate_event(
+        &mut state,
+        WireFormat::GeminiGenerateContent,
+        WireFormat::OpenAiChat,
+        &final_chunk,
+    )?;
+
+    let tool_delta = &events[0]["choices"][0]["delta"]["tool_calls"][0];
+    assert_eq!(tool_delta["function"]["name"], "run");
+    assert_eq!(tool_delta["function"]["arguments"], "{\"cmd\":\"ls\"}");
+    let terminal = events
+        .last()
+        .ok_or("gemini finish chunk should emit a terminal event")?;
+    // Function calls on the stream override Gemini's STOP finish reason.
+    assert_eq!(terminal["choices"][0]["finish_reason"], "tool_calls");
+    assert_eq!(terminal["usage"]["completion_tokens"], 5);
+    Ok(())
+}
+
+// Verifies OpenAI streamed tool calls buffer into one terminal Gemini chunk.
+#[test]
+fn openai_chat_stream_translates_to_gemini_terminal_chunk() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::GeminiGenerateContent);
+
+    for chunk in [
+        json!({
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {"content": "Hi"}}]
+        }),
+        json!({
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [{
+                "index": 0,
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "run", "arguments": "{\"cmd\":"}
+                }]}
+            }]
+        }),
+        json!({
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [{
+                "index": 0,
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "function": {"arguments": "\"ls\"}"}
+                }]}
+            }]
+        }),
+        json!({
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+        }),
+    ] {
+        let events = engine.translate_event(
+            &mut state,
+            WireFormat::OpenAiChat,
+            WireFormat::GeminiGenerateContent,
+            &chunk,
+        )?;
+        for event in &events {
+            // Text deltas stream through; tool-call fragments stay buffered.
+            assert!(event.get("candidates").is_some());
+        }
+    }
+
+    let finish = engine.finish_stream(&mut state, WireFormat::GeminiGenerateContent)?;
+    let terminal = finish
+        .last()
+        .ok_or("gemini finish should emit a terminal chunk")?;
+    let candidate = &terminal["candidates"][0];
+    assert_eq!(
+        candidate["content"]["parts"][0]["functionCall"],
+        json!({"name": "run", "args": {"cmd": "ls"}})
+    );
+    assert_eq!(candidate["finishReason"], "STOP");
+    assert_eq!(terminal["usageMetadata"]["promptTokenCount"], 3);
+    Ok(())
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,13 +12,13 @@ flowchart TB
     switchyard["Switchyard<br/>Local proxy, shared service, or embedded runtime"]
     backends["Model backends<br/>Hosted providers, private endpoints, local models"]
 
-    clients <-->|"OpenAI and Anthropic API formats"| switchyard
+    clients <-->|"OpenAI, Anthropic, and Gemini API formats"| switchyard
     switchyard <-->|"Provider-compatible requests and responses"| backends
 ```
 
-Clients connect using supported OpenAI or Anthropic API formats. Switchyard can
-route a request to a backend with a different native format and still return the
-response shape expected by the client.
+Clients connect using supported OpenAI, Anthropic, or Gemini API formats.
+Switchyard can route a request to a backend with a different native format and
+still return the response shape expected by the client.
 
 ## Request Lifecycle
 
@@ -48,6 +48,7 @@ formats select an endpoint directly and do not run capability probes.
 | `ANTHROPIC` | Always sends to `/v1/messages`. No probe. | You know the upstream is Anthropic-native (Anthropic API, NIM Claude routes). |
 | `RESPONSES` | Always sends to `/v1/responses`. No probe. | You know the upstream supports the OpenAI Responses API. Fails on NIM / non-OpenAI upstreams. |
 | `OPENAI` | Always sends to `/v1/chat/completions`. No probe. | You know the upstream is OpenAI-compatible (NIM, OpenRouter, etc). Safe universal choice. |
+| `GEMINI` | Always sends to `/v1beta/models/{model}:generateContent`. No probe. | You know the upstream is Gemini-native (`generativelanguage.googleapis.com`). Bare `gemini*` model IDs also fast-path here under `AUTO`. |
 | `AUTO` | Probes at startup, picks best format (see below). | Upstream is unknown or varies across deployments. Used by Claude Code and Codex launchers. OpenClaw is intentionally pinned to `OPENAI`. |
 | *(omitted)* | Defaults to `OPENAI` — no probe, no fast-path. Silently uses Chat Completions, which is wrong for Anthropic/Bedrock models. Always set `format:` explicitly. |  |
 Claude Code and Codex launchers use `AUTO` for their single-model targets.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -83,11 +83,12 @@ covers it in full.
 
 ## Formats and translation
 
-Clients reach Switchyard in one of three inbound formats: OpenAI Chat
-Completions, Anthropic Messages, or OpenAI Responses. Each target has its own
-backend format, set by its `format:` field, which is one of `openai`,
-`anthropic`, `responses`, or `auto`. When the two differ, Switchyard translates
-the request on the way out and the response on the way back.
+Clients reach Switchyard in one of four inbound formats: OpenAI Chat
+Completions, Anthropic Messages, OpenAI Responses, or Gemini generateContent.
+Each target has its own backend format, set by its `format:` field, which is
+one of `openai`, `anthropic`, `responses`, `gemini`, or `auto`. When the two
+differ, Switchyard translates the request on the way out and the response on
+the way back.
 
 That translation is what lets Claude Code, which speaks Anthropic Messages, run
 against an OpenAI-compatible model, and the reverse. The

--- a/switchyard/__init__.py
+++ b/switchyard/__init__.py
@@ -15,6 +15,7 @@ from switchyard.lib.backends import (
     AnthropicNativeBackend,
     EndpointHealth,
     EndpointHealthStatus,
+    GeminiNativeBackend,
     HealthPoller,
     LatencyServiceLLMBackend,
     OpenAiNativeBackend,
@@ -25,6 +26,7 @@ from switchyard.lib.backends.llm_target import (
 )
 from switchyard.lib.chat_request import (
     AnthropicChatRequest,
+    GeminiChatRequest,
     OpenAIChatRequest,
     ResponsesChatRequest,
 )
@@ -34,6 +36,9 @@ from switchyard.lib.chat_response import (
     AnthropicStreamingChatResponse,
     AnyResponseStream,
     CompletionChatResponse,
+    GeminiChatResponse,
+    GeminiResponseStream,
+    GeminiStreamingChatResponse,
     ResponsesApiChatResponse,
     ResponsesApiStream,
     ResponsesApiStreamingChatResponse,
@@ -109,6 +114,7 @@ if TYPE_CHECKING:
     from switchyard.lib.endpoints.anthropic_messages_endpoint import (
         AnthropicMessagesEndpoint,
     )
+    from switchyard.lib.endpoints.gemini_endpoint import GeminiEndpoint
     from switchyard.lib.endpoints.models_endpoint import ModelsEndpoint
     from switchyard.lib.endpoints.openai_chat_endpoint import (
         OpenAIChatEndpoint,
@@ -131,6 +137,10 @@ def __getattr__(name: str) -> Any:
         )
 
         return AnthropicMessagesEndpoint
+    if name == "GeminiEndpoint":
+        from switchyard.lib.endpoints.gemini_endpoint import GeminiEndpoint
+
+        return GeminiEndpoint
     if name == "ResponsesEndpoint":
         from switchyard.lib.endpoints.responses_endpoint import ResponsesEndpoint
 
@@ -151,6 +161,7 @@ __all__ = [
     "AnthropicChatRequest",
     "ChatRequest",
     "ChatRequestType",
+    "GeminiChatRequest",
     "OpenAIChatRequest",
     "ResponsesChatRequest",
     # Chain infrastructure
@@ -192,9 +203,11 @@ __all__ = [
     "profile_config",
     "profile_config_type",
     "AnthropicNativeBackend",
+    "GeminiNativeBackend",
     "OpenAiNativeBackend",
     "OpenAIChatEndpoint",
     "AnthropicMessagesEndpoint",
+    "GeminiEndpoint",
     "ResponsesEndpoint",
     "ModelsEndpoint",
     "build_switchyard_app",
@@ -234,9 +247,12 @@ __all__ = [
     "ResponsesApiChatResponse",
     "ResponsesApiStreamingChatResponse",
     "AnthropicStreamingChatResponse",
+    "GeminiChatResponse",
+    "GeminiStreamingChatResponse",
     "ResponseStream",
     "ResponsesApiStream",
     "AnthropicResponseStream",
+    "GeminiResponseStream",
     "AnyResponseStream",
 ]
 

--- a/switchyard/lib/backends/__init__.py
+++ b/switchyard/lib/backends/__init__.py
@@ -24,6 +24,7 @@ from switchyard.lib.backends.stats_llm_backend import (
 )
 from switchyard_rust.components import (
     AnthropicNativeBackend,
+    GeminiNativeBackend,
     OpenAiNativeBackend,
     OpenAiPassthroughBackend,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "BackendFormatResolver",
     "EndpointHealth",
     "EndpointHealthStatus",
+    "GeminiNativeBackend",
     "HealthPoller",
     "LatencyServiceLLMBackend",
     "OpenAiPassthroughBackend",

--- a/switchyard/lib/backends/backend_format_resolver.py
+++ b/switchyard/lib/backends/backend_format_resolver.py
@@ -83,6 +83,12 @@ class BackendFormatResolver:
                 reason="model prefix indicates native Anthropic; skipping probes",
             )
 
+        if _model_is_gemini(tier.model):
+            return BackendFormatResolution(
+                format=BackendFormat.GEMINI,
+                reason="model prefix indicates native Gemini; skipping probes",
+            )
+
         timeout_s = tier.endpoint.timeout_secs or _DEFAULT_TIMEOUT_S
 
         if probe_openai_chat_completions_support_sync(
@@ -122,6 +128,21 @@ class BackendFormatResolver:
             format=BackendFormat.OPENAI,
             reason="all probes failed; assuming Chat Completions",
         )
+
+
+def _model_is_gemini(model: str | None) -> bool:
+    """Return True if the model ID unambiguously identifies a native Gemini model.
+
+    Matches bare ``gemini<…>`` and ``models/gemini<…>`` IDs only — the naming
+    the Gemini API itself uses. Gateway-namespaced IDs like
+    ``google/gemini-…`` are intentionally NOT matched: OpenAI-compatible
+    gateways (e.g. OpenRouter) serve Gemini models over Chat Completions, so
+    probing is preferred over assuming the native generateContent format.
+    """
+    if not model:
+        return False
+    m = model.lower()
+    return m.startswith("gemini") or m.startswith("models/gemini")
 
 
 def _model_is_anthropic(model: str | None) -> bool:

--- a/switchyard/lib/backends/gemini_native_llm_backend.py
+++ b/switchyard/lib/backends/gemini_native_llm_backend.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rust-owned Gemini-native backend export."""
+
+from switchyard_rust.components import GeminiNativeBackend
+
+__all__ = ["GeminiNativeBackend"]

--- a/switchyard/lib/backends/multi_llm_backend.py
+++ b/switchyard/lib/backends/multi_llm_backend.py
@@ -19,6 +19,7 @@ from switchyard.lib.backends.llm_target import (
 from switchyard.lib.roles import LLMBackend
 from switchyard_rust.components import (
     AnthropicNativeBackend,
+    GeminiNativeBackend,
     LlmTargetBackend,
     MultiLlmBackend,
     OpenAiNativeBackend,
@@ -49,6 +50,8 @@ def build_native_backend(target: LlmTarget) -> LLMBackend:
         return OpenAiNativeBackend(target)
     if target.format == BackendFormat.ANTHROPIC:
         return AnthropicNativeBackend(target)
+    if target.format == BackendFormat.GEMINI:
+        return GeminiNativeBackend(target)
     raise ValueError(f"Unsupported backend format: {target.format!r}")
 
 

--- a/switchyard/lib/chat_request/__init__.py
+++ b/switchyard/lib/chat_request/__init__.py
@@ -5,6 +5,7 @@
 
 from switchyard.lib.chat_request.anthropic import AnthropicChatRequest
 from switchyard.lib.chat_request.base import ChatRequest, ChatRequestType
+from switchyard.lib.chat_request.gemini import GeminiChatRequest
 from switchyard.lib.chat_request.openai_chat import OpenAIChatRequest
 from switchyard.lib.chat_request.openai_responses import ResponsesChatRequest
 
@@ -12,6 +13,7 @@ __all__ = [
     "AnthropicChatRequest",
     "ChatRequest",
     "ChatRequestType",
+    "GeminiChatRequest",
     "OpenAIChatRequest",
     "ResponsesChatRequest",
 ]

--- a/switchyard/lib/chat_request/gemini.py
+++ b/switchyard/lib/chat_request/gemini.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemini generateContent request compatibility alias."""
+
+from typing import TypeAlias
+
+from switchyard_rust.core import ChatRequest as _ChatRequest
+
+GeminiChatRequest: TypeAlias = _ChatRequest
+
+__all__ = ["GeminiChatRequest"]

--- a/switchyard/lib/chat_response/__init__.py
+++ b/switchyard/lib/chat_response/__init__.py
@@ -8,6 +8,11 @@ from switchyard.lib.chat_response.anthropic import (
     AnthropicResponseStream,
     AnthropicStreamingChatResponse,
 )
+from switchyard.lib.chat_response.gemini import (
+    GeminiChatResponse,
+    GeminiResponseStream,
+    GeminiStreamingChatResponse,
+)
 from switchyard.lib.chat_response.openai_chat import (
     CompletionChatResponse,
     ResponseStream,
@@ -31,6 +36,9 @@ __all__ = [
     "ChatResponseStream",
     "ChatResponseType",
     "CompletionChatResponse",
+    "GeminiChatResponse",
+    "GeminiResponseStream",
+    "GeminiStreamingChatResponse",
     "ResponsesApiChatResponse",
     "ResponsesApiStream",
     "ResponsesApiStreamingChatResponse",

--- a/switchyard/lib/chat_response/gemini.py
+++ b/switchyard/lib/chat_response/gemini.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemini generateContent stream adapter re-export."""
+
+from typing import TypeAlias
+
+from switchyard_rust.core import ChatResponse as _ChatResponse
+from switchyard_rust.core import ChatResponseStream as _ChatResponseStream
+
+GeminiChatResponse: TypeAlias = _ChatResponse
+GeminiStreamingChatResponse: TypeAlias = _ChatResponse
+GeminiResponseStream: TypeAlias = _ChatResponseStream
+
+__all__ = [
+    "GeminiChatResponse",
+    "GeminiResponseStream",
+    "GeminiStreamingChatResponse",
+]

--- a/switchyard/lib/endpoints/__init__.py
+++ b/switchyard/lib/endpoints/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from switchyard.lib.endpoints.anthropic_messages_endpoint import (
         AnthropicMessagesEndpoint,
     )
+    from switchyard.lib.endpoints.gemini_endpoint import GeminiEndpoint
     from switchyard.lib.endpoints.models_endpoint import ModelsEndpoint
     from switchyard.lib.endpoints.openai_chat_endpoint import (
         OpenAIChatEndpoint,
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 __all__ = [
     "StatsEndpoint",
     "AnthropicMessagesEndpoint",
+    "GeminiEndpoint",
     "ModelsEndpoint",
     "OpenAIChatEndpoint",
     "ResponsesEndpoint",
@@ -39,6 +41,9 @@ def __getattr__(name: str) -> Any:
             AnthropicMessagesEndpoint,
         )
         return AnthropicMessagesEndpoint
+    elif name == "GeminiEndpoint":
+        from switchyard.lib.endpoints.gemini_endpoint import GeminiEndpoint
+        return GeminiEndpoint
     elif name == "OpenAIChatEndpoint":
         from switchyard.lib.endpoints.openai_chat_endpoint import (
             OpenAIChatEndpoint,

--- a/switchyard/lib/endpoints/gemini_endpoint.py
+++ b/switchyard/lib/endpoints/gemini_endpoint.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP endpoint serving a ``Switchyard`` as Gemini ``generateContent``.
+
+Paper-thin by design: wrap the raw JSON body in a Rust-backed Gemini request,
+run the chain, serialize the result. All Gemini ↔ OpenAI/Anthropic format
+conversion lives inside the chain (``TranslationEngine``), so the endpoint
+itself contains zero translation logic.
+
+Unlike the other inbound formats, Gemini encodes the model and the streaming
+choice in the URL rather than the body:
+
+- ``POST /v1beta/models/{model}:generateContent`` — buffered JSON response.
+- ``POST /v1beta/models/{model}:streamGenerateContent`` — SSE stream of
+  ``GenerateContentResponse`` chunks (clients append ``?alt=sse``).
+
+Both values are injected into the wrapped body as synthetic ``model`` and
+``stream`` fields; the Gemini codec and backend understand that convention
+and move them back into the upstream URL.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Body, FastAPI, Request
+from fastapi.responses import Response
+
+from switchyard.lib.endpoints.base import Endpoint as NemoSwitchyardEndpoint
+from switchyard.lib.endpoints.dispatch import dispatch_chat_request, serialize_chain_result
+from switchyard.lib.endpoints.sse_helpers import iter_gemini_sse
+from switchyard.lib.endpoints.upstream_error import (
+    context_exhausted_response,
+    handle_chain_exception,
+)
+from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.request_metadata import (
+    RequestMetadata,
+    attach_caller_api_key,
+    attach_request_metadata,
+)
+from switchyard_rust.core import (
+    ChatRequest,
+    SwitchyardContextPoolExhaustedError,
+    SwitchyardContextWindowExceededError,
+)
+
+log = logging.getLogger(__name__)
+
+
+class GeminiEndpoint(NemoSwitchyardEndpoint):
+    """Composable endpoint that exposes Gemini ``generateContent`` routes."""
+
+    def register(self, app: FastAPI) -> None:
+        """Attach the Gemini ``generateContent`` routes onto *app*."""
+        router = APIRouter()
+
+        @router.post("/v1beta/models/{model}:generateContent", response_model=None)
+        async def gemini_generate_content(
+            model: str,
+            request: Request,
+            body: Annotated[dict[str, Any], Body(...)],
+        ) -> Response:
+            return await _handle(request, model, body, stream=False)
+
+        @router.post("/v1beta/models/{model}:streamGenerateContent", response_model=None)
+        async def gemini_stream_generate_content(
+            model: str,
+            request: Request,
+            body: Annotated[dict[str, Any], Body(...)],
+        ) -> Response:
+            return await _handle(request, model, body, stream=True)
+
+        async def _handle(
+            request: Request,
+            model: str,
+            body: dict[str, Any],
+            *,
+            stream: bool,
+        ) -> Response:
+            obj = request.app.state.switchyard
+            log.debug(
+                "POST /v1beta/models/%s:%s keys=%s",
+                model,
+                "streamGenerateContent" if stream else "generateContent",
+                list(body.keys()),
+            )
+            # The URL carries what other formats put in the body; the codec
+            # and backend expect both as synthetic body fields.
+            body["model"] = model
+            body["stream"] = stream
+            ctx = ProxyContext()
+            attach_request_metadata(
+                ctx,
+                RequestMetadata.from_headers(request.headers),
+                request.headers,
+            )
+            attach_caller_api_key(ctx, request.headers)
+
+            chat_request = ChatRequest.gemini(body)
+            # Reject semantically invalid input (e.g. empty contents) at the
+            # inbound boundary; raises SwitchyardInvalidRequestError -> 400.
+            chat_request.validate()
+
+            try:
+                result: Any = await dispatch_chat_request(obj, chat_request, ctx)
+                if not isinstance(result, Response):
+                    log.debug(
+                        "Gemini generateContent chain returned model=%s stream=%s result=%s",
+                        model,
+                        stream,
+                        type(result).__name__,
+                    )
+                return serialize_chain_result(result, stream=stream, sse_iter=iter_gemini_sse)
+            except (SwitchyardContextPoolExhaustedError, SwitchyardContextWindowExceededError) as exc:
+                return context_exhausted_response(exc, inbound="gemini")
+            except Exception as exc:
+                return handle_chain_exception(
+                    exc,
+                    ctx,
+                    inbound="gemini",
+                    log_msg=f"Gemini generateContent chain raised model={model}",
+                )
+
+        app.include_router(router, tags=["Gemini Compatible"])

--- a/switchyard/lib/endpoints/sse_helpers.py
+++ b/switchyard/lib/endpoints/sse_helpers.py
@@ -159,6 +159,44 @@ async def iter_anthropic_sse(
         await _aclose_stream(events)
 
 
+async def iter_gemini_sse(
+    chunks: AsyncIterator[Mapping[str, object]],
+) -> AsyncGenerator[str, None]:
+    """Frame Gemini stream chunks into unnamed ``data: <json>\\n\\n`` lines.
+
+    Gemini's ``streamGenerateContent?alt=sse`` contract carries one complete
+    ``GenerateContentResponse`` JSON object per ``data:`` line, with no named
+    events and no ``[DONE]`` terminator — the final chunk is recognizable by
+    its ``finishReason`` and ``usageMetadata``.
+
+    Mid-stream iteration failures emit a final ``data:`` frame carrying a
+    Gemini-shaped ``{"error": {...}}`` payload and terminate — same error
+    quarantine pattern as :func:`iter_chat_completion_sse`.
+
+    Args:
+        chunks: Async iterator of Gemini chunk dicts.
+
+    Yields:
+        SSE-framed strings suitable for ``StreamingResponse``.
+    """
+    try:
+        async for chunk in chunks:
+            chunk_dict = dict(chunk) if isinstance(chunk, Mapping) else {"data": str(chunk)}
+            yield f"data: {json.dumps(chunk_dict)}\n\n"
+    except Exception as e:
+        log.error("Error during gemini streaming: %s: %s", type(e).__name__, e)
+        error_data = {
+            "error": {
+                "code": 500,
+                "message": repr(e)[:200],
+                "status": "INTERNAL",
+            }
+        }
+        yield f"data: {json.dumps(error_data)}\n\n"
+    finally:
+        await _aclose_stream(chunks)
+
+
 async def iter_preframed_sse(
     frames: AsyncIterator[object],
 ) -> AsyncGenerator[str, None]:

--- a/switchyard/lib/endpoints/upstream_error.py
+++ b/switchyard/lib/endpoints/upstream_error.py
@@ -37,7 +37,7 @@ from switchyard_rust.core import SwitchyardUpstreamError
 if TYPE_CHECKING:
     from switchyard.lib.proxy_context import ProxyContext
 
-Inbound = Literal["anthropic", "openai", "openai-responses"]
+Inbound = Literal["anthropic", "openai", "openai-responses", "gemini"]
 
 _log = logging.getLogger(__name__)
 

--- a/switchyard/lib/processors/format_translate.py
+++ b/switchyard/lib/processors/format_translate.py
@@ -302,6 +302,8 @@ def _target_request_type_for_backend_format(
     * OpenAI Chat inbound remains OpenAI Chat.
     * Responses-capable targets preserve OpenAI Responses instead of
       normalizing through Chat.
+    * Gemini inbound remains Gemini, preserving native generateContent
+      fields instead of translating them away.
     """
     if backend_format == BackendFormat.OPENAI:
         return ChatRequestType.OPENAI_CHAT

--- a/switchyard/lib/processors/format_translate.py
+++ b/switchyard/lib/processors/format_translate.py
@@ -223,6 +223,8 @@ class FormatTranslateResponseProcessor:
                 response,
                 original_body=_original_body(ctx),
             )
+        if request_type_value(original) == request_type_value(ChatRequestType.GEMINI):
+            return TranslationEngine().response_to(ChatRequestType.GEMINI, response)
         raise NotImplementedError(
             f"Unsupported original format for response translation: {original!r}",
         )
@@ -252,6 +254,8 @@ def _request_for_original_format(
         return request_with_type(original, cast("MessageCreateParamsBase", body))
     if request_type_value(original) == request_type_value(ChatRequestType.OPENAI_RESPONSES):
         return request_with_type(original, cast("ResponseCreateParamsBase", body))
+    if request_type_value(original) == request_type_value(ChatRequestType.GEMINI):
+        return request_with_type(original, body)
     raise NotImplementedError(f"Unsupported original format: {original!r}")
 
 
@@ -305,8 +309,12 @@ def _target_request_type_for_backend_format(
         return ChatRequestType.OPENAI_RESPONSES
     if backend_format == BackendFormat.ANTHROPIC:
         return ChatRequestType.ANTHROPIC
+    if backend_format == BackendFormat.GEMINI:
+        return ChatRequestType.GEMINI
     if backend_format == BackendFormat.AUTO:
         if request_type_matches(request, ChatRequestType.ANTHROPIC):
             return ChatRequestType.ANTHROPIC
+        if request_type_matches(request, ChatRequestType.GEMINI):
+            return ChatRequestType.GEMINI
         return ChatRequestType.OPENAI_CHAT
     raise ValueError(f"Unsupported backend_format: {backend_format!r}")

--- a/switchyard/server/server_util.py
+++ b/switchyard/server/server_util.py
@@ -91,7 +91,7 @@ def add_transport_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         choices=[f.value for f in InboundFormat],
-        help="Inbound API format: openai, anthropic, or both",
+        help="Inbound API format: openai, anthropic, gemini, or both",
     )
     parser.add_argument("--reload", action="store_true", help="Enable auto-reload")
 

--- a/switchyard/server/server_util.py
+++ b/switchyard/server/server_util.py
@@ -35,6 +35,7 @@ class InboundFormat(Enum):
     """Inbound wire format accepted by the proxy."""
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
+    GEMINI = "gemini"
     BOTH = "both"
 
 

--- a/switchyard/server/switchyard_app.py
+++ b/switchyard/server/switchyard_app.py
@@ -3,10 +3,10 @@
 
 """Convenience factory for serving a ``Switchyard`` or model table.
 
-The default setup registers all three inbound endpoints so the app
-can serve OpenAI Chat Completions, Anthropic Messages, and OpenAI
-Responses API clients simultaneously — the chain handles format
-translation internally.
+The default setup registers all four inbound endpoints so the app
+can serve OpenAI Chat Completions, Anthropic Messages, OpenAI
+Responses API, and Gemini generateContent clients simultaneously —
+the chain handles format translation internally.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ from switchyard.lib.endpoints.anthropic_messages_endpoint import (
 )
 from switchyard.lib.endpoints.base import Endpoint
 from switchyard.lib.endpoints.dispatch import invalid_request_response
+from switchyard.lib.endpoints.gemini_endpoint import GeminiEndpoint
 from switchyard.lib.endpoints.models_endpoint import ModelsEndpoint
 from switchyard.lib.endpoints.openai_chat_endpoint import (
     OpenAIChatEndpoint,
@@ -45,6 +46,14 @@ _LLM_ROUTES: frozenset[str] = frozenset({
     "/v1/messages",
     "/v1/responses",
 })
+
+#: Gemini routes carry the model in the path, so they match by prefix.
+_GEMINI_ROUTE_PREFIX = "/v1beta/models/"
+
+
+def _is_llm_route(path: str) -> bool:
+    """Return whether *path* serves LLM traffic (exact or Gemini-templated)."""
+    return path in _LLM_ROUTES or path.startswith(_GEMINI_ROUTE_PREFIX)
 
 if TYPE_CHECKING:
     from switchyard.lib.route_table import SwitchyardApp
@@ -67,15 +76,17 @@ async def _shutdown_components(components: Iterable[object]) -> None:
 def build_switchyard_app(switchyard: SwitchyardApp) -> FastAPI:
     """Create a FastAPI app serving *switchyard* over all inbound formats.
 
-    Registers three LLM endpoints plus a liveness probe:
+    Registers four LLM endpoints plus a liveness probe:
 
     - ``POST /v1/chat/completions`` (OpenAI Chat Completions)
     - ``POST /v1/messages``         (Anthropic Messages)
     - ``POST /v1/responses``        (OpenAI Responses API)
+    - ``POST /v1beta/models/{model}:generateContent`` (Gemini, plus
+      ``:streamGenerateContent`` for SSE)
     - ``GET  /v1/models``           (local model discovery)
     - ``GET  /health``              (liveness — always 200 when the process is up)
 
-    All three LLM routes go through the same chain — translation
+    All LLM routes go through the same chain — translation
     between wire formats is handled by ``TranslationEngine``
     inside the backend and ``TranslationEngine`` inside the
     translator.
@@ -124,7 +135,7 @@ def build_switchyard_app(switchyard: SwitchyardApp) -> FastAPI:
         body parameter. Non-LLM routes and non-body errors fall through to
         FastAPI's default 422 handler.
         """
-        if request.url.path in _LLM_ROUTES:
+        if _is_llm_route(request.url.path):
             body_errors = [e for e in exc.errors() if e.get("loc", (None,))[0] == "body"]
             if body_errors:
                 is_json_parse = any(e["type"] == "json_invalid" for e in body_errors)
@@ -161,7 +172,7 @@ def build_switchyard_app(switchyard: SwitchyardApp) -> FastAPI:
         upstream-error passthrough, internal exception, model-not-found).
         """
         response = await call_next(request)
-        if request.url.path in _LLM_ROUTES:
+        if _is_llm_route(request.url.path):
             outcome_metrics.record_client_response(response.status_code)
         return response
 
@@ -173,6 +184,7 @@ def build_switchyard_app(switchyard: SwitchyardApp) -> FastAPI:
         OpenAIChatEndpoint(),
         AnthropicMessagesEndpoint(),
         ResponsesEndpoint(),
+        GeminiEndpoint(),
         ModelsEndpoint(),
     ]:
         endpoint.register(app)

--- a/switchyard_rust/components.py
+++ b/switchyard_rust/components.py
@@ -17,6 +17,7 @@ _COMPONENT_EXPORTS = frozenset(
         "DimensionCollector",
         "DimensionScore",
         "EndpointConfig",
+        "GeminiNativeBackend",
         "IntakeQueueFullPolicy",
         "IntakeRequestMetadata",
         "IntakeRequestProcessor",
@@ -53,6 +54,7 @@ if TYPE_CHECKING:
     DimensionCollector: type[Any]
     DimensionScore: type[Any]
     EndpointConfig: type[Any]
+    GeminiNativeBackend: type[Any]
     IntakeQueueFullPolicy: type[Any]
     IntakeRequestMetadata: type[Any]
     IntakeRequestProcessor: type[Any]

--- a/switchyard_rust/components.pyi
+++ b/switchyard_rust/components.pyi
@@ -17,6 +17,7 @@ class BackendFormat:
     OPENAI: ClassVar[BackendFormat]
     RESPONSES: ClassVar[BackendFormat]
     ANTHROPIC: ClassVar[BackendFormat]
+    GEMINI: ClassVar[BackendFormat]
 
     value: str
 
@@ -227,6 +228,12 @@ class OpenAiPassthroughBackend(LLMBackend):
 
 
 class AnthropicNativeBackend(LLMBackend):
+    target: LlmTarget
+
+    def __init__(self, target: LlmTarget) -> None: ...
+
+
+class GeminiNativeBackend(LLMBackend):
     target: LlmTarget
 
     def __init__(self, target: LlmTarget) -> None: ...

--- a/switchyard_rust/core.py
+++ b/switchyard_rust/core.py
@@ -22,6 +22,7 @@ class _ChatRequestType(Protocol):
     OPENAI_CHAT: ClassVar[_ChatRequestType]
     OPENAI_RESPONSES: ClassVar[_ChatRequestType]
     ANTHROPIC: ClassVar[_ChatRequestType]
+    GEMINI: ClassVar[_ChatRequestType]
 
     value: str
 
@@ -42,6 +43,9 @@ class _ChatRequest(Protocol):
     @classmethod
     def anthropic(cls, body: Mapping[str, Any] | JsonValue) -> _ChatRequest: ...
 
+    @classmethod
+    def gemini(cls, body: Mapping[str, Any] | JsonValue) -> _ChatRequest: ...
+
     def set_model(self, model: str) -> None: ...
     def replace_body(self, body: Mapping[str, Any] | JsonValue) -> None: ...
     def to_body(self) -> JsonValue: ...
@@ -56,6 +60,8 @@ class _ChatResponseType(Protocol):
     OPENAI_RESPONSES_STREAM: ClassVar[_ChatResponseType]
     ANTHROPIC_COMPLETION: ClassVar[_ChatResponseType]
     ANTHROPIC_STREAM: ClassVar[_ChatResponseType]
+    GEMINI_COMPLETION: ClassVar[_ChatResponseType]
+    GEMINI_STREAM: ClassVar[_ChatResponseType]
 
     value: str
 
@@ -86,6 +92,12 @@ class _ChatResponse(Protocol):
 
     @classmethod
     def anthropic_stream(cls, stream: object) -> _ChatResponse: ...
+
+    @classmethod
+    def gemini_completion(cls, body: Mapping[str, Any] | JsonValue | object) -> _ChatResponse: ...
+
+    @classmethod
+    def gemini_stream(cls, stream: object) -> _ChatResponse: ...
 
     def replace_body(self, body: Mapping[str, Any] | JsonValue | object) -> None: ...
     def to_body(self) -> JsonValue: ...
@@ -466,6 +478,7 @@ if TYPE_CHECKING:
         OPENAI_CHAT: ClassVar[ChatRequestType]
         OPENAI_RESPONSES: ClassVar[ChatRequestType]
         ANTHROPIC: ClassVar[ChatRequestType]
+        GEMINI: ClassVar[ChatRequestType]
         value: str
 
     class ChatRequest:
@@ -481,6 +494,8 @@ if TYPE_CHECKING:
         def openai_responses(cls, body: Mapping[str, Any] | JsonValue) -> ChatRequest: ...
         @classmethod
         def anthropic(cls, body: Mapping[str, Any] | JsonValue) -> ChatRequest: ...
+        @classmethod
+        def gemini(cls, body: Mapping[str, Any] | JsonValue) -> ChatRequest: ...
         def validate(self) -> None: ...
         def set_model(self, model: str) -> None: ...
         def replace_body(self, body: Mapping[str, Any] | JsonValue) -> None: ...
@@ -495,6 +510,8 @@ if TYPE_CHECKING:
         OPENAI_RESPONSES_STREAM: ClassVar[ChatResponseType]
         ANTHROPIC_COMPLETION: ClassVar[ChatResponseType]
         ANTHROPIC_STREAM: ClassVar[ChatResponseType]
+        GEMINI_COMPLETION: ClassVar[ChatResponseType]
+        GEMINI_STREAM: ClassVar[ChatResponseType]
         value: str
 
     class ChatResponse:
@@ -525,6 +542,13 @@ if TYPE_CHECKING:
         ) -> ChatResponse: ...
         @classmethod
         def anthropic_stream(cls, stream: object) -> ChatResponse: ...
+        @classmethod
+        def gemini_completion(
+            cls,
+            body: Mapping[str, Any] | JsonValue | object,
+        ) -> ChatResponse: ...
+        @classmethod
+        def gemini_stream(cls, stream: object) -> ChatResponse: ...
         def replace_body(self, body: Mapping[str, Any] | JsonValue | object) -> None: ...
         def to_body(self) -> JsonValue: ...
 
@@ -665,7 +689,9 @@ def request_type_value(value: object) -> str:
         raise TypeError(f"Request type must be a string-like value, got {type(raw).__name__}")
     if raw == "anthropic_messages":
         return "anthropic"
-    if raw in {"openai_chat", "openai_responses", "anthropic"}:
+    if raw == "gemini_generate_content":
+        return "gemini"
+    if raw in {"openai_chat", "openai_responses", "anthropic", "gemini"}:
         return raw
     raise ValueError(f"Unknown request type: {value!r}")
 
@@ -680,6 +706,8 @@ def request_type_enum(value: object) -> _ChatRequestType:
         return request_type.OPENAI_RESPONSES
     if normalized == "anthropic":
         return request_type.ANTHROPIC
+    if normalized == "gemini":
+        return request_type.GEMINI
     raise ValueError(f"Unknown request type: {value!r}")
 
 
@@ -698,6 +726,8 @@ def request_with_type(request_type: object, body: Mapping[str, Any] | JsonValue)
         return cast("ChatRequest", chat_request.openai_responses(body))
     if normalized == "anthropic":
         return cast("ChatRequest", chat_request.anthropic(body))
+    if normalized == "gemini":
+        return cast("ChatRequest", chat_request.gemini(body))
     raise ValueError(f"Unknown request type: {request_type!r}")
 
 
@@ -720,6 +750,8 @@ def response_type_value(value: object) -> str:
         "openai_responses_stream",
         "anthropic_completion",
         "anthropic_stream",
+        "gemini_completion",
+        "gemini_stream",
     }:
         return raw
     raise ValueError(f"Unknown response type: {value!r}")
@@ -741,6 +773,10 @@ def response_type_enum(value: object) -> _ChatResponseType:
         return response_type.ANTHROPIC_COMPLETION
     if normalized == "anthropic_stream":
         return response_type.ANTHROPIC_STREAM
+    if normalized == "gemini_completion":
+        return response_type.GEMINI_COMPLETION
+    if normalized == "gemini_stream":
+        return response_type.GEMINI_STREAM
     raise ValueError(f"Unknown response type: {value!r}")
 
 
@@ -768,6 +804,10 @@ def response_with_type(
         return cast("ChatResponse", chat_response.anthropic_completion(body_or_stream))
     if normalized == "anthropic_stream":
         return cast("ChatResponse", chat_response.anthropic_stream(body_or_stream))
+    if normalized == "gemini_completion":
+        return cast("ChatResponse", chat_response.gemini_completion(body_or_stream))
+    if normalized == "gemini_stream":
+        return cast("ChatResponse", chat_response.gemini_stream(body_or_stream))
     raise ValueError(f"Unknown response type: {response_type!r}")
 
 
@@ -786,6 +826,8 @@ def response_type_for_request_type(
         )
     if normalized == "anthropic":
         return response_type_enum("anthropic_stream" if stream else "anthropic_completion")
+    if normalized == "gemini":
+        return response_type_enum("gemini_stream" if stream else "gemini_completion")
     raise ValueError(f"Unknown request type: {request_type!r}")
 
 
@@ -805,6 +847,8 @@ def response_matches_request_type(
         }
     if request_type_normalized == "anthropic":
         return response_type in {"anthropic_completion", "anthropic_stream"}
+    if request_type_normalized == "gemini":
+        return response_type in {"gemini_completion", "gemini_stream"}
     raise ValueError(f"Unknown request type: {request_type!r}")
 
 

--- a/switchyard_rust/translation.py
+++ b/switchyard_rust/translation.py
@@ -57,7 +57,9 @@ class _NativeModule(Protocol):
 
 
 _T = TypeVar("_T")
-_NativeFormat = Literal["openai_chat", "openai_responses", "anthropic_messages"]
+_NativeFormat = Literal[
+    "openai_chat", "openai_responses", "anthropic_messages", "gemini_generate_content"
+]
 _StreamOutput = Literal["objects", "chat_chunks", "responses_sse"]
 _native: _NativeModule | None = None
 _log = logging.getLogger(__name__)
@@ -288,7 +290,14 @@ def _format_name(value: str | ChatRequestType) -> _NativeFormat:
     raw = value.value if hasattr(value, "value") else str(value)
     if raw == "anthropic":
         raw = "anthropic_messages"
-    if raw in {"openai_chat", "openai_responses", "anthropic_messages"}:
+    if raw == "gemini":
+        raw = "gemini_generate_content"
+    if raw in {
+        "openai_chat",
+        "openai_responses",
+        "anthropic_messages",
+        "gemini_generate_content",
+    }:
         return cast(_NativeFormat, raw)
     raise ValueError(f"Unknown translation format: {value!r}")
 
@@ -314,6 +323,8 @@ def _response_format(response: ChatResponse) -> _NativeFormat:
         return "openai_responses"
     if response_type in {"anthropic_completion", "anthropic_stream"}:
         return "anthropic_messages"
+    if response_type in {"gemini_completion", "gemini_stream"}:
+        return "gemini_generate_content"
     raise NotImplementedError(
         f"Response translation not implemented for {type(response).__name__}"
     )
@@ -328,6 +339,8 @@ def _wrap_request(format_name: _NativeFormat, body: dict[str, Any]) -> ChatReque
         return request_with_type("openai_responses", body)
     if format_name == "anthropic_messages":
         return request_with_type("anthropic", body)
+    if format_name == "gemini_generate_content":
+        return request_with_type("gemini", body)
     raise ValueError(f"Unknown request format: {format_name!r}")
 
 
@@ -340,6 +353,8 @@ def _wrap_response(format_name: _NativeFormat, body: dict[str, Any]) -> ChatResp
         return ChatResponse.openai_responses_completion(body)
     if format_name == "anthropic_messages":
         return ChatResponse.anthropic_completion(body)
+    if format_name == "gemini_generate_content":
+        return ChatResponse.gemini_completion(body)
     raise ValueError(f"Unknown response format: {format_name!r}")
 
 
@@ -348,6 +363,7 @@ def _wrap_streaming_response(
     stream: AsyncIterable[Any],
 ) -> ChatResponse:
     from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
+    from switchyard.lib.chat_response.gemini import GeminiResponseStream
     from switchyard.lib.chat_response.openai_chat import ResponseStream
     from switchyard.lib.chat_response.openai_responses import ResponsesApiStream
     from switchyard_rust.core import ChatResponse
@@ -358,6 +374,8 @@ def _wrap_streaming_response(
         return ChatResponse.openai_responses_stream(ResponsesApiStream(cast(Any, stream)))
     if format_name == "anthropic_messages":
         return ChatResponse.anthropic_stream(AnthropicResponseStream(cast(Any, stream)))
+    if format_name == "gemini_generate_content":
+        return ChatResponse.gemini_stream(GeminiResponseStream(cast(Any, stream)))
     raise ValueError(f"Unknown streaming response format: {format_name!r}")
 
 

--- a/tests/contract/test_request_response_types.py
+++ b/tests/contract/test_request_response_types.py
@@ -17,6 +17,7 @@ import pytest
 
 from switchyard.lib.chat_request.anthropic import AnthropicChatRequest
 from switchyard.lib.chat_request.base import ChatRequest
+from switchyard.lib.chat_request.gemini import GeminiChatRequest
 from switchyard.lib.chat_request.openai_chat import OpenAIChatRequest
 from switchyard.lib.chat_request.openai_responses import ResponsesChatRequest
 from switchyard_rust.core import ChatRequestType, request_type_matches
@@ -38,6 +39,11 @@ ANTHROPIC_BODY = {
     "model": "claude-3-haiku",
     "messages": [{"role": "user", "content": "ping"}],
     "max_tokens": 16,
+}
+
+GEMINI_BODY = {
+    "model": "gemini-2.5-flash",
+    "contents": [{"role": "user", "parts": [{"text": "ping"}]}],
 }
 
 
@@ -62,6 +68,13 @@ REQUEST_CASES: list[tuple[str, RequestAlias, RequestFactory, object, dict]] = [
         ChatRequest.anthropic,
         ChatRequestType.ANTHROPIC,
         ANTHROPIC_BODY,
+    ),
+    (
+        "GeminiChatRequest",
+        GeminiChatRequest,
+        ChatRequest.gemini,
+        ChatRequestType.GEMINI,
+        GEMINI_BODY,
     ),
 ]
 

--- a/tests/test_backend_format_resolver.py
+++ b/tests/test_backend_format_resolver.py
@@ -87,6 +87,63 @@ def test_auto_model_prefix_anthropic_skips_probes(
 
 
 @pytest.mark.parametrize("model", [
+    "gemini-2.5-flash",
+    "gemini-3-pro-preview",
+    "models/gemini-2.5-pro",
+])
+def test_auto_model_prefix_gemini_skips_probes(
+    monkeypatch: pytest.MonkeyPatch, model: str
+) -> None:
+    """Bare gemini and models/gemini IDs → GEMINI without probing."""
+    monkeypatch.setattr(resolver_mod, "probe_openai_chat_completions_support_sync",
+                        _no_probe("chat-completions"))
+    monkeypatch.setattr(resolver_mod, "probe_anthropic_messages_support_sync",
+                        _no_probe("anthropic"))
+    monkeypatch.setattr(resolver_mod, "probe_openai_responses_support_sync",
+                        _no_probe("responses"))
+
+    resolution = resolver_mod.BackendFormatResolver.resolve(
+        LlmTarget(
+            model=model,
+            format=BackendFormat.AUTO,
+            base_url="https://generativelanguage.googleapis.com",
+            api_key="AIza-test",  # pragma: allowlist secret
+        ),
+    )
+
+    assert resolution.format is BackendFormat.GEMINI
+    assert "prefix" in resolution.reason
+
+
+@pytest.mark.parametrize("model", [
+    "google/gemini-2.5-flash",
+    "openrouter/google/gemini-2.5-pro",
+])
+def test_auto_gateway_gemini_model_probes_chat_completions_first(
+    monkeypatch: pytest.MonkeyPatch, model: str
+) -> None:
+    """Gateway-namespaced Gemini models are NOT fast-pathed; probing runs."""
+    chat_probe = _RecordingProbe(result=True)
+    monkeypatch.setattr(resolver_mod, "probe_openai_chat_completions_support_sync", chat_probe)
+    monkeypatch.setattr(resolver_mod, "probe_anthropic_messages_support_sync",
+                        _no_probe("anthropic"))
+    monkeypatch.setattr(resolver_mod, "probe_openai_responses_support_sync",
+                        _no_probe("responses"))
+
+    resolution = resolver_mod.BackendFormatResolver.resolve(
+        LlmTarget(
+            model=model,
+            format=BackendFormat.AUTO,
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-test",  # pragma: allowlist secret
+        ),
+    )
+
+    assert resolution.format is BackendFormat.OPENAI
+    assert len(chat_probe.calls) == 1
+
+
+@pytest.mark.parametrize("model", [
     "openrouter/anthropic/claude-3-5-sonnet",
     "aws/anthropic/bedrock-claude-opus-4-7",
 ])

--- a/tests/test_gemini_endpoint.py
+++ b/tests/test_gemini_endpoint.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Gemini generateContent FastAPI endpoint."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from switchyard.server.switchyard_app import build_switchyard_app
+from switchyard_rust.core import ChatRequest
+
+
+class _RecordingSwitchyard:
+    """Fake chain that records requests and replays a canned Gemini result."""
+
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.requests: list[ChatRequest] = []
+
+    async def call(self, request: ChatRequest, *, ctx: object | None = None) -> Any:
+        self.requests.append(request)
+        return self.result
+
+
+def _gemini_result() -> dict[str, Any]:
+    return {
+        "candidates": [{
+            "content": {"parts": [{"text": "OK"}], "role": "model"},
+            "finishReason": "STOP",
+            "index": 0,
+        }],
+        "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+        "modelVersion": "gemini-2.5-flash",
+        "responseId": "resp-1",
+    }
+
+
+def test_generate_content_route_injects_model_and_dispatches() -> None:
+    switchyard = _RecordingSwitchyard(_gemini_result())
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            json={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["candidates"][0]["content"]["parts"][0]["text"] == "OK"
+    request = switchyard.requests[0]
+    assert request.request_type.value == "gemini"
+    assert request.model == "gemini-2.5-flash"
+    assert request.body["stream"] is False
+
+
+def test_stream_generate_content_frames_chunks_as_sse() -> None:
+    async def chunks() -> AsyncIterator[dict[str, Any]]:
+        yield {"candidates": [{"content": {"parts": [{"text": "Hel"}], "role": "model"}}]}
+        yield {
+            "candidates": [{
+                "content": {"parts": [{"text": "lo"}], "role": "model"},
+                "finishReason": "STOP",
+            }],
+        }
+
+    switchyard = _RecordingSwitchyard(chunks())
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+            json={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = [
+        json.loads(line[len("data: "):])
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    text = "".join(
+        part.get("text", "")
+        for frame in frames
+        for part in frame["candidates"][0].get("content", {}).get("parts", [])
+    )
+    assert text == "Hello"
+    # Gemini streams end without a [DONE] sentinel.
+    assert "[DONE]" not in response.text
+    assert switchyard.requests[0].body["stream"] is True
+
+
+def test_empty_contents_is_rejected_with_400() -> None:
+    switchyard = _RecordingSwitchyard(_gemini_result())
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            json={"contents": []},
+        )
+
+    assert response.status_code == 400
+    assert switchyard.requests == []
+
+
+def test_unknown_action_verb_is_not_routed() -> None:
+    switchyard = _RecordingSwitchyard(_gemini_result())
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:countTokens",
+            json={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+        )
+
+    assert response.status_code == 404
+    assert switchyard.requests == []
+
+
+def test_malformed_json_body_maps_to_invalid_body_envelope() -> None:
+    switchyard = _RecordingSwitchyard(_gemini_result())
+    app = build_switchyard_app(switchyard)  # type: ignore[arg-type]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            content=b"{not json",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_body"

--- a/tests/test_gemini_native_llm_backend.py
+++ b/tests/test_gemini_native_llm_backend.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python binding tests for the Rust-owned Gemini native backend."""
+
+from __future__ import annotations
+
+import pytest
+
+from switchyard.lib.backends.multi_llm_backend import build_native_backend
+from switchyard_rust.components import BackendFormat, GeminiNativeBackend, LlmTarget
+from switchyard_rust.core import ChatRequestType
+
+
+def _gemini_target(**overrides: object) -> LlmTarget:
+    data: dict[str, object] = {
+        "id": "gemini",
+        "model": "gemini-2.5-flash",
+        "format": BackendFormat.GEMINI,
+        "base_url": "https://generativelanguage.googleapis.com",
+        "api_key": "AIza-test",
+        "timeout_secs": 12.5,
+    }
+    data.update(overrides)
+    return LlmTarget(**data)
+
+
+def test_constructs_from_resolved_gemini_target() -> None:
+    target = _gemini_target()
+
+    backend = GeminiNativeBackend(target)
+
+    assert backend.target == target
+    assert backend.target.endpoint.base_url == "https://generativelanguage.googleapis.com"
+    assert backend.target.endpoint.api_key == "AIza-test"
+    assert backend.target.endpoint.timeout_secs == 12.5
+
+
+def test_supported_request_types_is_gemini_only() -> None:
+    backend = GeminiNativeBackend(_gemini_target())
+
+    assert backend.supported_request_types == [ChatRequestType.GEMINI]
+
+
+@pytest.mark.parametrize(
+    "target_format",
+    [BackendFormat.OPENAI, BackendFormat.ANTHROPIC, BackendFormat.AUTO, "openai", "auto"],
+)
+def test_rejects_unresolved_or_non_gemini_target_format(target_format: object) -> None:
+    with pytest.raises(RuntimeError, match="resolved Gemini format"):
+        GeminiNativeBackend(_gemini_target(format=target_format))
+
+
+def test_build_native_backend_selects_gemini_binding() -> None:
+    backend = build_native_backend(_gemini_target())
+
+    assert isinstance(backend, GeminiNativeBackend)
+
+
+def test_target_is_immutable_after_binding_construction() -> None:
+    target = _gemini_target()
+    backend = GeminiNativeBackend(target)
+
+    with pytest.raises(AttributeError):
+        backend.target.model = "mutated"
+    assert backend.target.model == "gemini-2.5-flash"
+
+
+def test_request_types_are_value_objects_not_strings() -> None:
+    request_type = GeminiNativeBackend(_gemini_target()).supported_request_types[0]
+
+    assert request_type is ChatRequestType.GEMINI
+    assert request_type.value == "gemini"
+    assert not isinstance(request_type, str)

--- a/tests/test_gemini_native_llm_backend.py
+++ b/tests/test_gemini_native_llm_backend.py
@@ -18,7 +18,7 @@ def _gemini_target(**overrides: object) -> LlmTarget:
         "model": "gemini-2.5-flash",
         "format": BackendFormat.GEMINI,
         "base_url": "https://generativelanguage.googleapis.com",
-        "api_key": "AIza-test",
+        "api_key": "AIza-test",  # pragma: allowlist secret
         "timeout_secs": 12.5,
     }
     data.update(overrides)
@@ -32,7 +32,7 @@ def test_constructs_from_resolved_gemini_target() -> None:
 
     assert backend.target == target
     assert backend.target.endpoint.base_url == "https://generativelanguage.googleapis.com"
-    assert backend.target.endpoint.api_key == "AIza-test"
+    assert backend.target.endpoint.api_key == "AIza-test"  # pragma: allowlist secret
     assert backend.target.endpoint.timeout_secs == 12.5
 
 

--- a/tests/test_gemini_openai_translation.py
+++ b/tests/test_gemini_openai_translation.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Gemini generateContent translation to and from OpenAI Chat."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from switchyard_rust.translation import TranslationEngine
+
+ENGINE = TranslationEngine()
+
+
+def _translate_openai_request_to_gemini(**kwargs: Any) -> dict[str, Any]:
+    return ENGINE.translate_request("openai_chat", "gemini", kwargs)
+
+
+def _translate_gemini_request_to_openai(**kwargs: Any) -> dict[str, Any]:
+    return ENGINE.translate_request("gemini", "openai_chat", kwargs)
+
+
+def test_openai_system_and_user_map_to_system_instruction_and_contents():
+    result = _translate_openai_request_to_gemini(
+        model="gemini-2.5-flash",
+        messages=[
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+    )
+    assert result["systemInstruction"]["parts"][0]["text"] == "You are helpful."
+    assert result["contents"] == [{"role": "user", "parts": [{"text": "Hello"}]}]
+    assert result["model"] == "gemini-2.5-flash"
+
+
+def test_openai_sampling_and_stop_map_to_generation_config():
+    result = _translate_openai_request_to_gemini(
+        model="m",
+        messages=[{"role": "user", "content": "Hi"}],
+        max_tokens=256,
+        temperature=0.4,
+        top_p=0.9,
+        stop=["END"],
+        stream=True,
+    )
+    generation = result["generationConfig"]
+    assert generation["maxOutputTokens"] == 256
+    assert generation["temperature"] == 0.4
+    assert generation["topP"] == 0.9
+    assert generation["stopSequences"] == ["END"]
+    assert result["stream"] is True
+
+
+def test_openai_tools_are_sanitized_for_gemini_schema_subset():
+    result = _translate_openai_request_to_gemini(
+        model="m",
+        messages=[{"role": "user", "content": "Hi"}],
+        tools=[{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "path": {"type": "string", "default": "/tmp"},
+                        "limit": {"type": ["integer", "null"], "exclusiveMinimum": 0},
+                    },
+                    "required": ["path"],
+                },
+            },
+        }],
+        tool_choice="required",
+    )
+    declaration = result["tools"][0]["functionDeclarations"][0]
+    parameters = declaration["parameters"]
+    assert declaration["name"] == "read_file"
+    assert parameters["type"] == "OBJECT"
+    assert "$schema" not in parameters
+    assert "additionalProperties" not in parameters
+    assert parameters["properties"]["path"]["type"] == "STRING"
+    assert "default" not in parameters["properties"]["path"]
+    assert parameters["properties"]["limit"]["type"] == "INTEGER"
+    assert parameters["properties"]["limit"]["nullable"] is True
+    assert result["toolConfig"]["functionCallingConfig"]["mode"] == "ANY"
+
+
+def test_openai_tool_results_become_function_responses():
+    result = _translate_openai_request_to_gemini(
+        model="m",
+        messages=[
+            {"role": "user", "content": "Weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "22C sunny"},
+        ],
+    )
+    model_parts = result["contents"][1]["parts"]
+    assert model_parts[0]["functionCall"] == {"name": "get_weather", "args": {"city": "Paris"}}
+    response_part = result["contents"][2]["parts"][0]["functionResponse"]
+    assert response_part["name"] == "get_weather"
+    assert response_part["response"]["parts"][0]["text"] == "22C sunny"
+
+
+def test_gemini_request_maps_roles_tools_and_generation_config():
+    result = _translate_gemini_request_to_openai(
+        model="gemini-2.5-flash",
+        stream=True,
+        systemInstruction={"parts": [{"text": "Be terse."}]},
+        contents=[
+            {"role": "user", "parts": [{"text": "Hello"}]},
+            {"role": "model", "parts": [{"text": "Hi there"}]},
+        ],
+        tools=[{
+            "functionDeclarations": [{
+                "name": "run",
+                "parameters": {"type": "OBJECT", "properties": {"cmd": {"type": "STRING"}}},
+            }],
+        }],
+        toolConfig={"functionCallingConfig": {"mode": "AUTO"}},
+        generationConfig={"maxOutputTokens": 128, "temperature": 0.2, "stopSequences": ["END"]},
+    )
+    roles = [m["role"] for m in result["messages"]]
+    assert roles == ["system", "user", "assistant"]
+    assert result["model"] == "gemini-2.5-flash"
+    assert result["stream"] is True
+    assert result["max_completion_tokens"] == 128
+    assert result["temperature"] == 0.2
+    assert result["stop"] == ["END"]
+    assert result["tool_choice"] == "auto"
+    # Gemini's uppercase schema types are restored to JSON Schema form.
+    parameters = result["tools"][0]["function"]["parameters"]
+    assert parameters["type"] == "object"
+    assert parameters["properties"]["cmd"]["type"] == "string"
+
+
+def test_gemini_function_call_pairs_with_response_by_name_and_order():
+    result = _translate_gemini_request_to_openai(
+        contents=[
+            {"role": "user", "parts": [{"text": "Weather?"}]},
+            {"role": "model", "parts": [
+                {"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}},
+            ]},
+            {"role": "user", "parts": [
+                {"functionResponse": {"name": "get_weather", "response": {"result": "22C"}}},
+            ]},
+        ],
+    )
+    tool_calls = result["messages"][1]["tool_calls"]
+    tool_message = result["messages"][2]
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert tool_message["role"] == "tool"
+    assert tool_message["tool_call_id"] == tool_calls[0]["id"]
+
+
+def test_gemini_response_translates_to_openai_completion():
+    result = ENGINE.translate_response(
+        "gemini",
+        "openai_chat",
+        {
+            "candidates": [{
+                "content": {"parts": [{"text": "OK"}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 6,
+                "candidatesTokenCount": 1,
+                "thoughtsTokenCount": 20,
+                "totalTokenCount": 27,
+            },
+            "modelVersion": "gemini-2.5-flash",
+            "responseId": "resp-1",
+        },
+    )
+    choice = result["choices"][0]
+    assert choice["message"]["content"] == "OK"
+    assert choice["finish_reason"] == "stop"
+    # Thinking tokens fold into completion tokens.
+    assert result["usage"]["prompt_tokens"] == 6
+    assert result["usage"]["completion_tokens"] == 21
+    assert result["model"] == "gemini-2.5-flash"
+
+
+def test_gemini_function_call_response_maps_to_tool_calls_finish_reason():
+    result = ENGINE.translate_response(
+        "gemini",
+        "openai_chat",
+        {
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "functionCall": {"name": "get_weather", "args": {"city": "Paris"}},
+                    }],
+                    "role": "model",
+                },
+                # Gemini reports STOP even for function-call turns.
+                "finishReason": "STOP",
+            }],
+        },
+    )
+    choice = result["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_call = choice["message"]["tool_calls"][0]
+    assert tool_call["function"]["name"] == "get_weather"
+
+
+def test_openai_completion_translates_to_gemini_response():
+    result = ENGINE.translate_response(
+        "openai_chat",
+        "gemini",
+        {
+            "id": "chatcmpl-1",
+            "model": "gpt-4o-mini",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        },
+    )
+    candidate = result["candidates"][0]
+    assert candidate["content"]["parts"] == [{"text": "Hello"}]
+    assert candidate["content"]["role"] == "model"
+    assert candidate["finishReason"] == "STOP"
+    assert result["usageMetadata"]["promptTokenCount"] == 4
+    assert result["usageMetadata"]["candidatesTokenCount"] == 2
+    assert result["responseId"] == "chatcmpl-1"
+
+
+def test_gemini_max_tokens_finish_reason_maps_to_length():
+    result = ENGINE.translate_response(
+        "gemini",
+        "openai_chat",
+        {
+            "candidates": [{
+                "content": {"parts": [{"text": "truncat"}], "role": "model"},
+                "finishReason": "MAX_TOKENS",
+            }],
+        },
+    )
+    assert result["choices"][0]["finish_reason"] == "length"
+
+
+def test_gemini_thought_parts_do_not_leak_into_openai_content():
+    result = ENGINE.translate_response(
+        "gemini",
+        "openai_chat",
+        {
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {"text": "private planning", "thought": True},
+                        {"text": "Public answer"},
+                    ],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }],
+        },
+    )
+    content = result["choices"][0]["message"]["content"]
+    assert "private planning" not in content
+    assert "Public answer" in content
+
+
+async def _collect(stream: AsyncIterator[Any]) -> list[Any]:
+    return [event async for event in stream]
+
+
+async def _iter_events(events: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    for event in events:
+        yield event
+
+
+async def test_gemini_stream_translates_to_openai_chunks():
+    chunks = await _collect(
+        ENGINE.translate_stream(
+            "gemini",
+            "openai_chat",
+            _iter_events([
+                {
+                    "candidates": [{"content": {"parts": [{"text": "Hel"}], "role": "model"}}],
+                    "responseId": "r1",
+                    "modelVersion": "gemini-2.5-flash",
+                },
+                {
+                    "candidates": [{
+                        "content": {"parts": [{"text": "lo"}], "role": "model"},
+                        "finishReason": "STOP",
+                    }],
+                    "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 2},
+                },
+            ]),
+        )
+    )
+    text = "".join(chunk["choices"][0]["delta"].get("content") or "" for chunk in chunks)
+    assert text == "Hello"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+async def test_openai_stream_translates_to_gemini_chunks():
+    chunks = await _collect(
+        ENGINE.translate_stream(
+            "openai_chat",
+            "gemini",
+            _iter_events([
+                {
+                    "id": "chatcmpl-1",
+                    "model": "gpt-4o-mini",
+                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hi"}}],
+                },
+                {
+                    "id": "chatcmpl-1",
+                    "model": "gpt-4o-mini",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+                },
+            ]),
+        )
+    )
+    parts = [
+        part
+        for chunk in chunks
+        for part in chunk.get("candidates", [{}])[0].get("content", {}).get("parts", [])
+    ]
+    assert {"text": "Hi"} in parts
+    final = chunks[-1]["candidates"][0]
+    assert final["finishReason"] == "STOP"
+    assert chunks[-1]["usageMetadata"]["promptTokenCount"] == 3

--- a/tests/test_random_routing_llm_backend.py
+++ b/tests/test_random_routing_llm_backend.py
@@ -169,6 +169,7 @@ class TestMultiLlmBackendConstruction:
             "openai_chat",
             "openai_responses",
             "anthropic",
+            "gemini",
         ]
 
     def test_mapping_keys_fill_default_target_ids(self) -> None:

--- a/tests/test_routellm_llm_backend.py
+++ b/tests/test_routellm_llm_backend.py
@@ -64,6 +64,7 @@ def test_profile_builds_multi_llm_backend_without_stats() -> None:
         "openai_chat",
         "openai_responses",
         "anthropic",
+        "gemini",
     ]
 
 
@@ -81,6 +82,7 @@ def test_profile_wraps_multi_llm_backend_with_stats_when_enabled() -> None:
         "openai_chat",
         "openai_responses",
         "anthropic",
+        "gemini",
     ]
 
 

--- a/tests/test_switchyard_rust_core_bindings.py
+++ b/tests/test_switchyard_rust_core_bindings.py
@@ -47,6 +47,7 @@ def test_openai_chat_request_owns_body_and_exposes_model() -> None:
 def test_request_constructors_preserve_wire_format() -> None:
     responses = ChatRequest.openai_responses({"model": "gpt-4o", "input": "hello"})
     anthropic = ChatRequest.anthropic({"model": "claude-sonnet-4.5", "messages": []})
+    gemini = ChatRequest.gemini({"model": "gemini-2.5-flash", "contents": [{}]})
 
     assert responses.request_type == ChatRequestType.OPENAI_RESPONSES
     assert responses.request_type.value == "openai_responses"
@@ -54,6 +55,9 @@ def test_request_constructors_preserve_wire_format() -> None:
     assert anthropic.request_type == ChatRequestType.ANTHROPIC
     assert anthropic.request_type.value == "anthropic"
     assert anthropic.model == "claude-sonnet-4.5"
+    assert gemini.request_type == ChatRequestType.GEMINI
+    assert gemini.request_type.value == "gemini"
+    assert gemini.model == "gemini-2.5-flash"
 
 
 def test_set_model_mutates_rust_owned_body() -> None:
@@ -124,11 +128,18 @@ def test_response_constructors_preserve_wire_shape() -> None:
         "model": "claude-sonnet-4.5",
         "content": [],
     })
+    gemini = ChatResponse.gemini_completion({
+        "candidates": [],
+        "modelVersion": "gemini-2.5-flash",
+        "responseId": "resp-test",
+    })
 
     assert responses.response_type == ChatResponseType.OPENAI_RESPONSES_COMPLETION
     assert responses.response_type.value == "openai_responses_completion"
     assert anthropic.response_type == ChatResponseType.ANTHROPIC_COMPLETION
     assert anthropic.response_type.value == "anthropic_completion"
+    assert gemini.response_type == ChatResponseType.GEMINI_COMPLETION
+    assert gemini.response_type.value == "gemini_completion"
 
 
 async def test_stream_response_uses_rust_owned_async_stream_and_rejects_body_access() -> None:

--- a/tests/test_translation_engine_chaos.py
+++ b/tests/test_translation_engine_chaos.py
@@ -365,7 +365,9 @@ class TestRequestEngineEdgeCases:
 
     def test_anthropic_tool_result_with_structured_content(self, req_engine):
         """tool_result where content is a list of blocks (text + image)
-        should flatten text parts and JSON-serialize non-text blocks.
+        should flatten text parts; image attachments have no OpenAI tool
+        message representation and are dropped rather than leaked as
+        stringified base64 prompt text.
         """
         body = {
             "model": "claude-sonnet-4-20250514",
@@ -398,8 +400,8 @@ class TestRequestEngineEdgeCases:
         assert len(tool_msgs) == 1
         # Text is preserved
         assert "Temperature: 72F" in tool_msgs[0]["content"]
-        # Non-text block is JSON-serialized, not dropped
-        assert "image" in tool_msgs[0]["content"]
+        # The image payload must not leak into prompt text
+        assert "iVBORw" not in tool_msgs[0]["content"]
 
     def test_anthropic_content_list_with_non_dict_items(self, req_engine):
         """Content blocks that are not dicts (e.g. raw strings in the list)

--- a/tests/test_translation_matrix.py
+++ b/tests/test_translation_matrix.py
@@ -1,0 +1,911 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-format translation matrix: every source format to every target.
+
+Each scenario builds semantically equivalent request/response/stream payloads
+per wire format, translates them across every (source, target) pair, and
+asserts marker survival plus target-specific structural invariants. Markers
+are unique strings (and a distinctive base64 payload for attachments), so the
+assertions hold regardless of how a target codec arranges the content.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from switchyard_rust.translation import TranslationEngine
+
+ENGINE = TranslationEngine()
+
+OPENAI = "openai_chat"
+ANTHROPIC = "anthropic_messages"
+GEMINI = "gemini"
+FORMATS = [OPENAI, ANTHROPIC, GEMINI]
+
+SYSTEM_MARKER = "SYSTEM_MARKER_be_terse"
+TURN1_MARKER = "TURN1_MARKER_first_question"
+REPLY_MARKER = "REPLY_MARKER_assistant_answer"
+TURN2_MARKER = "TURN2_MARKER_follow_up"
+RESULT_MARKER = "RESULT_MARKER_22C_sunny"
+# base64 of "image_bytes_marker" — a distinctive payload to trace attachments.
+IMAGE_B64 = "aW1hZ2VfYnl0ZXNfbWFya2Vy"
+PDF_B64 = "cGRmX2J5dGVzX21hcmtlcg=="
+TOOL_NAME = "get_weather"
+TOOL_ARG_VALUE = "Paris"
+
+
+def translate(source: str, target: str, body: dict[str, Any]) -> dict[str, Any]:
+    return ENGINE.translate_request(source, target, body)
+
+
+def dumps(body: dict[str, Any]) -> str:
+    return json.dumps(body)
+
+
+def assert_structurally_valid(target: str, body: dict[str, Any]) -> None:
+    """Spot-check the encoded body satisfies the target API's hard rules."""
+    if target == OPENAI:
+        roles = {m["role"] for m in body["messages"]}
+        assert roles <= {"system", "developer", "user", "assistant", "tool"}
+        for message in body["messages"]:
+            if message["role"] == "tool":
+                assert message.get("tool_call_id"), "tool message must correlate to a call"
+    elif target == ANTHROPIC:
+        assert "max_tokens" in body
+        for message in body["messages"]:
+            assert message["role"] in {"user", "assistant"}
+    elif target == GEMINI:
+        for content in body["contents"]:
+            assert content["role"] in {"user", "model"}
+            assert content["parts"], "Gemini rejects empty parts arrays"
+
+
+# ---------------------------------------------------------------------------
+# Request scenarios
+# ---------------------------------------------------------------------------
+
+
+def _openai_image_part(data: str = IMAGE_B64) -> dict[str, Any]:
+    return {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{data}"}}
+
+
+def _anthropic_image_block(data: str = IMAGE_B64) -> dict[str, Any]:
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": data},
+    }
+
+
+def _gemini_image_part(data: str = IMAGE_B64) -> dict[str, Any]:
+    return {"inlineData": {"mimeType": "image/png", "data": data}}
+
+
+def text_system_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "model": "m",
+            "messages": [
+                {"role": "system", "content": SYSTEM_MARKER},
+                {"role": "user", "content": TURN1_MARKER},
+                {"role": "assistant", "content": REPLY_MARKER},
+                {"role": "user", "content": TURN2_MARKER},
+            ],
+        },
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "system": SYSTEM_MARKER,
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {"role": "assistant", "content": REPLY_MARKER},
+                {"role": "user", "content": TURN2_MARKER},
+            ],
+        },
+        GEMINI: {
+            "model": "m",
+            "systemInstruction": {"parts": [{"text": SYSTEM_MARKER}]},
+            "contents": [
+                {"role": "user", "parts": [{"text": TURN1_MARKER}]},
+                {"role": "model", "parts": [{"text": REPLY_MARKER}]},
+                {"role": "user", "parts": [{"text": TURN2_MARKER}]},
+            ],
+        },
+    }
+
+
+def image_start_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "model": "m",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    _openai_image_part(),
+                    {"type": "text", "text": TURN1_MARKER},
+                ],
+            }],
+        },
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    _anthropic_image_block(),
+                    {"type": "text", "text": TURN1_MARKER},
+                ],
+            }],
+        },
+        GEMINI: {
+            "model": "m",
+            "contents": [{
+                "role": "user",
+                "parts": [_gemini_image_part(), {"text": TURN1_MARKER}],
+            }],
+        },
+    }
+
+
+def image_mid_conversation_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {"role": "assistant", "content": REPLY_MARKER},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": TURN2_MARKER},
+                        _openai_image_part(),
+                    ],
+                },
+            ],
+        },
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {"role": "assistant", "content": REPLY_MARKER},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": TURN2_MARKER},
+                        _anthropic_image_block(),
+                    ],
+                },
+            ],
+        },
+        GEMINI: {
+            "model": "m",
+            "contents": [
+                {"role": "user", "parts": [{"text": TURN1_MARKER}]},
+                {"role": "model", "parts": [{"text": REPLY_MARKER}]},
+                {
+                    "role": "user",
+                    "parts": [{"text": TURN2_MARKER}, _gemini_image_part()],
+                },
+            ],
+        },
+    }
+
+
+def _openai_tools() -> list[dict[str, Any]]:
+    return [{
+        "type": "function",
+        "function": {
+            "name": TOOL_NAME,
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }]
+
+
+def tools_round_trip_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": TOOL_NAME,
+                            "arguments": json.dumps({"city": TOOL_ARG_VALUE}),
+                        },
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": RESULT_MARKER},
+                {"role": "user", "content": TURN2_MARKER},
+            ],
+            "tools": _openai_tools(),
+        },
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": TOOL_NAME,
+                        "input": {"city": TOOL_ARG_VALUE},
+                    }],
+                },
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": RESULT_MARKER,
+                    }],
+                },
+                {"role": "user", "content": TURN2_MARKER},
+            ],
+            "tools": [{
+                "name": TOOL_NAME,
+                "description": "Get weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }],
+        },
+        GEMINI: {
+            "model": "m",
+            "contents": [
+                {"role": "user", "parts": [{"text": TURN1_MARKER}]},
+                {
+                    "role": "model",
+                    "parts": [{
+                        "functionCall": {"name": TOOL_NAME, "args": {"city": TOOL_ARG_VALUE}},
+                    }],
+                },
+                {
+                    "role": "user",
+                    "parts": [{
+                        "functionResponse": {
+                            "name": TOOL_NAME,
+                            "response": {"parts": [{"text": RESULT_MARKER}]},
+                        },
+                    }],
+                },
+                {"role": "user", "parts": [{"text": TURN2_MARKER}]},
+            ],
+            "tools": [{
+                "functionDeclarations": [{
+                    "name": TOOL_NAME,
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {"city": {"type": "STRING"}},
+                        "required": ["city"],
+                    },
+                }],
+            }],
+        },
+    }
+
+
+def tool_result_image_bodies() -> dict[str, dict[str, Any]]:
+    """Tool results carrying an image attachment (screenshot-style tools).
+
+    OpenAI has no wire shape for this, so it only appears as a source for
+    Anthropic and Gemini.
+    """
+    return {
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "messages": [
+                {"role": "user", "content": TURN1_MARKER},
+                {
+                    "role": "assistant",
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "take_screenshot",
+                        "input": {},
+                    }],
+                },
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": [
+                            {"type": "text", "text": RESULT_MARKER},
+                            _anthropic_image_block(),
+                        ],
+                    }],
+                },
+            ],
+        },
+        GEMINI: {
+            "model": "m",
+            "contents": [
+                {"role": "user", "parts": [{"text": TURN1_MARKER}]},
+                {
+                    "role": "model",
+                    "parts": [{"functionCall": {"name": "take_screenshot", "args": {}}}],
+                },
+                {
+                    "role": "user",
+                    "parts": [{
+                        "functionResponse": {
+                            "name": "take_screenshot",
+                            "response": {"parts": [
+                                {"text": RESULT_MARKER},
+                                _gemini_image_part(),
+                            ]},
+                        },
+                    }],
+                },
+            ],
+        },
+    }
+
+
+def pdf_attachment_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        ANTHROPIC: {
+            "model": "m",
+            "max_tokens": 256,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": TURN1_MARKER},
+                    {
+                        "type": "document",
+                        "source": {"type": "base64", "data": PDF_B64},
+                    },
+                ],
+            }],
+        },
+        GEMINI: {
+            "model": "m",
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": TURN1_MARKER},
+                    {"inlineData": {"mimeType": "application/pdf", "data": PDF_B64}},
+                ],
+            }],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Request matrix tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_text_and_system_survive_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, text_system_bodies()[source])
+    encoded = dumps(body)
+    for marker in (SYSTEM_MARKER, TURN1_MARKER, REPLY_MARKER, TURN2_MARKER):
+        assert marker in encoded, f"{marker} lost translating {source} -> {target}"
+    assert_structurally_valid(target, body)
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_image_at_conversation_start_survives_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, image_start_bodies()[source])
+    encoded = dumps(body)
+    assert TURN1_MARKER in encoded
+    assert IMAGE_B64 in encoded, f"image payload lost translating {source} -> {target}"
+    assert_structurally_valid(target, body)
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_image_mid_conversation_survives_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, image_mid_conversation_bodies()[source])
+    encoded = dumps(body)
+    for marker in (TURN1_MARKER, REPLY_MARKER, TURN2_MARKER):
+        assert marker in encoded
+    assert IMAGE_B64 in encoded, f"mid-conversation image lost {source} -> {target}"
+    # The image must stay attached to the final user turn, not migrate.
+    if target == OPENAI:
+        assert IMAGE_B64 in dumps(body["messages"][-1])
+    elif target == ANTHROPIC:
+        assert IMAGE_B64 in dumps(body["messages"][-1])
+    elif target == GEMINI:
+        assert IMAGE_B64 in dumps(body["contents"][-1])
+    assert_structurally_valid(target, body)
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_tool_round_trip_survives_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, tools_round_trip_bodies()[source])
+    encoded = dumps(body)
+    assert TOOL_NAME in encoded, f"tool declaration/call lost {source} -> {target}"
+    assert TOOL_ARG_VALUE in encoded, f"tool arguments lost {source} -> {target}"
+    assert RESULT_MARKER in encoded, f"tool result lost {source} -> {target}"
+    assert TURN2_MARKER in encoded
+    assert_structurally_valid(target, body)
+    # Call/result correlation must hold in the target's own idiom.
+    if target == OPENAI:
+        calls = [
+            call
+            for message in body["messages"]
+            for call in message.get("tool_calls") or []
+        ]
+        results = [m for m in body["messages"] if m["role"] == "tool"]
+        assert calls and results
+        assert results[0]["tool_call_id"] == calls[0]["id"]
+    elif target == ANTHROPIC:
+        uses = [
+            block
+            for message in body["messages"]
+            if isinstance(message["content"], list)
+            for block in message["content"]
+            if block.get("type") == "tool_use"
+        ]
+        results = [
+            block
+            for message in body["messages"]
+            if isinstance(message["content"], list)
+            for block in message["content"]
+            if block.get("type") == "tool_result"
+        ]
+        assert uses and results
+        assert results[0]["tool_use_id"] == uses[0]["id"]
+    elif target == GEMINI:
+        calls = [
+            part["functionCall"]
+            for content in body["contents"]
+            for part in content["parts"]
+            if "functionCall" in part
+        ]
+        responses = [
+            part["functionResponse"]
+            for content in body["contents"]
+            for part in content["parts"]
+            if "functionResponse" in part
+        ]
+        assert calls and responses
+        assert responses[0]["name"] == calls[0]["name"]
+
+
+@pytest.mark.parametrize("source", [ANTHROPIC, GEMINI])
+@pytest.mark.parametrize("target", FORMATS)
+def test_tool_result_image_attachment_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, tool_result_image_bodies()[source])
+    encoded = dumps(body)
+    assert RESULT_MARKER in encoded, f"tool result text lost {source} -> {target}"
+    assert IMAGE_B64 in encoded, f"tool-result image lost {source} -> {target}"
+    if target == OPENAI:
+        # OpenAI tool messages are text-only: the payload must not be
+        # stringified into the tool message; it is hoisted into a following
+        # user message where vision models can read it.
+        tool_messages = [m for m in body["messages"] if m["role"] == "tool"]
+        assert tool_messages
+        assert all(IMAGE_B64 not in dumps(m) for m in tool_messages)
+        tool_index = body["messages"].index(tool_messages[-1])
+        hoisted = body["messages"][tool_index + 1]
+        assert hoisted["role"] == "user"
+        assert IMAGE_B64 in dumps(hoisted)
+    if target == ANTHROPIC:
+        result_blocks = [
+            block
+            for message in body["messages"]
+            if isinstance(message["content"], list)
+            for block in message["content"]
+            if block.get("type") == "tool_result"
+        ]
+        assert any(
+            isinstance(block.get("content"), list)
+            and any(entry.get("type") == "image" for entry in block["content"])
+            for block in result_blocks
+        ), "tool-result image must be a typed image block, not stringified JSON"
+    if target == GEMINI and source != GEMINI:
+        # Hoisted to a sibling part of the same user turn: Gemini does not
+        # read media nested inside the functionResponse payload. Same-format
+        # traffic is preserved verbatim, so this only applies to translations.
+        result_contents = [
+            content
+            for content in body["contents"]
+            if any("functionResponse" in part for part in content["parts"])
+        ]
+        assert result_contents
+        assert any(
+            "inlineData" in part
+            for content in result_contents
+            for part in content["parts"]
+        ), "tool-result image must be a sibling inlineData part"
+    assert_structurally_valid(target, body)
+
+
+@pytest.mark.parametrize("source", [ANTHROPIC, GEMINI])
+@pytest.mark.parametrize("target", FORMATS)
+def test_pdf_attachment_every_pair(source: str, target: str) -> None:
+    body = translate(source, target, pdf_attachment_bodies()[source])
+    encoded = dumps(body)
+    assert TURN1_MARKER in encoded
+    assert PDF_B64 in encoded, f"document payload lost {source} -> {target}"
+    assert_structurally_valid(target, body)
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("intermediate", FORMATS)
+def test_two_hop_translation_preserves_content(source: str, intermediate: str) -> None:
+    """source -> intermediate -> source keeps text, images, and tool traffic."""
+    first = translate(source, intermediate, tools_round_trip_bodies()[source])
+    back = translate(intermediate, source, first)
+    encoded = dumps(back)
+    for marker in (TOOL_NAME, TOOL_ARG_VALUE, RESULT_MARKER, TURN2_MARKER):
+        assert marker in encoded, f"{marker} lost on {source} -> {intermediate} -> {source}"
+    assert_structurally_valid(source, back)
+
+    first = translate(source, intermediate, image_mid_conversation_bodies()[source])
+    back = translate(intermediate, source, first)
+    assert IMAGE_B64 in dumps(back), f"image lost on {source} -> {intermediate} -> {source}"
+
+
+# ---------------------------------------------------------------------------
+# Response matrix
+# ---------------------------------------------------------------------------
+
+RESPONSE_TEXT_MARKER = "RESPONSE_TEXT_MARKER_final_answer"
+
+
+def text_response_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "id": "chatcmpl-1",
+            "model": "m",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": RESPONSE_TEXT_MARKER},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+        },
+        ANTHROPIC: {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "m",
+            "content": [{"type": "text", "text": RESPONSE_TEXT_MARKER}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 11, "output_tokens": 7},
+        },
+        GEMINI: {
+            "candidates": [{
+                "content": {"parts": [{"text": RESPONSE_TEXT_MARKER}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 11,
+                "candidatesTokenCount": 7,
+                "totalTokenCount": 18,
+            },
+            "modelVersion": "m",
+            "responseId": "resp-1",
+        },
+    }
+
+
+def tool_call_response_bodies() -> dict[str, dict[str, Any]]:
+    return {
+        OPENAI: {
+            "id": "chatcmpl-1",
+            "model": "m",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": TOOL_NAME,
+                            "arguments": json.dumps({"city": TOOL_ARG_VALUE}),
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        },
+        ANTHROPIC: {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "m",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": TOOL_NAME,
+                "input": {"city": TOOL_ARG_VALUE},
+            }],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 5, "output_tokens": 3},
+        },
+        GEMINI: {
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "functionCall": {"name": TOOL_NAME, "args": {"city": TOOL_ARG_VALUE}},
+                    }],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }],
+        },
+    }
+
+
+TOOLISH_STOP = {OPENAI: "tool_calls", ANTHROPIC: "tool_use", GEMINI: "STOP"}
+
+
+def response_stop_value(target: str, body: dict[str, Any]) -> str:
+    if target == OPENAI:
+        return str(body["choices"][0]["finish_reason"])
+    if target == ANTHROPIC:
+        return str(body["stop_reason"])
+    return str(body["candidates"][0]["finishReason"])
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_text_response_translates_every_pair(source: str, target: str) -> None:
+    body = ENGINE.translate_response(source, target, text_response_bodies()[source])
+    assert RESPONSE_TEXT_MARKER in dumps(body)
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_tool_call_response_translates_every_pair(source: str, target: str) -> None:
+    body = ENGINE.translate_response(source, target, tool_call_response_bodies()[source])
+    encoded = dumps(body)
+    assert TOOL_NAME in encoded
+    assert TOOL_ARG_VALUE in encoded
+    assert response_stop_value(target, body) == TOOLISH_STOP[target], (
+        f"tool-call stop reason wrong for {source} -> {target}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming matrix
+# ---------------------------------------------------------------------------
+
+
+def text_stream_events() -> dict[str, list[dict[str, Any]]]:
+    return {
+        OPENAI: [
+            {
+                "id": "chatcmpl-1",
+                "model": "m",
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hel"}}],
+            },
+            {
+                "id": "chatcmpl-1",
+                "model": "m",
+                "choices": [{"index": 0, "delta": {"content": "lo"}, "finish_reason": "stop"}],
+            },
+        ],
+        ANTHROPIC: [
+            {"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {}}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hel"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "lo"},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 2},
+            },
+            {"type": "message_stop"},
+        ],
+        GEMINI: [
+            {
+                "candidates": [{"content": {"parts": [{"text": "Hel"}], "role": "model"}}],
+                "responseId": "resp-1",
+                "modelVersion": "m",
+            },
+            {
+                "candidates": [{
+                    "content": {"parts": [{"text": "lo"}], "role": "model"},
+                    "finishReason": "STOP",
+                }],
+                "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 2},
+            },
+        ],
+    }
+
+
+def tool_stream_events() -> dict[str, list[dict[str, Any]]]:
+    arguments = json.dumps({"city": TOOL_ARG_VALUE})
+    return {
+        OPENAI: [
+            {
+                "id": "chatcmpl-1",
+                "model": "m",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": TOOL_NAME, "arguments": arguments[:9]},
+                    }]},
+                }],
+            },
+            {
+                "id": "chatcmpl-1",
+                "model": "m",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": [{
+                        "index": 0,
+                        "function": {"arguments": arguments[9:]},
+                    }]},
+                }],
+            },
+            {
+                "id": "chatcmpl-1",
+                "model": "m",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            },
+        ],
+        ANTHROPIC: [
+            {"type": "message_start", "message": {"id": "msg_1", "model": "m", "usage": {}}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_1", "name": TOOL_NAME, "input": {}},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": arguments[:9]},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": arguments[9:]},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use"},
+                "usage": {"output_tokens": 4},
+            },
+            {"type": "message_stop"},
+        ],
+        GEMINI: [
+            {
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "functionCall": {"name": TOOL_NAME, "args": {"city": TOOL_ARG_VALUE}},
+                        }],
+                        "role": "model",
+                    },
+                    "finishReason": "STOP",
+                }],
+                "responseId": "resp-1",
+                "modelVersion": "m",
+            },
+        ],
+    }
+
+
+def run_stream(source: str, target: str, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    from switchyard_rust.translation import _format_name
+
+    translator = ENGINE._inner.stream(_format_name(source), _format_name(target), None, None)
+    out: list[dict[str, Any]] = []
+    for event in events:
+        out.extend(translator.translate_event(event))
+    out.extend(translator.finish())
+    return out
+
+
+def stream_text(target: str, events: list[dict[str, Any]]) -> str:
+    if target == OPENAI:
+        return "".join(
+            (event.get("choices") or [{}])[0].get("delta", {}).get("content") or ""
+            for event in events
+        )
+    if target == ANTHROPIC:
+        return "".join(
+            event.get("delta", {}).get("text", "")
+            for event in events
+            if event.get("type") == "content_block_delta"
+        )
+    return "".join(
+        part.get("text", "")
+        for event in events
+        for part in ((event.get("candidates") or [{}])[0].get("content") or {}).get("parts", [])
+        if not part.get("thought")
+    )
+
+
+def stream_tool_calls(target: str, events: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    """Returns (name, joined argument json) pairs reconstructed from a stream."""
+    if target == OPENAI:
+        name = ""
+        arguments = ""
+        for event in events:
+            for call in (event.get("choices") or [{}])[0].get("delta", {}).get("tool_calls") or []:
+                name = call.get("function", {}).get("name") or name
+                arguments += call.get("function", {}).get("arguments") or ""
+        return [(name, arguments)] if name else []
+    if target == ANTHROPIC:
+        name = ""
+        arguments = ""
+        for event in events:
+            if event.get("type") == "content_block_start":
+                block = event.get("content_block", {})
+                if block.get("type") == "tool_use":
+                    name = block.get("name", "")
+            if event.get("type") == "content_block_delta":
+                delta = event.get("delta", {})
+                if delta.get("type") == "input_json_delta":
+                    arguments += delta.get("partial_json", "")
+        return [(name, arguments)] if name else []
+    calls = []
+    for event in events:
+        for part in ((event.get("candidates") or [{}])[0].get("content") or {}).get("parts", []):
+            if "functionCall" in part:
+                call = part["functionCall"]
+                calls.append((call.get("name", ""), json.dumps(call.get("args", {}))))
+    return calls
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_text_stream_translates_every_pair(source: str, target: str) -> None:
+    if source == target:
+        pytest.skip("same-format streams pass through endpoints untranslated")
+    events = run_stream(source, target, text_stream_events()[source])
+    assert stream_text(target, events) == "Hello", f"stream text lost {source} -> {target}"
+
+
+@pytest.mark.parametrize("source", FORMATS)
+@pytest.mark.parametrize("target", FORMATS)
+def test_tool_stream_translates_every_pair(source: str, target: str) -> None:
+    if source == target:
+        pytest.skip("same-format streams pass through endpoints untranslated")
+    events = run_stream(source, target, tool_stream_events()[source])
+    calls = stream_tool_calls(target, events)
+    assert calls, f"tool call lost in stream {source} -> {target}"
+    name, arguments = calls[0]
+    assert name == TOOL_NAME
+    assert TOOL_ARG_VALUE in arguments


### PR DESCRIPTION
### What

Adds Gemini generateContent as a first-class wire format on both sides of the chain, completing the inbound × backend matrix to `{OpenAI Chat, OpenAI Responses, Anthropic Messages, Gemini} × {openai, responses, anthropic, gemini}`:

- **Codec** (`crates/switchyard-translation/src/codecs/gemini/`): buffered + streaming translation through the neutral IR — `contents`/`parts` roles, `systemInstruction`, `inlineData`/`fileData` media, `functionCall`/`functionResponse` (paired by name + order with synthesized tool-call IDs), `thought` parts and `thoughtSignature` round-trip, `generationConfig` (including JSON mode ↔ `response_format`), `usageMetadata` (thinking tokens folded into output counts), and finish-reason mapping.
- **Backend** (`GeminiNativeBackend`): `x-goog-api-key` auth with `GEMINI_API_KEY` fallback, `v1beta` URL building, SSE parsing via the shared helpers, and context-window 400 → `ContextWindowExceeded` per the chain contract.
- **Inbound endpoints**: FastAPI `GeminiEndpoint` (`POST /v1beta/models/{model}:generateContent` and `:streamGenerateContent`) plus the matching route on the Rust axum server, with Gemini SSE framing (unnamed `data:` frames, no `[DONE]`) and Gemini-shaped error envelopes.
- **Wiring**: `WireFormat`/`ChatRequestType`/`ChatResponseType`/`BackendFormat` variants threaded through components, server, stats/intake capture, dimension collector, `MultiLlmBackend` defaults, PyO3 bindings, stubs, and public exports. `BackendFormat.AUTO` fast-paths bare `gemini*` model IDs (gateway-namespaced IDs like `google/gemini-*` still probe, since those serve Chat Completions).
- **Cross-format attachment fixes** surfaced by matrix testing (three of the four predate Gemini): data-URL images now normalize to typed base64 sources (previously dropped toward Gemini and emitted as invalid `url` sources toward Anthropic); Anthropic-native images/documents decode into typed sources instead of raw passthrough blobs; tool-result images stay typed blocks toward Anthropic, hoist to sibling `inlineData` parts toward Gemini, and hoist into a following user message toward OpenAI (previously the base64 payload was stringified into prompt text); parameterless tools get the `input_schema.type: "object"` Anthropic requires.

### Why

Switchyard translates any inbound format to any backend, but Gemini clients could not be served and Gemini upstreams could not be targeted natively. This adds both directions so Gemini-speaking tools work against OpenAI/Anthropic backends and existing clients can route to `generativelanguage.googleapis.com` — and fixes the attachment defects the new cross-format test matrix exposed.

Closes #47

### How

Gemini encodes the model and streaming choice in the URL (`:generateContent` vs `:streamGenerateContent?alt=sse`) rather than the body, so the internal Gemini wire body carries synthetic `model`/`stream` fields: endpoints inject them from the URL and the backend moves them back out. Tool declarations pass through a schema sanitizer (uppercase types, unsupported Draft-2020 keywords stripped, union types collapsed to `nullable`, enums coerced to STRING) because Gemini's OpenAPI-style subset rejects real-world tool schemas with `400 Unknown name`. Gemini reports `finishReason: STOP` even for function-call turns, so tool-call presence drives the normalized stop reason (`tool_calls`/`tool_use` for clients). Tool-result media hoisting exists because Gemini models do not read media nested in the `functionResponse` payload and 2.5 rejects the dedicated multimodal field (verified against the live API); same-format passthrough remains byte-faithful.

### Tests

- New: Gemini codec/backend/stream cases in the translation crate tests, `Gemini` added to the 4×4 `lossless_roundtrip` fixtures, backend unit tests in `backends/gemini.rs`, and Python suites for the endpoint, backend binding, and gemini↔openai translation.
- New `tests/test_translation_matrix.py`: every source→target pair × {text + system, image at conversation start, image mid-conversation, tool round trips with ID correlation, tool results carrying images, PDF attachments, two-hop `A→B→A` re-translation, response stop-reason mapping, text/tool streaming}.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass (toolchain 1.96.1).
- `uv run ruff check .` clean, `uv run mypy switchyard` clean, `uv run pytest tests/ -m "not integration"` green (2011 passed).
- Slim-install smoke: default install imports, `GeminiNativeBackend` resolvable, heavy packages absent.
- Manual smoke (live, not in CI): full 3×3 inbound×backend matrix against real OpenAI/Anthropic/Gemini APIs — 60/60 checks covering text, streaming, tool call + result round trips, vision (a generated red PNG the model must name, at conversation start, mid-conversation, and inside tool results). Ran via an in-process ASGI harness around `build_switchyard_app`.

### Checklist

- [x] One class per file; filename = `snake_case` of the primary class.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` (`GeminiEndpoint`, `GeminiNativeBackend`, `GeminiChatRequest`, `GeminiChatResponse`, `GeminiResponseStream`, `GeminiStreamingChatResponse`).
- [x] Unit tests added for new components / bug fixes.
- [x] Docs updated (`docs/architecture.md`, `docs/core_concepts.md`, `AGENTS.md` env table + structure, format-enumerating agent skills).
- [x] Commits signed off per the DCO.

### Notes for reviewers

- This adds an HTTP endpoint and public exports, which `AGENTS.md` lists as ask-first surfaces — flagging explicitly for maintainer sign-off.
- Gemini 3.x multi-turn tool use with thinking enabled requires clients to echo `thoughtSignature`; signatures round-trip through the codec (client-echo path), but there is no cross-request signature cache. Gemini 2.5 accepts replay without signatures.
- Converting data-URL images to base64 sources loses the OpenAI `detail` hint on those images when preservation is disabled; remote-URL images keep it. Trade-off taken so the payload survives toward Anthropic/Gemini at all.
- OpenAI has no wire shape for tool-result images, so they hoist into a user message following the tool messages (after all tool messages, to keep the assistant→tool adjacency contract). Happy to gate this behind policy if maintainers prefer dropping.
- The `--inbound` serve flag gains a `gemini` choice for parity; like the existing choices it does not yet filter mounted endpoints (`build_and_serve` ignores it today).
- Live provider checks are not wired into CI (they need real keys); the hermetic suite covers the same paths with fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Gemini support across the app, including new request/response handling, streaming, and endpoint routing.
  * Expanded translation and backend selection so Gemini can be used alongside existing AI providers.
  * Exposed Gemini support in Python and Rust-facing interfaces for easier integration.

* **Bug Fixes**
  * Improved request validation, response mapping, and stream formatting for Gemini conversations.
  * Better handling of tool calls, usage tracking, and media attachments during translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
