### PR TITLE
chore(config): enable LLM and codex_cli conflict-resolution tiers in sir-merge-a-lot config

### DIFF
--- a/.sir-merge-a-lot.yml
+++ b/.sir-merge-a-lot.yml
@@ -1,4 +1,4 @@
-# .sir-merge-a-lot.yml — switchyard onboarding (initial)
+# .sir-merge-a-lot.yml — switchyard
 #
 # Trigger mode: on_demand
 # Meaning: the bot does NOTHING on PRs until explicitly invited via
@@ -16,10 +16,22 @@
 # grooming), update this file via a normal PR + review.
 trigger_mode: "on_demand"
 
-# Optional: GLAMR LLM resolver. Disabled for the initial onboarding —
-# switchyard team explicitly opts in by flipping this to true.
-# glamr:
-#   enabled: false
+# LLM conflict resolver. Fires only when the deterministic ladder
+# (rerere -> Mergiraf) cannot resolve a conflict, and only on PRs the
+# bot was explicitly invited to groom (on_demand mode). Every LLM
+# resolution passes the bot's bounded-edit safety check; resolutions
+# touching lines outside conflict markers are rejected.
+llm:
+  enabled: true
+
+# Coding-agent fallback tier. When the raw-LLM resolver fails
+# (prompt too large for the LLM, or LLM timeout), the bot dispatches
+# the conflicted file to a sandboxed codex_cli run (via OpenShell)
+# instead of immediately escalating to a human. Trigger reasons,
+# timeout (600s), and per-MR attempt cap (1) use the bot's defaults.
+# Requires the SMAL worker deployment to be an image with the
+# OpenShell contract (AIREAPP-1853); on older images this is a no-op.
+coding_agent_provider: codex_cli
 
 # Optional: merge-command allowlist. With on_demand mode, command-
 # driven merges still require a commenter on this list (and standard


### PR DESCRIPTION
## What

Updates `.sir-merge-a-lot.yml` to enable the merge bot's LLM and coding-agent conflict-resolution tiers, while keeping grooming strictly on-demand:

- **`trigger_mode: "on_demand"`** — unchanged. The bot takes no action on any PR until explicitly invited via `@sir-merge-a-lot groom`. No autonomous grooming, no autonomous merging.
- **`llm: enabled: true`** — makes LLM conflict resolution explicit. Replaces the deprecated commented-out `glamr:` block, whose comment incorrectly claimed the resolver was disabled (the bot's code default is enabled). The LLM tier fires only when the deterministic ladder (rerere → Mergiraf) cannot resolve a conflict, and every resolution passes the bot's bounded-edit safety check.
- **`coding_agent_provider: codex_cli`** — opts into the coding-agent fallback tier: when the raw-LLM resolver fails (prompt too large, or LLM timeout), the conflicted file is dispatched to a sandboxed codex_cli run instead of immediately escalating to a human. Trigger reasons, timeout (600s), and per-MR attempt cap (1) are intentionally omitted — they match the bot's built-in defaults exactly.

## Why

Follow-up to the sir-merge-a-lot on-demand onboarding: enables the conflict-resolution ladder's LLM and codex_cli tiers so invited grooms can resolve conflicts the deterministic tools can't, while the bot retains zero autonomous authority.

## How tested

- [ ] `uv run ruff check .` clean — N/A, YAML-only config change
- [ ] `uv run mypy switchyard` clean — N/A, YAML-only config change
- [ ] `uv run pytest tests/` green — N/A, YAML-only config change
- [x] Manual smoke: parsed this exact file with sir-merge-a-lot's `load_config` and the strict resolver-layer hydrator (`coding_agent_config_from_smal_config`, which raises on any misconfiguration). Zero warnings; hydrates to `trigger_mode=on_demand`, `llm_enabled=True`, and `CodingAgentConfig(provider=codex_cli, trigger_reasons={llm_timeout, prompt_too_large_for_llm}, timeout=600s, max_attempts_per_mr=1)`.

## Checklist

- [ ] One class per file — N/A, no code changed
- [ ] Public symbols exported — N/A, no code changed
- [ ] Unit tests — N/A, no code changed
- [ ] README / `--help` — N/A, no customer-facing surface changed
- [x] Commits signed off (`Signed-off-by`) per the DCO.

## Notes for reviewers

The codex_cli tier is a silent no-op until the SMAL worker deployment polling this repo runs the nemo-agent-hub image with the OpenShell contract (AIREAPP-1853) — verify the worker image before expecting coding-agent dispatches. Rollback at any time is deleting the two new blocks (or the file) via a normal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)