### PR TITLE
feat: expose StageRouter baseline route

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -270,7 +270,7 @@
         "filename": "crates/switchyard-components-v2/src/profiles/stage_router.rs",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 1249
+        "line_number": 1254
       }
     ],
     "crates/switchyard-components-v2/tests/stage_router_profile.rs": [
@@ -1189,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-08T13:59:09Z"
+  "generated_at": "2026-07-08T18:36:52Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -270,7 +270,7 @@
         "filename": "crates/switchyard-components-v2/src/profiles/stage_router.rs",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 1254
+        "line_number": 1265
       }
     ],
     "crates/switchyard-components-v2/tests/stage_router_profile.rs": [
@@ -304,7 +304,7 @@
         "filename": "docs/cli_reference.md",
         "hashed_secret": "414cb2d928610e260b1b00de84c809d2adef2480",
         "is_verified": false,
-        "line_number": 605
+        "line_number": 607
       }
     ],
     "examples/minimal.py": [
@@ -1189,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-08T18:36:52Z"
+  "generated_at": "2026-07-08T22:21:00Z"
 }

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -243,6 +243,12 @@ pub struct RoutingDecision {
     pub router: DecisionProvider,
     /// Target route selected by Switchyard.
     pub route: RoutingTarget,
+    /// Optional counterfactual route used to estimate the effect of this decision.
+    ///
+    /// Profiles must omit this field unless they define an explicit, defensible
+    /// baseline. Relay must not infer a baseline from the selected route.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub baseline_route: Option<RoutingTarget>,
     /// Optional confidence score.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confidence: Option<f64>,
@@ -512,6 +518,7 @@ fn stage_router_processed_to_decision(
     freshness: Option<FeatureFreshness>,
 ) -> Result<RoutingDecision> {
     let target = profile.target_for_decision(&processed.decision)?;
+    let baseline_route = routing_target(profile.capable_target(), "capable".to_string())?;
     let (reason_code, reason_summary, feature_state) = match freshness {
         None => (
             "stage_router_feature_cold_default".to_string(),
@@ -541,6 +548,7 @@ fn stage_router_processed_to_decision(
             version: "v1".to_string(),
         },
         route: routing_target(target, processed.decision.tier.as_str().to_string())?,
+        baseline_route: Some(baseline_route),
         confidence: processed.decision.confidence,
         reason_code: Some(reason_code),
         reason_summary: Some(reason_summary),
@@ -688,6 +696,31 @@ mod tests {
     }
 
     #[test]
+    fn routing_decision_contract_accepts_legacy_payloads_without_baseline() -> TestResult {
+        let legacy = json!({
+            "schema_version": ROUTING_DECISION_SCHEMA_VERSION,
+            "decision_id": "decision-1",
+            "router": {"name": "random-routing", "version": "v1"},
+            "route": {
+                "tier": "capable",
+                "target_model": "frontier/model",
+                "backend_id": "capable-target",
+                "target_protocol_profile": "openai_chat",
+                "target_endpoint": "/v1/chat/completions"
+            }
+        });
+
+        let decision: RoutingDecision = serde_json::from_value(legacy)?;
+
+        assert_eq!(decision.schema_version, ROUTING_DECISION_SCHEMA_VERSION);
+        assert_eq!(decision.baseline_route, None);
+        assert!(serde_json::to_value(decision)?
+            .get("baseline_route")
+            .is_none());
+        Ok(())
+    }
+
+    #[test]
     fn routing_request_validation_requires_identity_protocol_and_materialization_shape(
     ) -> TestResult {
         let mut request = routing_request()?;
@@ -737,7 +770,11 @@ mod tests {
         assert_eq!(decision.route.backend_id, "capable-target");
         assert_eq!(decision.route.target_model, "frontier/model");
         assert_eq!(decision.route.target_protocol_profile, "openai_chat");
+        assert_eq!(decision.baseline_route, None);
         assert_eq!(decision.router.name, "random-routing");
+
+        let encoded = serde_json::to_value(decision)?;
+        assert!(encoded.get("baseline_route").is_none());
         Ok(())
     }
 

--- a/crates/switchyard-components-v2/src/decision.rs
+++ b/crates/switchyard-components-v2/src/decision.rs
@@ -322,7 +322,13 @@ pub async fn decision_for_stage_router_routing(
     let (processed, freshness) = profile
         .process_decision_snapshot(input, relay_snapshot.as_ref())
         .await?;
-    stage_router_processed_to_decision(profile, &request, processed, freshness)
+    stage_router_processed_to_decision(
+        profile,
+        &request,
+        processed,
+        freshness,
+        relay_snapshot.as_ref(),
+    )
 }
 // Builds the request-only state needed by policies that can route from summaries.
 pub(crate) fn summary_profile_input(request: &RoutingRequest) -> Result<ProfileInput> {
@@ -516,6 +522,7 @@ fn stage_router_processed_to_decision(
     request: &RoutingRequest,
     processed: StageRouterProcessedRequest,
     freshness: Option<FeatureFreshness>,
+    snapshot: Option<&RelaySnapshot>,
 ) -> Result<RoutingDecision> {
     let target = profile.target_for_decision(&processed.decision)?;
     let baseline_route = routing_target(profile.capable_target(), "capable".to_string())?;
@@ -534,7 +541,41 @@ fn stage_router_processed_to_decision(
             ),
             "fresh",
         ),
+        Some(FeatureFreshness::Stale) => (
+            "stage_router_feature_stale_default".to_string(),
+            "selected the configured StageRouter picker default because Relay feature state is stale"
+                .to_string(),
+            "stale",
+        ),
     };
+    let mut metadata = BTreeMap::from([
+        (
+            "source".to_string(),
+            Value::from(processed.decision.source.as_str()),
+        ),
+        ("score".to_string(), Value::from(processed.decision.score)),
+        ("feature_state".to_string(), Value::from(feature_state)),
+    ]);
+    if let Some(snapshot) = snapshot {
+        metadata.extend([
+            (
+                "snapshot_age_millis".to_string(),
+                Value::from(snapshot.age_millis),
+            ),
+            (
+                "snapshot_max_age_millis".to_string(),
+                Value::from(snapshot.max_age_millis),
+            ),
+            (
+                "snapshot_event_count".to_string(),
+                Value::from(snapshot.event_count),
+            ),
+            (
+                "snapshot_turn_depth".to_string(),
+                Value::from(snapshot.turn_depth),
+            ),
+        ]);
+    }
     Ok(RoutingDecision {
         schema_version: ROUTING_DECISION_SCHEMA_VERSION.to_string(),
         decision_id: format!(
@@ -552,14 +593,7 @@ fn stage_router_processed_to_decision(
         confidence: processed.decision.confidence,
         reason_code: Some(reason_code),
         reason_summary: Some(reason_summary),
-        metadata: BTreeMap::from([
-            (
-                "source".to_string(),
-                Value::from(processed.decision.source.as_str()),
-            ),
-            ("score".to_string(), Value::from(processed.decision.score)),
-            ("feature_state".to_string(), Value::from(feature_state)),
-        ]),
+        metadata,
     })
 }
 

--- a/crates/switchyard-components-v2/src/features.rs
+++ b/crates/switchyard-components-v2/src/features.rs
@@ -4,6 +4,7 @@
 //! Bounded, router-neutral snapshots reconstructed from Relay ATOF events.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::time::Instant;
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -22,15 +23,19 @@ pub const DEFAULT_MAX_RELAY_RETAINED_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_MAX_ATOF_EVENT_BYTES: usize = 256 * 1024;
 /// Default maximum encoded size accepted for one ATOF request batch.
 pub const DEFAULT_MAX_ATOF_BATCH_BYTES: usize = 4 * 1024 * 1024;
+/// Default maximum age of the most recently ingested routing event before a snapshot is stale.
+pub const DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS: u64 = 5 * 60 * 1_000;
 
 /// Readiness of an ATOF-derived feature snapshot consumed by a router.
 ///
-/// Absence is represented as `None`; the initial typed state is fresh only.
+/// Absence is represented as `None` by callers that perform an exact lookup.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FeatureFreshness {
     /// The snapshot contains routing-ready reconstructed history.
     Fresh,
+    /// The snapshot exists but its most recent accepted event is too old for routing.
+    Stale,
 }
 
 // JSON values retain both serialized content and heap-backed container
@@ -82,6 +87,8 @@ pub struct RelaySnapshotLimits {
     pub max_event_bytes: usize,
     /// Maximum encoded size of one HTTP ingestion batch.
     pub max_batch_bytes: usize,
+    /// Maximum age of the most recently ingested routing signal at decision time.
+    pub max_snapshot_age_millis: u64,
 }
 
 impl RelaySnapshotLimits {
@@ -107,6 +114,12 @@ impl RelaySnapshotLimits {
                 self.max_event_bytes, self.max_batch_bytes
             )));
         }
+        if self.max_snapshot_age_millis == 0 {
+            return Err(SwitchyardError::InvalidConfig(
+                "Relay snapshot limit max_snapshot_age_millis must be greater than zero"
+                    .to_string(),
+            ));
+        }
         Ok(self)
     }
 }
@@ -120,6 +133,7 @@ impl Default for RelaySnapshotLimits {
             max_retained_bytes: DEFAULT_MAX_RELAY_RETAINED_BYTES,
             max_event_bytes: DEFAULT_MAX_ATOF_EVENT_BYTES,
             max_batch_bytes: DEFAULT_MAX_ATOF_BATCH_BYTES,
+            max_snapshot_age_millis: DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
         }
     }
 }
@@ -135,6 +149,12 @@ pub struct RelaySnapshot {
     pub turn_depth: u64,
     /// Number of unique recognized events ingested for this identity.
     pub event_count: u64,
+    /// Readiness derived from the monotonic age of the latest accepted routing signal.
+    pub freshness: FeatureFreshness,
+    /// Monotonic age of the latest accepted routing signal when this snapshot was read.
+    pub age_millis: u64,
+    /// Configured age threshold used to classify this snapshot.
+    pub max_age_millis: u64,
 }
 
 /// Per-batch ingestion outcome, including every non-mutating drop category.
@@ -289,6 +309,7 @@ impl RelaySnapshotAccumulator {
             prepared.push(self.prepare_event(index, event, encoded_size)?);
         }
 
+        let ingested_at = Instant::now();
         let mut report = RelayIngestReport {
             received_events: prepared.len() as u64,
             ..RelayIngestReport::default()
@@ -298,7 +319,7 @@ impl RelaySnapshotAccumulator {
             match event {
                 PreparedRelayEvent::Drop(reason) => report.record_drop(reason),
                 PreparedRelayEvent::Recognized(event) => {
-                    inner.ingest(event, self.limits, &mut report);
+                    inner.ingest(event, ingested_at, self.limits, &mut report);
                 }
             }
         }
@@ -309,16 +330,34 @@ impl RelaySnapshotAccumulator {
 
     /// Returns a snapshot only for the exact `(session_id, owner_id)` key.
     pub fn snapshot(&self, key: &RelayIdentityKey) -> Option<RelaySnapshot> {
+        self.snapshot_at(key, Instant::now())
+    }
+
+    fn snapshot_at(&self, key: &RelayIdentityKey, now: Instant) -> Option<RelaySnapshot> {
         let inner = self.inner.read();
-        inner.identities.get(key).map(|state| RelaySnapshot {
-            identity: key.clone(),
-            messages: state
-                .messages
-                .iter()
-                .map(|message| message.value.clone())
-                .collect(),
-            turn_depth: state.turn_depth,
-            event_count: state.event_count,
+        inner.identities.get(key).and_then(|state| {
+            let freshness_anchor = state.signal_updated_at.or(state.updated_at)?;
+            let age_millis =
+                u64::try_from(now.saturating_duration_since(freshness_anchor).as_millis())
+                    .unwrap_or(u64::MAX);
+            let freshness = if age_millis <= self.limits.max_snapshot_age_millis {
+                FeatureFreshness::Fresh
+            } else {
+                FeatureFreshness::Stale
+            };
+            Some(RelaySnapshot {
+                identity: key.clone(),
+                messages: state
+                    .messages
+                    .iter()
+                    .map(|message| message.value.clone())
+                    .collect(),
+                turn_depth: state.turn_depth,
+                event_count: state.event_count,
+                freshness,
+                age_millis,
+                max_age_millis: self.limits.max_snapshot_age_millis,
+            })
         })
     }
 
@@ -414,6 +453,7 @@ impl RelayAccumulatorState {
     fn ingest(
         &mut self,
         event: RecognizedRelayEvent,
+        ingested_at: Instant,
         limits: RelaySnapshotLimits,
         report: &mut RelayIngestReport,
     ) {
@@ -441,7 +481,7 @@ impl RelayAccumulatorState {
 
         self.insert_dedupe(event.dedupe_key, event.dedupe_retained_bytes);
         self.ensure_identity(event.identity.clone(), event.identity_retained_bytes);
-        self.apply_update(&event.identity, event.update);
+        self.apply_update(&event.identity, event.update, ingested_at);
         report.ingested_events = report.ingested_events.saturating_add(1);
     }
 
@@ -500,17 +540,19 @@ impl RelayAccumulatorState {
         self.retained_state_bytes = self.retained_state_bytes.saturating_add(retained_key_bytes);
     }
 
-    fn apply_update(&mut self, key: &RelayIdentityKey, update: RelayUpdate) {
+    fn apply_update(&mut self, key: &RelayIdentityKey, update: RelayUpdate, ingested_at: Instant) {
         let Some(state) = self.identities.get_mut(key) else {
             return;
         };
         state.event_count = state.event_count.saturating_add(1);
+        state.updated_at = Some(ingested_at);
         match update {
             RelayUpdate::TurnStart => {
                 state.turn_depth = state.turn_depth.saturating_add(1);
             }
             RelayUpdate::TurnEnd => {}
             RelayUpdate::Message(message) => {
+                state.signal_updated_at = Some(ingested_at);
                 self.retained_state_bytes = self
                     .retained_state_bytes
                     .saturating_add(message.retained_bytes);
@@ -587,6 +629,8 @@ struct RelayIdentityState {
     turn_depth: u64,
     event_count: u64,
     retained_key_bytes: usize,
+    updated_at: Option<Instant>,
+    signal_updated_at: Option<Instant>,
 }
 
 #[derive(Debug)]
@@ -862,6 +906,7 @@ mod tests {
             max_retained_bytes: 64 * 1024,
             max_event_bytes: 4_096,
             max_batch_bytes: 16_384,
+            max_snapshot_age_millis: DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
         }
     }
 
@@ -921,6 +966,7 @@ mod tests {
         let limits = RelaySnapshotLimits::default().validate()?;
         assert!(limits.max_batch_bytes >= limits.max_event_bytes);
         assert_eq!(limits.max_retained_bytes, 64 * 1024 * 1024);
+        assert_eq!(limits.max_snapshot_age_millis, 5 * 60 * 1_000);
         Ok(())
     }
 
@@ -938,6 +984,12 @@ mod tests {
             ..RelaySnapshotLimits::default()
         };
         assert!(inverted.validate().is_err());
+
+        let zero_age = RelaySnapshotLimits {
+            max_snapshot_age_millis: 0,
+            ..RelaySnapshotLimits::default()
+        };
+        assert!(zero_age.validate().is_err());
     }
 
     #[test]
@@ -1052,12 +1104,58 @@ mod tests {
         assert_eq!(owner.messages[0]["role"], "assistant");
         assert_eq!(owner.messages[1]["role"], "tool");
         assert_eq!(owner.messages[1]["content"], "ok");
+        assert_eq!(owner.freshness, FeatureFreshness::Fresh);
+        assert!(owner.age_millis <= owner.max_age_millis);
         assert!(accumulator
             .snapshot(&RelayIdentityKey::new(
                 "session-1",
                 Some("owner-b".to_string())
             ))
             .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn snapshot_freshness_uses_monotonic_ingestion_age() -> Result<()> {
+        let max_age_millis = 250;
+        let accumulator = RelaySnapshotAccumulator::with_limits(RelaySnapshotLimits {
+            max_snapshot_age_millis: max_age_millis,
+            ..limits(4, 8, 16)
+        })?;
+        let key = RelayIdentityKey::session_only("session-freshness");
+        accumulator.ingest_batch(&[tool_event(
+            Some("session-freshness"),
+            None,
+            "tool-freshness",
+            "end",
+            json!({"output": "ok"}),
+        )])?;
+
+        let fresh = accumulator
+            .snapshot(&key)
+            .ok_or_else(|| SwitchyardError::Other("missing fresh snapshot".to_string()))?;
+        assert_eq!(fresh.freshness, FeatureFreshness::Fresh);
+        assert_eq!(fresh.max_age_millis, max_age_millis);
+
+        let stale = accumulator
+            .snapshot_at(
+                &key,
+                Instant::now() + std::time::Duration::from_millis(max_age_millis + 1),
+            )
+            .ok_or_else(|| SwitchyardError::Other("missing stale snapshot".to_string()))?;
+        assert_eq!(stale.freshness, FeatureFreshness::Stale);
+        assert!(stale.age_millis > stale.max_age_millis);
+
+        // A new turn changes lifecycle depth but must not make old routing
+        // evidence fresh again.
+        accumulator.ingest_batch(&[turn_event("session-freshness", "turn-freshness", "start")])?;
+        let still_stale = accumulator
+            .snapshot_at(
+                &key,
+                Instant::now() + std::time::Duration::from_millis(max_age_millis + 1),
+            )
+            .ok_or_else(|| SwitchyardError::Other("missing stale snapshot".to_string()))?;
+        assert_eq!(still_stale.freshness, FeatureFreshness::Stale);
         Ok(())
     }
 

--- a/crates/switchyard-components-v2/src/lib.rs
+++ b/crates/switchyard-components-v2/src/lib.rs
@@ -33,7 +33,7 @@ pub use features::{
     RelaySnapshotAccumulator, RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES,
     DEFAULT_MAX_ATOF_EVENT_BYTES, DEFAULT_MAX_RELAY_DEDUPE_ENTRIES,
     DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY, DEFAULT_MAX_RELAY_IDENTITIES,
-    DEFAULT_MAX_RELAY_RETAINED_BYTES,
+    DEFAULT_MAX_RELAY_RETAINED_BYTES, DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
 };
 pub use profile::{
     reconcile_session_id, session_id_from_normalized_headers, Profile, ProfileHooks, ProfileInput,

--- a/crates/switchyard-components-v2/src/profiles/llm_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/llm_routing.rs
@@ -599,6 +599,7 @@ pub async fn decision_for_llm_routing(
             version: profile.decision_router_version(),
         },
         route: routing_target(target, processed.decision.tier.clone())?,
+        baseline_route: None,
         confidence: processed.decision.confidence,
         reason_code: Some(processed.decision.source),
         reason_summary: Some(processed.decision.reason),

--- a/crates/switchyard-components-v2/src/profiles/random_routing.rs
+++ b/crates/switchyard-components-v2/src/profiles/random_routing.rs
@@ -225,6 +225,7 @@ pub async fn decision_for_random_routing(
             version: "v1".to_string(),
         },
         route: routing_target(target, processed.decision.tier.as_str().to_string())?,
+        baseline_route: None,
         confidence: None,
         reason_code: Some("random_weighted".to_string()),
         reason_summary: Some("selected by weighted random routing".to_string()),

--- a/crates/switchyard-components-v2/src/profiles/stage_router.rs
+++ b/crates/switchyard-components-v2/src/profiles/stage_router.rs
@@ -321,21 +321,29 @@ impl StageRouterProfile {
         snapshot: Option<&RelaySnapshot>,
     ) -> Result<(StageRouterProcessedRequest, Option<FeatureFreshness>)> {
         let original_model = input.request.model().map(std::borrow::ToOwned::to_owned);
-        let (decision, freshness) = match self.signal_from_relay_snapshot(snapshot) {
+        let (decision, freshness) = match snapshot
+            .filter(|snapshot| snapshot.freshness == FeatureFreshness::Fresh)
+            .and_then(|snapshot| self.signal_from_relay_snapshot(Some(snapshot)))
+        {
             Some(signal) => (
                 self.pick(&input.request, &signal, original_model).await?,
                 Some(FeatureFreshness::Fresh),
             ),
-            None => (
-                self.decision_for_tier(
-                    self.picker.default_tier(),
-                    original_model,
-                    StageRouterDecisionSource::FallOpen,
-                    0.0,
-                    None,
-                )?,
-                None,
-            ),
+            None => {
+                let freshness = snapshot
+                    .filter(|snapshot| !snapshot.messages.is_empty())
+                    .map(|snapshot| snapshot.freshness);
+                (
+                    self.decision_for_tier(
+                        self.picker.default_tier(),
+                        original_model,
+                        StageRouterDecisionSource::FallOpen,
+                        0.0,
+                        None,
+                    )?,
+                    freshness,
+                )
+            }
         };
         input.request.set_model(decision.selected_model.as_str());
         self.record_decision_source(decision.source)?;
@@ -946,11 +954,11 @@ fn summarise_signal(
     );
     let recent_messages = recent_messages(request, recent_window);
     if recent_messages.is_empty() {
-        return format!("Decide STRONG or WEAK for the next call. {state_line}");
+        return format!("Decide CAPABLE or EFFICIENT for the next call. {state_line}");
     }
 
     let mut lines = vec![
-        "Decide STRONG or WEAK for the next call.".to_string(),
+        "Decide CAPABLE or EFFICIENT for the next call.".to_string(),
         state_line,
         "Recent turns (most recent last):".to_string(),
     ];
@@ -1222,6 +1230,9 @@ mod tests {
             event_count: messages.len() as u64,
             messages,
             turn_depth,
+            freshness: FeatureFreshness::Fresh,
+            age_millis: 0,
+            max_age_millis: 300_000,
         }
     }
 
@@ -1362,6 +1373,59 @@ mod tests {
             StageRouterDecisionSource::Override
         );
         assert_eq!(processed.decision.confidence, Some(1.0));
+        assert!(observed(&calls)?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stage_router_decision_stale_history_uses_configured_default_without_classifier(
+    ) -> Result<()> {
+        let (mut profile, calls) = profile(
+            target("capable", "frontier/model")?,
+            target("efficient", "cheap/model")?,
+            StageRouterPickerMode::EfficientFirst,
+            0.0,
+            vec![BackendAction::Ok],
+            vec![BackendAction::Ok],
+        )?;
+        profile.classifier = Some(StageRouterTierClassifier::new(
+            &StageRouterClassifierConfig {
+                model: "unreachable-classifier".to_string(),
+                api_key: "test-key".to_string(),
+                base_url: Some("http://127.0.0.1:1/v1".to_string()),
+                timeout_secs: 0.01,
+                recent_turn_window: 1,
+                max_tokens: CLASSIFIER_MAX_TOKENS,
+                system_prompt: None,
+            },
+        )?);
+        let mut snapshot = relay_snapshot(
+            vec![json!({
+                "role": "tool",
+                "tool_call_id": "call-oom",
+                "content": "critical failure: out of memory",
+            })],
+            3,
+        );
+        snapshot.freshness = FeatureFreshness::Stale;
+        snapshot.age_millis = snapshot.max_age_millis + 1;
+
+        let (processed, freshness) = profile
+            .process_decision_snapshot(
+                profile_input(ChatRequest::openai_chat(json!({
+                    "model": "smart-stage-router",
+                }))),
+                Some(&snapshot),
+            )
+            .await?;
+
+        assert_eq!(freshness, Some(FeatureFreshness::Stale));
+        assert_eq!(processed.decision.tier, StageRouterTier::Efficient);
+        assert_eq!(
+            processed.decision.source,
+            StageRouterDecisionSource::FallOpen
+        );
+        assert_eq!(processed.decision.confidence, None);
         assert!(observed(&calls)?.is_empty());
         Ok(())
     }

--- a/crates/switchyard-components-v2/src/profiles/stage_router.rs
+++ b/crates/switchyard-components-v2/src/profiles/stage_router.rs
@@ -499,6 +499,11 @@ impl StageRouterProfile {
             .map(TargetBackend::target)
     }
 
+    /// Returns the configured capable target used as the routing counterfactual.
+    pub(crate) fn capable_target(&self) -> &LlmTarget {
+        self.capable_backend.target()
+    }
+
     fn tier_for_target(&self, target_id: &LlmTargetId) -> Result<StageRouterTier> {
         if *target_id == self.capable_backend.target().id {
             Ok(StageRouterTier::Capable)

--- a/crates/switchyard-py/src/server_bindings.rs
+++ b/crates/switchyard-py/src/server_bindings.rs
@@ -12,6 +12,7 @@ use switchyard_components_v2::{
     RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES, DEFAULT_MAX_ATOF_EVENT_BYTES,
     DEFAULT_MAX_RELAY_DEDUPE_ENTRIES, DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
     DEFAULT_MAX_RELAY_IDENTITIES, DEFAULT_MAX_RELAY_RETAINED_BYTES,
+    DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
 };
 use switchyard_server::{run_server, ServerRunOptions, DEFAULT_LISTEN_BACKLOG};
 
@@ -32,6 +33,7 @@ use crate::errors::py_core_error;
     atof_max_retained_bytes = DEFAULT_MAX_RELAY_RETAINED_BYTES,
     atof_max_event_bytes = DEFAULT_MAX_ATOF_EVENT_BYTES,
     atof_max_batch_bytes = DEFAULT_MAX_ATOF_BATCH_BYTES,
+    atof_max_snapshot_age_millis = DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
 ))]
 // PyO3 exposes these as named Python deployment options; grouping them would
 // replace simple keyword arguments with a binding-only configuration class.
@@ -50,6 +52,7 @@ fn run_profile_server(
     atof_max_retained_bytes: usize,
     atof_max_event_bytes: usize,
     atof_max_batch_bytes: usize,
+    atof_max_snapshot_age_millis: u64,
 ) -> PyResult<()> {
     let ip: IpAddr = host.parse().map_err(|error| {
         PyValueError::new_err(format!(
@@ -69,6 +72,7 @@ fn run_profile_server(
             max_retained_bytes: atof_max_retained_bytes,
             max_event_bytes: atof_max_event_bytes,
             max_batch_bytes: atof_max_batch_bytes,
+            max_snapshot_age_millis: atof_max_snapshot_age_millis,
         },
     };
 

--- a/crates/switchyard-server/src/cli.rs
+++ b/crates/switchyard-server/src/cli.rs
@@ -11,6 +11,7 @@ use switchyard_components_v2::{
     RelaySnapshotLimits, DEFAULT_MAX_ATOF_BATCH_BYTES, DEFAULT_MAX_ATOF_EVENT_BYTES,
     DEFAULT_MAX_RELAY_DEDUPE_ENTRIES, DEFAULT_MAX_RELAY_HISTORY_PER_IDENTITY,
     DEFAULT_MAX_RELAY_IDENTITIES, DEFAULT_MAX_RELAY_RETAINED_BYTES,
+    DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS,
 };
 use switchyard_core::Result;
 use switchyard_server::{run_server, ServerRunOptions, DEFAULT_LISTEN_BACKLOG};
@@ -97,6 +98,14 @@ pub(crate) struct ServerArgs {
         default_value_t = DEFAULT_MAX_ATOF_BATCH_BYTES
     )]
     pub(crate) atof_max_batch_bytes: usize,
+
+    /// Maximum age of the latest accepted ATOF routing signal before a snapshot is stale.
+    #[arg(
+        long,
+        env = "SWITCHYARD_ATOF_MAX_SNAPSHOT_AGE_MILLIS",
+        default_value_t = DEFAULT_MAX_RELAY_SNAPSHOT_AGE_MILLIS
+    )]
+    pub(crate) atof_max_snapshot_age_millis: u64,
 }
 
 impl ServerArgs {
@@ -119,6 +128,7 @@ impl ServerArgs {
                 max_retained_bytes: self.atof_max_retained_bytes,
                 max_event_bytes: self.atof_max_event_bytes,
                 max_batch_bytes: self.atof_max_batch_bytes,
+                max_snapshot_age_millis: self.atof_max_snapshot_age_millis,
             },
         }
     }
@@ -154,6 +164,8 @@ mod tests {
             "1024",
             "--atof-max-batch-bytes",
             "2048",
+            "--atof-max-snapshot-age-millis",
+            "3000",
         ])?;
 
         let options = args.into_options();
@@ -164,6 +176,7 @@ mod tests {
         assert_eq!(options.relay_snapshot_limits.max_retained_bytes, 2000);
         assert_eq!(options.relay_snapshot_limits.max_event_bytes, 1024);
         assert_eq!(options.relay_snapshot_limits.max_batch_bytes, 2048);
+        assert_eq!(options.relay_snapshot_limits.max_snapshot_age_millis, 3000);
         Ok(())
     }
 }

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -112,6 +112,7 @@ profiles:
     assert_eq!(decision["route"]["backend_id"], "capable");
     assert_eq!(decision["route"]["target_model"], "upstream-capable");
     assert_eq!(decision["route"]["target_protocol_profile"], "openai_chat");
+    assert!(decision.get("baseline_route").is_none());
     Ok(())
 }
 
@@ -154,6 +155,19 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
     assert_eq!(warm["router"]["name"], "stage_router");
     assert_eq!(warm["route"]["backend_id"], "capable");
     assert_eq!(warm["route"]["target_model"], "provider/capable");
+    assert_eq!(
+        warm["route"]["target_protocol_profile"],
+        "anthropic_messages"
+    );
+    assert_eq!(warm["route"]["target_endpoint"], "/v1/messages");
+    assert_eq!(warm["baseline_route"]["tier"], "capable");
+    assert_eq!(warm["baseline_route"]["backend_id"], "capable");
+    assert_eq!(warm["baseline_route"]["target_model"], "provider/capable");
+    assert_eq!(
+        warm["baseline_route"]["target_protocol_profile"],
+        "anthropic_messages"
+    );
+    assert_eq!(warm["baseline_route"]["target_endpoint"], "/v1/messages");
     assert_eq!(warm["reason_code"], "override");
     assert_eq!(warm["confidence"], 1.0);
     assert_eq!(warm["metadata"]["feature_state"], "fresh");
@@ -167,6 +181,9 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
     assert_eq!(cold.status(), StatusCode::OK);
     let cold = json_body(cold).await?;
     assert_eq!(cold["route"]["backend_id"], "efficient");
+    assert_eq!(cold["route"]["target_protocol_profile"], "openai_responses");
+    assert_eq!(cold["route"]["target_endpoint"], "/v1/responses");
+    assert_eq!(cold["baseline_route"], warm["baseline_route"]);
     assert_eq!(cold["reason_code"], "stage_router_feature_cold_default");
     assert!(cold["confidence"].is_null());
     assert_eq!(cold["metadata"]["feature_state"], "cold");
@@ -1831,11 +1848,11 @@ fn stage_router_decision_yaml() -> &'static str {
 targets:
   capable:
     model: provider/capable
-    format: openai
+    format: anthropic
     base_url: http://127.0.0.1:1/v1
   efficient:
     model: provider/efficient
-    format: openai
+    format: responses
     base_url: http://127.0.0.1:1/v1
 profiles:
   remote-stage_router:

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -172,6 +172,12 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
     assert_eq!(warm["confidence"], 1.0);
     assert_eq!(warm["metadata"]["feature_state"], "fresh");
     assert_eq!(warm["metadata"]["source"], "override");
+    assert_eq!(warm["metadata"]["snapshot_event_count"], 1);
+    assert_eq!(warm["metadata"]["snapshot_turn_depth"], 0);
+    assert_eq!(warm["metadata"]["snapshot_max_age_millis"], 300_000);
+    assert!(warm["metadata"]["snapshot_age_millis"]
+        .as_u64()
+        .is_some_and(|age| age <= 300_000));
 
     let mut cold_request = routing_request_json("remote-stage_router", "summary_only", None);
     cold_request["identity"]["session_id"] = json!("different-session");
@@ -188,6 +194,58 @@ async fn stage_router_decision_warms_from_one_relay_record_without_target_dispat
     assert!(cold["confidence"].is_null());
     assert_eq!(cold["metadata"]["feature_state"], "cold");
     assert_eq!(cold["metadata"]["source"], "fall_open");
+    assert!(cold["metadata"].get("snapshot_age_millis").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn stage_router_decision_falls_open_when_relay_snapshot_is_stale() -> TestResult {
+    let state = state_from_yaml(stage_router_decision_yaml())?.with_relay_snapshot_limits(
+        RelaySnapshotLimits {
+            max_snapshot_age_millis: 1,
+            ..RelaySnapshotLimits::default()
+        },
+    )?;
+    let app = build_switchyard_router(state);
+    let event = tool_event(
+        "stale-oom",
+        "end",
+        Some("session-1"),
+        None,
+        json!({"output": "process failed: out of memory"}),
+    );
+    let ingest = app
+        .clone()
+        .oneshot(ndjson_request(&format!("{event}\n"), None)?)
+        .await?;
+    assert_eq!(ingest.status(), StatusCode::OK);
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let response = app
+        .oneshot(request(
+            "POST",
+            "/v1/routing/decision",
+            Some(routing_request_json(
+                "remote-stage_router",
+                "summary_only",
+                None,
+            )),
+        )?)
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let decision = json_body(response).await?;
+    assert_eq!(decision["route"]["backend_id"], "efficient");
+    assert_eq!(
+        decision["reason_code"],
+        "stage_router_feature_stale_default"
+    );
+    assert_eq!(decision["metadata"]["feature_state"], "stale");
+    assert_eq!(decision["metadata"]["source"], "fall_open");
+    assert_eq!(decision["metadata"]["snapshot_max_age_millis"], 1);
+    assert!(decision["metadata"]["snapshot_age_millis"]
+        .as_u64()
+        .is_some_and(|age| age > 1));
     Ok(())
 }
 
@@ -896,6 +954,7 @@ profiles:
         max_retained_bytes: 4_096,
         max_event_bytes: 256,
         max_batch_bytes: 512,
+        max_snapshot_age_millis: 300_000,
     })?;
     let app = build_switchyard_router(state.clone());
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -217,6 +217,7 @@ switchyard [--routing-profiles PATH] serve [--config PATH]
                  [--atof-max-retained-bytes BYTES]
                  [--atof-max-event-bytes BYTES]
                  [--atof-max-batch-bytes BYTES]
+                 [--atof-max-snapshot-age-millis MILLISECONDS]
 ```
 
 **Flags**
@@ -233,6 +234,7 @@ switchyard [--routing-profiles PATH] serve [--config PATH]
 | `--atof-max-identities`, `--atof-max-history-per-identity`, `--atof-max-dedupe-entries` | Fixed in-memory caps for exact Relay identities, reconstructed messages per identity, and event idempotency keys. The matching `SWITCHYARD_ATOF_MAX_*` environment variables are also accepted. |
 | `--atof-max-retained-bytes` | Hard cap on exact encoded message bytes plus retained identity and dedupe string bytes (default: 64 MiB). Defaults to `SWITCHYARD_ATOF_MAX_RETAINED_BYTES` when set. |
 | `--atof-max-event-bytes`, `--atof-max-batch-bytes` | Fixed request limits for one event and one finite HTTP batch. The event limit cannot exceed the batch limit. The matching `SWITCHYARD_ATOF_MAX_*` environment variables are also accepted. |
+| `--atof-max-snapshot-age-millis` | Maximum monotonic age of the latest accepted routing signal before an exact Relay snapshot is stale (default: 300000, or five minutes). Turn lifecycle events do not refresh existing signal age. Stale StageRouter snapshots bypass scoring and classification and return the picker default with explicit stale metadata. Defaults to `SWITCHYARD_ATOF_MAX_SNAPSHOT_AGE_MILLIS` when set. |
 
 **Notes**
 

--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -29,6 +29,17 @@ into a confidence score for "this turn needs the capable tier", then routes:
 - the **capable** tier for uncertain, exploratory, or error-recovery turns, and
 - the **efficient** tier for settled, mechanical turns.
 
+For Decision API routing, Switchyard reconstructs this history from Relay ATOF
+events under the request's exact session/owner identity. Snapshot readiness is
+based on the latest material routing signal's monotonic ingestion age rather
+than the event's wall-clock timestamp, so client clock skew cannot make old
+state appear current. Turn lifecycle events do not refresh existing signal age. A missing or
+tool-history-free snapshot is `cold`; a snapshot older than
+`--atof-max-snapshot-age-millis` is `stale`. Cold and stale snapshots bypass the
+scorer and optional classifier and return the configured picker default. The
+decision metadata records `feature_state` and, when a snapshot exists, its age,
+threshold, event count, and turn depth.
+
 `confidence_threshold` sets how sure that estimate must be before the router acts
 on the signal alone. Below it, the turn stays on the picker's default tier (or,
 if you added the optional classifier, goes to it first). A turn with no


### PR DESCRIPTION
## What

Add an optional `baseline_route` to `switchyard.routing_decision.v1`, have StageRouter report its configured capable target as the explicit counterfactual route, and make Relay-fed StageRouter snapshots expire deterministically.

The freshness policy uses monotonic server ingestion time and tracks the newest material routing signal separately from turn lifecycle activity. A default five-minute maximum age is configurable through `--atof-max-snapshot-age-millis`, `SWITCHYARD_ATOF_MAX_SNAPSHOT_AGE_MILLIS`, and the Python binding. Stale snapshots bypass the dimensions scorer and classifier and return the configured picker default.

Every StageRouter decision exposes additive `router_metadata` with `feature_state` (`cold`, `fresh`, or `stale`), snapshot age and limit, event count, turn depth, and decision source. Turn start/end events cannot refresh old routing evidence.

Other routing profiles omit `baseline_route` until they define a defensible counterfactual. Existing v1 clients remain compatible because all fields are additive and optional.

## Why

Relay needs an explicit baseline to calculate model-routing cost effects without guessing from the client model or selected route. It also needs to know whether a Decision API result came from current ATOF evidence or a safe default after the evidence expired. Keeping both policies in Switchyard preserves routing-policy ownership.

Relates to [NVIDIA/NeMo-Relay #369](https://github.com/NVIDIA/NeMo-Relay/pull/369) and [NVIDIA/NeMo-Relay #389](https://github.com/NVIDIA/NeMo-Relay/pull/389).

## Review guidelines

1. Start with `crates/switchyard-components-v2/src/decision.rs` for the additive baseline contract.
2. Review `crates/switchyard-components-v2/src/profiles/stage_router.rs` for material-signal timestamps, freshness state, and stale fallback.
3. Review `crates/switchyard-server/src/atof.rs` and CLI/config wiring for monotonic ingestion and the maximum-age setting.
4. Verify the policy boundary: StageRouter owns the capable baseline; Relay must not infer one. Profiles without an explicit policy omit it.
5. Verify lifecycle-only events do not extend snapshot freshness.

## How tested

- [x] `cargo fmt --all -- --check`.
- [x] `cargo test --ignore-rust-version -p switchyard-components-v2` — 74 passed.
- [x] Full profile suites, including cold/fresh/stale and capable/efficient selections.
- [x] `cargo test --ignore-rust-version -p switchyard-server --test server` — 34 passed.
- [x] `cargo test --ignore-rust-version -p switchyard-server --test profile_migration` — 10 passed.
- [x] `cargo check --ignore-rust-version -p switchyard-py`.
- [x] `cargo clippy --ignore-rust-version -p switchyard-components-v2 -p switchyard-server -p switchyard-py --all-targets -- -D warnings`.
- [x] `detect-secrets` pre-commit hook after refreshing baseline line metadata.
- [x] Real Relay/Claude Code E2E: one cold and four fresh dimensions decisions, snapshot age metadata preserved end to end, and Sonnet/Opus committed routes observed.

## Previous feedback addressed

- Kept the Decision API schema version stable and the new fields additive.
- Omitted baselines for profiles that cannot yet state a defensible counterfactual.
- Replaced remaining user-facing Cascade terminology with StageRouter.
- Added an explicit freshness limit rather than allowing accumulated Relay state to influence routing indefinitely.
- Kept freshness based on material evidence so lifecycle traffic cannot accidentally revive an old snapshot.
- Preserved cross-protocol selected/baseline targets and Python serialization compatibility.

## Checklist

- [x] Unit, server integration, and real E2E coverage added.
- [x] Legacy payloads without `baseline_route` or freshness metadata remain valid.
- [x] No secret values are stored; the secret baseline change only refreshes line numbers.
- [x] Commits signed off per DCO.
