### PR TITLE
docs: fix LLM classifier routing example

### DIFF
--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -63,12 +63,6 @@ profiles:
     classifier_recent_turn_window: 4
 ```
 
-Use a distinct upstream `model` for each target. The profile server registers
-both target IDs and upstream model IDs as direct aliases, so reusing an upstream
-model across targets causes a duplicate-registration error at startup. The
-OpenRouter-specific `extra_body` in this example requests that reasoning be
-disabled only for the classifier call.
-
 The classifier target must use `format: openai`. Start the profile server with:
 
 ```bash

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -44,8 +44,11 @@ targets:
     format: openai
   classifier:
     endpoint: openrouter
-    model: openai/gpt-4o-mini
+    model: nvidia/nemotron-3-nano-30b-a3b
     format: openai
+    extra_body:
+      reasoning:
+        enabled: false
 
 profiles:
   smart:
@@ -59,6 +62,12 @@ profiles:
     classifier_fail_open: true
     classifier_recent_turn_window: 4
 ```
+
+Use a distinct upstream `model` for each target. The profile server registers
+both target IDs and upstream model IDs as direct aliases, so reusing an upstream
+model across targets causes a duplicate-registration error at startup. The
+OpenRouter-specific `extra_body` in this example requests that reasoning be
+disabled only for the classifier call.
 
 The classifier target must use `format: openai`. Start the profile server with:
 


### PR DESCRIPTION
## Summary

- Update the LLM classifier-routing OpenRouter example to use a distinct Nemotron classifier target.

## Why

The previous example registers `openai/gpt-4o-mini` twice and fails at startup with `SwitchyardDuplicateRegistrationError`.

Fixes #36.

## Validation

- `cd docs && make publish`
- `git diff --check`
- profile tested locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the routing algorithms example to use a different classifier model configuration.
  * Added an example setting to disable reasoning in the classifier target while keeping the same output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->