### PR TITLE
docs: add external contribution quick guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or discussion
-    url: https://github.com/NVIDIA/switchyard/discussions
+    url: https://github.com/NVIDIA-NeMo/Switchyard/discussions
     about: For usage questions and design discussion, please open a Discussion instead of an Issue.
   - name: Security vulnerability
     url: https://www.nvidia.com/en-us/security/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -234,7 +234,7 @@
         "filename": "CONTRIBUTING.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 161
       }
     ],
     "DEVELOPMENT.md": [
@@ -1189,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-08T09:06:49Z"
+  "generated_at": "2026-07-09T16:18:37Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -234,7 +234,7 @@
         "filename": "CONTRIBUTING.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 162
       }
     ],
     "DEVELOPMENT.md": [
@@ -1189,5 +1189,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-09T16:18:37Z"
+  "generated_at": "2026-07-09T16:39:36Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,36 @@
 
 Thank you for your interest in contributing! This document outlines the development workflow, testing practices, and code standards.
 
+## External Contributions
+
+We welcome contributions of all sizes, from typo fixes to new features. The short version:
+
+1. [Fork the repository](https://github.com/NVIDIA-NeMo/Switchyard/fork) and clone your fork:
+
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/Switchyard.git
+   cd Switchyard
+   git remote add upstream https://github.com/NVIDIA-NeMo/Switchyard.git
+   ```
+
+2. Pick the right process for the size of your change:
+   - **Small changes** (typos, docs, focused bug fixes under ~100 lines): open a PR directly, no issue needed.
+   - **Larger changes** (new features, refactors, anything 100+ lines): [open an issue](https://github.com/NVIDIA-NeMo/Switchyard/issues/new/choose) first so maintainers can confirm the direction before you invest time.
+
+3. Create a branch, make your change, and run the checks in [Code standards](#2-code-standards).
+
+4. Commit with a DCO sign-off (see [Signing Your Work](#signing-your-work)):
+
+   ```bash
+   git commit -s -m "fix: description of the change"
+   ```
+
+5. Push to your fork and open a PR against `main`, linking any related issues (e.g. "Closes #42").
+
+Review is requested automatically from the core team via [CODEOWNERS](.github/CODEOWNERS), so there is no need to pick reviewers. Keep each PR focused on one concern, include tests for behavior changes, and respond to feedback with follow-up commits rather than force-pushes.
+
+Using AI tools to write code is fine, but you must understand and be able to explain every change in your PR.
+
 ## Setup
 
 See [Development](DEVELOPMENT.md) for full setup instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,9 @@ Commit messages must follow
 [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
 This is enforced locally by the `commit-msg` hook and in GitHub Actions.
 
+Every commit must also carry a DCO sign-off (`git commit -s`), enforced by the
+required DCO check on every PR. See [Signing Your Work](#signing-your-work).
+
 - ✓ `fix: handle async context cleanup in ProxyContext`
 - ✓ `feat: add stage-router routing backend`
 - ✗ `Fixed stuff` / `Updated code`
@@ -140,10 +143,8 @@ feat(api)!: remove legacy route option
    Keep the PR title conventional too, because GitHub can use the PR title for
    the squash-merge commit.
 
-Maintainers should mark these GitHub status checks as required on `main`:
-
-- `Commitlint / Commit messages`
-- `PR Title / Validate PR title`
+The `CI Success` and `DCO` status checks are required on `main`; the other
+workflows (commitlint, PR title) run on every PR but are advisory.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Adds an External Contributions section at the top of CONTRIBUTING.md so first-time contributors see the end-to-end flow before the internal development details. Modeled on the ai-dynamo/dynamo contribution guide, trimmed to the essentials:

- Fork-and-clone workflow (the existing setup instructions assume push access to this repo, which external contributors do not have)
- Size-based process: small fixes go straight to a PR, larger changes (~100+ lines or new features) start with an issue
- DCO sign-off step, pointing at the existing Signing Your Work section
- Note that reviewers are requested automatically via CODEOWNERS
- Expectation to understand and be able to explain AI-assisted code

Also includes a few small related fixes:

- Internal workflow now notes the DCO sign-off requirement (the DCO check is required on every PR as of today), and the stale note about which status checks should be required now reflects reality (CI Success + DCO)
- Issue-template contact link for questions pointed at the wrong org (NVIDIA/switchyard, a 404); now points at this repo's Discussions, which is enabled
- detect-secrets baseline refreshed (line numbers shifted by the CONTRIBUTING.md insertion)