### PR TITLE
ci: enforce DCO sign-off on pull request commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,12 +204,42 @@ jobs:
             --with "${SWITCHYARD_EXTRAS_PACKAGE}" \
             switchyard serve --help > /dev/null
 
+  # DCO is a hard gate on PRs: every commit must carry a Signed-off-by
+  # trailer (https://developercertificate.org/), as required by
+  # CONTRIBUTING.md. Merge commits (e.g. GitHub's "Update branch") are
+  # exempt. Skipped on main pushes, which ci-success tolerates.
+  dco:
+    name: DCO
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check Signed-off-by on all PR commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          missing=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+            --paginate \
+            --jq '.[] | select(.parents | length < 2)
+                      | select(.commit.message | test("(^|\\n)Signed-off-by: .+ <.+@.+>") | not)
+                      | .sha[0:8] + " " + (.commit.message | split("\n")[0])')
+          if [ -n "$missing" ]; then
+            echo "Commits missing a Signed-off-by trailer:"
+            echo "$missing"
+            echo
+            echo "Sign off past commits with: git rebase --signoff origin/main, then push."
+            echo "Sign off future commits with: git commit -s"
+            exit 1
+          fi
+          echo "All commits signed off."
+
   # Single required check for branch protection. Gates on every job above so
   # the ruleset never needs editing when jobs are added or renamed.
   ci-success:
     name: CI Success
     if: always()
-    needs: [lint, spdx-headers, secrets, rust, typecheck, test, slim-install-smoke]
+    needs: [lint, spdx-headers, secrets, rust, typecheck, test, slim-install-smoke, dco]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded


### PR DESCRIPTION
## Summary

CONTRIBUTING.md says sign-off is required, but nothing enforces it: recent commits merged to main without a Signed-off-by trailer, and the repo has no DCO app or check. This adds enforcement as a CI job, following the pattern ai-dynamo/dynamo uses (they run the DCO probot app; this is the same check as a plain Actions job, avoiding an org app install).

- New `dco` job in ci.yml: fails if any PR commit lacks a `Signed-off-by: Name <email>` trailer, with instructions for fixing (`git rebase --signoff`)
- Merge commits (e.g. GitHub's Update branch button) are exempt, matching the probot behavior
- Wired into the existing `ci-success` aggregator, so it becomes a required check with no ruleset changes
- Runs only on `pull_request` events; skipped on pushes to main, which `ci-success` tolerates

Verified the check logic against live data: PR #40 (signed) passes, the commits from PR #37 (unsigned) are correctly flagged.

Note one difference from Dynamo: their config exempts org members from DCO; this job requires sign-off from everyone, matching what CONTRIBUTING.md states. In-flight PRs with unsigned commits will need a `git rebase --signoff` once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated checks to ensure pull requests include the required commit sign-off information.
  * Updated the main CI status so it only passes when the sign-off check succeeds along with the existing validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->