### PR TITLE
fix: point question contact link at this repo's Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or discussion
-    url: https://github.com/NVIDIA/switchyard/discussions
+    url: https://github.com/NVIDIA-NeMo/Switchyard/discussions
     about: For usage questions and design discussion, please open a Discussion instead of an Issue.
   - name: Security vulnerability
     url: https://www.nvidia.com/en-us/security/


### PR DESCRIPTION
The issue-template contact link for questions pointed at https://github.com/NVIDIA/switchyard/discussions, which is the wrong org (404). Discussions is now enabled on this repo; this points the link at the right place.

With blank issues disabled, this link is the only path the new-issue chooser offers for questions, so it was a dead end for anyone trying to ask one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the issue template’s external discussion link to point to the current community support location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->