### PR TITLE
DO NOT MERGE: sir-merge-a-lot clean-groom comment validation

### DIFF
--- a/SMAL_COMMENT_E2E.md
+++ b/SMAL_COMMENT_E2E.md
@@ -1,0 +1,8 @@
+# sir-merge-a-lot clean-groom comment validation (temporary)
+
+Final validation PR: the bot's clean-groom path now posts a
+"Rebase succeeded" audit comment (AIREAPP-2100, deployed in 1.224.0).
+This branch is intentionally one commit behind `main`.
+
+**DO NOT MERGE.** This PR will be closed and its branch deleted after
+the validation completes.


### PR DESCRIPTION
Final validation PR for the sir-merge-a-lot mergeability agent, following #38 (clean groom) and #39 (resolution ladder).

**What this validates:** the bot's clean-groom path previously force-pushed silently; as of release 1.224.0 it posts the same "Rebase succeeded" audit comment GitLab users get — with recovery instructions and the force-with-lease details. This branch is one commit behind `main` (cut from `bacab4c`, missing #40) with a single standalone marker file, guaranteeing a conflict-free update.

**DO NOT MERGE** — this PR will be closed and the branch deleted once the comment is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a temporary notice about clean-groom comment validation.
  * Clarified that the validation flow posts a “Rebase succeeded” audit comment.
  * Included a warning not to merge while validation is in progress, noting the branch will be closed and deleted afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->