### PR TITLE
feat(benchmark): add terminal-bench 2.1 dataset support

### DIFF
--- a/benchmark/DATASETS.md
+++ b/benchmark/DATASETS.md
@@ -12,6 +12,21 @@ benchmark/datasets/openthoughts-tblite-closed-book
 Use this page when you want to prepare a different Harbor dataset for the same
 Switchyard benchmark runner.
 
+## Supported Datasets
+
+These Harbor datasets are supported out of the box — `prepare_harbor_dataset.py` recognizes each
+one and generates the right closed-book proxy allowlist automatically:
+
+| Dataset | Harbor id | Closed-book allowlist |
+|---------|-----------|-----------------------|
+| TB Lite (default) | `openthoughts-tblite@2.0` | none beyond the closed-book base |
+| Terminal-Bench 2.0 | `terminal-bench/terminal-bench-2` | TB2 Oracle package/data sources |
+| Terminal-Bench 2.1 | `terminal-bench/terminal-bench-2-1` | shares the TB2 Oracle allowlist |
+| SWE-Bench Pro | `cais/swebenchpro` | none beyond the closed-book base |
+
+Any other Harbor dataset that matches the [supported shape](#supported-shape) can still be prepared;
+it just receives no dataset-specific allowlist. Generate commands for each are below.
+
 ## Supported Shape
 
 `prepare_harbor_dataset.py` is a repo-local dataset rewriter, not a published Harbor adapter. It can
@@ -33,6 +48,16 @@ the package and data sources needed by the official Oracle solutions:
 uv run --no-sync python benchmark/prepare_harbor_dataset.py \
   --source-dataset terminal-bench/terminal-bench-2 \
   --output-dir benchmark/datasets/terminal-bench-2-closed-book \
+  --overwrite
+```
+
+Terminal-Bench 2.1 is the verified iteration of 2.0. It shares the same task family and Oracle
+egress, so the generated proxy allowlist matches 2.0:
+
+```bash
+uv run --no-sync python benchmark/prepare_harbor_dataset.py \
+  --source-dataset terminal-bench/terminal-bench-2-1 \
+  --output-dir benchmark/datasets/terminal-bench-2-1-closed-book \
   --overwrite
 ```
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,6 +119,16 @@ uv run --no-sync python benchmark/prepare_harbor_dataset.py \
   --overwrite
 ```
 
+Terminal-Bench 2.1 (the verified iteration of 2.0) is supported the same way and shares the 2.0
+Oracle allowlist:
+
+```bash
+uv run --no-sync python benchmark/prepare_harbor_dataset.py \
+  --source-dataset terminal-bench/terminal-bench-2-1 \
+  --output-dir benchmark/datasets/terminal-bench-2-1-closed-book \
+  --overwrite
+```
+
 SWE-Bench Pro is supported with the Harbor dataset `cais/swebenchpro`. The generated dataset uses
 the same pinned-agent and closed-book proxy path without opening dataset-specific agent egress.
 

--- a/benchmark/prepare_harbor_dataset.py
+++ b/benchmark/prepare_harbor_dataset.py
@@ -30,6 +30,9 @@ AGENT_VERSIONS_FILE = SCRIPT_DIR / "agent-versions.env"
 PROXY_ASSET_DIR = SCRIPT_DIR / "closed_book_proxy" / "proxy"
 AGENT_ENTRYPOINT = "switchyard-agent-entrypoint.sh"
 TERMINAL_BENCH_2_SOURCE_DATASET = "terminal-bench/terminal-bench-2"
+TERMINAL_BENCH_2_1_SOURCE_DATASET = "terminal-bench/terminal-bench-2-1"
+# Shared across the TB2 family (2.0 + the 2.1 verified iteration): 2.1 tweaks
+# timeouts/resources on existing tasks, so its Oracle solutions reach the same hosts.
 TERMINAL_BENCH_2_PROXY_ALLOWLIST_HOSTS = (
     "api.github.com",
     "api.launchpad.net",
@@ -128,7 +131,7 @@ def _exported_dataset_candidates(download_root: Path, source_dataset: str) -> li
 
 def _proxy_allowlist_hosts_for_dataset(source_dataset: str) -> tuple[str, ...]:
     source_name = source_dataset.split("@", 1)[0]
-    if source_name == TERMINAL_BENCH_2_SOURCE_DATASET:
+    if source_name in (TERMINAL_BENCH_2_SOURCE_DATASET, TERMINAL_BENCH_2_1_SOURCE_DATASET):
         return TERMINAL_BENCH_2_PROXY_ALLOWLIST_HOSTS
     return ()
 

--- a/tests/test_prepare_harbor_dataset.py
+++ b/tests/test_prepare_harbor_dataset.py
@@ -116,6 +116,29 @@ def test_terminal_bench_2_dataset_adds_proxy_allowlist_hosts(tmp_path: Path) -> 
         assert host in manifest["closed_book"]["proxy_allowlist_hosts"]
 
 
+def test_terminal_bench_2_1_dataset_reuses_terminal_bench_2_allowlist(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_task(source, "tb21-task", "[environment]\n", "FROM ubuntu:22.04\n")
+
+    output = _prepare(
+        tmp_path,
+        source,
+        source_dataset="terminal-bench/terminal-bench-2-1",
+    )
+    allowlist = (output / "tb21-task" / "environment" / "proxy" / "allowlist-base.txt").read_text()
+    manifest = json.loads((output / "switchyard_dataset_manifest.json").read_text())
+
+    for host in (
+        "archive.ubuntu.com",
+        "pypi.org",
+        "github.com",
+        "huggingface.co",
+        "download.pytorch.org",
+    ):
+        assert host in allowlist
+        assert host in manifest["closed_book"]["proxy_allowlist_hosts"]
+
+
 def test_swe_bench_pro_dataset_keeps_agent_proxy_allowlist_empty(tmp_path: Path) -> None:
     source = tmp_path / "source"
     _write_task(source, "swe-task", "[environment]\n", "FROM ubuntu:22.04\n")


### PR DESCRIPTION
## What

Adds out-of-the-box support for **Terminal-Bench 2.1** (`terminal-bench/terminal-bench-2-1`) in the benchmark dataset prep pipeline, mirroring the existing TB 2.0 support.

TB 2.1 is the [verified iteration of 2.0](https://github.com/harbor-framework/terminal-bench-2-1) — 26 tasks tweaked for timeouts/resources/reward-hacking robustness, same task family. Because the Oracle solutions reach the same package/data hosts, 2.1 reuses the TB 2.0 closed-book proxy allowlist.

## Changes

- `prepare_harbor_dataset.py`: register `TERMINAL_BENCH_2_1_SOURCE_DATASET`; `_proxy_allowlist_hosts_for_dataset` now returns the shared TB2 allowlist for both 2.0 and 2.1. Reusing the allowlist is necessary — the default `()` would leave 2.1 closed-book runs with no package egress and break Oracle verification.
- `tests/test_prepare_harbor_dataset.py`: new test asserting 2.1 reuses the TB2 allowlist.
- `benchmark/DATASETS.md`: new **Supported Datasets** section (TB Lite, TB 2.0, TB 2.1, SWE-Bench Pro) + a 2.1 generate command.
- `benchmark/README.md`: 2.1 generate command alongside 2.0.

## Generate

```bash
uv run --no-sync python benchmark/prepare_harbor_dataset.py \
  --source-dataset terminal-bench/terminal-bench-2-1 \
  --output-dir benchmark/datasets/terminal-bench-2-1-closed-book --overwrite
```

## Verification

- `uv run --no-sync pytest tests/test_prepare_harbor_dataset.py` — 11 passed
- `uv run ruff check` — clean

## To confirm on first real run (not statically verifiable)

- Registry id `terminal-bench/terminal-bench-2-1` is taken from the upstream repo README; confirm it resolves on first `harbor download`.
- If any 2.1-modified task added a new external dependency, its Oracle fails visibly in closed-book logs — grep generated Dockerfiles for hosts outside the current allowlist and add any new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Terminal-Bench 2.1 dataset variant.
  * Expanded dataset mapping so more Harbor benchmark datasets are available out of the box.

* **Documentation**
  * Updated dataset setup guides with new examples and instructions for Terminal-Bench 2.1.
  * Added a supported datasets reference showing available dataset IDs and allowlist behavior.

* **Bug Fixes**
  * Ensured Terminal-Bench 2.1 uses the same approved host access rules as Terminal-Bench 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->