### PR TITLE
feat(translation): harden cross-protocol translation

### DIFF
--- a/crates/switchyard-translation/Cargo.toml
+++ b/crates/switchyard-translation/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+rust-version = "1.93.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -6,7 +6,7 @@
 use serde_json::{json, Map, Value};
 
 use crate::codecs::common::{provider_extensions, text_from_blocks};
-use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
+use crate::codecs::openai_chat::{decode_file_source, decode_image_source, decode_image_url};
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
 };
@@ -311,18 +311,24 @@ impl FormatCodec for AnthropicMessagesCodec {
                 diagnostics: Vec::new(),
             });
         }
-        let output = response.first_output();
-        let content = output
-            .map(|output| encode_anthropic_content(&output.content))
-            .unwrap_or_else(|| vec![json!({"type": "text", "text": ""})]);
+        let mut content = response
+            .outputs
+            .iter()
+            .flat_map(|output| encode_anthropic_content(&output.content))
+            .collect::<Vec<_>>();
+        if content.is_empty() {
+            content.push(json!({"type": "text", "text": ""}));
+        }
         let body = json!({
             "id": response.id.clone().unwrap_or_else(|| "msg_switchyard".to_string()),
             "type": "message",
             "role": "assistant",
             "model": response.model.clone().unwrap_or_else(|| "unknown".to_string()),
             "content": content,
-            "stop_reason": output
-                .and_then(|output| output.stop_reason)
+            "stop_reason": response.outputs
+                .iter()
+                .rev()
+                .find_map(|output| output.stop_reason)
                 .map(anthropic_stop_reason)
                 .unwrap_or("end_turn"),
             "stop_sequence": Value::Null,
@@ -475,8 +481,7 @@ fn decode_anthropic_content_block(
         Some("image") => {
             let source = block
                 .get("source")
-                .cloned()
-                .map(ImageSource::Raw)
+                .map(decode_anthropic_image_source)
                 .unwrap_or_else(|| ImageSource::Raw(Value::Object(block.clone())));
             vec![ContentBlock::Image { source }]
         }
@@ -491,6 +496,31 @@ fn decode_anthropic_content_block(
             raw: Value::Object(block.clone()),
         }],
     })
+}
+
+fn decode_anthropic_image_source(source: &Value) -> ImageSource {
+    let Some(source_object) = source.as_object() else {
+        return ImageSource::Raw(source.clone());
+    };
+    match source_object.get("type").and_then(Value::as_str) {
+        Some("url") => source_object
+            .get("url")
+            .and_then(Value::as_str)
+            .map(|url| decode_image_url(url, None))
+            .unwrap_or_else(|| ImageSource::Raw(source.clone())),
+        Some("base64") => source_object
+            .get("data")
+            .and_then(Value::as_str)
+            .map(|data| ImageSource::Base64 {
+                media_type: source_object
+                    .get("media_type")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                data: data.to_string(),
+            })
+            .unwrap_or_else(|| ImageSource::Raw(source.clone())),
+        _ => ImageSource::Raw(source.clone()),
+    }
 }
 
 // Converts Anthropic tool-result content into text-like IR blocks.

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -173,6 +173,7 @@ fn encode_anthropic_stream(
             Vec::new()
         }
         ConversationStreamEvent::Error { message } => {
+            state.finished = true;
             vec![json!({"type": "error", "error": {"message": message}})]
         }
     }
@@ -180,6 +181,9 @@ fn encode_anthropic_stream(
 
 // Emits any missing Anthropic terminal events and closes open content blocks.
 fn finish_anthropic_stream(state: &mut StreamTranslationState) -> Vec<Value> {
+    if state.finished {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     if !state.emitted_message_start {
         out.extend(encode_anthropic_stream(

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -533,6 +533,7 @@ fn anthropic_stop_reason(reason: Option<&str>) -> String {
     match reason {
         Some("length") => "max_tokens".to_string(),
         Some("tool_calls") | Some("function_call") => "tool_use".to_string(),
+        Some("content_filter" | "refusal") => "refusal".to_string(),
         Some("end_turn") | Some("max_tokens") | Some("tool_use") | Some("stop_sequence") => {
             reason.unwrap_or("end_turn").to_string()
         }

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -323,29 +323,27 @@ impl FormatCodec for OpenAiChatCodec {
                 diagnostics: Vec::new(),
             });
         }
-        let output = response.first_output();
-        let content = output
+        let content = response
+            .outputs
+            .iter()
             .map(|output| text_from_blocks(&output.content, ""))
-            .unwrap_or_default();
-        let tool_calls = output
-            .map(|output| {
-                output
-                    .content
-                    .iter()
-                    .filter_map(|block| match block {
-                        ContentBlock::ToolCall(call) => Some(json!({
-                            "id": call.id,
-                            "type": "function",
-                            "function": {
-                                "name": call.name,
-                                "arguments": json_string(&call.arguments),
-                            },
-                        })),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
+            .collect::<String>();
+        let tool_calls = response
+            .outputs
+            .iter()
+            .flat_map(|output| output.content.iter())
+            .filter_map(|block| match block {
+                ContentBlock::ToolCall(call) => Some(json!({
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json_string(&call.arguments),
+                    },
+                })),
+                _ => None,
             })
-            .unwrap_or_default();
+            .collect::<Vec<_>>();
         let mut message = json!({
             "role": "assistant",
             "content": if content.is_empty() && !tool_calls.is_empty() {
@@ -354,10 +352,14 @@ impl FormatCodec for OpenAiChatCodec {
                 Value::String(content)
             },
         });
-        if let Some(reasoning) = output
+        let reasoning = response
+            .outputs
+            .iter()
             .map(|output| reasoning_text_from_blocks(&output.content, "\n"))
             .filter(|reasoning| !reasoning.is_empty())
-        {
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !reasoning.is_empty() {
             message["reasoning_content"] = Value::String(reasoning);
         }
         if !tool_calls.is_empty() {
@@ -372,8 +374,10 @@ impl FormatCodec for OpenAiChatCodec {
             "choices": [{
                 "index": 0,
                 "message": message,
-                "finish_reason": output
-                    .and_then(|output| output.stop_reason)
+                "finish_reason": response.outputs
+                    .iter()
+                    .rev()
+                    .find_map(|output| output.stop_reason)
                     .map(openai_finish_reason)
                     .unwrap_or("stop"),
             }],
@@ -503,38 +507,48 @@ pub(crate) fn decode_openai_content(
 pub(crate) fn decode_image_source(block: &Map<String, Value>) -> Option<ImageSource> {
     if let Some(image_url) = block.get("image_url") {
         if let Some(url) = image_url.as_str() {
-            return Some(ImageSource::Url {
-                url: url.to_string(),
-                detail: block
+            return Some(decode_image_url(
+                url,
+                block
                     .get("detail")
                     .and_then(Value::as_str)
                     .map(ToOwned::to_owned),
-            });
+            ));
         }
         if let Some(payload) = image_url.as_object() {
-            return payload
-                .get("url")
-                .and_then(Value::as_str)
-                .map(|url| ImageSource::Url {
-                    url: url.to_string(),
-                    detail: payload
+            return payload.get("url").and_then(Value::as_str).map(|url| {
+                decode_image_url(
+                    url,
+                    payload
                         .get("detail")
                         .or_else(|| block.get("detail"))
                         .and_then(Value::as_str)
                         .map(ToOwned::to_owned),
-                });
+                )
+            });
         }
     }
-    if let Some(image_url) = block.get("image_url").and_then(Value::as_str) {
-        return Some(ImageSource::Url {
-            url: image_url.to_string(),
-            detail: block
-                .get("detail")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned),
-        });
-    }
     None
+}
+
+pub(crate) fn decode_image_url(url: &str, detail: Option<String>) -> ImageSource {
+    if let Some((media_type, data)) = base64_data_uri_parts(url) {
+        ImageSource::Base64 {
+            media_type: Some(media_type.to_string()),
+            data: data.to_string(),
+        }
+    } else {
+        ImageSource::Url {
+            url: url.to_string(),
+            detail,
+        }
+    }
+}
+
+fn base64_data_uri_parts(url: &str) -> Option<(&str, &str)> {
+    let (metadata, data) = url.strip_prefix("data:")?.split_once(',')?;
+    let media_type = metadata.strip_suffix(";base64")?;
+    (!media_type.is_empty() && !data.is_empty()).then_some((media_type, data))
 }
 
 /// Decodes OpenAI file block shapes into normalized file sources.

--- a/crates/switchyard-translation/src/codecs/openai_chat/mod.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/mod.rs
@@ -9,4 +9,6 @@ mod stream;
 pub use buffered::OpenAiChatCodec;
 pub use stream::OpenAiChatStreamCodec;
 
-pub(crate) use buffered::{decode_file_source, decode_image_source};
+pub(crate) use buffered::{
+    decode_file_source, decode_image_source, decode_image_url, parse_arguments,
+};

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -373,6 +373,7 @@ fn openai_finish_reason(reason: Option<&str>) -> String {
         Some("end_turn") | Some("stop_sequence") | None => "stop".to_string(),
         Some("max_tokens") => "length".to_string(),
         Some("tool_use") => "tool_calls".to_string(),
-        Some(other) => other.to_string(),
+        Some("content_filter" | "refusal") => "content_filter".to_string(),
+        Some(_) => "stop".to_string(),
     }
 }

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -51,6 +51,15 @@ fn decode_openai_chat_stream(
             message: "OpenAI stream event is not an object".to_string(),
         }];
     };
+    if let Some(error) = object.get("error") {
+        return vec![ConversationStreamEvent::Error {
+            message: error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown OpenAI stream error")
+                .to_string(),
+        }];
+    }
 
     let mut out = Vec::new();
     if !state.saw_message_start {
@@ -204,7 +213,10 @@ fn encode_openai_chat_stream(
                 Some(openai_usage_value(state)),
             )]
         }
-        ConversationStreamEvent::Error { message } => vec![json!({"error": {"message": message}})],
+        ConversationStreamEvent::Error { message } => {
+            state.finished = true;
+            vec![json!({"error": {"message": message}})]
+        }
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use serde_json::{json, Map, Value};
 
 use crate::codecs::common::{provider_extensions, reasoning_text_from_blocks, text_from_blocks};
-use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
+use crate::codecs::openai_chat::{decode_file_source, decode_image_source, parse_arguments};
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
 };
@@ -16,8 +16,8 @@ use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::ir::{
-    is_known_role_name, ContentBlock, ConversationRequest, ConversationResponse, MediaSource,
-    Message, OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput, Role,
+    is_known_role_name, ContentBlock, ConversationRequest, ConversationResponse, ImageSource,
+    MediaSource, Message, OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput, Role,
     SamplingParams, StopReason, ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
 };
 use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
@@ -854,9 +854,10 @@ fn encode_responses_content(
             ContentBlock::Refusal { text } => {
                 blocks.push(json!({"type": "refusal", "refusal": text}));
             }
-            ContentBlock::Image { source } => {
-                blocks.push(json!({"type": "input_image", "image_url": source}));
-            }
+            ContentBlock::Image { source } => blocks.push(json!({
+                "type": "input_image",
+                "image_url": responses_image_url(source, diagnostics, policy)?,
+            })),
             ContentBlock::Audio { source } => blocks.push(match source {
                 MediaSource::Raw(raw) => json!({"type": "input_text", "text": json_string(raw)}),
                 MediaSource::Url { url, media_type } => json!({
@@ -898,6 +899,29 @@ fn encode_responses_content(
         }
     }
     Ok(Value::Array(blocks))
+}
+
+fn responses_image_url(
+    source: &ImageSource,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Value> {
+    match source {
+        ImageSource::Url { url, .. } => Ok(Value::String(url.clone())),
+        ImageSource::Base64 { media_type, data } => Ok(Value::String(format!(
+            "data:{};base64,{data}",
+            media_type.as_deref().unwrap_or("application/octet-stream")
+        ))),
+        ImageSource::Raw(Value::String(url)) => Ok(Value::String(url.clone())),
+        ImageSource::Raw(raw) => {
+            push_lossy(
+                diagnostics,
+                policy,
+                "raw image source cannot be represented as a Responses image URL",
+            )?;
+            Ok(Value::String(json_string(raw)))
+        }
+    }
 }
 
 // Encodes normalized tool definitions into Responses tool JSON.
@@ -965,7 +989,10 @@ fn decode_responses_output_item(
                     .and_then(Value::as_str)
                     .unwrap_or_default()
                     .to_string(),
-                arguments: item.get("arguments").cloned().unwrap_or_else(|| json!({})),
+                arguments: item
+                    .get("arguments")
+                    .map(parse_arguments)
+                    .unwrap_or_else(|| json!({})),
             })],
             stop_reason: Some(StopReason::ToolUse),
         })),

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -133,10 +133,19 @@ fn decode_responses_stream(
                 state.saw_backend_usage = true;
                 out.push(ConversationStreamEvent::Usage(usage));
             }
-            out.push(ConversationStreamEvent::MessageStop {
-                reason: (event_type == Some("response.incomplete"))
-                    .then(|| "incomplete".to_string()),
-            });
+            let reason = if event_type == Some("response.incomplete") {
+                let reason = responses_incomplete_reason(event);
+                state.incomplete = true;
+                state.incomplete_reason = reason.map(ToOwned::to_owned);
+                match reason {
+                    Some("max_output_tokens" | "max_tokens") => Some("max_tokens".to_string()),
+                    Some("content_filter") => Some("content_filter".to_string()),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            out.push(ConversationStreamEvent::MessageStop { reason });
             out
         }
         Some("response.failed" | "error") => vec![ConversationStreamEvent::Error {
@@ -188,6 +197,11 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
         return Vec::new();
     }
     let mut out = ensure_responses_created(state);
+    let status = if state.incomplete {
+        "incomplete"
+    } else {
+        "completed"
+    };
     if state.response_text_started {
         if let Some(output_index) = state.response_text_output_index {
             out.push(json!({
@@ -202,7 +216,7 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
                 "item": {
                     "type": "message",
                     "role": "assistant",
-                    "status": "completed",
+                    "status": status,
                     "content": [{"type": "output_text", "text": state.response_text}],
                 },
             }));
@@ -221,7 +235,7 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
             let item = json!({
                 "type": "reasoning",
                 "id": format!("rs_{output_index}"),
-                "status": "completed",
+                "status": status,
                 "content": [{
                     "type": "reasoning_text",
                     "text": state.response_reasoning_text,
@@ -266,7 +280,7 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
             "call_id": tool.id.clone().unwrap_or_else(|| format!("call_{output_index}")),
             "name": tool.name.clone().unwrap_or_default(),
             "arguments": tool.arguments,
-            "status": "completed",
+            "status": status,
         });
         out.push(json!({
             "type": "response.output_item.done",
@@ -282,12 +296,23 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
         .map(|(_, item)| item)
         .collect::<Vec<_>>();
 
+    let terminal_type = if state.incomplete {
+        "response.incomplete"
+    } else {
+        "response.completed"
+    };
+    let incomplete_details = state.incomplete.then(|| {
+        json!({
+            "reason": state.incomplete_reason.as_deref().unwrap_or("unknown"),
+        })
+    });
     out.push(json!({
-        "type": "response.completed",
+        "type": terminal_type,
         "response": {
             "id": responses_id(state),
             "object": "response",
-            "status": "completed",
+            "status": status,
+            "incomplete_details": incomplete_details,
             "model": target_model_or_source_model(state),
             "output": output,
             "usage": responses_usage_value(&state.usage),
@@ -295,6 +320,14 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
     }));
     state.finished = true;
     out
+}
+
+fn responses_incomplete_reason(event: &Value) -> Option<&str> {
+    event
+        .get("response")
+        .and_then(|response| response.get("incomplete_details"))
+        .and_then(|details| details.get("reason"))
+        .and_then(Value::as_str)
 }
 
 fn responses_error_message(event: &Value) -> String {

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -120,7 +120,7 @@ fn decode_responses_stream(
                 .unwrap_or_default()
         }
         Some("response.output_item.done") => decode_responses_output_item_done(event, state),
-        Some("response.completed") => {
+        Some("response.completed" | "response.incomplete") => {
             let mut out = Vec::new();
             if let Some(usage) = event
                 .get("response")
@@ -133,15 +133,14 @@ fn decode_responses_stream(
                 state.saw_backend_usage = true;
                 out.push(ConversationStreamEvent::Usage(usage));
             }
-            out.push(ConversationStreamEvent::MessageStop { reason: None });
+            out.push(ConversationStreamEvent::MessageStop {
+                reason: (event_type == Some("response.incomplete"))
+                    .then(|| "incomplete".to_string()),
+            });
             out
         }
-        Some("error") => vec![ConversationStreamEvent::Error {
-            message: event
-                .get("message")
-                .and_then(Value::as_str)
-                .unwrap_or("unknown Responses stream error")
-                .to_string(),
+        Some("response.failed" | "error") => vec![ConversationStreamEvent::Error {
+            message: responses_error_message(event),
         }],
         _ => Vec::new(),
     }
@@ -177,6 +176,7 @@ fn encode_responses_stream(
             Vec::new()
         }
         ConversationStreamEvent::Error { message } => {
+            state.finished = true;
             vec![json!({"type": "error", "message": message})]
         }
     }
@@ -184,6 +184,9 @@ fn encode_responses_stream(
 
 // Emits final OpenAI Responses completion events from accumulated state.
 fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
+    if state.finished {
+        return Vec::new();
+    }
     let mut out = ensure_responses_created(state);
     if state.response_text_started {
         if let Some(output_index) = state.response_text_output_index {
@@ -292,6 +295,21 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
     }));
     state.finished = true;
     out
+}
+
+fn responses_error_message(event: &Value) -> String {
+    event
+        .get("message")
+        .or_else(|| event.get("error").and_then(|error| error.get("message")))
+        .or_else(|| {
+            event
+                .get("response")
+                .and_then(|response| response.get("error"))
+                .and_then(|error| error.get("message"))
+        })
+        .and_then(Value::as_str)
+        .unwrap_or("unknown Responses stream error")
+        .to_string()
 }
 
 // Converts Responses function-call item creation into a neutral tool-call delta.

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -39,6 +39,8 @@ pub struct StreamTranslationState {
     pub(crate) saw_backend_usage: bool,
     pub(crate) usage_extras: BTreeMap<String, u64>,
     pub(crate) stop_reason: Option<String>,
+    pub(crate) incomplete: bool,
+    pub(crate) incomplete_reason: Option<String>,
 
     pub(crate) next_content_index: usize,
     pub(crate) text_block_index: Option<usize>,

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -666,6 +666,73 @@ fn responses_function_call_arguments_wrap_non_object_values_for_anthropic() -> T
     Ok(())
 }
 
+#[test]
+fn anthropic_images_translate_to_responses_image_urls() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "image", "source": {"type": "url", "url": "https://example.test/cat.png"}},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGVsbG8="}}
+            ]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["input"][0]["content"][0],
+        json!({"type": "input_image", "image_url": "https://example.test/cat.png"})
+    );
+    assert_eq!(
+        output["input"][0]["content"][1],
+        json!({"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="})
+    );
+    Ok(())
+}
+
+#[test]
+fn openai_data_uri_translates_to_anthropic_base64_image() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt",
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,aGVsbG8="}
+            }]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["messages"][0]["content"][0],
+        json!({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "aGVsbG8="}
+        })
+    );
+    Ok(())
+}
+
 // Verifies deferred Responses messages remain after matching tool results.
 #[test]
 fn responses_deferred_message_stays_after_matching_tool_result_for_openai_chat() -> TestResult {

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -320,3 +320,66 @@ fn openai_chat_response_with_text_and_tool_call_translates_both_to_responses() -
     assert_eq!(output["output"][1]["call_id"], "call_1");
     Ok(())
 }
+
+#[test]
+fn responses_mixed_text_and_tool_output_translates_to_single_message_protocols() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "resp_1",
+        "object": "response",
+        "status": "completed",
+        "model": "gpt-5",
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "Checking", "annotations": []}]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{\"q\":\"rust\"}"
+            }
+        ],
+        "usage": {"input_tokens": 4, "output_tokens": 3, "total_tokens": 7}
+    });
+
+    let chat = engine
+        .translate_response(
+            WireFormat::OpenAiResponses,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(chat["choices"][0]["message"]["content"], "Checking");
+    assert_eq!(
+        chat["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"],
+        "{\"q\":\"rust\"}"
+    );
+
+    let anthropic = engine
+        .translate_response(
+            WireFormat::OpenAiResponses,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(
+        anthropic["content"][0],
+        json!({"type": "text", "text": "Checking"})
+    );
+    assert_eq!(
+        anthropic["content"][1],
+        json!({
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "lookup",
+            "input": {"q": "rust"}
+        })
+    );
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -123,6 +123,102 @@ fn provider_errors_do_not_emit_synthetic_success_terminals() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn responses_incomplete_preserves_supported_target_semantics() -> TestResult {
+    let engine = TranslationEngine::default();
+    let created = json!({
+        "type": "response.created",
+        "response": {"id": "resp_1", "model": "gpt-4o"}
+    });
+    let max_tokens = json!({
+        "type": "response.incomplete",
+        "response": {
+            "id": "resp_1",
+            "model": "gpt-4o",
+            "incomplete_details": {"reason": "max_output_tokens"}
+        }
+    });
+
+    let mut chat_state =
+        StreamTranslationState::new(WireFormat::OpenAiResponses, WireFormat::OpenAiChat);
+    engine.translate_event(
+        &mut chat_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::OpenAiChat,
+        &created,
+    )?;
+    let chat_events = engine.translate_event(
+        &mut chat_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::OpenAiChat,
+        &max_tokens,
+    )?;
+    assert_eq!(chat_events[0]["choices"][0]["finish_reason"], "length");
+
+    let mut anthropic_state =
+        StreamTranslationState::new(WireFormat::OpenAiResponses, WireFormat::AnthropicMessages);
+    engine.translate_event(
+        &mut anthropic_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::AnthropicMessages,
+        &created,
+    )?;
+    engine.translate_event(
+        &mut anthropic_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::AnthropicMessages,
+        &json!({
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_1",
+                "model": "gpt-4o",
+                "incomplete_details": {"reason": "content_filter"}
+            }
+        }),
+    )?;
+    let anthropic_events =
+        engine.finish_stream(&mut anthropic_state, WireFormat::AnthropicMessages)?;
+    let Some(message_delta) = anthropic_events
+        .iter()
+        .find(|event| event["type"] == "message_delta")
+    else {
+        return Err("expected Anthropic terminal message_delta".into());
+    };
+    assert_eq!(message_delta["delta"]["stop_reason"], "refusal");
+
+    let mut responses_state =
+        StreamTranslationState::new(WireFormat::OpenAiResponses, WireFormat::OpenAiResponses);
+    engine.translate_event(
+        &mut responses_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::OpenAiResponses,
+        &created,
+    )?;
+    let mut response_events = engine.translate_event(
+        &mut responses_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::OpenAiResponses,
+        &max_tokens,
+    )?;
+    response_events
+        .extend(engine.finish_stream(&mut responses_state, WireFormat::OpenAiResponses)?);
+    let Some(incomplete) = response_events
+        .iter()
+        .find(|event| event["type"] == "response.incomplete")
+    else {
+        return Err("expected final Responses incomplete event".into());
+    };
+    assert_eq!(incomplete["response"]["status"], "incomplete");
+    assert_eq!(
+        incomplete["response"]["incomplete_details"]["reason"],
+        "max_output_tokens"
+    );
+    assert!(!response_events
+        .iter()
+        .any(|event| event["type"] == "response.completed"));
+    Ok(())
+}
+
 // Verifies Chat target streams expose upstream model identity, not the client request alias.
 #[test]
 fn anthropic_to_openai_chat_uses_source_model_even_with_target_override() -> TestResult {

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -88,6 +88,41 @@ fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn provider_errors_do_not_emit_synthetic_success_terminals() -> TestResult {
+    let engine = TranslationEngine::default();
+
+    let mut chat_state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let chat_events = engine.translate_event(
+        &mut chat_state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &json!({"error": {"message": "chat failed"}}),
+    )?;
+    assert_eq!(chat_events[0]["type"], "error");
+    assert!(engine
+        .finish_stream(&mut chat_state, WireFormat::AnthropicMessages)?
+        .is_empty());
+
+    let mut responses_state =
+        StreamTranslationState::new(WireFormat::OpenAiResponses, WireFormat::OpenAiChat);
+    let response_events = engine.translate_event(
+        &mut responses_state,
+        WireFormat::OpenAiResponses,
+        WireFormat::OpenAiChat,
+        &json!({
+            "type": "response.failed",
+            "response": {"error": {"message": "responses failed"}}
+        }),
+    )?;
+    assert_eq!(response_events[0]["error"]["message"], "responses failed");
+    assert!(engine
+        .finish_stream(&mut responses_state, WireFormat::OpenAiChat)?
+        .is_empty());
+    Ok(())
+}
+
 // Verifies Chat target streams expose upstream model identity, not the client request alias.
 #[test]
 fn anthropic_to_openai_chat_uses_source_model_even_with_target_override() -> TestResult {


### PR DESCRIPTION
## What

Harden the public `switchyard-translation` crate for downstream Rust consumers that need to make Switchyard routing decisions actionable across provider protocols.

- Normalize Anthropic base64 image sources and OpenAI data URIs through the shared image representation.
- Preserve mixed text and tool-call outputs when translating OpenAI Responses results to OpenAI Chat Completions or Anthropic Messages.
- Parse Responses function-call arguments before creating normalized tool calls.
- Propagate OpenAI Chat and Responses stream failures without synthesizing a later success terminal.
- Preserve `response.incomplete` for Responses clients and map its reason to valid Chat or Anthropic terminal semantics.
- Declare Rust 1.93 as the crate-specific minimum supported Rust version so the library can be consumed by the Relay plugin without raising Relay's toolchain requirement.
- Add focused request, buffered-response, and streaming regression coverage.

## Why

Switchyard should own the provider-protocol translation engine needed to execute its routing decisions. A reusable library lets infrastructure consumers use the same n-by-n request, buffered-response, and streaming behavior instead of maintaining downstream translation forks.

This is the Switchyard-side companion to [NVIDIA/NeMo-Relay #369](https://github.com/NVIDIA/NeMo-Relay/pull/369). Relay consumes this crate only when its native Switchyard plugin feature is enabled; routing-service lifecycle, credentials, dispatch, retries, and observability remain Relay-owned.

The PR is based on `topic/nemo-relay-integration` after [#35](https://github.com/NVIDIA-NeMo/Switchyard/pull/35), keeping StageRouter baseline/freshness policy separate from translation behavior.

## How tested

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p switchyard-translation` — 61 passed
- [x] `cargo clippy -p switchyard-translation --all-targets -- -D warnings`
- [x] `cargo test -p switchyard-translation` in `rust:1.93.0` — 61 passed
- [x] Downstream Relay builds both without and with its optional `switchyard` feature
- [x] `cargo test -p nemo-relay-switchyard` — 31 passed
- [x] Relay Switchyard process E2E — buffered, streaming, and fail-open paths passed

## Checklist

- [x] Unit tests added for corrected translation behavior.
- [x] Existing public translation entry points remain intact.
- [x] No routing, server, credential, or dispatch behavior is introduced.
- [x] Commits signed off per the DCO.
- [x] Python-only class/export checklist items are not applicable to this Rust crate.
- [x] No customer-facing CLI or Python surface changed.

## Notes for reviewers

Suggested review order:

1. Request image and tool-argument normalization in the buffered codecs.
2. Multi-output buffered response encoding for Chat and Anthropic targets.
3. Stream failure and incomplete-terminal behavior.
4. The translation-matrix regression fixtures.
5. The crate-scoped Rust 1.93 compatibility override.

The change deliberately remains protocol-neutral. Relay-specific target binding, fallback policy, and unsupported-extension fail-open rules stay outside this crate.
