### PR TITLE
feat(advisor): executor+advisor strategies on any Chat wire (tool_call default, review_gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,23 @@ Direct Rust bindings for migrated concrete processors/backends are exposed from
 | Response component | Plain Python/Rust object | `async process(ctx, response) -> ChatResponse` | Post-process (logging, stats) |
 | `TranslationEngine` | `switchyard_rust.translation` | `async translate(ctx, request, response) -> Any` | Convert to client's wire format |
 
+### Multi-call backends
+
+`AdvisorProfileConfig` (`switchyard/lib/profiles/advisor.py`) dispatches on `AdvisorConfig.strategy`
+to one of two backends. `AdvisorToolCallBackend` (`tool_call`, default) offers the executor a
+proxy-intercepted `advisor` tool; `AdvisorLoopBackend` (`review_gate`) injects no tool and instead
+reviews the executor's first no-tool-call turn, because front-loaded advice suppressed the
+executor's own test-and-iterate loop — its trigger is proxy-side, so prefer it for executors that
+rarely call tools. Advisor text goes into the system prompt and the first user message, never the
+newest turn, so the upstream cache prefix stays stable across a session. Both are multi-call — one
+`call(...)` issues several upstream requests before returning one `ChatResponse`, so "exactly one
+per chain" holds at the chain level only — and both do their own stats accounting into the
+classifier bucket, so they must not be wrapped in `StatsLlmBackend`, which rejects Python-only
+backends; `with_runtime_components` attaches the accumulator instead. Executor and advisor targets
+dispatch independently on `LlmTarget.format`; `responses` is rejected at `AdvisorConfig` validation.
+Compose with a `type: advisor` route (`switchyard/cli/route_bundle.py`) or an `AdvisorPresets`
+helper.
+
 ## Project Structure
 
 ```
@@ -183,6 +200,8 @@ switchyard/
 │   │   ├── openai_llm_backend.py           # OpenAiPassthroughBackend
 │   │   ├── openai_native_backend.py        # OpenAiNativeBackend
 │   │   ├── anthropic_native_llm_backend.py # AnthropicNativeBackend
+│   │   ├── advisor_tool_call_backend.py    # AdvisorToolCallBackend (advisor tool_call strategy)
+│   │   ├── advisor_loop_backend.py         # AdvisorLoopBackend (advisor review_gate strategy)
 │   │   ├── llm_target.py                   # LlmTarget, BackendFormat
 │   │   ├── multi_llm_backend.py            # MultiLlmBackend helpers
 │   │   ├── stats_llm_backend.py            # StatsLlmBackend

--- a/benchmark/run-baseline.sh
+++ b/benchmark/run-baseline.sh
@@ -881,9 +881,21 @@ if [[ "\${SERVER_ENABLED}" == "1" ]]; then
     DOCKER_RUN_ARGS=(
         -d --rm
         --name "\${SWITCHYARD_DOCKER_CONTAINER}"
-        --network "\${SWITCHYARD_DOCKER_NETWORK}"
-        --network-alias "\${SWITCHYARD_DOCKER_SERVICE_NAME}"
-        -p "127.0.0.1:$(q "${PORT}"):$(q "${PORT}")"
+    )
+    if [[ "\${SWITCHYARD_DOCKER_NETWORK_MODE:-bridge}" == "host" ]]; then
+        # Host networking: for upstreams only routable from the host (VPN /
+        # corp-internal gateways that Docker bridge networks cannot reach).
+        # Pair with --harbor-server-url http://<host-ip>:<port> so task
+        # containers reach the server at the host address.
+        DOCKER_RUN_ARGS+=(--network host)
+    else
+        DOCKER_RUN_ARGS+=(
+            --network "\${SWITCHYARD_DOCKER_NETWORK}"
+            --network-alias "\${SWITCHYARD_DOCKER_SERVICE_NAME}"
+            -p "127.0.0.1:$(q "${PORT}"):$(q "${PORT}")"
+        )
+    fi
+    DOCKER_RUN_ARGS+=(
         -v "\${REPO_ROOT}:\${REPO_ROOT}:ro"
         -v "\${RUN_DIR}:\${RUN_DIR}"
     )

--- a/crates/switchyard-components/src/backends/anthropic.rs
+++ b/crates/switchyard-components/src/backends/anthropic.rs
@@ -80,24 +80,36 @@ impl AnthropicNativeBackend {
     }
 
     fn outbound_body(&self, request: &ChatRequest) -> Result<Value> {
-        let mut body = match request.request_type() {
-            ChatRequestType::Anthropic => request.body().clone(),
-            source => {
-                self.translation
-                    .translate_request(
-                        request_wire_format(source),
-                        WireFormat::AnthropicMessages,
-                        request.body(),
-                        &self.translation_policy,
-                    )
-                    .map_err(|error| {
-                        SwitchyardError::Backend(format!(
-                            "failed to translate {source:?} request to Anthropic Messages: {error}"
-                        ))
-                    })?
-                    .body
-            }
-        };
+        // Native Anthropic requests are a TRUE passthrough: forward the client's
+        // body verbatim, rewriting only the model id (routing) and merging any
+        // operator-configured `extra_body`. The strips/normalization in the
+        // translated branch below exist for OpenAI/Responses -> Anthropic bodies,
+        // which can carry fields/shapes the Anthropic API rejects. Applying them
+        // to a real Anthropic client (e.g. Claude Code) silently drops valid
+        // Anthropic features — `context_management` (context auto-compaction),
+        // signed thinking blocks, mid-conversation system turns, client tool ids
+        // — which a passthrough must never do.
+        if matches!(request.request_type(), ChatRequestType::Anthropic) {
+            let mut body = request.body().clone();
+            set_json_model(&mut body, self.target.model.as_str());
+            merge_target_extra_body(&mut body, self.target.extra_body.as_ref());
+            return Ok(body);
+        }
+        let mut body = self
+            .translation
+            .translate_request(
+                request_wire_format(request.request_type()),
+                WireFormat::AnthropicMessages,
+                request.body(),
+                &self.translation_policy,
+            )
+            .map_err(|error| {
+                SwitchyardError::Backend(format!(
+                    "failed to translate {:?} request to Anthropic Messages: {error}",
+                    request.request_type()
+                ))
+            })?
+            .body;
         set_json_model(&mut body, self.target.model.as_str());
         strip_anthropic_incompatible_fields(&mut body);
         normalize_anthropic_body(&mut body);

--- a/crates/switchyard-components/tests/adversarial_native_backends.rs
+++ b/crates/switchyard-components/tests/adversarial_native_backends.rs
@@ -669,9 +669,9 @@ fn anthropic_backend_is_anthropic_only() -> Result<()> {
     Ok(())
 }
 
-// Non-streaming Anthropic calls should strip incompatible fields and stamp context.
+// Non-streaming native Anthropic calls forward the body verbatim and stamp context.
 #[tokio::test]
-async fn anthropic_non_streaming_strips_incompatible_fields_and_records_context() -> Result<()> {
+async fn anthropic_native_passthrough_forwards_body_verbatim() -> Result<()> {
     let server = OneShotServer::json(
         200,
         json!({
@@ -731,16 +731,22 @@ async fn anthropic_non_streaming_strips_incompatible_fields_and_records_context(
     );
     assert_eq!(request.body["model"], "target-claude");
     assert_eq!(request.body["messages"][0]["content"], "hello");
-    assert!(request.body.get("reasoning_effort").is_none());
-    assert!(request.body.get("context_management").is_none());
+    // Native Anthropic is a verbatim passthrough: client fields are preserved,
+    // not stripped (only the model id is rewritten for routing). Stripping these
+    // belongs to the translated path, not a real /v1/messages request.
+    assert_eq!(request.body["reasoning_effort"], "high");
+    assert_eq!(
+        request.body["context_management"],
+        json!({"strategy": "auto"})
+    );
     assert_eq!(request.body["made_up_beta_field"], json!({"kept": true}));
     assert_eq!(request.body["extra_body"], json!({"caller": "value"}));
     Ok(())
 }
 
-// Anthropic-native calls should downgrade Opus-4.8-style system turns for legacy targets.
+// Native Anthropic passthrough must NOT relocate message-level system/developer turns.
 #[tokio::test]
-async fn anthropic_lifts_message_level_system_roles_before_native_call() -> Result<()> {
+async fn anthropic_native_passthrough_does_not_lift_system_messages() -> Result<()> {
     let server = OneShotServer::json(200, json!({"id": "msg-test", "content": []}))?;
     let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
     let mut ctx = ProxyContext::new();
@@ -767,28 +773,24 @@ async fn anthropic_lifts_message_level_system_roles_before_native_call() -> Resu
         .await?;
     let request = server.captured()?;
 
-    assert_eq!(request.body["system"], "System rules.\n\nDeveloper rules.");
-    let messages = request.body["messages"]
-        .as_array()
-        .ok_or_else(|| SwitchyardError::Other("messages should be an array".to_string()))?;
-    let roles = messages
-        .iter()
-        .map(|message| {
-            message
-                .get("role")
-                .and_then(Value::as_str)
-                .unwrap_or("<missing>")
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(roles, vec!["user", "assistant"]);
-    assert_eq!(messages[0]["content"], "hello");
-    assert_eq!(messages[1]["content"], "ready");
+    // Verbatim: no top-level system is synthesized, and the system/developer
+    // turns stay exactly where the client put them.
+    assert!(request.body.get("system").is_none());
+    assert_eq!(
+        request.body["messages"],
+        json!([
+            {"role": "system", "content": "System rules."},
+            {"role": "user", "content": "hello"},
+            {"role": "developer", "content": [{"type": "text", "text": "Developer rules."}]},
+            {"role": "assistant", "content": "ready"}
+        ])
+    );
     Ok(())
 }
 
-// Interleaved system turns should preserve encounter order after lifting.
+// Interleaved system/developer turns are preserved in place (no lifting) on passthrough.
 #[tokio::test]
-async fn anthropic_lifts_multiple_interleaved_system_messages_in_order() -> Result<()> {
+async fn anthropic_native_passthrough_preserves_interleaved_system_messages() -> Result<()> {
     let server = OneShotServer::json(200, json!({"id": "msg-test", "content": []}))?;
     let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
     let mut ctx = ProxyContext::new();
@@ -813,24 +815,25 @@ async fn anthropic_lifts_multiple_interleaved_system_messages_in_order() -> Resu
         .await?;
     let request = server.captured()?;
 
-    assert_eq!(
-        request.body["system"],
-        "Top-level rules.\n\nFirst lifted system.\n\nSecond lifted system.\n\nDeveloper lifted system."
-    );
+    // Verbatim: top-level system unchanged, all message-level turns preserved in place.
+    assert_eq!(request.body["system"], "Top-level rules.");
     assert_eq!(
         request.body["messages"],
         json!([
+            {"role": "system", "content": "First lifted system."},
             {"role": "user", "content": "first user"},
+            {"role": "system", "content": "Second lifted system."},
             {"role": "assistant", "content": "assistant reply"},
+            {"role": "developer", "content": "Developer lifted system."},
             {"role": "user", "content": "second user"}
         ])
     );
     Ok(())
 }
 
-// Existing structured Anthropic system prompts should keep their shape when lifted text is added.
+// Structured system prompt and message-level system (incl. non-text blocks) pass through untouched.
 #[tokio::test]
-async fn anthropic_lifts_message_level_system_into_existing_system_blocks() -> Result<()> {
+async fn anthropic_native_passthrough_preserves_structured_system_and_messages() -> Result<()> {
     let server = OneShotServer::json(200, json!({"id": "msg-test", "content": []}))?;
     let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
     let mut ctx = ProxyContext::new();
@@ -858,16 +861,25 @@ async fn anthropic_lifts_message_level_system_into_existing_system_blocks() -> R
         .await?;
     let request = server.captured()?;
 
+    // Verbatim: structured system kept as-is; the message-level system turn
+    // (including its image block) is preserved, not downgraded into system.
     assert_eq!(
         request.body["system"],
-        json!([
-            {"type": "text", "text": "Existing system."},
-            {"type": "text", "text": "Lifted system.\n\nLifted input text."}
-        ])
+        json!([{"type": "text", "text": "Existing system."}])
     );
     assert_eq!(
         request.body["messages"],
-        json!([{"role": "user", "content": "hello"}])
+        json!([
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Lifted system."},
+                    {"type": "image", "source": {"type": "url", "url": "https://example.test/a.png"}},
+                    {"type": "input_text", "text": "Lifted input text."}
+                ]
+            },
+            {"role": "user", "content": "hello"}
+        ])
     );
     Ok(())
 }
@@ -898,9 +910,9 @@ async fn anthropic_translates_responses_requests_with_default_max_tokens() -> Re
     Ok(())
 }
 
-// Invalid Anthropic tool-use IDs should be sanitized consistently with results.
+// Native Anthropic passthrough preserves client tool-use IDs verbatim (no sanitization).
 #[tokio::test]
-async fn anthropic_sanitizes_invalid_tool_use_ids_and_matching_results() -> Result<()> {
+async fn anthropic_native_passthrough_preserves_tool_use_ids() -> Result<()> {
     let server = OneShotServer::json(200, json!({"id": "msg-test", "content": []}))?;
     let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
     let mut ctx = ProxyContext::new();
@@ -936,8 +948,10 @@ async fn anthropic_sanitizes_invalid_tool_use_ids_and_matching_results() -> Resu
         .await?;
     let request = server.captured()?;
 
+    // Verbatim: the client's tool-use id is forwarded unchanged (sanitization
+    // belongs to the translated path; a real Anthropic client sends valid ids).
     let tool_use_id = &request.body["messages"][1]["content"][0]["id"];
-    assert_eq!(tool_use_id, "toolu_01_bad_id");
+    assert_eq!(tool_use_id, "toolu_01*bad:id");
     assert_eq!(
         &request.body["messages"][2]["content"][0]["tool_use_id"],
         tool_use_id
@@ -945,9 +959,9 @@ async fn anthropic_sanitizes_invalid_tool_use_ids_and_matching_results() -> Resu
     Ok(())
 }
 
-// Unsigned synthetic thinking blocks should be removed before Anthropic replay.
+// Native Anthropic passthrough preserves thinking blocks verbatim (no stripping).
 #[tokio::test]
-async fn anthropic_strips_unsigned_thinking_blocks_before_native_call() -> Result<()> {
+async fn anthropic_native_passthrough_preserves_thinking_blocks() -> Result<()> {
     let server = OneShotServer::json(200, json!({"id": "msg-test", "content": []}))?;
     let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
     let mut ctx = ProxyContext::new();
@@ -985,15 +999,22 @@ async fn anthropic_strips_unsigned_thinking_blocks_before_native_call() -> Resul
         .await?;
     let request = server.captured()?;
 
+    // Verbatim: thinking blocks (signed or not) are preserved; the upstream API
+    // decides what to accept. Stripping unsigned blocks belongs to the translated
+    // path, where they are synthetic translation artifacts.
     assert_eq!(
         request.body["messages"][0]["content"]
             .as_array()
             .ok_or_else(|| SwitchyardError::Other("content should be an array".to_string()))?
             .len(),
-        1
+        2
     );
     assert_eq!(
         request.body["messages"][0]["content"][0]["type"],
+        "thinking"
+    );
+    assert_eq!(
+        request.body["messages"][0]["content"][1]["type"],
         "tool_use"
     );
     assert_eq!(
@@ -1004,7 +1025,10 @@ async fn anthropic_strips_unsigned_thinking_blocks_before_native_call() -> Resul
         request.body["messages"][1]["content"][0]["thinking"],
         "real"
     );
-    assert_eq!(request.body["messages"][2]["content"], "");
+    assert_eq!(
+        request.body["messages"][2]["content"],
+        json!([{"type": "thinking", "thinking": "only synthetic"}])
+    );
     Ok(())
 }
 

--- a/switchyard/__init__.py
+++ b/switchyard/__init__.py
@@ -40,6 +40,9 @@ from switchyard.lib.chat_response import (
 from switchyard.lib.processors.rl_logging_request_processor import RlLoggingRequestProcessor
 from switchyard.lib.processors.rl_logging_response_processor import RlLoggingResponseProcessor
 from switchyard.lib.profiles import (
+    AdvisorConfig,
+    AdvisorPresets,
+    AdvisorProfileConfig,
     ClassifierConfig,
     ContextAwareProfile,
     DeterministicRoutingConfig,
@@ -132,6 +135,10 @@ __all__ = [
     # Chain infrastructure
     "Switchyard",
     "LLMBackend",
+    # Advisor (executor consults a stronger advisor model)
+    "AdvisorConfig",
+    "AdvisorPresets",
+    "AdvisorProfileConfig",
     "StageRouterConfig",
     "StageRouterProfileConfig",
     "ClassifierConfig",

--- a/switchyard/cli/route_bundle.py
+++ b/switchyard/cli/route_bundle.py
@@ -35,11 +35,13 @@ from switchyard.lib.backends.llm_target import LlmTarget, coerce_llm_target
 from switchyard.lib.processors.llm_classifier import DEFAULT_MAX_REQUEST_CHARS
 from switchyard.lib.processors.llm_classifier.presets import PROFILE_FACTORIES
 from switchyard.lib.profiles import (
+    AdvisorProfileConfig,
     DeterministicRoutingProfileConfig,
     EscalationRouterProfileConfig,
     ProfileSwitchyard,
     StageRouterProfileConfig,
 )
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
 from switchyard.lib.profiles.deterministic_routing_config import DeterministicRoutingConfig
 from switchyard.lib.profiles.escalation_router_config import EscalationRouterConfig
 from switchyard.lib.profiles.random_routing import RandomRoutingConfig
@@ -247,6 +249,37 @@ _ESCALATION_JUDGE_KEYS = frozenset({
     "prompt_path",
     "max_request_chars",
 })
+
+_ADVISOR_ROUTE_KEYS = (
+    _ROUTE_METADATA_KEYS
+    | _TARGET_DEFAULT_ROUTE_KEYS
+    | frozenset({
+        "executor",
+        "advisor",
+        "strategy",
+        "advisor_tool_name",
+        "max_uses",
+        "inject_steering",
+        "executor_steering",
+        "advisor_length_line",
+        "advisor_system_prompt",
+        "advisor_tool_description",
+        "reviewer_system_prompt",
+        "redo_feedback_prefix",
+        "gate_trigger",
+        "gate_trigger_pattern",
+        "max_reviews",
+        "gate_stall_turns",
+        "gate_min_tool_results",
+        "seed_plan_advice",
+        "seed_advice_prefix",
+        "advisor_max_tokens",
+        "advisor_temperature",
+        "transcript_max_chars",
+        "fail_open",
+        "enable_stats",
+    })
+)
 _DETERMINISTIC_CLASSIFIER_KEYS = frozenset({
     "model",
     "api_key",
@@ -279,6 +312,7 @@ _ROUTE_KEYS_BY_TYPE: Mapping[str, frozenset[str]] = {
     "deterministic": _DETERMINISTIC_ROUTE_KEYS,
     "escalation_router": _ESCALATION_ROUTE_KEYS,
     "stage_router": _STAGE_ROUTER_ROUTE_KEYS,
+    "advisor": _ADVISOR_ROUTE_KEYS,
 }
 _DEFAULT_KEYS_BY_TYPE: Mapping[str, frozenset[str]] = {
     "model": _TARGET_DEFAULT_KEYS,
@@ -286,6 +320,7 @@ _DEFAULT_KEYS_BY_TYPE: Mapping[str, frozenset[str]] = {
     "deterministic": _TARGET_DEFAULT_KEYS,
     "escalation_router": _TARGET_DEFAULT_KEYS,
     "stage_router": _TARGET_DEFAULT_KEYS,
+    "advisor": _TARGET_DEFAULT_KEYS,
 }
 
 def _deterministic_profile_factories() -> dict[
@@ -720,6 +755,16 @@ def _build_route_chain(
             extra_response_processors=extra_response_processors,
         )
 
+    if route_type == "advisor":
+        return _advisor_switchyard(
+            model_id,
+            route,
+            target_defaults=target_defaults,
+            stats=stats,
+            pre_routing_request_processors=pre_routing_request_processors,
+            extra_response_processors=extra_response_processors,
+        )
+
     raise RouteBundleConfigError(f"unsupported route type {route_type!r}")
 
 
@@ -1079,6 +1124,44 @@ def _stage_router_switchyard(
     )
 
 
+def _advisor_switchyard(
+    model_id: str,  # noqa: ARG001 - kept for dispatch-call symmetry with siblings
+    route: Mapping[str, object],
+    *,
+    target_defaults: Mapping[str, object],
+    stats: StatsAccumulator,
+    pre_routing_request_processors: Sequence[Any] = (),
+    extra_response_processors: Sequence[Any] = (),
+) -> ChainRuntime:
+    """Build an executor + advisor chain from a ``type: advisor`` route.
+
+    Mirrors :func:`_stage_router_switchyard`: the ``executor`` / ``advisor``
+    tiers and scalar fields go through the shared ``_route_config`` →
+    :meth:`AdvisorConfig.model_validate` path. Both tiers are required, and
+    each tier's ``format`` selects its wire independently — ``anthropic``
+    (native ``/v1/messages``; the executor passthrough preserves prompt
+    caching) or ``openai`` (``/chat/completions``; Qwen/DeepSeek/vLLM/NIM/
+    OpenAI endpoints). ``responses`` targets are rejected at validation.
+    ``strategy`` selects the advisor mode: ``tool_call`` (default) offers the
+    executor a proxy-intercepted ``advisor`` tool; ``review_gate`` gates the
+    executor with a once-per-session advisor review. Both strategies work on
+    either wire.
+    """
+    config = AdvisorConfig.model_validate(
+        _route_config(route, target_defaults, ("executor", "advisor"))
+    )
+    return ProfileSwitchyard(
+        AdvisorProfileConfig.from_config(config)
+        .build()
+        .with_runtime_components(
+            stats_accumulator=stats,
+            enable_stats=config.enable_stats,
+            pre_request_processors=pre_routing_request_processors,
+            response_processors=extra_response_processors,
+        )
+    )
+
+
 def _passthrough_target(
     model_id: str,
     route: Mapping[str, object],
@@ -1227,6 +1310,7 @@ def _route_type(model_id: str, route: Mapping[str, object]) -> str:
         "escalation_router": "escalation_router",
         "stage_router": "stage_router",
         "stage_router_routing": "stage_router",
+        "advisor": "advisor",
     }
     try:
         return aliases[normalized]

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -36,9 +36,14 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     if args.routing_log_file:
         from switchyard.lib.processors.routing_log_response_processor import (
             RoutingLogResponseProcessor,
+            register_routing_log_sink,
         )
 
-        response_processors.append(RoutingLogResponseProcessor(args.routing_log_file))
+        routing_log = RoutingLogResponseProcessor(args.routing_log_file)
+        response_processors.append(routing_log)
+        # Multi-call backends (advisor strategies) emit their proxy-internal
+        # usage (consults, discarded turns) into the same log via this sink.
+        register_routing_log_sink(routing_log)
 
     table = load_route_bundle_table(
         args.routing_profiles,

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -160,7 +160,10 @@ class AdvisorLoopBackend(LLMBackend):
         # hashed prefix mints a fresh key per turn, silently resetting the
         # ``max_reviews`` budget. That failure is otherwise invisible — it only
         # shows up as unexplained advisor spend — so warn once past a threshold
-        # no legitimate single-agent run should reach.
+        # no legitimate single-agent run should reach. Tracked over *every*
+        # request, not just reviewed ones: a gate that never fires still churns
+        # keys, and that must stay observable.
+        self._sessions_seen: set[str] = set()
         self._session_churn_warned = False
         # Resolve format: auto before wire selection; injected fakes must pin
         # a concrete format (probing a fake's endpoint makes no sense).
@@ -208,20 +211,26 @@ class AdvisorLoopBackend(LLMBackend):
         body = dict(normalized.body)
         messages: list[dict[str, Any]] = list(body.get("messages") or [])
         session = _session_key(body.get("system"), messages)
-        if (
-            not self._session_churn_warned
-            and session not in self._review_counts
-            and len(self._review_counts) >= _SESSION_CHURN_WARN_AT
-        ):
-            self._session_churn_warned = True
-            log.warning(
-                "AdvisorLoopBackend: %d distinct session keys seen on one backend "
-                "instance; the hashed conversation prefix is unstable for this "
-                "client, so the max_reviews=%d budget is resetting per turn and "
-                "the advisor is being consulted far more than configured",
+        if session not in self._sessions_seen:
+            self._sessions_seen.add(session)
+            log.info(
+                "AdvisorLoopBackend: new session key (%d distinct seen, %d reviewed)",
+                len(self._sessions_seen),
                 len(self._review_counts),
-                self._config.max_reviews,
             )
+            if (
+                not self._session_churn_warned
+                and len(self._sessions_seen) >= _SESSION_CHURN_WARN_AT
+            ):
+                self._session_churn_warned = True
+                log.warning(
+                    "AdvisorLoopBackend: %d distinct session keys seen on one backend "
+                    "instance; the hashed conversation prefix is unstable for this "
+                    "client, so the max_reviews=%d budget is resetting per turn and "
+                    "the advisor may be consulted far more than configured",
+                    len(self._sessions_seen),
+                    self._config.max_reviews,
+                )
 
         # Seed the session with upfront advisor advice (consulted once at the
         # session-opening request, cached, and re-injected identically on every

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -1,0 +1,910 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``LLMBackend`` that gates the executor with a once-per-session advisor review.
+
+This is the ``review_gate`` strategy of :class:`AdvisorConfig`; the
+executor-triggered tool-call strategy lives in
+``switchyard/lib/backends/advisor_tool_call_backend.py``.
+
+An earlier design offered the executor an ``advisor`` tool it could call
+mid-generation. Trace analysis showed that front-loading the advisor's plan
+*suppressed the executor's own test-and-iterate loop* — it trusted the plan,
+one-shot it, and declared "done" prematurely (e.g. solving a concurrency task in
+4 turns vs the 17 the unadvised baseline needed to catch the bug). Net effect
+was within noise, with real losses on tasks the baseline solved by iterating.
+
+This backend instead uses the advisor as a **once-per-session review gate**:
+
+1. The executor works the task with its **own** tools (no advisor tool injected,
+   no upfront advice) — its iteration loop is untouched.
+2. The first time the executor produces a turn with **no tool calls** — either a
+   plan it is about to execute, or a claim that the task is complete — the
+   backend consults the advisor **once** to review the full transcript:
+   - ``APPROVE`` → the executor's turn is returned unchanged (sound plan / done).
+   - ``REDO`` → the advisor's optimized plan is fed back as a user turn and the
+     executor is re-invoked to **keep working** (it produces tool calls again).
+3. Subsequent turns in the same session pass through unreviewed
+   (once-per-session), so the gate can force at most one extra round of work.
+
+This is a near-superset of solo behavior — identical to the bare executor until
+"done", plus one quality gate — so it is downside-protected (≈ baseline if the
+advisor always approves) while catching premature convergence.
+
+The executor's wire is selected by ``config.executor.format``: ``anthropic``
+executors are delegated verbatim to an :class:`AnthropicNativeBackend`
+(``/v1/messages`` — the client's ``cache_control`` breakpoints reach the
+upstream unchanged, so prompt caching is honored); ``openai`` executors
+(Qwen, DeepSeek, vLLM/NIM, OpenAI) are delegated verbatim to an
+:class:`OpenAiNativeBackend` (``/chat/completions``). Tool use is read from
+the wire's native shape (Anthropic ``stop_reason``/``tool_use`` blocks, or
+OpenAI ``tool_calls``/``finish_reason``); the REDO feedback is plain-string
+assistant/user turns, valid on both wires, with a config-tunable prefix
+(``redo_feedback_prefix``). The advisor tier is likewise format-dispatched
+(``_build_advisor_caller``): Anthropic Messages or OpenAI Chat Completions.
+Because the gate's trigger is proxy-side (the first no-tool-call turn), it
+fires regardless of the executor's own tool-use discipline — the property
+that distinguishes it from the executor-triggered tool-call strategy on weak
+executors.
+
+Chain integration::
+
+    [RequestProcessor*] → AdvisorLoopBackend → [ResponseProcessor*] → TranslationEngine
+
+Declares ``supported_request_types`` for the executor's wire so the
+TranslationEngine normalizes any inbound format to it once. The outer chain's
+``StatsResponseProcessor`` records executor token usage (including cache reads)
+from the returned response; this backend additionally records the advisor
+review's usage into the classifier bucket and stamps ``ctx.selected_model``.
+
+Streaming is single-pass: until a session is reviewed, each executor turn is
+streamed and buffered while detecting whether it has tool calls; a passed-through
+/ approved turn's buffered events are replayed verbatim, so the turn is generated
+once. After the review fires, the session is pure passthrough (the upstream
+stream is returned directly — true streaming, full caching, zero overhead).
+Once-per-session is tracked in-process by a hash of the conversation's stable
+prefix (system + first user message); all of a task's turns hit the same per-run
+switchyard pod. A pod restart mid-session could allow a second review (rare,
+harmless).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+import httpx
+
+from switchyard.lib.backends.llm_target import BackendFormat
+from switchyard.lib.backends.multi_llm_backend import (
+    build_native_backend,
+    resolve_llm_target,
+)
+from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
+from switchyard.lib.chat_response.openai_chat import ResponseStream
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.roles import LLMBackend
+from switchyard_rust.core import (
+    ChatRequestType,
+    ChatResponse,
+    ChatResponseType,
+    request_type_enum,
+    request_type_matches,
+    request_with_type,
+)
+from switchyard_rust.translation import TranslationEngine
+
+if TYPE_CHECKING:
+    from switchyard.lib.backends.llm_target import LlmTarget
+    from switchyard.lib.proxy_context import ProxyContext
+    from switchyard.lib.stats_accumulator import StatsAccumulator
+    from switchyard_rust.core import ChatRequest
+
+log = logging.getLogger(__name__)
+
+_ANTHROPIC_VERSION = "2023-06-01"
+
+
+class AdvisorCaller(Protocol):
+    """Consults the advisor model and returns ``(text, usage)``."""
+
+    async def advise(self, *, system: str, transcript: str) -> tuple[str, Any]:
+        ...
+
+
+@dataclass
+class _ExecTurn:
+    """One executor turn, normalized across the buffered streaming / completion paths."""
+
+    has_tool_use: bool
+    content: str | None
+    latency_ms: float
+    completion_body: Any | None = None
+    stream_events: list[Any] | None = None
+
+
+class AdvisorLoopBackend(LLMBackend):
+    """Executor backend gated by a once-per-session advisor review (native Anthropic)."""
+
+    def __init__(
+        self,
+        config: AdvisorConfig,
+        *,
+        stats_accumulator: StatsAccumulator | None = None,
+        executor_backend: LLMBackend | None = None,
+        advisor_caller: AdvisorCaller | None = None,
+    ) -> None:
+        self._config = config
+        self._stats = stats_accumulator if config.enable_stats else None
+        self._translation = TranslationEngine()
+        # Reviews already spent per session (budgeted by ``max_reviews``),
+        # keyed by conversation prefix hash. In-process; a task's turns share
+        # one switchyard pod.
+        self._review_counts: dict[str, int] = {}
+        # Sessions whose stall checkpoint (gate_stall_turns) already fired.
+        self._stall_fired: set[str] = set()
+        # Per-session seed advice cache for seed_plan_advice ("" = unseeded).
+        self._seed_advice: dict[str, str] = {}
+        # Resolve format: auto before wire selection; injected fakes must pin
+        # a concrete format (probing a fake's endpoint makes no sense).
+        executor_target = (
+            config.executor if executor_backend is not None
+            else resolve_llm_target(config.executor)
+        )
+        self._request_type_name = _gate_request_type(executor_target.format)
+        self._request_type = cast(
+            "ChatRequestType", request_type_enum(self._request_type_name),
+        )
+        self._is_openai = self._request_type_name == "openai_chat"
+        # Pre-compiled pattern trigger; None selects the no_tool_call trigger.
+        self._trigger_pattern = (
+            re.compile(config.gate_trigger_pattern)
+            if config.gate_trigger == "pattern"
+            else None
+        )
+        # The executor is delegated to verbatim so caching survives
+        # (cache_control breakpoints on Anthropic; prefix stability on OpenAI).
+        self._executor_backend = executor_backend or build_native_backend(executor_target)
+        self._advisor_caller = advisor_caller or _build_advisor_caller(config)
+
+    async def startup(self) -> None:
+        await self._executor_backend.startup()
+
+    async def shutdown(self) -> None:
+        await self._executor_backend.shutdown()
+
+    @property
+    def supported_request_types(self) -> list[ChatRequestType]:
+        """The executor's native wire; inbound formats are normalized to it."""
+        return [self._request_type]
+
+    async def call(self, ctx: ProxyContext, request: ChatRequest) -> ChatResponse:
+        normalized = self._translation.request_to_any_of(
+            request, self.supported_request_types,
+        )
+        if not request_type_matches(normalized, self._request_type):
+            raise TypeError(
+                "AdvisorLoopBackend expected a "
+                f"{self._request_type_name} request after translation"
+            )
+
+        body = dict(normalized.body)
+        messages: list[dict[str, Any]] = list(body.get("messages") or [])
+        session = _session_key(body.get("system"), messages)
+
+        # Seed the session with upfront advisor advice (consulted once at the
+        # session-opening request, cached, and re-injected identically on every
+        # later turn so the upstream cache prefix stays stable).
+        if self._config.seed_plan_advice:
+            advice = await _seed_advice_for(
+                self._seed_advice, session, messages,
+                caller=self._advisor_caller, config=self._config, stats=self._stats,
+            )
+            if advice:
+                messages = _with_length_line(
+                    messages, self._config.seed_advice_prefix + advice,
+                )
+                body = {**body, "messages": messages}
+                normalized = request_with_type(self._request_type_name, body)
+
+        # Once the session's review budget (``max_reviews``) is spent, every
+        # turn is pure passthrough — return the upstream stream directly
+        # (true streaming, caching intact, no buffering).
+        if self._review_counts.get(session, 0) >= self._config.max_reviews:
+            return await self._passthrough(ctx, normalized)
+
+        # Budget remains: run the executor and inspect its turn.
+        turn = await self._run_executor(ctx, normalized)
+
+        # Stall checkpoint (once per session): the conversation has grown past
+        # ``gate_stall_turns`` assistant turns without the main trigger having
+        # fired — review mid-task regardless of the turn's shape.
+        stall = (
+            self._config.gate_stall_turns > 0
+            and session not in self._stall_fired
+            and sum(1 for m in messages if m.get("role") == "assistant")
+            >= self._config.gate_stall_turns
+        )
+
+        # Trigger check. "no_tool_call" gates the first turn without tool
+        # calls (function-calling harnesses; ``gate_min_tool_results`` skips
+        # early commentary turns before any real work exists); "pattern"
+        # gates the first turn whose text matches the configured marker
+        # (text-protocol harnesses, e.g. terminus's ``task_complete: true``
+        # declaration).
+        if self._trigger_pattern is not None:
+            triggered = bool(self._trigger_pattern.search(turn.content or ""))
+        else:
+            triggered = not turn.has_tool_use and (
+                _count_tool_results(messages) >= self._config.gate_min_tool_results
+            )
+        if not (triggered or stall):
+            return await self._finish(ctx, turn)
+
+        # Trigger fired: a plan, a "done", the marker, or a stall checkpoint.
+        # Gate it, spending review budget.
+        if stall and not triggered:
+            self._stall_fired.add(session)
+        self._review_counts[session] = self._review_counts.get(session, 0) + 1
+        verdict, plan = await self._review(messages, turn.content)
+        if verdict != "REDO":
+            return await self._finish(ctx, turn)
+
+        # REDO: feed the optimized plan back and re-invoke so the executor keeps
+        # working instead of stopping. The session is now reviewed, so the redo
+        # turn (and everything after it) is plain passthrough.
+        # Plain-string assistant/user turns are valid on both wires, so the
+        # feedback shape needs no dialect. The prefix is config-tunable
+        # (``redo_feedback_prefix``) for per-executor-family steering.
+        redo_messages = [
+            *messages,
+            {"role": "assistant", "content": turn.content or ""},
+            {"role": "user", "content": self._config.redo_feedback_prefix + plan},
+        ]
+        redo_body = {**body, "messages": redo_messages}
+        redo_request = request_with_type(self._request_type_name, redo_body)
+        return await self._passthrough(ctx, redo_request)
+
+    # ------------------------------------------------------------------
+    # Executor turn
+    # ------------------------------------------------------------------
+
+    async def _run_executor(self, ctx: ProxyContext, request: ChatRequest) -> _ExecTurn:
+        """Call the executor, buffering its response to detect tool use."""
+        started = time.monotonic()
+        try:
+            response = await self._executor_backend.call(ctx, request)
+        except Exception:
+            # Includes ContextWindowExceeded (the chain uses it for evict-and-retry).
+            if self._stats is not None:
+                await self._stats.record_error(self._config.executor.model)
+            raise
+
+        latency_ms = (time.monotonic() - started) * 1000.0
+        if response.response_type == ChatResponseType.ANTHROPIC_STREAM:
+            events, has_tool_use, content = await _consume_anthropic_stream(response.stream)
+            return _ExecTurn(
+                has_tool_use=has_tool_use,
+                content=content,
+                latency_ms=latency_ms,
+                stream_events=events,
+            )
+        if response.response_type == ChatResponseType.OPENAI_STREAM:
+            events, message, _usage = await _consume_openai_stream(response.stream)
+            return _ExecTurn(
+                has_tool_use=bool(message.get("tool_calls")),
+                content=message.get("content") or None,
+                latency_ms=latency_ms,
+                stream_events=events,
+            )
+        body = response.to_body()
+        if self._is_openai:
+            has_tool_use, content = _openai_completion_tool_use(body)
+        else:
+            has_tool_use, content = _completion_tool_use(body)
+        return _ExecTurn(
+            has_tool_use=has_tool_use,
+            content=content,
+            latency_ms=latency_ms,
+            completion_body=body,
+        )
+
+    async def _passthrough(self, ctx: ProxyContext, request: ChatRequest) -> ChatResponse:
+        """Call the executor and return its response verbatim (no buffering)."""
+        started = time.monotonic()
+        try:
+            response = await self._executor_backend.call(ctx, request)
+        except Exception:
+            if self._stats is not None:
+                await self._stats.record_error(self._config.executor.model)
+            raise
+        await self._stamp(ctx, (time.monotonic() - started) * 1000.0)
+        return response
+
+    async def _finish(self, ctx: ProxyContext, turn: _ExecTurn) -> ChatResponse:
+        """Record stats, stamp ctx, and rebuild the buffered turn as a response."""
+        await self._stamp(ctx, turn.latency_ms)
+        if turn.stream_events is not None:
+            if self._is_openai:
+                return ChatResponse.openai_stream(
+                    ResponseStream(_replay_events(turn.stream_events))
+                )
+            return ChatResponse.anthropic_stream(
+                AnthropicResponseStream(_replay_events(turn.stream_events))
+            )
+        if self._is_openai:
+            return ChatResponse.openai_completion(turn.completion_body)
+        return ChatResponse.anthropic_completion(turn.completion_body)
+
+    async def _stamp(self, ctx: ProxyContext, latency_ms: float) -> None:
+        ctx.selected_model = self._config.executor.model
+        ctx.backend_call_latency_ms = latency_ms
+        if self._stats is not None:
+            await self._stats.record_success(self._config.executor.model, latency_ms)
+
+    # ------------------------------------------------------------------
+    # Advisor review
+    # ------------------------------------------------------------------
+
+    async def _review(
+        self, messages: list[dict[str, Any]], terminal_content: str | None,
+    ) -> tuple[str, str]:
+        """Consult the advisor once; return ``(verdict, plan)``.
+
+        ``verdict`` is ``"APPROVE"`` or ``"REDO"``. On a fail-open advisor error
+        or an unparseable reply, defaults to ``APPROVE`` (do not disrupt a
+        possibly-correct turn).
+        """
+        transcript = self._serialize_transcript(messages, terminal_content)
+        started = time.monotonic()
+        try:
+            text, usage = await self._advisor_caller.advise(
+                system=self._config.reviewer_system_prompt, transcript=transcript,
+            )
+        except Exception as exc:
+            if not self._config.fail_open:
+                raise
+            log.warning("AdvisorLoopBackend: review failed; approving (fail-open): %s", exc)
+            if self._stats is not None:
+                await self._stats.record_classifier_error(self._config.advisor.model)
+            _audit_review(verdict="APPROVE", error=str(exc), usage=None,
+                          latency_ms=(time.monotonic() - started) * 1000.0)
+            return "APPROVE", ""
+        latency_ms = (time.monotonic() - started) * 1000.0
+        verdict, plan = _parse_verdict(text)
+        # Record the advisor review's token usage so the run's own cost output
+        # (``routing_stats_final.json``) accounts for the advisor, not just the
+        # executor. Recorded into the classifier bucket — the advisor review is
+        # a secondary-model consult, like the escalation judge — so its cost
+        # rolls into ``cost_estimate.total_cost``.
+        if self._stats is not None:
+            prompt_tokens, completion_tokens = _usage_tokens(usage)
+            await self._stats.record_classifier_usage(
+                model=self._config.advisor.model,
+                prompt_tokens=prompt_tokens or 0,
+                completion_tokens=completion_tokens or 0,
+                cached_tokens=0,
+                latency_ms=latency_ms,
+            )
+        _audit_review(verdict=verdict, error=None, usage=usage, latency_ms=latency_ms)
+        return verdict, plan
+
+    def _serialize_transcript(
+        self, messages: list[dict[str, Any]], terminal_content: str | None,
+    ) -> str:
+        """Serialize the conversation + the executor's terminal turn for review."""
+        text = json.dumps(messages, default=str, ensure_ascii=False)
+        cap = self._config.transcript_max_chars
+        if len(text) > cap:
+            text = text[: cap - 16] + "...<truncated>"
+        tail = terminal_content or "(no text)"
+        return (
+            f"Conversation so far (JSON):\n\n{text}\n\n"
+            f"The executor's latest turn (a plan, or its claim the task is done):\n{tail}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Advisor callers
+# ----------------------------------------------------------------------
+
+
+def _build_advisor_caller(config: AdvisorConfig) -> AdvisorCaller:
+    """Build the advisor caller for ``config.advisor``, dispatched on its format."""
+    from switchyard.lib.backends.llm_target import BackendFormat
+    from switchyard.lib.backends.multi_llm_backend import resolve_llm_target
+
+    target = resolve_llm_target(config.advisor)
+    if target.format == BackendFormat.ANTHROPIC:
+        return _AnthropicAdvisorCaller(
+            api_key=target.endpoint.api_key,
+            base_url=target.endpoint.base_url,
+            model=target.model,
+            max_tokens=config.advisor_max_tokens,
+            temperature=config.advisor_temperature,
+            timeout=target.endpoint.timeout_secs,
+        )
+    if target.format == BackendFormat.OPENAI:
+        return _OpenAiAdvisorCaller(
+            target=target,
+            max_tokens=config.advisor_max_tokens,
+            temperature=config.advisor_temperature,
+        )
+    raise ValueError(
+        f"advisor tier does not support format {target.format!r}; "
+        "use 'openai' or 'anthropic'"
+    )
+
+
+class _AnthropicAdvisorCaller:
+    """Reviews via an Anthropic-Messages advisor (``/v1/messages``, Bearer auth)."""
+
+    def __init__(
+        self, *, api_key: str | None, base_url: str | None, model: str,
+        max_tokens: int, temperature: float | None, timeout: float | None,
+    ) -> None:
+        self._url = _messages_url(base_url)
+        self._api_key = api_key
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        self._timeout = timeout
+
+    async def advise(self, *, system: str, transcript: str) -> tuple[str, Any]:
+        body: dict[str, Any] = {
+            "model": self._model,
+            "system": system,
+            "messages": [{"role": "user", "content": transcript}],
+            "max_tokens": self._max_tokens,
+        }
+        if self._temperature is not None:
+            body["temperature"] = self._temperature
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(self._url, json=body, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        return _anthropic_text(data), data.get("usage")
+
+
+class _OpenAiAdvisorCaller:
+    """Consults an OpenAI-Chat advisor (``/chat/completions`` via the SDK).
+
+    Covers OSS advisors (DeepSeek, Qwen on vLLM/NIM) and OpenAI. Built with
+    ``max_retries=0`` so a slow or down advisor falls through to the backend's
+    own ``fail_open`` handling at the configured timeout instead of
+    compounding via SDK exponential backoff (same rationale as the LLM
+    classifier's client).
+    """
+
+    def __init__(
+        self, *, target: LlmTarget, max_tokens: int, temperature: float | None,
+    ) -> None:
+        from switchyard.lib.llm_client import OpenAILLMClient
+
+        self._client = OpenAILLMClient(
+            api_key=target.endpoint.api_key,
+            base_url=target.endpoint.base_url,
+            timeout=target.endpoint.timeout_secs,
+            max_retries=0,
+        )
+        self._model = target.model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+        # Forward target-level overrides so gateway auth headers and vLLM
+        # chat-template hints configured on the route work here too.
+        self._extra_body = dict(target.extra_body) if target.extra_body else None
+        self._extra_headers = dict(target.extra_headers) if target.extra_headers else None
+
+    async def advise(self, *, system: str, transcript: str) -> tuple[str, Any]:
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": transcript},
+            ],
+            "max_tokens": self._max_tokens,
+        }
+        if self._temperature is not None:
+            kwargs["temperature"] = self._temperature
+        if self._extra_body is not None:
+            kwargs["extra_body"] = self._extra_body
+        if self._extra_headers is not None:
+            kwargs["extra_headers"] = self._extra_headers
+        result = await self._client.acompletion(**kwargs)
+        choices = getattr(result, "choices", None) or []
+        content = getattr(getattr(choices[0], "message", None), "content", None) if choices else None
+        return (content or "").strip(), getattr(result, "usage", None)
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers
+# ----------------------------------------------------------------------
+
+
+async def _consume_anthropic_stream(stream: Any) -> tuple[list[Any], bool, str | None]:
+    """Buffer an Anthropic stream; return (events, has_tool_use, assistant_text)."""
+    events: list[Any] = []
+    has_tool_use = False
+    text_parts: list[str] = []
+    async for event in stream:
+        events.append(event)
+        etype = _ev(event, "type")
+        if etype == "content_block_start":
+            if _ev(_ev(event, "content_block"), "type") == "tool_use":
+                has_tool_use = True
+        elif etype == "content_block_delta":
+            delta = _ev(event, "delta")
+            if _ev(delta, "type") == "text_delta":
+                piece = _ev(delta, "text")
+                if isinstance(piece, str):
+                    text_parts.append(piece)
+        elif etype == "message_delta":
+            if _ev(_ev(event, "delta"), "stop_reason") == "tool_use":
+                has_tool_use = True
+    return events, has_tool_use, ("".join(text_parts) or None)
+
+
+async def _replay_events(events: list[Any]) -> Any:
+    """Replay buffered stream events verbatim as a fresh async stream."""
+    for event in events:
+        yield event
+
+
+def _completion_tool_use(body: Any) -> tuple[bool, str | None]:
+    """Read (has_tool_use, assistant_text) from an Anthropic completion body."""
+    if not isinstance(body, dict):
+        return False, None
+    content = body.get("content") or []
+    has_tool_use = body.get("stop_reason") == "tool_use" or any(
+        isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+    )
+    return has_tool_use, (_blocks_text(content) or None)
+
+
+def _openai_completion_tool_use(body: Any) -> tuple[bool, str | None]:
+    """Read (has_tool_use, assistant_text) from an OpenAI chat.completion body.
+
+    Detection is by ``tool_calls`` presence with ``finish_reason`` as a
+    fallback — some OSS servers mislabel tool-call turns as ``stop``.
+    """
+    if not isinstance(body, dict):
+        return False, None
+    choices = body.get("choices") or [{}]
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = choice.get("message") or {}
+    has_tool_use = bool(message.get("tool_calls")) or choice.get("finish_reason") == "tool_calls"
+    return has_tool_use, (message.get("content") or None)
+
+
+def _gate_request_type(fmt: BackendFormat) -> str:
+    """Map a resolved executor format to its ``request_with_type`` discriminator."""
+    if fmt == BackendFormat.ANTHROPIC:
+        return "anthropic"
+    if fmt == BackendFormat.OPENAI:
+        return "openai_chat"
+    if fmt == BackendFormat.RESPONSES:
+        # Backstop for format: auto resolving to a Responses endpoint; the
+        # config validator rejects an explicit responses format earlier.
+        raise ValueError(
+            "the advisor strategies are Chat-shaped and do not support "
+            "Responses executors; use format 'openai' or 'anthropic'"
+        )
+    raise ValueError(
+        f"advisor executor format {fmt!r} must be resolved before constructing "
+        "the backend (pin format: 'openai' or 'anthropic' when supplying "
+        "executor_backend)"
+    )
+
+
+async def _consume_openai_stream(
+    stream: Any,
+) -> tuple[list[Any], dict[str, Any], dict[str, int]]:
+    """Buffer an OpenAI Chat stream; reassemble the assistant message and usage.
+
+    Events are the ``chat.completion.chunk`` dicts the native backend's SSE
+    parser yields (``[DONE]`` is consumed upstream and never appears; the
+    backend force-injects ``stream_options.include_usage`` so a final usage
+    chunk normally arrives). ``delta.tool_calls`` fragments merge by ``index``:
+    non-empty ``id``/``name`` replace, ``arguments`` fragments concatenate.
+    Shared by both advisor strategies.
+    """
+    events: list[Any] = []
+    text_parts: list[str] = []
+    slots: dict[int, dict[str, str]] = {}
+    usage = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
+    async for event in stream:
+        events.append(event)
+        chunk_usage = _ev(event, "usage")
+        if isinstance(chunk_usage, dict):
+            usage["input_tokens"] = int(chunk_usage.get("prompt_tokens") or 0)
+            usage["output_tokens"] = int(chunk_usage.get("completion_tokens") or 0)
+            details = chunk_usage.get("prompt_tokens_details") or {}
+            usage["cached_tokens"] = int(details.get("cached_tokens") or 0)
+        choices = _ev(event, "choices") or []
+        delta = _ev(choices[0], "delta") if choices else None
+        if delta is None:
+            continue
+        piece = _ev(delta, "content")
+        if isinstance(piece, str):
+            text_parts.append(piece)
+        for fragment in _ev(delta, "tool_calls") or []:
+            index = int(_ev(fragment, "index") or 0)
+            slot = slots.setdefault(index, {"id": "", "name": "", "arguments": ""})
+            fragment_id = _ev(fragment, "id")
+            if isinstance(fragment_id, str) and fragment_id:
+                slot["id"] = fragment_id
+            function = _ev(fragment, "function") or {}
+            name = _ev(function, "name")
+            if isinstance(name, str) and name:
+                slot["name"] = name
+            arguments = _ev(function, "arguments")
+            if isinstance(arguments, str):
+                slot["arguments"] += arguments
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts) or None,
+    }
+    if slots:
+        message["tool_calls"] = [
+            {
+                # A missing id (some OSS servers omit it in deltas) gets a
+                # synthesized one so the tool result can reference it.
+                "id": slot["id"] or f"call_switchyard_{index}",
+                "type": "function",
+                "function": {
+                    "name": slot["name"],
+                    # Empty arguments become "{}" so strict endpoints accept
+                    # the replayed history.
+                    "arguments": slot["arguments"] or "{}",
+                },
+            }
+            for index, slot in sorted(slots.items())
+        ]
+    return events, message, usage
+
+
+def _ev(event: Any, key: str) -> Any:
+    """Read a field from a stream event (dict from Rust, or an SDK object)."""
+    if event is None:
+        return None
+    if isinstance(event, dict):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
+def _with_length_line(
+    messages: list[dict[str, Any]], line: str,
+) -> list[dict[str, Any]]:
+    """Append a line of text to the **first** user message.
+
+    The doc suggests the latest user message, but the client never sees this
+    injection, so re-injecting into each turn's newest message would shift the
+    upstream cache prefix every turn. The first user message is constant across
+    a session, keeping the prefix stable; the advisor still reads the line via
+    the forwarded transcript. The list branch emits ``{"type": "text", ...}``
+    parts, valid on both the Anthropic and OpenAI wires. Shared by the advisor
+    length line, and by ``seed_plan_advice`` for the seeded upfront plan.
+    """
+    msgs = [dict(m) for m in messages]
+    for msg in msgs:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, list):
+            msg["content"] = [*content, {"type": "text", "text": line}]
+        elif isinstance(content, str) or content is None:
+            msg["content"] = f"{content or ''}\n\n{line}".lstrip()
+        break
+    return msgs
+
+
+def _seed_transcript(messages: list[dict[str, Any]], cap: int) -> str:
+    """Serialize the session-opening messages for the seed consult."""
+    text = json.dumps(messages, default=str, ensure_ascii=False)
+    if len(text) > cap:
+        text = text[: cap - 16] + "...<truncated>"
+    return (
+        f"The task the executor is about to start (JSON):\n\n{text}\n\n"
+        "The executor has not begun yet. Review the task and give your best "
+        "upfront plan: the approach, the pitfalls to avoid, and the first "
+        "concrete steps."
+    )
+
+
+async def _seed_advice_for(
+    cache: dict[str, str],
+    session: str,
+    messages: list[dict[str, Any]],
+    *,
+    caller: AdvisorCaller,
+    config: AdvisorConfig,
+    stats: StatsAccumulator | None,
+) -> str:
+    """Per-session seed advice for ``seed_plan_advice`` (both strategies).
+
+    The advisor is consulted once per session, at a request that opens the
+    conversation (no assistant turns yet); the advice is cached so every later
+    turn of the session re-injects the identical text (stable cache prefix).
+    A session first seen mid-conversation (e.g. after a proxy restart) is
+    cached as unseeded — injecting new advice mid-session would shift the
+    upstream prefix. Fail-open: a failed consult caches "" (no retry storm).
+    """
+    cached = cache.get(session)
+    if cached is not None:
+        return cached
+    if any(m.get("role") == "assistant" for m in messages):
+        cache[session] = ""
+        return ""
+    advice = await _fetch_seed_advice(
+        caller=caller, config=config, messages=messages, stats=stats,
+    )
+    cache[session] = advice
+    return advice
+
+
+async def _fetch_seed_advice(
+    *,
+    caller: AdvisorCaller,
+    config: AdvisorConfig,
+    messages: list[dict[str, Any]],
+    stats: StatsAccumulator | None,
+) -> str:
+    """Consult the advisor for an upfront plan; "" on fail-open failure."""
+    transcript = _seed_transcript(messages, config.transcript_max_chars)
+    started = time.monotonic()
+    try:
+        advice, usage = await caller.advise(
+            system=config.advisor_system_prompt, transcript=transcript,
+        )
+    except Exception as exc:
+        if not config.fail_open:
+            raise
+        log.warning("seed_plan_advice: advisor call failed; proceeding unseeded: %s", exc)
+        if stats is not None:
+            await stats.record_classifier_error(config.advisor.model)
+        _audit_seed(error=str(exc), usage=None,
+                    latency_ms=(time.monotonic() - started) * 1000.0)
+        return ""
+    latency_ms = (time.monotonic() - started) * 1000.0
+    if stats is not None:
+        prompt_tokens, completion_tokens = _usage_tokens(usage)
+        await stats.record_classifier_usage(
+            model=config.advisor.model,
+            prompt_tokens=prompt_tokens or 0,
+            completion_tokens=completion_tokens or 0,
+            cached_tokens=0,
+            latency_ms=latency_ms,
+        )
+    _audit_seed(error=None, usage=usage, latency_ms=latency_ms)
+    return advice.strip()
+
+
+def _audit_seed(*, error: str | None, usage: Any, latency_ms: float) -> None:
+    """Emit a one-line ``advisor_seed=...`` audit record to stderr."""
+    payload: dict[str, Any] = {
+        "advisor_seed": True,
+        "error": error,
+        "latency_ms": round(latency_ms, 1),
+    }
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    if prompt_tokens is not None:
+        payload["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        payload["completion_tokens"] = completion_tokens
+    sys.stderr.write(f"advisor_seed={json.dumps(payload, sort_keys=True)}\n")
+    sys.stderr.flush()
+
+
+def _count_tool_results(messages: list[dict[str, Any]]) -> int:
+    """Count tool results across both wires (OpenAI ``role: tool`` messages,
+    Anthropic ``tool_result`` blocks in user messages)."""
+    n = 0
+    for m in messages:
+        if m.get("role") == "tool":
+            n += 1
+        elif m.get("role") == "user" and isinstance(m.get("content"), list):
+            n += sum(
+                1 for b in m["content"]
+                if isinstance(b, dict) and b.get("type") == "tool_result"
+            )
+    return n
+
+
+def _session_key(system: Any, messages: list[dict[str, Any]]) -> str:
+    """Stable per-session key: hash of system prompt + first user message."""
+    parts: list[str] = ["S:" + _blocks_text(system)]
+    for m in messages:
+        if m.get("role") == "user":
+            parts.append("U:" + _blocks_text(m.get("content")))
+            break
+    return hashlib.sha256("\n".join(parts).encode("utf-8", "ignore")).hexdigest()
+
+
+def _blocks_text(content: Any) -> str:
+    """Flatten Anthropic content (string, or a list of blocks) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and isinstance(b.get("text"), str)
+        )
+    return ""
+
+
+def _parse_verdict(text: str) -> tuple[str, str]:
+    """Parse the reviewer reply into (verdict, plan). Unclear → APPROVE."""
+    stripped = (text or "").strip()
+    head = stripped[:16].upper()
+    if head.startswith("APPROVE"):
+        return "APPROVE", ""
+    if head.startswith("REDO"):
+        plan = stripped[4:].lstrip(" :\n-").strip()
+        return "REDO", plan or stripped
+    return "APPROVE", ""
+
+
+def _messages_url(base_url: str | None) -> str:
+    """Resolve the Anthropic Messages URL from a target base URL."""
+    base = (base_url or "https://api.anthropic.com").rstrip("/")
+    if base.endswith("/v1/messages"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/messages"
+    return f"{base}/v1/messages"
+
+
+def _anthropic_text(data: dict[str, Any]) -> str:
+    """Join the ``text`` content blocks of an Anthropic Messages response."""
+    content = data.get("content") or []
+    return "".join(
+        b.get("text", "") for b in content
+        if isinstance(b, dict) and b.get("type") == "text"
+    ).strip()
+
+
+def _usage_tokens(usage: Any) -> tuple[int | None, int | None]:
+    """Read (input, output) token counts from Anthropic- or OpenAI-shaped usage."""
+    if usage is None:
+        return None, None
+
+    def get(*names: str) -> int | None:
+        for name in names:
+            value = usage.get(name) if isinstance(usage, dict) else getattr(usage, name, None)
+            if value is not None:
+                return int(value)
+        return None
+
+    return get("input_tokens", "prompt_tokens"), get("output_tokens", "completion_tokens")
+
+
+def _audit_review(*, verdict: str, error: str | None, usage: Any, latency_ms: float) -> None:
+    """Emit a one-line ``advisor_review=...`` audit record to stderr."""
+    payload: dict[str, Any] = {
+        "advisor_review": True,
+        "verdict": verdict,
+        "error": error,
+        "latency_ms": round(latency_ms, 1),
+    }
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    if prompt_tokens is not None:
+        payload["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        payload["completion_tokens"] = completion_tokens
+    sys.stderr.write(f"advisor_review={json.dumps(payload, sort_keys=True)}\n")
+    sys.stderr.flush()
+
+
+__all__ = ["AdvisorCaller", "AdvisorLoopBackend"]

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -63,7 +63,8 @@ streamed and buffered while detecting whether it has tool calls; a passed-throug
 once. After the review fires, the session is pure passthrough (the upstream
 stream is returned directly — true streaming, full caching, zero overhead).
 Once-per-session is tracked in-process by a hash of the conversation's stable
-prefix (system + first user message); all of a task's turns hit the same per-run
+prefix — the client's ``cache_control``-marked system prefix plus the first user
+message (see ``_session_key``); all of a task's turns hit the same per-run
 switchyard pod. A pod restart mid-session could allow a second review (rare,
 harmless).
 """

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -109,6 +109,11 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _ANTHROPIC_VERSION = "2023-06-01"
+#: Distinct session keys on one backend instance past which the hashed
+#: conversation prefix is assumed unstable (see ``_session_key``). A single
+#: agent run legitimately opens a handful of conversations (the main thread plus
+#: any sub-agents); dozens means the key is churning per turn.
+_SESSION_CHURN_WARN_AT = 12
 
 
 class AdvisorCaller(Protocol):
@@ -151,6 +156,12 @@ class AdvisorLoopBackend(LLMBackend):
         self._stall_fired: set[str] = set()
         # Per-session seed advice cache for seed_plan_advice ("" = unseeded).
         self._seed_advice: dict[str, str] = {}
+        # Guard against session-key instability: a harness that mutates the
+        # hashed prefix mints a fresh key per turn, silently resetting the
+        # ``max_reviews`` budget. That failure is otherwise invisible — it only
+        # shows up as unexplained advisor spend — so warn once past a threshold
+        # no legitimate single-agent run should reach.
+        self._session_churn_warned = False
         # Resolve format: auto before wire selection; injected fakes must pin
         # a concrete format (probing a fake's endpoint makes no sense).
         executor_target = (
@@ -197,6 +208,20 @@ class AdvisorLoopBackend(LLMBackend):
         body = dict(normalized.body)
         messages: list[dict[str, Any]] = list(body.get("messages") or [])
         session = _session_key(body.get("system"), messages)
+        if (
+            not self._session_churn_warned
+            and session not in self._review_counts
+            and len(self._review_counts) >= _SESSION_CHURN_WARN_AT
+        ):
+            self._session_churn_warned = True
+            log.warning(
+                "AdvisorLoopBackend: %d distinct session keys seen on one backend "
+                "instance; the hashed conversation prefix is unstable for this "
+                "client, so the max_reviews=%d budget is resetting per turn and "
+                "the advisor is being consulted far more than configured",
+                len(self._review_counts),
+                self._config.max_reviews,
+            )
 
         # Seed the session with upfront advisor advice (consulted once at the
         # session-opening request, cached, and re-injected identically on every
@@ -823,13 +848,48 @@ def _count_tool_results(messages: list[dict[str, Any]]) -> int:
 
 
 def _session_key(system: Any, messages: list[dict[str, Any]]) -> str:
-    """Stable per-session key: hash of system prompt + first user message."""
-    parts: list[str] = ["S:" + _blocks_text(system)]
+    """Stable per-session key: hash of the cache-stable system prefix + first user message.
+
+    The system prompt is *not* constant across a session on real agent harnesses:
+    Claude Code re-renders volatile context (reminders, todo state, environment)
+    into it on every request. Hashing the whole thing minted a fresh key per turn,
+    silently resetting the ``max_reviews`` budget — observed as 87 reviews on a
+    single Terminal-Bench task instead of the configured 2.
+
+    Only the portion up to and including the client's last ``cache_control``
+    breakpoint is used: that prefix is stable by construction, because the client
+    is asserting it is byte-identical across turns for prompt caching. Anything
+    after the final breakpoint is volatile by definition and must not affect
+    session identity. Clients that set no breakpoint fall back to the first user
+    message alone, which is the stable task statement.
+    """
+    parts: list[str] = ["S:" + _cache_stable_system_text(system)]
     for m in messages:
         if m.get("role") == "user":
             parts.append("U:" + _blocks_text(m.get("content")))
             break
     return hashlib.sha256("\n".join(parts).encode("utf-8", "ignore")).hexdigest()
+
+
+def _cache_stable_system_text(system: Any) -> str:
+    """System text through the last ``cache_control`` breakpoint (stable prefix).
+
+    Returns "" when the client marks no breakpoint, so session identity then rests
+    on the first user message rather than on volatile per-turn system content.
+    """
+    if isinstance(system, str):
+        # A bare string carries no breakpoint information; it is echoed verbatim
+        # by clients that do not use structured system blocks.
+        return system
+    if not isinstance(system, list):
+        return ""
+    last_breakpoint = -1
+    for index, block in enumerate(system):
+        if isinstance(block, dict) and block.get("cache_control"):
+            last_breakpoint = index
+    if last_breakpoint < 0:
+        return ""
+    return _blocks_text(system[: last_breakpoint + 1])
 
 
 def _blocks_text(content: Any) -> str:

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -62,10 +62,15 @@ streamed and buffered while detecting whether it has tool calls; a passed-throug
 / approved turn's buffered events are replayed verbatim, so the turn is generated
 once. After the review fires, the session is pure passthrough (the upstream
 stream is returned directly — true streaming, full caching, zero overhead).
-Once-per-session is tracked in-process by a hash of the conversation's stable
-prefix — the client's ``cache_control``-marked system prefix plus the first user
-message (see ``_session_key``); all of a task's turns hit the same per-run
-switchyard pod. A pod restart mid-session could allow a second review (rare,
+The review budget is enforced at two levels. ``max_reviews`` caps reviews per
+backend instance — one instance serves one run, so that is the per-task ceiling
+and the authoritative bound on advisor spend. Beneath it, the same value caps
+reviews per conversation, keyed by a hash of the conversation's stable prefix
+(the client's ``cache_control``-marked system prefix plus the first user
+message; see ``_session_key``). The instance ceiling exists because that hash is
+not reliably stable: harnesses compact history, spawn sub-conversations, and
+re-render system context, each of which mints a fresh key and would otherwise
+refill a purely per-session budget. A pod restart mid-run resets both (rare,
 harmless).
 """
 
@@ -166,6 +171,13 @@ class AdvisorLoopBackend(LLMBackend):
         # keys, and that must stay observable.
         self._sessions_seen: set[str] = set()
         self._session_churn_warned = False
+        # Reviews spent across the whole backend instance. One instance serves
+        # one run, so this is the per-task ceiling and the authoritative bound
+        # on advisor spend; ``_review_counts`` remains the per-conversation
+        # bound beneath it. See the budget check in ``call`` for why a
+        # session-keyed budget alone is not sufficient.
+        self._reviews_this_instance = 0
+        self._instance_budget_logged = False
         # Resolve format: auto before wire selection; injected fakes must pin
         # a concrete format (probing a fake's endpoint makes no sense).
         executor_target = (
@@ -248,9 +260,30 @@ class AdvisorLoopBackend(LLMBackend):
                 body = {**body, "messages": messages}
                 normalized = request_with_type(self._request_type_name, body)
 
-        # Once the session's review budget (``max_reviews``) is spent, every
-        # turn is pure passthrough — return the upstream stream directly
-        # (true streaming, caching intact, no buffering).
+        # Once the review budget is spent, every turn is pure passthrough —
+        # return the upstream stream directly (true streaming, caching intact,
+        # no buffering).
+        #
+        # The budget is enforced at TWO levels, and the instance level is the
+        # one that actually bounds spend. Session identity is a content hash and
+        # is not reliably stable: agent harnesses compact history, spawn
+        # sub-conversations, and re-render system context, each of which mints a
+        # fresh key and silently refills a purely per-session budget. Measured on
+        # Terminal-Bench, one task minted up to 194 keys and drew 107 reviews
+        # against a configured ``max_reviews`` of 2. A backend instance serves a
+        # single run, so capping per instance expresses what ``max_reviews``
+        # is meant to mean — reviews for *this task* — regardless of how the
+        # client slices the conversation.
+        if self._reviews_this_instance >= self._config.max_reviews:
+            if not self._instance_budget_logged:
+                self._instance_budget_logged = True
+                log.info(
+                    "AdvisorLoopBackend: instance review budget (max_reviews=%d) "
+                    "spent across %d session key(s); remaining turns pass through",
+                    self._config.max_reviews,
+                    len(self._sessions_seen),
+                )
+            return await self._passthrough(ctx, normalized)
         if self._review_counts.get(session, 0) >= self._config.max_reviews:
             return await self._passthrough(ctx, normalized)
 
@@ -287,6 +320,7 @@ class AdvisorLoopBackend(LLMBackend):
         if stall and not triggered:
             self._stall_fired.add(session)
         self._review_counts[session] = self._review_counts.get(session, 0) + 1
+        self._reviews_this_instance += 1
         verdict, plan = await self._review(messages, turn.content)
         if verdict != "REDO":
             return await self._finish(ctx, turn)

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -630,6 +630,7 @@ def _build_advisor_caller(config: AdvisorConfig) -> AdvisorCaller:
             max_tokens=config.advisor_max_tokens,
             temperature=config.advisor_temperature,
             timeout=target.endpoint.timeout_secs,
+            extra_body=dict(target.extra_body) if target.extra_body else None,
         )
     if target.format == BackendFormat.OPENAI:
         return _OpenAiAdvisorCaller(
@@ -644,11 +645,18 @@ def _build_advisor_caller(config: AdvisorConfig) -> AdvisorCaller:
 
 
 class _AnthropicAdvisorCaller:
-    """Reviews via an Anthropic-Messages advisor (``/v1/messages``, Bearer auth)."""
+    """Reviews via an Anthropic-Messages advisor (``/v1/messages``, Bearer auth).
+
+    ``extra_body`` from the advisor target is merged into every consult body,
+    so operators can pin reasoning settings (``output_config.effort``,
+    ``thinking``) per advisor tier, matching what the router profiles can do
+    for their targets.
+    """
 
     def __init__(
         self, *, api_key: str | None, base_url: str | None, model: str,
         max_tokens: int, temperature: float | None, timeout: float | None,
+        extra_body: dict[str, Any] | None = None,
     ) -> None:
         self._url = _messages_url(base_url)
         self._api_key = api_key
@@ -656,6 +664,7 @@ class _AnthropicAdvisorCaller:
         self._max_tokens = max_tokens
         self._temperature = temperature
         self._timeout = timeout
+        self._extra_body = dict(extra_body) if extra_body else None
 
     async def advise(self, *, system: str, transcript: str) -> tuple[str, Any]:
         body: dict[str, Any] = {
@@ -666,6 +675,12 @@ class _AnthropicAdvisorCaller:
         }
         if self._temperature is not None:
             body["temperature"] = self._temperature
+        if self._extra_body:
+            # Config-supplied fields win over defaults but never clobber the
+            # consult's core fields (model/system/messages/max_tokens).
+            for key, value in self._extra_body.items():
+                if key not in ("model", "system", "messages", "max_tokens"):
+                    body[key] = value
         headers = {
             "Authorization": f"Bearer {self._api_key}",
             "anthropic-version": _ANTHROPIC_VERSION,

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -531,21 +531,23 @@ class AdvisorLoopBackend(LLMBackend):
         # escalation judge — its cost rolls into ``cost_estimate.total_cost``)
         # AND into the routing log, so per-session stats
         # (``/v1/routing/session-stats``) attribute it to the caller's session.
-        prompt_tokens, completion_tokens = _usage_tokens(usage)
+        tokens = _advisor_usage(usage)
         if self._stats is not None:
             await self._stats.record_classifier_usage(
                 model=self._config.advisor.model,
-                prompt_tokens=prompt_tokens or 0,
-                completion_tokens=completion_tokens or 0,
-                cached_tokens=0,
+                prompt_tokens=tokens["prompt_tokens"],
+                completion_tokens=tokens["completion_tokens"],
+                cached_tokens=tokens["cached_tokens"],
                 latency_ms=latency_ms,
             )
         _emit_routing_usage(
             ctx,
             model=self._config.advisor.model,
             tier="advisor_review",
-            prompt_tokens=prompt_tokens or 0,
-            completion_tokens=completion_tokens or 0,
+            prompt_tokens=tokens["prompt_tokens"],
+            completion_tokens=tokens["completion_tokens"],
+            cached_tokens=tokens["cached_tokens"],
+            cache_creation_tokens=tokens["cache_creation_tokens"],
         )
         _audit_review(
             verdict=verdict, error=None, usage=usage, latency_ms=latency_ms,
@@ -976,13 +978,13 @@ async def _fetch_seed_advice(
                     latency_ms=(time.monotonic() - started) * 1000.0)
         return ""
     latency_ms = (time.monotonic() - started) * 1000.0
-    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    tokens = _advisor_usage(usage)
     if stats is not None:
         await stats.record_classifier_usage(
             model=config.advisor.model,
-            prompt_tokens=prompt_tokens or 0,
-            completion_tokens=completion_tokens or 0,
-            cached_tokens=0,
+            prompt_tokens=tokens["prompt_tokens"],
+            completion_tokens=tokens["completion_tokens"],
+            cached_tokens=tokens["cached_tokens"],
             latency_ms=latency_ms,
         )
     if ctx is not None:
@@ -990,8 +992,10 @@ async def _fetch_seed_advice(
             ctx,
             model=config.advisor.model,
             tier="advisor_seed",
-            prompt_tokens=prompt_tokens or 0,
-            completion_tokens=completion_tokens or 0,
+            prompt_tokens=tokens["prompt_tokens"],
+            completion_tokens=tokens["completion_tokens"],
+            cached_tokens=tokens["cached_tokens"],
+            cache_creation_tokens=tokens["cache_creation_tokens"],
         )
     _audit_seed(error=None, usage=usage, latency_ms=latency_ms)
     return advice.strip()
@@ -1004,11 +1008,7 @@ def _audit_seed(*, error: str | None, usage: Any, latency_ms: float) -> None:
         "error": error,
         "latency_ms": round(latency_ms, 1),
     }
-    prompt_tokens, completion_tokens = _usage_tokens(usage)
-    if prompt_tokens is not None:
-        payload["prompt_tokens"] = prompt_tokens
-    if completion_tokens is not None:
-        payload["completion_tokens"] = completion_tokens
+    _merge_audit_tokens(payload, usage)
     sys.stderr.write(f"advisor_seed={json.dumps(payload, sort_keys=True)}\n")
     sys.stderr.flush()
 
@@ -1137,6 +1137,46 @@ def _usage_tokens(usage: Any) -> tuple[int | None, int | None]:
     return get("input_tokens", "prompt_tokens"), get("output_tokens", "completion_tokens")
 
 
+def _advisor_usage(usage: Any) -> dict[str, int]:
+    """Token fields for an advisor consult, with cache buckets folded in.
+
+    Anthropic-shaped usage reports cache reads/writes as SIBLINGS of
+    ``input_tokens`` — and some gateways (NVIDIA Inference Hub's bedrock
+    routes) auto-cache large prompts server-side even when the caller set no
+    ``cache_control``, so a consult's real input lands almost entirely in
+    ``cache_creation_input_tokens`` while ``input_tokens`` reads as ~2.
+    ``prompt_tokens`` here is the inclusive total, matching the routing-log
+    processor's accounting; OpenAI ``prompt_tokens`` are already inclusive.
+    """
+
+    def get(container: Any, name: str) -> int:
+        value = (
+            container.get(name) if isinstance(container, dict)
+            else getattr(container, name, None)
+        )
+        return int(value) if value is not None else 0
+
+    input_tokens, output_tokens = _usage_tokens(usage)
+    cache_read = get(usage, "cache_read_input_tokens")
+    cache_creation = get(usage, "cache_creation_input_tokens")
+    if cache_read or cache_creation:
+        prompt = (input_tokens or 0) + cache_read + cache_creation
+        cached = cache_read
+    else:
+        prompt = input_tokens or 0
+        details = (
+            usage.get("prompt_tokens_details") if isinstance(usage, dict)
+            else getattr(usage, "prompt_tokens_details", None)
+        )
+        cached = get(details, "cached_tokens") if details is not None else 0
+    return {
+        "prompt_tokens": prompt,
+        "cached_tokens": cached,
+        "cache_creation_tokens": cache_creation,
+        "completion_tokens": output_tokens or 0,
+    }
+
+
 def _audit_review(
     *,
     verdict: str,
@@ -1159,13 +1199,22 @@ def _audit_review(
     }
     if reply_head is not None:
         payload["reply_head"] = reply_head.strip()[:160]
-    prompt_tokens, completion_tokens = _usage_tokens(usage)
-    if prompt_tokens is not None:
-        payload["prompt_tokens"] = prompt_tokens
-    if completion_tokens is not None:
-        payload["completion_tokens"] = completion_tokens
+    _merge_audit_tokens(payload, usage)
     sys.stderr.write(f"advisor_review={json.dumps(payload, sort_keys=True)}\n")
     sys.stderr.flush()
+
+
+def _merge_audit_tokens(payload: dict[str, Any], usage: Any) -> None:
+    """Add cache-inclusive token fields to an audit payload (no-op when None)."""
+    if usage is None:
+        return
+    tokens = _advisor_usage(usage)
+    payload["prompt_tokens"] = tokens["prompt_tokens"]
+    payload["completion_tokens"] = tokens["completion_tokens"]
+    if tokens["cache_creation_tokens"]:
+        payload["cache_creation_tokens"] = tokens["cache_creation_tokens"]
+    if tokens["cached_tokens"]:
+        payload["cached_tokens"] = tokens["cached_tokens"]
 
 
 def _emit_routing_usage(
@@ -1176,6 +1225,7 @@ def _emit_routing_usage(
     prompt_tokens: int,
     completion_tokens: int,
     cached_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> None:
     """Append a proxy-internal usage record to the routing log, if one is active.
 
@@ -1196,6 +1246,7 @@ def _emit_routing_usage(
         tier=tier,
         prompt_tokens=prompt_tokens,
         cached_tokens=cached_tokens,
+        cache_creation_tokens=cache_creation_tokens,
         completion_tokens=completion_tokens,
     )
 

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -62,16 +62,20 @@ streamed and buffered while detecting whether it has tool calls; a passed-throug
 / approved turn's buffered events are replayed verbatim, so the turn is generated
 once. After the review fires, the session is pure passthrough (the upstream
 stream is returned directly — true streaming, full caching, zero overhead).
-The review budget is enforced at two levels. ``max_reviews`` caps reviews per
-backend instance — one instance serves one run, so that is the per-task ceiling
-and the authoritative bound on advisor spend. Beneath it, the same value caps
-reviews per conversation, keyed by a hash of the conversation's stable prefix
-(the client's ``cache_control``-marked system prefix plus the first user
-message; see ``_session_key``). The instance ceiling exists because that hash is
-not reliably stable: harnesses compact history, spawn sub-conversations, and
-re-render system context, each of which mints a fresh key and would otherwise
-refill a purely per-session budget. A pod restart mid-run resets both (rare,
-harmless).
+The review budget (``max_reviews``) is keyed by the caller-declared session
+identity: the ``proxy_x_session_id`` header (parsed into
+``RequestMetadata.session_id`` by the endpoints) when present, else a single
+instance-wide scope. Benchmark harnesses stamp that header with the evaluation
+id on every request — including sub-agent conversations — so on a gateway
+shared by many tasks each task gets its own budget, exactly the "reviews for
+*this* task" semantics ``max_reviews`` is meant to have. The content hash of
+the conversation prefix (``_session_key``) is NOT used for budgeting — it is
+not reliably stable (harnesses compact history, spawn sub-conversations, and
+re-render system context) — and only keys the seed-advice cache and the stall
+checkpoint. Failed advisor consults do not consume budget; after
+``_MAX_FAILED_CONSULTS_PER_SCOPE`` failures a scope stops consulting entirely,
+bounding latency against a down advisor. A pod restart mid-run resets the
+budget (rare, harmless).
 """
 
 from __future__ import annotations
@@ -95,6 +99,7 @@ from switchyard.lib.backends.multi_llm_backend import (
 from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
 from switchyard.lib.chat_response.openai_chat import ResponseStream
 from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.request_metadata import CTX_REQUEST_METADATA
 from switchyard.lib.roles import LLMBackend
 from switchyard_rust.core import (
     ChatRequestType,
@@ -120,6 +125,13 @@ _ANTHROPIC_VERSION = "2023-06-01"
 #: agent run legitimately opens a handful of conversations (the main thread plus
 #: any sub-agents); dozens means the key is churning per turn.
 _SESSION_CHURN_WARN_AT = 12
+#: Budget scope for callers that send no ``proxy_x_session_id`` header.
+_INSTANCE_SCOPE = "__instance__"
+#: Failed (fail-open) consults tolerated per budget scope before the gate stops
+#: consulting. Failures refund the review budget — a transient advisor error
+#: must not silently exhaust ``max_reviews`` with zero real reviews — so this
+#: separate cap is what bounds per-turn consult latency against a down advisor.
+_MAX_FAILED_CONSULTS_PER_SCOPE = 3
 
 
 class AdvisorCaller(Protocol):
@@ -131,13 +143,20 @@ class AdvisorCaller(Protocol):
 
 @dataclass
 class _ExecTurn:
-    """One executor turn, normalized across the buffered streaming / completion paths."""
+    """One executor turn, normalized across the buffered streaming / completion paths.
+
+    Token counts let a REDO-discarded turn (which the client never sees, so the
+    outer stats processor never prices it) be recorded explicitly.
+    """
 
     has_tool_use: bool
     content: str | None
     latency_ms: float
     completion_body: Any | None = None
     stream_events: list[Any] | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
 
 
 class AdvisorLoopBackend(LLMBackend):
@@ -154,30 +173,26 @@ class AdvisorLoopBackend(LLMBackend):
         self._config = config
         self._stats = stats_accumulator if config.enable_stats else None
         self._translation = TranslationEngine()
-        # Reviews already spent per session (budgeted by ``max_reviews``),
-        # keyed by conversation prefix hash. In-process; a task's turns share
-        # one switchyard pod.
-        self._review_counts: dict[str, int] = {}
         # Sessions whose stall checkpoint (gate_stall_turns) already fired.
         self._stall_fired: set[str] = set()
         # Per-session seed advice cache for seed_plan_advice ("" = unseeded).
         self._seed_advice: dict[str, str] = {}
-        # Guard against session-key instability: a harness that mutates the
-        # hashed prefix mints a fresh key per turn, silently resetting the
-        # ``max_reviews`` budget. That failure is otherwise invisible — it only
-        # shows up as unexplained advisor spend — so warn once past a threshold
-        # no legitimate single-agent run should reach. Tracked over *every*
-        # request, not just reviewed ones: a gate that never fires still churns
-        # keys, and that must stay observable.
+        # Session-key churn observability: the hashed conversation prefix keys
+        # the seed cache and stall checkpoint, so instability there degrades
+        # those features (it no longer affects the review budget, which keys on
+        # the caller's session header). Tracked over *every* request so churn
+        # stays observable even when the gate never fires.
         self._sessions_seen: set[str] = set()
         self._session_churn_warned = False
-        # Reviews spent across the whole backend instance. One instance serves
-        # one run, so this is the per-task ceiling and the authoritative bound
-        # on advisor spend; ``_review_counts`` remains the per-conversation
-        # bound beneath it. See the budget check in ``call`` for why a
-        # session-keyed budget alone is not sufficient.
-        self._reviews_this_instance = 0
-        self._instance_budget_logged = False
+        # Review budget, keyed by ``_budget_scope``: the caller's
+        # ``proxy_x_session_id`` header when present (one evaluation/task on
+        # benchmark harnesses, shared by its sub-agents), else one
+        # instance-wide scope. On a gateway shared by many tasks this gives
+        # each task its own ``max_reviews`` budget. Failed consults refund the
+        # budget and count separately (``_MAX_FAILED_CONSULTS_PER_SCOPE``).
+        self._reviews_by_scope: dict[str, int] = {}
+        self._failed_consults_by_scope: dict[str, int] = {}
+        self._budget_logged_scopes: set[str] = set()
         # Resolve format: auto before wire selection; injected fakes must pin
         # a concrete format (probing a fake's endpoint makes no sense).
         executor_target = (
@@ -227,9 +242,8 @@ class AdvisorLoopBackend(LLMBackend):
         if session not in self._sessions_seen:
             self._sessions_seen.add(session)
             log.info(
-                "AdvisorLoopBackend: new session key (%d distinct seen, %d reviewed)",
+                "AdvisorLoopBackend: new session key (%d distinct seen)",
                 len(self._sessions_seen),
-                len(self._review_counts),
             )
             if (
                 not self._session_churn_warned
@@ -239,10 +253,10 @@ class AdvisorLoopBackend(LLMBackend):
                 log.warning(
                     "AdvisorLoopBackend: %d distinct session keys seen on one backend "
                     "instance; the hashed conversation prefix is unstable for this "
-                    "client, so the max_reviews=%d budget is resetting per turn and "
-                    "the advisor may be consulted far more than configured",
+                    "client, so seed-advice caching and stall checkpoints may misfire "
+                    "(the review budget is unaffected — it keys on the caller's "
+                    "session header)",
                     len(self._sessions_seen),
-                    self._config.max_reviews,
                 )
 
         # Seed the session with upfront advisor advice (consulted once at the
@@ -252,6 +266,7 @@ class AdvisorLoopBackend(LLMBackend):
             advice = await _seed_advice_for(
                 self._seed_advice, session, messages,
                 caller=self._advisor_caller, config=self._config, stats=self._stats,
+                ctx=ctx,
             )
             if advice:
                 messages = _with_length_line(
@@ -264,27 +279,30 @@ class AdvisorLoopBackend(LLMBackend):
         # return the upstream stream directly (true streaming, caching intact,
         # no buffering).
         #
-        # The budget is enforced at TWO levels, and the instance level is the
-        # one that actually bounds spend. Session identity is a content hash and
-        # is not reliably stable: agent harnesses compact history, spawn
-        # sub-conversations, and re-render system context, each of which mints a
-        # fresh key and silently refills a purely per-session budget. Measured on
+        # The budget keys on the caller's declared session identity
+        # (``proxy_x_session_id`` header), NOT on the conversation content hash:
+        # content hashes are unstable (harnesses compact history, spawn
+        # sub-conversations, re-render system context — measured on
         # Terminal-Bench, one task minted up to 194 keys and drew 107 reviews
-        # against a configured ``max_reviews`` of 2. A backend instance serves a
-        # single run, so capping per instance expresses what ``max_reviews``
-        # is meant to mean — reviews for *this task* — regardless of how the
-        # client slices the conversation.
-        if self._reviews_this_instance >= self._config.max_reviews:
-            if not self._instance_budget_logged:
-                self._instance_budget_logged = True
+        # against a configured ``max_reviews`` of 2), and an instance-wide cap
+        # breaks the other way on a gateway shared by many tasks, where it
+        # would bound reviews for the whole run instead of per task. The header
+        # is stamped per evaluation by benchmark harnesses (sub-agents
+        # included), so it expresses exactly "reviews for *this* task"; callers
+        # that send no header fall back to one instance-wide scope.
+        scope = self._budget_scope(ctx)
+        if self._scope_exhausted(scope):
+            if scope not in self._budget_logged_scopes:
+                self._budget_logged_scopes.add(scope)
                 log.info(
-                    "AdvisorLoopBackend: instance review budget (max_reviews=%d) "
-                    "spent across %d session key(s); remaining turns pass through",
+                    "AdvisorLoopBackend: review budget spent for scope %s "
+                    "(max_reviews=%d, reviews=%d, failed consults=%d); "
+                    "remaining turns pass through",
+                    scope,
                     self._config.max_reviews,
-                    len(self._sessions_seen),
+                    self._reviews_by_scope.get(scope, 0),
+                    self._failed_consults_by_scope.get(scope, 0),
                 )
-            return await self._passthrough(ctx, normalized)
-        if self._review_counts.get(session, 0) >= self._config.max_reviews:
             return await self._passthrough(ctx, normalized)
 
         # Budget remains: run the executor and inspect its turn.
@@ -316,12 +334,18 @@ class AdvisorLoopBackend(LLMBackend):
             return await self._finish(ctx, turn)
 
         # Trigger fired: a plan, a "done", the marker, or a stall checkpoint.
-        # Gate it, spending review budget.
+        # Gate it. Budget is reserved before the consult (so concurrent
+        # requests in one scope cannot overdraw across the await) and refunded
+        # if the consult itself failed — a fail-open error is not a review.
         if stall and not triggered:
             self._stall_fired.add(session)
-        self._review_counts[session] = self._review_counts.get(session, 0) + 1
-        self._reviews_this_instance += 1
-        verdict, plan = await self._review(messages, turn.content)
+        self._reviews_by_scope[scope] = self._reviews_by_scope.get(scope, 0) + 1
+        verdict, plan, consulted = await self._review(messages, turn.content, ctx)
+        if not consulted:
+            self._reviews_by_scope[scope] -= 1
+            self._failed_consults_by_scope[scope] = (
+                self._failed_consults_by_scope.get(scope, 0) + 1
+            )
         if verdict != "REDO":
             return await self._finish(ctx, turn)
 
@@ -331,6 +355,11 @@ class AdvisorLoopBackend(LLMBackend):
         # Plain-string assistant/user turns are valid on both wires, so the
         # feedback shape needs no dialect. The prefix is config-tunable
         # (``redo_feedback_prefix``) for per-executor-family steering.
+        # The gated turn is discarded (the client never sees it) — record its
+        # usage into the classifier bucket and the routing log so the run's
+        # cost output prices it, mirroring the tool_call strategy's handling
+        # of proxy-internal turns.
+        await self._record_discarded_turn(ctx, turn)
         redo_messages = [
             *messages,
             {"role": "assistant", "content": turn.content or ""},
@@ -339,6 +368,20 @@ class AdvisorLoopBackend(LLMBackend):
         redo_body = {**body, "messages": redo_messages}
         redo_request = request_with_type(self._request_type_name, redo_body)
         return await self._passthrough(ctx, redo_request)
+
+    def _budget_scope(self, ctx: ProxyContext) -> str:
+        """Review-budget key: the caller's session header, else instance-wide."""
+        metadata = ctx.metadata.get(CTX_REQUEST_METADATA)
+        session_id = getattr(metadata, "session_id", None)
+        return f"client:{session_id}" if session_id else _INSTANCE_SCOPE
+
+    def _scope_exhausted(self, scope: str) -> bool:
+        """True when a scope has no review budget or too many failed consults."""
+        return (
+            self._reviews_by_scope.get(scope, 0) >= self._config.max_reviews
+            or self._failed_consults_by_scope.get(scope, 0)
+            >= _MAX_FAILED_CONSULTS_PER_SCOPE
+        )
 
     # ------------------------------------------------------------------
     # Executor turn
@@ -357,31 +400,43 @@ class AdvisorLoopBackend(LLMBackend):
 
         latency_ms = (time.monotonic() - started) * 1000.0
         if response.response_type == ChatResponseType.ANTHROPIC_STREAM:
-            events, has_tool_use, content = await _consume_anthropic_stream(response.stream)
+            events, has_tool_use, content, usage = await _consume_anthropic_stream(
+                response.stream
+            )
             return _ExecTurn(
                 has_tool_use=has_tool_use,
                 content=content,
                 latency_ms=latency_ms,
                 stream_events=events,
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+                cached_tokens=usage["cached_tokens"],
             )
         if response.response_type == ChatResponseType.OPENAI_STREAM:
-            events, message, _usage = await _consume_openai_stream(response.stream)
+            events, message, usage = await _consume_openai_stream(response.stream)
             return _ExecTurn(
                 has_tool_use=bool(message.get("tool_calls")),
                 content=message.get("content") or None,
                 latency_ms=latency_ms,
                 stream_events=events,
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+                cached_tokens=usage["cached_tokens"],
             )
         body = response.to_body()
         if self._is_openai:
             has_tool_use, content = _openai_completion_tool_use(body)
         else:
             has_tool_use, content = _completion_tool_use(body)
+        usage = _completion_usage(body, is_openai=self._is_openai)
         return _ExecTurn(
             has_tool_use=has_tool_use,
             content=content,
             latency_ms=latency_ms,
             completion_body=body,
+            input_tokens=usage["input_tokens"],
+            output_tokens=usage["output_tokens"],
+            cached_tokens=usage["cached_tokens"],
         )
 
     async def _passthrough(self, ctx: ProxyContext, request: ChatRequest) -> ChatResponse:
@@ -417,18 +472,41 @@ class AdvisorLoopBackend(LLMBackend):
         if self._stats is not None:
             await self._stats.record_success(self._config.executor.model, latency_ms)
 
+    async def _record_discarded_turn(self, ctx: ProxyContext, turn: _ExecTurn) -> None:
+        """Price a REDO-discarded executor turn into the classifier bucket + routing log."""
+        if self._stats is not None:
+            await self._stats.record_classifier_usage(
+                model=self._config.executor.model,
+                prompt_tokens=turn.input_tokens,
+                completion_tokens=turn.output_tokens,
+                cached_tokens=turn.cached_tokens,
+                latency_ms=turn.latency_ms,
+            )
+        _emit_routing_usage(
+            ctx,
+            model=self._config.executor.model,
+            tier="review_gate_discarded",
+            prompt_tokens=turn.input_tokens,
+            completion_tokens=turn.output_tokens,
+            cached_tokens=turn.cached_tokens,
+        )
+
     # ------------------------------------------------------------------
     # Advisor review
     # ------------------------------------------------------------------
 
     async def _review(
-        self, messages: list[dict[str, Any]], terminal_content: str | None,
-    ) -> tuple[str, str]:
-        """Consult the advisor once; return ``(verdict, plan)``.
+        self,
+        messages: list[dict[str, Any]],
+        terminal_content: str | None,
+        ctx: ProxyContext,
+    ) -> tuple[str, str, bool]:
+        """Consult the advisor once; return ``(verdict, plan, consulted)``.
 
         ``verdict`` is ``"APPROVE"`` or ``"REDO"``. On a fail-open advisor error
         or an unparseable reply, defaults to ``APPROVE`` (do not disrupt a
-        possibly-correct turn).
+        possibly-correct turn). ``consulted`` is False when the advisor call
+        itself failed, so the caller can refund the review budget.
         """
         transcript = self._serialize_transcript(messages, terminal_content)
         started = time.monotonic()
@@ -444,16 +522,17 @@ class AdvisorLoopBackend(LLMBackend):
                 await self._stats.record_classifier_error(self._config.advisor.model)
             _audit_review(verdict="APPROVE", error=str(exc), usage=None,
                           latency_ms=(time.monotonic() - started) * 1000.0)
-            return "APPROVE", ""
+            return "APPROVE", "", False
         latency_ms = (time.monotonic() - started) * 1000.0
         verdict, plan = _parse_verdict(text)
         # Record the advisor review's token usage so the run's own cost output
-        # (``routing_stats_final.json``) accounts for the advisor, not just the
-        # executor. Recorded into the classifier bucket — the advisor review is
-        # a secondary-model consult, like the escalation judge — so its cost
-        # rolls into ``cost_estimate.total_cost``.
+        # accounts for the advisor, not just the executor: into the classifier
+        # bucket (the advisor review is a secondary-model consult, like the
+        # escalation judge — its cost rolls into ``cost_estimate.total_cost``)
+        # AND into the routing log, so per-session stats
+        # (``/v1/routing/session-stats``) attribute it to the caller's session.
+        prompt_tokens, completion_tokens = _usage_tokens(usage)
         if self._stats is not None:
-            prompt_tokens, completion_tokens = _usage_tokens(usage)
             await self._stats.record_classifier_usage(
                 model=self._config.advisor.model,
                 prompt_tokens=prompt_tokens or 0,
@@ -461,21 +540,44 @@ class AdvisorLoopBackend(LLMBackend):
                 cached_tokens=0,
                 latency_ms=latency_ms,
             )
-        _audit_review(verdict=verdict, error=None, usage=usage, latency_ms=latency_ms)
-        return verdict, plan
+        _emit_routing_usage(
+            ctx,
+            model=self._config.advisor.model,
+            tier="advisor_review",
+            prompt_tokens=prompt_tokens or 0,
+            completion_tokens=completion_tokens or 0,
+        )
+        _audit_review(
+            verdict=verdict, error=None, usage=usage, latency_ms=latency_ms,
+            reply_head=text,
+        )
+        return verdict, plan, True
 
     def _serialize_transcript(
         self, messages: list[dict[str, Any]], terminal_content: str | None,
     ) -> str:
-        """Serialize the conversation + the executor's terminal turn for review."""
+        """Serialize the conversation + the executor's terminal turn for review.
+
+        Over ``transcript_max_chars``, the MIDDLE is dropped: the head keeps
+        the task statement, the tail keeps the executor's most recent work —
+        the part a completeness review is actually about. (Head-only
+        truncation left the reviewer judging "genuinely done?" without ever
+        seeing the recent evidence.)
+        """
         text = json.dumps(messages, default=str, ensure_ascii=False)
         cap = self._config.transcript_max_chars
         if len(text) > cap:
-            text = text[: cap - 16] + "...<truncated>"
-        tail = terminal_content or "(no text)"
+            head = cap // 4
+            tail = cap - head
+            text = (
+                text[:head]
+                + "\n...<middle of the conversation truncated>...\n"
+                + text[-tail:]
+            )
+        tail_turn = terminal_content or "(no text)"
         return (
             f"Conversation so far (JSON):\n\n{text}\n\n"
-            f"The executor's latest turn (a plan, or its claim the task is done):\n{tail}"
+            f"The executor's latest turn (a plan, or its claim the task is done):\n{tail_turn}"
         )
 
 
@@ -601,15 +703,22 @@ class _OpenAiAdvisorCaller:
 # ----------------------------------------------------------------------
 
 
-async def _consume_anthropic_stream(stream: Any) -> tuple[list[Any], bool, str | None]:
-    """Buffer an Anthropic stream; return (events, has_tool_use, assistant_text)."""
+async def _consume_anthropic_stream(
+    stream: Any,
+) -> tuple[list[Any], bool, str | None, dict[str, int]]:
+    """Buffer an Anthropic stream; return (events, has_tool_use, assistant_text, usage)."""
     events: list[Any] = []
     has_tool_use = False
     text_parts: list[str] = []
+    usage = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
     async for event in stream:
         events.append(event)
         etype = _ev(event, "type")
-        if etype == "content_block_start":
+        if etype == "message_start":
+            start_usage = _ev(_ev(event, "message"), "usage") or {}
+            usage["input_tokens"] = int(start_usage.get("input_tokens") or 0)
+            usage["cached_tokens"] = int(start_usage.get("cache_read_input_tokens") or 0)
+        elif etype == "content_block_start":
             if _ev(_ev(event, "content_block"), "type") == "tool_use":
                 has_tool_use = True
         elif etype == "content_block_delta":
@@ -621,7 +730,25 @@ async def _consume_anthropic_stream(stream: Any) -> tuple[list[Any], bool, str |
         elif etype == "message_delta":
             if _ev(_ev(event, "delta"), "stop_reason") == "tool_use":
                 has_tool_use = True
-    return events, has_tool_use, ("".join(text_parts) or None)
+            delta_usage = _ev(event, "usage") or {}
+            usage["output_tokens"] = int(delta_usage.get("output_tokens") or 0)
+    return events, has_tool_use, ("".join(text_parts) or None), usage
+
+
+def _completion_usage(body: Any, *, is_openai: bool) -> dict[str, int]:
+    """Read ``_ExecTurn`` token counts from a non-streamed completion body."""
+    usage = body.get("usage") if isinstance(body, dict) else None
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    details = usage if isinstance(usage, dict) else {}
+    if is_openai:
+        cached = (details.get("prompt_tokens_details") or {}).get("cached_tokens") or 0
+    else:
+        cached = details.get("cache_read_input_tokens") or 0
+    return {
+        "input_tokens": prompt_tokens or 0,
+        "output_tokens": completion_tokens or 0,
+        "cached_tokens": int(cached),
+    }
 
 
 async def _replay_events(events: list[Any]) -> Any:
@@ -800,6 +927,7 @@ async def _seed_advice_for(
     caller: AdvisorCaller,
     config: AdvisorConfig,
     stats: StatsAccumulator | None,
+    ctx: ProxyContext | None = None,
 ) -> str:
     """Per-session seed advice for ``seed_plan_advice`` (both strategies).
 
@@ -817,7 +945,7 @@ async def _seed_advice_for(
         cache[session] = ""
         return ""
     advice = await _fetch_seed_advice(
-        caller=caller, config=config, messages=messages, stats=stats,
+        caller=caller, config=config, messages=messages, stats=stats, ctx=ctx,
     )
     cache[session] = advice
     return advice
@@ -829,6 +957,7 @@ async def _fetch_seed_advice(
     config: AdvisorConfig,
     messages: list[dict[str, Any]],
     stats: StatsAccumulator | None,
+    ctx: ProxyContext | None = None,
 ) -> str:
     """Consult the advisor for an upfront plan; "" on fail-open failure."""
     transcript = _seed_transcript(messages, config.transcript_max_chars)
@@ -847,14 +976,22 @@ async def _fetch_seed_advice(
                     latency_ms=(time.monotonic() - started) * 1000.0)
         return ""
     latency_ms = (time.monotonic() - started) * 1000.0
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
     if stats is not None:
-        prompt_tokens, completion_tokens = _usage_tokens(usage)
         await stats.record_classifier_usage(
             model=config.advisor.model,
             prompt_tokens=prompt_tokens or 0,
             completion_tokens=completion_tokens or 0,
             cached_tokens=0,
             latency_ms=latency_ms,
+        )
+    if ctx is not None:
+        _emit_routing_usage(
+            ctx,
+            model=config.advisor.model,
+            tier="advisor_seed",
+            prompt_tokens=prompt_tokens or 0,
+            completion_tokens=completion_tokens or 0,
         )
     _audit_seed(error=None, usage=usage, latency_ms=latency_ms)
     return advice.strip()
@@ -948,16 +1085,22 @@ def _blocks_text(content: Any) -> str:
     return ""
 
 
+#: First APPROVE/REDO token in the reply's head decides the verdict. A window
+#: (rather than a strict first-word match) tolerates the wrappers reviewers
+#: actually produce — "**REDO**", "Verdict: REDO", a leading pleasantry —
+#: which a startswith parser silently turned into APPROVE.
+_VERDICT_RE = re.compile(r"\b(APPROVE|REDO)\b", re.IGNORECASE)
+_VERDICT_WINDOW = 64
+
+
 def _parse_verdict(text: str) -> tuple[str, str]:
     """Parse the reviewer reply into (verdict, plan). Unclear → APPROVE."""
     stripped = (text or "").strip()
-    head = stripped[:16].upper()
-    if head.startswith("APPROVE"):
+    match = _VERDICT_RE.search(stripped[:_VERDICT_WINDOW])
+    if match is None or match.group(1).upper() == "APPROVE":
         return "APPROVE", ""
-    if head.startswith("REDO"):
-        plan = stripped[4:].lstrip(" :\n-").strip()
-        return "REDO", plan or stripped
-    return "APPROVE", ""
+    plan = stripped[match.end():].lstrip(" *_:\n-").strip()
+    return "REDO", plan or stripped
 
 
 def _messages_url(base_url: str | None) -> str:
@@ -994,14 +1137,28 @@ def _usage_tokens(usage: Any) -> tuple[int | None, int | None]:
     return get("input_tokens", "prompt_tokens"), get("output_tokens", "completion_tokens")
 
 
-def _audit_review(*, verdict: str, error: str | None, usage: Any, latency_ms: float) -> None:
-    """Emit a one-line ``advisor_review=...`` audit record to stderr."""
+def _audit_review(
+    *,
+    verdict: str,
+    error: str | None,
+    usage: Any,
+    latency_ms: float,
+    reply_head: str | None = None,
+) -> None:
+    """Emit a one-line ``advisor_review=...`` audit record to stderr.
+
+    ``reply_head`` carries the raw reply's first characters so a verdict the
+    parser read differently than the reviewer intended is visible in the logs
+    (the parsed verdict alone hides misparses).
+    """
     payload: dict[str, Any] = {
         "advisor_review": True,
         "verdict": verdict,
         "error": error,
         "latency_ms": round(latency_ms, 1),
     }
+    if reply_head is not None:
+        payload["reply_head"] = reply_head.strip()[:160]
     prompt_tokens, completion_tokens = _usage_tokens(usage)
     if prompt_tokens is not None:
         payload["prompt_tokens"] = prompt_tokens
@@ -1009,6 +1166,38 @@ def _audit_review(*, verdict: str, error: str | None, usage: Any, latency_ms: fl
         payload["completion_tokens"] = completion_tokens
     sys.stderr.write(f"advisor_review={json.dumps(payload, sort_keys=True)}\n")
     sys.stderr.flush()
+
+
+def _emit_routing_usage(
+    ctx: ProxyContext,
+    *,
+    model: str,
+    tier: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached_tokens: int = 0,
+) -> None:
+    """Append a proxy-internal usage record to the routing log, if one is active.
+
+    The routing-log response processor only sees the chain's terminal
+    response; advisor consults and REDO-discarded executor turns happen inside
+    the backend and would otherwise be invisible to
+    ``/v1/routing/session-stats`` — and with it, per-model cost attribution.
+    """
+    from switchyard.lib.processors.routing_log_response_processor import (
+        emit_auxiliary_record,
+    )
+
+    metadata = ctx.metadata.get(CTX_REQUEST_METADATA)
+    emit_auxiliary_record(
+        session_id=getattr(metadata, "session_id", None),
+        task=getattr(metadata, "task", None),
+        model=model,
+        tier=tier,
+        prompt_tokens=prompt_tokens,
+        cached_tokens=cached_tokens,
+        completion_tokens=completion_tokens,
+    )
 
 
 __all__ = ["AdvisorCaller", "AdvisorLoopBackend"]

--- a/switchyard/lib/backends/advisor_loop_backend.py
+++ b/switchyard/lib/backends/advisor_loop_backend.py
@@ -157,6 +157,9 @@ class _ExecTurn:
     input_tokens: int = 0
     output_tokens: int = 0
     cached_tokens: int = 0
+    #: Reasoning-model internal text (OpenAI ``reasoning_content``); the
+    #: fallback evidence when a gated turn has no visible content at all.
+    reasoning_text: str | None = None
 
 
 class AdvisorLoopBackend(LLMBackend):
@@ -339,8 +342,16 @@ class AdvisorLoopBackend(LLMBackend):
         # if the consult itself failed — a fail-open error is not a review.
         if stall and not triggered:
             self._stall_fired.add(session)
+        # A reasoning-only turn (no visible text) still triggers; hand the
+        # advisor the reasoning as labeled evidence instead of "(no text)".
+        review_tail = turn.content
+        if review_tail is None and turn.reasoning_text:
+            review_tail = (
+                "(the executor produced no visible text this turn; its "
+                "internal reasoning follows)\n" + turn.reasoning_text
+            )
         self._reviews_by_scope[scope] = self._reviews_by_scope.get(scope, 0) + 1
-        verdict, plan, consulted = await self._review(messages, turn.content, ctx)
+        verdict, plan, consulted = await self._review(messages, review_tail, ctx)
         if not consulted:
             self._reviews_by_scope[scope] -= 1
             self._failed_consults_by_scope[scope] = (
@@ -360,9 +371,13 @@ class AdvisorLoopBackend(LLMBackend):
         # cost output prices it, mirroring the tool_call strategy's handling
         # of proxy-internal turns.
         await self._record_discarded_turn(ctx, turn)
+        # The assistant echo prefers visible text, then the model's own
+        # reasoning (its generated tokens, upstream-only), then "" — an empty
+        # echo both risks strict-endpoint rejection and gives the executor a
+        # void to continue from.
         redo_messages = [
             *messages,
-            {"role": "assistant", "content": turn.content or ""},
+            {"role": "assistant", "content": turn.content or turn.reasoning_text or ""},
             {"role": "user", "content": self._config.redo_feedback_prefix + plan},
         ]
         redo_body = {**body, "messages": redo_messages}
@@ -422,10 +437,13 @@ class AdvisorLoopBackend(LLMBackend):
                 input_tokens=usage["input_tokens"],
                 output_tokens=usage["output_tokens"],
                 cached_tokens=usage["cached_tokens"],
+                reasoning_text=message.get("reasoning_content") or None,
             )
         body = response.to_body()
+        reasoning_text = None
         if self._is_openai:
             has_tool_use, content = _openai_completion_tool_use(body)
+            reasoning_text = _openai_completion_reasoning(body)
         else:
             has_tool_use, content = _completion_tool_use(body)
         usage = _completion_usage(body, is_openai=self._is_openai)
@@ -437,6 +455,7 @@ class AdvisorLoopBackend(LLMBackend):
             input_tokens=usage["input_tokens"],
             output_tokens=usage["output_tokens"],
             cached_tokens=usage["cached_tokens"],
+            reasoning_text=reasoning_text,
         )
 
     async def _passthrough(self, ctx: ProxyContext, request: ChatRequest) -> ChatResponse:
@@ -531,6 +550,7 @@ class AdvisorLoopBackend(LLMBackend):
         # escalation judge — its cost rolls into ``cost_estimate.total_cost``)
         # AND into the routing log, so per-session stats
         # (``/v1/routing/session-stats``) attribute it to the caller's session.
+        # Recorded even for an unparseable reply — the tokens were spent.
         tokens = _advisor_usage(usage)
         if self._stats is not None:
             await self._stats.record_classifier_usage(
@@ -549,6 +569,14 @@ class AdvisorLoopBackend(LLMBackend):
             cached_tokens=tokens["cached_tokens"],
             cache_creation_tokens=tokens["cache_creation_tokens"],
         )
+        if verdict == "":
+            # No leading APPROVE/REDO in the reply: treat as a failed consult
+            # (caller refunds the budget) and pass the turn through unchanged.
+            _audit_review(
+                verdict="UNPARSEABLE", error=None, usage=usage,
+                latency_ms=latency_ms, reply_head=text,
+            )
+            return "APPROVE", "", False
         _audit_review(
             verdict=verdict, error=None, usage=usage, latency_ms=latency_ms,
             reply_head=text,
@@ -785,6 +813,16 @@ def _openai_completion_tool_use(body: Any) -> tuple[bool, str | None]:
     return has_tool_use, (message.get("content") or None)
 
 
+def _openai_completion_reasoning(body: Any) -> str | None:
+    """Read ``reasoning_content`` from an OpenAI chat.completion body, if any."""
+    if not isinstance(body, dict):
+        return None
+    choices = body.get("choices") or [{}]
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = choice.get("message") or {}
+    return message.get("reasoning_content") or None
+
+
 def _gate_request_type(fmt: BackendFormat) -> str:
     """Map a resolved executor format to its ``request_with_type`` discriminator."""
     if fmt == BackendFormat.ANTHROPIC:
@@ -819,6 +857,7 @@ async def _consume_openai_stream(
     """
     events: list[Any] = []
     text_parts: list[str] = []
+    reasoning_parts: list[str] = []
     slots: dict[int, dict[str, str]] = {}
     usage = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
     async for event in stream:
@@ -836,6 +875,12 @@ async def _consume_openai_stream(
         piece = _ev(delta, "content")
         if isinstance(piece, str):
             text_parts.append(piece)
+        # Reasoning models (nemotron on vLLM/NIM) can emit turns whose ONLY
+        # output is reasoning_content; keep it so the review gate has
+        # something to show the advisor when visible content is empty.
+        reasoning_piece = _ev(delta, "reasoning_content")
+        if isinstance(reasoning_piece, str):
+            reasoning_parts.append(reasoning_piece)
         for fragment in _ev(delta, "tool_calls") or []:
             index = int(_ev(fragment, "index") or 0)
             slot = slots.setdefault(index, {"id": "", "name": "", "arguments": ""})
@@ -854,6 +899,8 @@ async def _consume_openai_stream(
         "role": "assistant",
         "content": "".join(text_parts) or None,
     }
+    if reasoning_parts:
+        message["reasoning_content"] = "".join(reasoning_parts)
     if slots:
         message["tool_calls"] = [
             {
@@ -1085,19 +1132,29 @@ def _blocks_text(content: Any) -> str:
     return ""
 
 
-#: First APPROVE/REDO token in the reply's head decides the verdict. A window
-#: (rather than a strict first-word match) tolerates the wrappers reviewers
-#: actually produce — "**REDO**", "Verdict: REDO", a leading pleasantry —
-#: which a startswith parser silently turned into APPROVE.
-_VERDICT_RE = re.compile(r"\b(APPROVE|REDO)\b", re.IGNORECASE)
-_VERDICT_WINDOW = 64
+#: Anchored verdict match: markdown/quote wrappers and a "Verdict:"-style
+#: label may precede the verdict word, but PROSE may not — an unanchored
+#: window turned "I cannot approve this — REDO: run the tests" into APPROVE
+#: (first case-insensitive token wins). Tolerated prefixes: whitespace,
+#: ``*_#>"'([`` characters, and a short label ending in ``:``.
+_VERDICT_RE = re.compile(
+    r"^[\s*_#>\"'\(\[`]*(?:(?:final\s+)?verdict\s*:\s*[\s*_#>\"'\(\[`]*)?(APPROVE|REDO)\b",
+    re.IGNORECASE,
+)
 
 
 def _parse_verdict(text: str) -> tuple[str, str]:
-    """Parse the reviewer reply into (verdict, plan). Unclear → APPROVE."""
+    """Parse the reviewer reply into (verdict, plan).
+
+    Returns ``("", "")`` when no leading verdict is found — the caller treats
+    that as a failed consult (budget refunded) rather than a silent APPROVE,
+    so a hedged or malformed reply cannot burn the review budget.
+    """
     stripped = (text or "").strip()
-    match = _VERDICT_RE.search(stripped[:_VERDICT_WINDOW])
-    if match is None or match.group(1).upper() == "APPROVE":
+    match = _VERDICT_RE.match(stripped)
+    if match is None:
+        return "", ""
+    if match.group(1).upper() == "APPROVE":
         return "APPROVE", ""
     plan = stripped[match.end():].lstrip(" *_:\n-").strip()
     return "REDO", plan or stripped

--- a/switchyard/lib/backends/advisor_tool_call_backend.py
+++ b/switchyard/lib/backends/advisor_tool_call_backend.py
@@ -1,0 +1,865 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``LLMBackend`` that re-creates Anthropic's advisor tool proxy-side, on any Chat wire.
+
+Anthropic's native ``advisor_20260301`` server tool runs the advisor
+sub-inference server-side, so it is unavailable on gateways that only proxy
+model traffic (e.g. NVIDIA Inference Hub) — and it only exists for Anthropic
+models at all. This backend reproduces the *executor-triggered* behavior in
+the proxy, for **any** Chat-shaped executor:
+
+1. Offer the executor a real, parameterless ``advisor`` tool (empty schema —
+   like the native tool, the executor signals timing and the proxy supplies
+   context).
+2. Call the executor. If its turn contains ``advisor`` tool calls, intercept
+   them **before they reach the client**, consult the advisor model on the
+   transcript (including the text the executor produced so far in the turn,
+   mirroring the native tool's context), append the advice as the tool
+   result, and call the executor again.
+3. Loop until the executor returns an advisor-free turn (a real tool call for
+   the client, or a final answer), then return that turn.
+
+Once ``max_uses`` consultations have happened in a request, further advisor
+calls receive a ``max_uses exceeded`` tool result without a consult — the
+executor sees the error and continues, mirroring the native tool's
+``max_uses_exceeded`` error result.
+
+The executor's wire format is selected by ``config.executor.format`` and
+handled by a private dialect object:
+
+* ``anthropic`` — the executor call is delegated verbatim to an
+  :class:`AnthropicNativeBackend` (``/v1/messages``), so the client's
+  ``cache_control`` breakpoints reach the upstream unchanged and prompt
+  caching is honored. Thinking blocks round-trip verbatim for upstreams that
+  verify signatures.
+* ``openai`` — the executor call is delegated verbatim to an
+  :class:`OpenAiNativeBackend` (``/chat/completions``), covering OSS models
+  (Qwen, DeepSeek on vLLM/NIM) and OpenAI. Vendor-specific assistant fields
+  (e.g. ``reasoning_content``) are dropped from the rebuilt advisor turns so
+  strict endpoints accept the replayed history.
+
+The advisor tier is likewise format-dispatched (see
+``advisor_loop_backend._build_advisor_caller``); tiers mix freely.
+``responses`` targets are rejected — the loop is Chat-shaped.
+
+Steering is injected cache-stably: the executor steering is prepended to the
+system prompt and the advisor length line is appended to the **first** user
+message (both constant across a session's turns; the native doc suggests the
+latest user message, but re-injecting there would shift the cached prefix on
+every turn because the client never sees the injection). The same placement
+holds on the OpenAI wire, where vLLM/OpenAI automatic prefix caching also
+wants a stable prefix.
+
+A turn that mixes advisor and client tool calls is regenerated: the appended
+assistant turn keeps only the advisor calls (plus text/thinking), and the
+sibling client calls are re-issued advice-informed on the next iteration. The
+native API instead pauses with the client calls pending; a proxy cannot,
+because it can neither execute the client's tools nor hand the client a turn
+containing a tool it was never offered.
+
+Chain integration::
+
+    [RequestProcessor*] → AdvisorToolCallBackend → [ResponseProcessor*] → TranslationEngine
+
+Declares ``supported_request_types`` for the executor's wire so the
+TranslationEngine normalizes any inbound format to it once. The outer chain's
+``StatsResponseProcessor`` records the terminal turn's token usage; this
+backend additionally records the advisor consults **and the intermediate
+executor turns** (which the client never sees) into the classifier bucket, so
+the run's cost output prices the full loop, and stamps ``ctx.selected_model``.
+
+Streaming is single-pass: each executor turn is streamed and buffered while
+its content is reassembled to detect advisor calls; the terminal turn's
+buffered events are replayed verbatim, so the turn the client pays for is
+generated exactly once. Advice is not persisted across client turns (the
+client cannot carry advisor exchanges back); its effect lives in the terminal
+turn the client keeps.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from switchyard.lib.backends.advisor_loop_backend import (
+    AdvisorCaller,
+    _blocks_text,
+    _build_advisor_caller,
+    _consume_openai_stream,
+    _ev,
+    _replay_events,
+    _seed_advice_for,
+    _session_key,
+    _usage_tokens,
+    _with_length_line,
+)
+from switchyard.lib.backends.llm_target import BackendFormat
+from switchyard.lib.backends.multi_llm_backend import (
+    build_native_backend,
+    resolve_llm_target,
+)
+from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
+from switchyard.lib.chat_response.openai_chat import ResponseStream
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.roles import LLMBackend
+from switchyard_rust.core import (
+    ChatRequestType,
+    ChatResponse,
+    ChatResponseType,
+    request_type_enum,
+    request_type_matches,
+    request_with_type,
+)
+from switchyard_rust.translation import TranslationEngine
+
+if TYPE_CHECKING:
+    from switchyard.lib.proxy_context import ProxyContext
+    from switchyard.lib.stats_accumulator import StatsAccumulator
+    from switchyard_rust.core import ChatRequest
+
+log = logging.getLogger(__name__)
+
+#: Tool result handed to the executor for advisor calls past the ``max_uses``
+#: cap (mirrors the native tool's ``max_uses_exceeded`` error result).
+_MAX_USES_RESULT = "[advisor unavailable: max_uses exceeded]"
+
+#: Per-tool cap on the description text included in the advisor's transcript.
+_TOOL_SUMMARY_DESC_CHARS = 200
+
+
+@dataclass
+class _ToolCallTurn:
+    """One executor turn, normalized across wire formats and delivery modes.
+
+    ``advisor_calls`` are the turn's advisor invocations in the executor's
+    native shape (Anthropic ``tool_use`` blocks / OpenAI ``tool_calls``
+    entries); ``message`` is the format-native assistant payload the dialect
+    rebuilds the feedback turn from (Anthropic content-block list / OpenAI
+    assistant message dict). Exactly one of ``completion_body`` /
+    ``stream_events`` carries the payload for verbatim replay if the turn is
+    terminal.
+    """
+
+    advisor_calls: list[dict[str, Any]]
+    text: str
+    message: Any
+    latency_ms: float
+    input_tokens: int
+    output_tokens: int
+    cached_tokens: int
+    completion_body: Any | None = None
+    stream_events: list[Any] | None = None
+
+
+class _WireDialect(Protocol):
+    """Wire-format-specific operations of the advisor tool-call loop."""
+
+    #: ``request_with_type`` discriminator for the executor's wire
+    #: (``"anthropic"`` or ``"openai_chat"``).
+    request_type: str
+
+    def advisor_tool_def(self, *, name: str, description: str) -> dict[str, Any]:
+        """Build the synthetic, parameterless ``advisor`` tool definition."""
+        ...
+
+    def inject_steering(
+        self,
+        body: dict[str, Any],
+        messages: list[dict[str, Any]],
+        *,
+        steering: str,
+        length_line: str,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Return (body, messages) with executor steering injected cache-stably."""
+        ...
+
+    def tool_summaries(self, tools: list[dict[str, Any]]) -> list[tuple[str, str]]:
+        """Return (name, description) pairs for the client's tools."""
+        ...
+
+    async def parse_turn(
+        self,
+        response: ChatResponse,
+        *,
+        advisor_tool_name: str,
+        latency_ms: float,
+    ) -> _ToolCallTurn:
+        """Buffer and reassemble an executor response into a ``_ToolCallTurn``."""
+        ...
+
+    def feedback_messages(
+        self, turn: _ToolCallTurn, advice: str,
+    ) -> list[dict[str, Any]]:
+        """Messages appending the advisor turn + its tool result(s)."""
+        ...
+
+    def replay(self, turn: _ToolCallTurn) -> ChatResponse:
+        """Rebuild the buffered terminal turn as a verbatim response."""
+        ...
+
+
+class _AnthropicDialect:
+    """Anthropic Messages wire (``tool_use`` blocks, ``tool_result`` turns)."""
+
+    request_type = "anthropic"
+
+    def advisor_tool_def(self, *, name: str, description: str) -> dict[str, Any]:
+        return {
+            "name": name,
+            "description": description,
+            "input_schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        }
+
+    def inject_steering(
+        self,
+        body: dict[str, Any],
+        messages: list[dict[str, Any]],
+        *,
+        steering: str,
+        length_line: str,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        body = {**body, "system": _prepend_system(body.get("system"), steering)}
+        return body, _with_length_line(messages, length_line)
+
+    def tool_summaries(self, tools: list[dict[str, Any]]) -> list[tuple[str, str]]:
+        return [(str(t.get("name", "?")), str(t.get("description", ""))) for t in tools]
+
+    async def parse_turn(
+        self,
+        response: ChatResponse,
+        *,
+        advisor_tool_name: str,
+        latency_ms: float,
+    ) -> _ToolCallTurn:
+        if response.response_type == ChatResponseType.ANTHROPIC_STREAM:
+            events, blocks, usage = await _consume_stream(response.stream)
+            return self._turn(
+                blocks, advisor_tool_name, latency_ms, stream_events=events, **usage,
+            )
+        completion: Any = response.to_body()
+        blocks = [b for b in (completion.get("content") or []) if isinstance(b, dict)]
+        prompt_tokens, completion_tokens = _usage_tokens(completion.get("usage"))
+        cached = (completion.get("usage") or {}).get("cache_read_input_tokens") or 0
+        return self._turn(
+            blocks,
+            advisor_tool_name,
+            latency_ms,
+            input_tokens=prompt_tokens or 0,
+            output_tokens=completion_tokens or 0,
+            cached_tokens=int(cached),
+            completion_body=completion,
+        )
+
+    def _turn(
+        self,
+        blocks: list[dict[str, Any]],
+        advisor_tool_name: str,
+        latency_ms: float,
+        **kwargs: Any,
+    ) -> _ToolCallTurn:
+        advisor_calls = [
+            b for b in blocks
+            if b.get("type") == "tool_use" and b.get("name") == advisor_tool_name
+        ]
+        return _ToolCallTurn(
+            advisor_calls=advisor_calls,
+            text=_blocks_text(blocks),
+            message=blocks,
+            latency_ms=latency_ms,
+            **kwargs,
+        )
+
+    def feedback_messages(
+        self, turn: _ToolCallTurn, advice: str,
+    ) -> list[dict[str, Any]]:
+        # Thinking blocks must round-trip verbatim for upstreams that verify
+        # signatures; sibling client calls are dropped (regenerated next turn).
+        return [
+            {
+                "role": "assistant",
+                "content": _advisor_only_content(turn.message, turn.advisor_calls),
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": call.get("id"), "content": advice}
+                    for call in turn.advisor_calls
+                ],
+            },
+        ]
+
+    def replay(self, turn: _ToolCallTurn) -> ChatResponse:
+        if turn.stream_events is not None:
+            return ChatResponse.anthropic_stream(
+                AnthropicResponseStream(_replay_events(turn.stream_events))
+            )
+        return ChatResponse.anthropic_completion(turn.completion_body)
+
+
+class _OpenAiDialect:
+    """OpenAI Chat Completions wire (``tool_calls``, ``role: tool`` results)."""
+
+    request_type = "openai_chat"
+
+    def advisor_tool_def(self, *, name: str, description: str) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+    def inject_steering(
+        self,
+        body: dict[str, Any],
+        messages: list[dict[str, Any]],
+        *,
+        steering: str,
+        length_line: str,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        # OpenAI carries the system prompt as a leading message, not a body
+        # field. _with_length_line's list branch already emits the OpenAI
+        # content-part shape, so it is shared verbatim.
+        messages = _prepend_system_message(messages, steering)
+        return body, _with_length_line(messages, length_line)
+
+    def tool_summaries(self, tools: list[dict[str, Any]]) -> list[tuple[str, str]]:
+        summaries: list[tuple[str, str]] = []
+        for tool in tools:
+            raw_function = tool.get("function")
+            function = raw_function if isinstance(raw_function, dict) else {}
+            summaries.append(
+                (str(function.get("name", "?")), str(function.get("description", "")))
+            )
+        return summaries
+
+    async def parse_turn(
+        self,
+        response: ChatResponse,
+        *,
+        advisor_tool_name: str,
+        latency_ms: float,
+    ) -> _ToolCallTurn:
+        if response.response_type == ChatResponseType.OPENAI_STREAM:
+            events, message, usage = await _consume_openai_stream(response.stream)
+            return self._turn(
+                message, advisor_tool_name, latency_ms, stream_events=events, **usage,
+            )
+        completion: Any = response.to_body()
+        choices = completion.get("choices") or [{}]
+        message = dict(choices[0].get("message") or {})
+        usage_value = completion.get("usage")
+        prompt_tokens, completion_tokens = _usage_tokens(usage_value)
+        cached = ((usage_value or {}).get("prompt_tokens_details") or {}).get(
+            "cached_tokens"
+        ) or 0
+        return self._turn(
+            message,
+            advisor_tool_name,
+            latency_ms,
+            input_tokens=prompt_tokens or 0,
+            output_tokens=completion_tokens or 0,
+            cached_tokens=int(cached),
+            completion_body=completion,
+        )
+
+    def _turn(
+        self,
+        message: dict[str, Any],
+        advisor_tool_name: str,
+        latency_ms: float,
+        **kwargs: Any,
+    ) -> _ToolCallTurn:
+        return _ToolCallTurn(
+            advisor_calls=_openai_advisor_calls(message, advisor_tool_name),
+            # reasoning_content is intentionally excluded, matching the
+            # Anthropic dialect excluding thinking blocks from the text.
+            text=str(message.get("content") or ""),
+            message=message,
+            latency_ms=latency_ms,
+            **kwargs,
+        )
+
+    def feedback_messages(
+        self, turn: _ToolCallTurn, advice: str,
+    ) -> list[dict[str, Any]]:
+        kept_ids = {call.get("id") for call in turn.advisor_calls}
+        # OpenAI requires exactly one role:"tool" message per tool_call id in
+        # the preceding assistant message; the same advice is fanned out.
+        return [
+            _advisor_only_message(turn.message, kept_ids),
+            *(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.get("id"),
+                    "content": advice,
+                }
+                for call in turn.advisor_calls
+            ),
+        ]
+
+    def replay(self, turn: _ToolCallTurn) -> ChatResponse:
+        if turn.stream_events is not None:
+            return ChatResponse.openai_stream(
+                ResponseStream(_replay_events(turn.stream_events))
+            )
+        return ChatResponse.openai_completion(turn.completion_body)
+
+
+def _dialect_for_format(fmt: BackendFormat) -> _WireDialect:
+    """Return the wire dialect for a resolved executor format."""
+    if fmt == BackendFormat.ANTHROPIC:
+        return _AnthropicDialect()
+    if fmt == BackendFormat.OPENAI:
+        return _OpenAiDialect()
+    if fmt == BackendFormat.RESPONSES:
+        # Backstop for format: auto resolving to a Responses endpoint; the
+        # config validator rejects an explicit responses format earlier.
+        raise ValueError(
+            "the advisor tool-call loop is Chat-shaped and does not support "
+            "Responses executors; use format 'openai' or 'anthropic'"
+        )
+    raise ValueError(
+        f"advisor executor format {fmt!r} must be resolved before constructing "
+        "AdvisorToolCallBackend (pin format: 'openai' or 'anthropic' when "
+        "supplying executor_backend)"
+    )
+
+
+class AdvisorToolCallBackend(LLMBackend):
+    """Executor backend offering a proxy-intercepted ``advisor`` tool (any Chat wire)."""
+
+    #: Absolute backstop on executor calls per request. ``max_uses`` already
+    #: bounds consults; this bounds an executor that keeps calling the advisor
+    #: through ``max_uses exceeded`` results.
+    _HARD_ITERATION_CAP = 8
+
+    def __init__(
+        self,
+        config: AdvisorConfig,
+        *,
+        stats_accumulator: StatsAccumulator | None = None,
+        executor_backend: LLMBackend | None = None,
+        advisor_caller: AdvisorCaller | None = None,
+    ) -> None:
+        self._config = config
+        self._stats = stats_accumulator if config.enable_stats else None
+        self._translation = TranslationEngine()
+        # Resolve format: auto before dialect selection; injected fakes must
+        # pin a concrete format (probing a fake's endpoint makes no sense).
+        executor_target = (
+            config.executor if executor_backend is not None
+            else resolve_llm_target(config.executor)
+        )
+        self._dialect = _dialect_for_format(executor_target.format)
+        self._request_type = cast(
+            "ChatRequestType", request_type_enum(self._dialect.request_type),
+        )
+        # The executor is delegated to verbatim so caching survives
+        # (cache_control breakpoints on Anthropic; prefix stability on OpenAI).
+        self._executor_backend = executor_backend or build_native_backend(executor_target)
+        self._advisor_caller = advisor_caller or _build_advisor_caller(config)
+        # Per-session seed advice cache for seed_plan_advice ("" = unseeded).
+        self._seed_advice: dict[str, str] = {}
+
+    async def startup(self) -> None:
+        await self._executor_backend.startup()
+
+    async def shutdown(self) -> None:
+        await self._executor_backend.shutdown()
+
+    @property
+    def supported_request_types(self) -> list[ChatRequestType]:
+        """The executor's native wire; inbound formats are normalized to it."""
+        return [self._request_type]
+
+    async def call(self, ctx: ProxyContext, request: ChatRequest) -> ChatResponse:
+        normalized = self._translation.request_to_any_of(
+            request, self.supported_request_types,
+        )
+        if not request_type_matches(normalized, self._request_type):
+            raise TypeError(
+                "AdvisorToolCallBackend expected a "
+                f"{self._dialect.request_type} request after translation"
+            )
+
+        body = dict(normalized.body)
+        messages: list[dict[str, Any]] = list(body.get("messages") or [])
+        base_tools: list[dict[str, Any]] = list(body.get("tools") or [])
+        # Seed the session with upfront advisor advice (consulted once at the
+        # session-opening request, cached, and re-injected identically on every
+        # later turn so the upstream cache prefix stays stable). Applied before
+        # steering so the advice directly follows the task text.
+        if self._config.seed_plan_advice:
+            session = _session_key(body.get("system"), messages)
+            advice = await _seed_advice_for(
+                self._seed_advice, session, messages,
+                caller=self._advisor_caller, config=self._config, stats=self._stats,
+            )
+            if advice:
+                messages = _with_length_line(
+                    messages, self._config.seed_advice_prefix + advice,
+                )
+        if self._config.inject_steering:
+            body, messages = self._dialect.inject_steering(
+                body,
+                messages,
+                steering=self._config.executor_steering,
+                length_line=self._config.advisor_length_line,
+            )
+        tools = [
+            *base_tools,
+            self._dialect.advisor_tool_def(
+                name=self._config.advisor_tool_name,
+                description=self._config.advisor_tool_description,
+            ),
+        ]
+        tool_summaries = self._dialect.tool_summaries(base_tools)
+
+        advisor_uses = 0
+        turn: _ToolCallTurn | None = None
+        for _ in range(self._HARD_ITERATION_CAP):
+            turn_body = {**body, "messages": messages, "tools": tools}
+            turn = await self._run_executor(
+                ctx, request_with_type(self._dialect.request_type, turn_body),
+            )
+
+            if not turn.advisor_calls:
+                # Real tool call(s) for the client, or a final answer.
+                return await self._finish(ctx, turn)
+
+            # This turn stays proxy-internal — price it into the classifier bucket
+            # (under the executor model) so the run's cost output sees it.
+            await self._record_internal_turn(turn)
+
+            if advisor_uses < self._config.max_uses:
+                advisor_uses += 1
+                advice = await self._consult_advisor(messages, turn.text, tool_summaries)
+            else:
+                advice = _MAX_USES_RESULT
+
+            messages = [*messages, *self._dialect.feedback_messages(turn, advice)]
+
+        log.warning(
+            "AdvisorToolCallBackend: hit hard iteration cap (%d) without a terminal "
+            "executor turn; returning the last result.",
+            self._HARD_ITERATION_CAP,
+        )
+        if turn is None:  # unreachable: _HARD_ITERATION_CAP >= 1
+            raise RuntimeError("AdvisorToolCallBackend produced no executor turn")
+        return await self._finish(ctx, turn)
+
+    # ------------------------------------------------------------------
+    # Executor turn
+    # ------------------------------------------------------------------
+
+    async def _run_executor(self, ctx: ProxyContext, request: ChatRequest) -> _ToolCallTurn:
+        """Call the executor, buffering its response and reassembling the turn."""
+        started = time.monotonic()
+        try:
+            response = await self._executor_backend.call(ctx, request)
+        except Exception:
+            # Includes ContextWindowExceeded (the chain uses it for evict-and-retry).
+            if self._stats is not None:
+                await self._stats.record_error(self._config.executor.model)
+            raise
+
+        latency_ms = (time.monotonic() - started) * 1000.0
+        return await self._dialect.parse_turn(
+            response,
+            advisor_tool_name=self._config.advisor_tool_name,
+            latency_ms=latency_ms,
+        )
+
+    async def _finish(self, ctx: ProxyContext, turn: _ToolCallTurn) -> ChatResponse:
+        """Record stats, stamp ctx, and rebuild the terminal turn as a response."""
+        ctx.selected_model = self._config.executor.model
+        ctx.backend_call_latency_ms = turn.latency_ms
+        if self._stats is not None:
+            await self._stats.record_success(self._config.executor.model, turn.latency_ms)
+        return self._dialect.replay(turn)
+
+    async def _record_internal_turn(self, turn: _ToolCallTurn) -> None:
+        """Price a proxy-internal executor turn into the classifier bucket."""
+        if self._stats is None:
+            return
+        await self._stats.record_classifier_usage(
+            model=self._config.executor.model,
+            prompt_tokens=turn.input_tokens,
+            completion_tokens=turn.output_tokens,
+            cached_tokens=turn.cached_tokens,
+            latency_ms=turn.latency_ms,
+        )
+
+    # ------------------------------------------------------------------
+    # Advisor consultation
+    # ------------------------------------------------------------------
+
+    async def _consult_advisor(
+        self,
+        messages: list[dict[str, Any]],
+        current_turn_text: str,
+        tool_summaries: list[tuple[str, str]],
+    ) -> str:
+        """Consult the advisor on the transcript and return its guidance.
+
+        On failure with ``fail_open`` set, returns a short "unavailable" marker
+        so the executor can proceed; the failed call still counts toward
+        ``max_uses`` at the call site, bounding retries against a down advisor.
+        """
+        transcript = self._serialize_transcript(messages, current_turn_text, tool_summaries)
+        started = time.monotonic()
+        try:
+            advice, usage = await self._advisor_caller.advise(
+                system=self._config.advisor_system_prompt, transcript=transcript,
+            )
+        except Exception as exc:
+            if not self._config.fail_open:
+                raise
+            log.warning(
+                "AdvisorToolCallBackend: advisor call failed; continuing unadvised: %s", exc,
+            )
+            if self._stats is not None:
+                await self._stats.record_classifier_error(self._config.advisor.model)
+            _audit_advisor(error=str(exc), usage=None,
+                           latency_ms=(time.monotonic() - started) * 1000.0)
+            return f"[advisor unavailable: {type(exc).__name__}]"
+
+        latency_ms = (time.monotonic() - started) * 1000.0
+        if self._stats is not None:
+            prompt_tokens, completion_tokens = _usage_tokens(usage)
+            await self._stats.record_classifier_usage(
+                model=self._config.advisor.model,
+                prompt_tokens=prompt_tokens or 0,
+                completion_tokens=completion_tokens or 0,
+                cached_tokens=0,
+                latency_ms=latency_ms,
+            )
+        _audit_advisor(error=None, usage=usage, latency_ms=latency_ms)
+        return advice
+
+    def _serialize_transcript(
+        self,
+        messages: list[dict[str, Any]],
+        current_turn_text: str,
+        tool_summaries: list[tuple[str, str]],
+    ) -> str:
+        """Serialize the conversation for the advisor, newest turns kept first.
+
+        Mirrors the native tool's context: the executor's tools (as a compact
+        name — description summary; full schemas would swamp the char budget),
+        the conversation, and the text the executor has produced so far in the
+        turn that called the advisor. When over ``transcript_max_chars``, the
+        **oldest** messages are dropped — the newest turns are the ones the
+        consult is about.
+        """
+        sections: list[str] = []
+        if tool_summaries:
+            summary = "\n".join(
+                f"- {name}: {desc[:_TOOL_SUMMARY_DESC_CHARS]}"
+                for name, desc in tool_summaries
+            )
+            sections.append(f"Tools available to the executor:\n{summary}")
+
+        parts = [json.dumps(m, default=str, ensure_ascii=False) for m in messages]
+        cap = self._config.transcript_max_chars
+        kept: list[str] = []
+        total = 0
+        for part in reversed(parts):
+            if kept and total + len(part) > cap:
+                break
+            if not kept and len(part) > cap:
+                part = "...<truncated>" + part[-(cap - 16):]
+            kept.append(part)
+            total += len(part)
+        kept.reverse()
+        omitted = len(parts) - len(kept)
+        header = "Conversation so far (JSON, oldest first"
+        if omitted:
+            header += f"; {omitted} earlier messages omitted"
+        sections.append(header + "):\n[" + ",\n".join(kept) + "]")
+
+        sections.append(
+            "The executor's turn so far (it is consulting you now):\n"
+            + (current_turn_text or "(no text)")
+        )
+        return "\n\n".join(sections)
+
+
+# ----------------------------------------------------------------------
+# Anthropic-wire helpers
+# ----------------------------------------------------------------------
+
+
+async def _consume_stream(
+    stream: Any,
+) -> tuple[list[Any], list[dict[str, Any]], dict[str, int]]:
+    """Buffer an Anthropic stream; reassemble its content blocks and usage.
+
+    Events are the dicts the native backend's SSE parser yields. Returns
+    ``(events, blocks, usage)`` where ``usage`` carries ``input_tokens`` /
+    ``output_tokens`` / ``cached_tokens`` keyword-ready for ``_ToolCallTurn``.
+    """
+    events: list[Any] = []
+    blocks: dict[int, dict[str, Any]] = {}
+    json_parts: dict[int, list[str]] = {}
+    usage = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
+    async for event in stream:
+        events.append(event)
+        etype = _ev(event, "type")
+        if etype == "message_start":
+            start_usage = _ev(_ev(event, "message"), "usage") or {}
+            usage["input_tokens"] = int(start_usage.get("input_tokens") or 0)
+            usage["cached_tokens"] = int(start_usage.get("cache_read_input_tokens") or 0)
+        elif etype == "content_block_start":
+            index = int(_ev(event, "index") or 0)
+            block = _ev(event, "content_block")
+            blocks[index] = dict(block) if isinstance(block, dict) else {}
+        elif etype == "content_block_delta":
+            index = int(_ev(event, "index") or 0)
+            block = blocks.setdefault(index, {})
+            delta = _ev(event, "delta")
+            dtype = _ev(delta, "type")
+            if dtype == "text_delta":
+                block["text"] = str(block.get("text") or "") + str(_ev(delta, "text") or "")
+            elif dtype == "input_json_delta":
+                json_parts.setdefault(index, []).append(str(_ev(delta, "partial_json") or ""))
+            elif dtype == "thinking_delta":
+                block["thinking"] = (
+                    str(block.get("thinking") or "") + str(_ev(delta, "thinking") or "")
+                )
+            elif dtype == "signature_delta":
+                block["signature"] = _ev(delta, "signature")
+        elif etype == "message_delta":
+            delta_usage = _ev(event, "usage") or {}
+            usage["output_tokens"] = int(delta_usage.get("output_tokens") or 0)
+    for index, parts in json_parts.items():
+        joined = "".join(parts).strip()
+        try:
+            blocks[index]["input"] = json.loads(joined) if joined else {}
+        except json.JSONDecodeError:
+            blocks[index]["input"] = {}
+    ordered = [blocks[i] for i in sorted(blocks)]
+    return events, ordered, usage
+
+
+def _advisor_only_content(
+    blocks: list[dict[str, Any]], advisor_calls: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """The assistant turn's blocks with sibling (non-advisor) tool calls dropped."""
+    kept_ids = {call.get("id") for call in advisor_calls}
+    return [
+        b for b in blocks
+        if b.get("type") != "tool_use" or b.get("id") in kept_ids
+    ]
+
+
+def _prepend_system(system: Any, prefix: str) -> Any:
+    """Prepend steering to an Anthropic ``system`` field (string or block list)."""
+    if system is None or system == "":
+        return prefix
+    if isinstance(system, str):
+        return f"{prefix}\n\n{system}"
+    if isinstance(system, list):
+        return [{"type": "text", "text": prefix}, *system]
+    return f"{prefix}\n\n{system}"
+
+
+# ----------------------------------------------------------------------
+# OpenAI-wire helpers
+# ----------------------------------------------------------------------
+
+
+def _openai_advisor_calls(
+    message: dict[str, Any], tool_name: str,
+) -> list[dict[str, Any]]:
+    """The message's advisor ``tool_calls``, detected by function name.
+
+    Detection is by tool-call presence, never ``finish_reason`` — some OSS
+    servers mislabel tool-call turns as ``stop``.
+    """
+    return [
+        tc for tc in (message.get("tool_calls") or [])
+        if isinstance(tc, dict)
+        and (tc.get("function") or {}).get("name") == tool_name
+    ]
+
+
+def _advisor_only_message(
+    message: dict[str, Any], kept_ids: set[Any],
+) -> dict[str, Any]:
+    """The assistant message with sibling (non-advisor) tool calls dropped.
+
+    Key-whitelisted on purpose: vendor fields such as ``reasoning_content``
+    are dropped so strict endpoints (OpenAI proper) accept the round-trip;
+    the advisor already saw the turn's text via the transcript.
+    """
+    return {
+        "role": "assistant",
+        "content": message.get("content"),
+        "tool_calls": [
+            tc for tc in (message.get("tool_calls") or [])
+            if isinstance(tc, dict) and tc.get("id") in kept_ids
+        ],
+    }
+
+
+def _prepend_system_message(
+    messages: list[dict[str, Any]], prefix: str,
+) -> list[dict[str, Any]]:
+    """Prepend steering to the first ``system``/``developer`` message.
+
+    When the request carries no system-role message at all, one is inserted at
+    index 0 so the steering still leads the prompt (and the prefix cache stays
+    stable across the session's turns).
+    """
+    msgs = [dict(m) for m in messages]
+    for msg in msgs:
+        if msg.get("role") not in ("system", "developer"):
+            continue
+        content = msg.get("content")
+        if isinstance(content, list):
+            msg["content"] = [{"type": "text", "text": prefix}, *content]
+        else:
+            msg["content"] = f"{prefix}\n\n{content or ''}".rstrip()
+        return msgs
+    return [{"role": "system", "content": prefix}, *msgs]
+
+
+# ----------------------------------------------------------------------
+# Audit
+# ----------------------------------------------------------------------
+
+
+def _audit_advisor(*, error: str | None, usage: Any, latency_ms: float) -> None:
+    """Emit a one-line ``advisor_call=...`` audit record to stderr."""
+    payload: dict[str, Any] = {
+        "advisor_call": True,
+        "error": error,
+        "latency_ms": round(latency_ms, 1),
+    }
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    if prompt_tokens is not None:
+        payload["prompt_tokens"] = prompt_tokens
+    if completion_tokens is not None:
+        payload["completion_tokens"] = completion_tokens
+    sys.stderr.write(f"advisor_call={json.dumps(payload, sort_keys=True)}\n")
+    sys.stderr.flush()
+
+
+__all__ = ["AdvisorToolCallBackend"]

--- a/switchyard/lib/backends/advisor_tool_call_backend.py
+++ b/switchyard/lib/backends/advisor_tool_call_backend.py
@@ -88,11 +88,13 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from switchyard.lib.backends.advisor_loop_backend import (
     AdvisorCaller,
+    _advisor_usage,
     _blocks_text,
     _build_advisor_caller,
     _consume_openai_stream,
     _emit_routing_usage,
     _ev,
+    _merge_audit_tokens,
     _replay_events,
     _seed_advice_for,
     _session_key,
@@ -653,21 +655,23 @@ class AdvisorToolCallBackend(LLMBackend):
             return f"[advisor unavailable: {type(exc).__name__}]"
 
         latency_ms = (time.monotonic() - started) * 1000.0
-        prompt_tokens, completion_tokens = _usage_tokens(usage)
+        tokens = _advisor_usage(usage)
         if self._stats is not None:
             await self._stats.record_classifier_usage(
                 model=self._config.advisor.model,
-                prompt_tokens=prompt_tokens or 0,
-                completion_tokens=completion_tokens or 0,
-                cached_tokens=0,
+                prompt_tokens=tokens["prompt_tokens"],
+                completion_tokens=tokens["completion_tokens"],
+                cached_tokens=tokens["cached_tokens"],
                 latency_ms=latency_ms,
             )
         _emit_routing_usage(
             ctx,
             model=self._config.advisor.model,
             tier="advisor_consult",
-            prompt_tokens=prompt_tokens or 0,
-            completion_tokens=completion_tokens or 0,
+            prompt_tokens=tokens["prompt_tokens"],
+            completion_tokens=tokens["completion_tokens"],
+            cached_tokens=tokens["cached_tokens"],
+            cache_creation_tokens=tokens["cache_creation_tokens"],
         )
         _audit_advisor(error=None, usage=usage, latency_ms=latency_ms)
         return advice
@@ -872,11 +876,7 @@ def _audit_advisor(*, error: str | None, usage: Any, latency_ms: float) -> None:
         "error": error,
         "latency_ms": round(latency_ms, 1),
     }
-    prompt_tokens, completion_tokens = _usage_tokens(usage)
-    if prompt_tokens is not None:
-        payload["prompt_tokens"] = prompt_tokens
-    if completion_tokens is not None:
-        payload["completion_tokens"] = completion_tokens
+    _merge_audit_tokens(payload, usage)
     sys.stderr.write(f"advisor_call={json.dumps(payload, sort_keys=True)}\n")
     sys.stderr.flush()
 

--- a/switchyard/lib/backends/advisor_tool_call_backend.py
+++ b/switchyard/lib/backends/advisor_tool_call_backend.py
@@ -91,6 +91,7 @@ from switchyard.lib.backends.advisor_loop_backend import (
     _blocks_text,
     _build_advisor_caller,
     _consume_openai_stream,
+    _emit_routing_usage,
     _ev,
     _replay_events,
     _seed_advice_for,
@@ -510,6 +511,7 @@ class AdvisorToolCallBackend(LLMBackend):
             advice = await _seed_advice_for(
                 self._seed_advice, session, messages,
                 caller=self._advisor_caller, config=self._config, stats=self._stats,
+                ctx=ctx,
             )
             if advice:
                 messages = _with_length_line(
@@ -545,11 +547,13 @@ class AdvisorToolCallBackend(LLMBackend):
 
             # This turn stays proxy-internal — price it into the classifier bucket
             # (under the executor model) so the run's cost output sees it.
-            await self._record_internal_turn(turn)
+            await self._record_internal_turn(ctx, turn)
 
             if advisor_uses < self._config.max_uses:
                 advisor_uses += 1
-                advice = await self._consult_advisor(messages, turn.text, tool_summaries)
+                advice = await self._consult_advisor(
+                    ctx, messages, turn.text, tool_summaries,
+                )
             else:
                 advice = _MAX_USES_RESULT
 
@@ -594,16 +598,23 @@ class AdvisorToolCallBackend(LLMBackend):
             await self._stats.record_success(self._config.executor.model, turn.latency_ms)
         return self._dialect.replay(turn)
 
-    async def _record_internal_turn(self, turn: _ToolCallTurn) -> None:
-        """Price a proxy-internal executor turn into the classifier bucket."""
-        if self._stats is None:
-            return
-        await self._stats.record_classifier_usage(
+    async def _record_internal_turn(self, ctx: ProxyContext, turn: _ToolCallTurn) -> None:
+        """Price a proxy-internal executor turn into the classifier bucket + routing log."""
+        if self._stats is not None:
+            await self._stats.record_classifier_usage(
+                model=self._config.executor.model,
+                prompt_tokens=turn.input_tokens,
+                completion_tokens=turn.output_tokens,
+                cached_tokens=turn.cached_tokens,
+                latency_ms=turn.latency_ms,
+            )
+        _emit_routing_usage(
+            ctx,
             model=self._config.executor.model,
+            tier="advisor_internal_turn",
             prompt_tokens=turn.input_tokens,
             completion_tokens=turn.output_tokens,
             cached_tokens=turn.cached_tokens,
-            latency_ms=turn.latency_ms,
         )
 
     # ------------------------------------------------------------------
@@ -612,6 +623,7 @@ class AdvisorToolCallBackend(LLMBackend):
 
     async def _consult_advisor(
         self,
+        ctx: ProxyContext,
         messages: list[dict[str, Any]],
         current_turn_text: str,
         tool_summaries: list[tuple[str, str]],
@@ -641,8 +653,8 @@ class AdvisorToolCallBackend(LLMBackend):
             return f"[advisor unavailable: {type(exc).__name__}]"
 
         latency_ms = (time.monotonic() - started) * 1000.0
+        prompt_tokens, completion_tokens = _usage_tokens(usage)
         if self._stats is not None:
-            prompt_tokens, completion_tokens = _usage_tokens(usage)
             await self._stats.record_classifier_usage(
                 model=self._config.advisor.model,
                 prompt_tokens=prompt_tokens or 0,
@@ -650,6 +662,13 @@ class AdvisorToolCallBackend(LLMBackend):
                 cached_tokens=0,
                 latency_ms=latency_ms,
             )
+        _emit_routing_usage(
+            ctx,
+            model=self._config.advisor.model,
+            tier="advisor_consult",
+            prompt_tokens=prompt_tokens or 0,
+            completion_tokens=completion_tokens or 0,
+        )
         _audit_advisor(error=None, usage=usage, latency_ms=latency_ms)
         return advice
 

--- a/switchyard/lib/processors/routing_log_response_processor.py
+++ b/switchyard/lib/processors/routing_log_response_processor.py
@@ -73,6 +73,10 @@ class RoutingLogResponseProcessor:
             "tier": ctx.metadata.get("_random_routing_tier", "") or (ctx.selected_target or ""),
             **_usage_tokens(response.body),
         }
+        self._append(record)
+
+    def _append(self, record: dict[str, Any]) -> None:
+        """Append one record as a JSON line; write failures never propagate."""
         try:
             line = json.dumps(record, separators=(",", ":"))
             with self._lock, self._log_file.open("a", encoding="utf-8") as handle:
@@ -150,6 +154,56 @@ class RoutingLogResponseProcessor:
         )
 
         return RoutingLogStatsEndpoint(self)
+
+
+#: Process-global sink for proxy-internal usage records (advisor consults,
+#: REDO-discarded executor turns). Multi-call backends issue upstream requests
+#: beneath the chain, so this response processor never sees them; the backends
+#: emit records here instead. Registered by the serving entry point that owns
+#: the routing log; None (the default) makes emission a no-op.
+_AUX_SINK: RoutingLogResponseProcessor | None = None
+
+
+def register_routing_log_sink(processor: RoutingLogResponseProcessor | None) -> None:
+    """Register (or clear) the routing log that receives auxiliary records."""
+    global _AUX_SINK
+    _AUX_SINK = processor
+
+
+def emit_auxiliary_record(
+    *,
+    session_id: str | None,
+    task: str | None,
+    model: str,
+    tier: str,
+    prompt_tokens: int = 0,
+    cached_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> None:
+    """Append a proxy-internal usage record to the registered routing log.
+
+    The record shape matches ``_write_record`` exactly, so
+    ``snapshot_session`` (and with it ``/v1/routing/session-stats``)
+    aggregates chain-terminal and proxy-internal usage alike.
+    """
+    sink = _AUX_SINK
+    if sink is None:
+        return
+    sink._append({
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "task": task,
+        "trial_id": None,
+        "session_id": session_id,
+        "model": model,
+        "tier": tier,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "cache_creation_tokens": cache_creation_tokens,
+        "completion_tokens": completion_tokens,
+        "reasoning_tokens": 0,
+        "total_tokens": prompt_tokens + completion_tokens,
+    })
 
 
 def _usage_tokens(body: object) -> dict[str, int]:

--- a/switchyard/lib/profiles/__init__.py
+++ b/switchyard/lib/profiles/__init__.py
@@ -3,6 +3,9 @@
 
 """Python profile abstractions for programmatic routing profiles."""
 
+from switchyard.lib.profiles.advisor import AdvisorProfileConfig
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.profiles.advisor_presets import AdvisorPresets
 from switchyard.lib.profiles.deterministic_routing_config import (
     DeterministicRoutingConfig,
 )
@@ -48,6 +51,9 @@ from switchyard.lib.profiles.table import (
 from switchyard.lib.profiles.translate_profile_config import TranslateProfileConfig
 
 __all__ = [
+    "AdvisorConfig",
+    "AdvisorPresets",
+    "AdvisorProfileConfig",
     "StageRouterProfileConfig",
     "StageRouterConfig",
     "ClassifierConfig",

--- a/switchyard/lib/profiles/advisor.py
+++ b/switchyard/lib/profiles/advisor.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Profile-owned advisor construction.
+
+Chain shape::
+
+    [ReasoningEffortNormalizer] → AdvisorToolCallBackend | AdvisorLoopBackend
+
+``config.strategy`` selects the backend: ``"tool_call"`` (default) offers the
+executor a proxy-intercepted ``advisor`` tool
+(:class:`~switchyard.lib.backends.advisor_tool_call_backend.AdvisorToolCallBackend`);
+``"review_gate"`` consults the advisor once per session at the executor's first
+no-tool-call turn
+(:class:`~switchyard.lib.backends.advisor_loop_backend.AdvisorLoopBackend`).
+The executor call is delegated verbatim to the native backend for
+``executor.format`` — Anthropic keeps ``cache_control`` intact; OpenAI keeps
+the Chat body intact — and the advisor caller likewise dispatches on
+``advisor.format``. Both backends stamp ``ctx.selected_model`` and record the
+advisor's usage themselves; they cannot be wrapped by ``StatsLlmBackend``, so
+the runtime attaches the shared accumulator through the ``_stats``
+compatibility hook. Serving-level stats processors arrive via
+``with_runtime_components``, like every other profile.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.profiles.chain import ComponentChainProfile
+from switchyard.lib.profiles.table import profile_config
+
+
+@profile_config("advisor")
+class AdvisorProfileConfig:
+    """Profile config wrapper for executor + stronger-advisor chains."""
+
+    config: AdvisorConfig
+
+    @classmethod
+    def from_config(cls, config: AdvisorConfig) -> Self:
+        """Create a profile config from the validated parsing model."""
+        return cls(config=config)
+
+    def build(self) -> ComponentChainProfile:
+        """Build the advisor profile runtime for the configured strategy."""
+        from switchyard.lib.processors.reasoning_effort_normalizer import (
+            ReasoningEffortNormalizer,
+        )
+
+        config = self.config
+        backend: Any
+        if config.strategy == "review_gate":
+            from switchyard.lib.backends.advisor_loop_backend import AdvisorLoopBackend
+
+            backend = AdvisorLoopBackend(config)
+        else:
+            from switchyard.lib.backends.advisor_tool_call_backend import (
+                AdvisorToolCallBackend,
+            )
+
+            backend = AdvisorToolCallBackend(config)
+
+        # Normalize unsupported ``reasoning_effort`` values (Claude Code's
+        # ``/effort xhigh`` in particular) before they reach the executor.
+        # Same placement as the plan-execute profile.
+        return ComponentChainProfile(
+            request_processors=[ReasoningEffortNormalizer()],
+            backend=backend,
+        )
+
+
+__all__ = ["AdvisorProfileConfig"]

--- a/switchyard/lib/profiles/advisor_config.py
+++ b/switchyard/lib/profiles/advisor_config.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Config model for the advisor profile.
+
+An advisor chain pairs an **executor** (the base model under test) with a
+stronger **advisor**. ``strategy`` selects how the advisor participates:
+
+* ``"tool_call"`` (default, the shipping strategy) — the executor is offered a
+  real, parameterless ``advisor`` tool. When it calls, the backend consults the
+  advisor model on the full transcript and feeds the guidance back as the tool
+  result, looping until the executor stops asking. The proxy-side re-creation
+  of Anthropic's ``advisor_20260301`` server tool for gateways that cannot run
+  it server-side. See ``switchyard/lib/backends/advisor_tool_call_backend.py``.
+
+* ``"review_gate"`` — no advisor tool is injected. The executor works the task
+  with its own tools; when it first produces a no-tool-call turn — a plan, or
+  a claim of "done" — the backend consults the advisor once to APPROVE or send
+  it back (REDO) with an optimized plan. See
+  ``switchyard/lib/backends/advisor_loop_backend.py``.
+
+Both tiers are ordinary targets; each tier's ``format`` selects its wire
+independently and tiers mix freely under either strategy. ``anthropic``
+targets are served native Anthropic-Messages with the body passed through
+verbatim (the client's prompt caching survives); ``openai`` targets (Qwen,
+DeepSeek, vLLM/NIM, OpenAI) are served OpenAI Chat Completions, likewise
+verbatim. ``responses`` targets are rejected (the advisor loop is Chat-shaped).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+from switchyard.lib.backends.llm_target import BackendFormat, LlmTarget, coerce_llm_target
+from switchyard.lib.profiles.advisor_prompts import (
+    ADVISOR_LENGTH_LINE,
+    ADVISOR_SYSTEM_PROMPT,
+    ADVISOR_TOOL_DESCRIPTION,
+    EXECUTOR_STEERING,
+    REDO_FEEDBACK_PREFIX,
+    REVIEWER_SYSTEM_PROMPT,
+    SEED_ADVICE_PREFIX,
+)
+
+
+class AdvisorConfig(BaseModel):
+    """Configuration for the advisor profile.
+
+    Attributes:
+        executor: The base model under test. Runs the user-visible chat
+            completion with the client's own tools.
+        advisor: The stronger advisor model. Must be at least as capable.
+        strategy: How the advisor participates. ``"tool_call"`` offers the
+            executor a real ``advisor`` tool it calls mid-generation;
+            ``"review_gate"`` consults the advisor once per session at the
+            executor's first no-tool-call turn.
+
+        advisor_tool_name: (tool_call) Tool name the executor calls to consult
+            the advisor. Must match what the steering prompt references
+            (``"advisor"``).
+        max_uses: (tool_call) Per-request cap on advisor consultations. Over-cap
+            calls receive a ``max_uses exceeded`` tool result without a consult
+            (mirroring the native tool's ``max_uses_exceeded`` error result)
+            and the executor continues. Failed (fail-open) consultations count
+            toward this cap, which bounds retry storms when the advisor is
+            unavailable.
+        inject_steering: (tool_call) Prepend ``executor_steering`` to the
+            executor's system prompt and append ``advisor_length_line`` to the
+            latest user turn. The doc notes executors under-call the advisor
+            without this; keep it a toggle so a benchmark can ablate steering.
+        executor_steering: (tool_call) Verbatim doc steering for the executor.
+        advisor_length_line: (tool_call) Verbatim doc length hint, injected into
+            the latest user turn (the advisor sees it via the transcript).
+        advisor_system_prompt: (tool_call) System prompt for the advisor's own
+            LLM call (authored — the doc publishes none).
+        advisor_tool_description: (tool_call) Description for the synthetic
+            ``advisor`` tool.
+
+        reviewer_system_prompt: (review_gate) System prompt for the advisor's
+            review call; instructs the APPROVE / REDO contract.
+        redo_feedback_prefix: (review_gate) Prepended to the advisor's REDO
+            plan when it is injected back to the executor as a user turn.
+            Tune per executor family (e.g. append "continue using tool calls
+            only" for small OSS executors).
+        gate_trigger: (review_gate) What fires the once-per-session review.
+            ``"no_tool_call"`` (default) reviews the executor's first turn
+            without tool calls — right for function-calling agent harnesses.
+            ``"pattern"`` reviews the first turn whose text matches
+            ``gate_trigger_pattern`` — for text-protocol harnesses (e.g.
+            Terminal-Bench's terminus), where every turn lacks tool calls and
+            completion is declared with a textual marker instead.
+        gate_trigger_pattern: (review_gate) Regex searched against the
+            executor turn's text when ``gate_trigger`` is ``"pattern"``
+            (e.g. ``task_complete["\\s>:]*true`` for terminus).
+        max_reviews: (review_gate) Per-session budget of advisor reviews.
+            The default (1) preserves the original once-per-session gate;
+            higher values re-review later trigger turns (e.g. a re-declared
+            completion after a REDO), making the gate a sequential
+            best-of-(N+1) with the advisor as judge.
+        gate_stall_turns: (review_gate) When > 0, additionally trigger a
+            review (once per session, consuming review budget) at the first
+            request whose conversation already carries at least this many
+            assistant turns — a mid-task checkpoint for executors that grind
+            without ever declaring completion. 0 disables.
+        gate_min_tool_results: (review_gate) For the ``no_tool_call``
+            trigger: only review a no-tool-call turn when the conversation
+            carries at least this many tool results — skips reviewing early
+            commentary turns on chatty harnesses. 0 reviews as before.
+
+        seed_plan_advice: (both strategies) Consult the advisor once at the
+            start of each session — before the executor's first turn — and
+            inject its upfront plan into the session's first user message
+            (``seed_advice_prefix`` + advice). The advice is cached per
+            session (keyed by the conversation's stable prefix) and
+            re-injected identically on every turn, so it stays visible for
+            the whole session while the upstream cache prefix stays stable.
+            Proxy-triggered, so it fires even on executors/harnesses that
+            never call tools. The seed consult uses ``advisor_system_prompt``.
+            Fail-open: a failed seed consult leaves the session unseeded.
+        seed_advice_prefix: Prepended to the seeded advice when it is
+            injected into the first user message.
+
+        advisor_max_tokens: Cap on the advisor's output per call (the doc's
+            recommended starting point is 2048).
+        advisor_temperature: Sampling temperature for the advisor call. ``None``
+            (default) omits the field — required for Anthropic targets that
+            reject ``temperature``.
+        transcript_max_chars: Cap on the serialized transcript handed to the
+            advisor, so a long agent conversation can't blow its context.
+        fail_open: When ``True`` (default), an advisor-call failure degrades
+            gracefully — the executor proceeds unadvised (tool_call) or the
+            turn passes through as APPROVE (review_gate). When ``False``, the
+            failure surfaces as 5xx.
+        enable_stats: Record executor success/error + latency into the shared
+            accumulator and stamp ``ctx.selected_model``.
+        preset: Optional name of the preset that produced this config.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    executor: LlmTarget
+    advisor: LlmTarget
+    strategy: Literal["tool_call", "review_gate"] = "tool_call"
+
+    # tool_call strategy
+    advisor_tool_name: str = "advisor"
+    max_uses: int = Field(default=2, ge=1)
+    inject_steering: bool = True
+    executor_steering: str = EXECUTOR_STEERING
+    advisor_length_line: str = ADVISOR_LENGTH_LINE
+    advisor_system_prompt: str = ADVISOR_SYSTEM_PROMPT
+    advisor_tool_description: str = ADVISOR_TOOL_DESCRIPTION
+
+    # review_gate strategy
+    reviewer_system_prompt: str = REVIEWER_SYSTEM_PROMPT
+    redo_feedback_prefix: str = REDO_FEEDBACK_PREFIX
+    gate_trigger: Literal["no_tool_call", "pattern"] = "no_tool_call"
+    gate_trigger_pattern: str = ""
+    max_reviews: int = Field(default=1, ge=1)
+    gate_stall_turns: int = Field(default=0, ge=0)
+    gate_min_tool_results: int = Field(default=0, ge=0)
+
+    # shared
+    seed_plan_advice: bool = False
+    seed_advice_prefix: str = SEED_ADVICE_PREFIX
+    advisor_max_tokens: int = Field(default=2048, ge=1)
+    advisor_temperature: float | None = None
+    transcript_max_chars: int = Field(default=24_000, ge=256)
+    fail_open: bool = True
+    enable_stats: bool = True
+    preset: str | None = None
+
+    @field_validator("executor", "advisor", mode="before")
+    @classmethod
+    def _coerce_target(cls, value: object, info: ValidationInfo) -> LlmTarget:
+        return coerce_llm_target(value, default_id=info.field_name or "target")
+
+    @field_validator("executor", "advisor")
+    @classmethod
+    def _target_model_non_empty(cls, tier: LlmTarget) -> LlmTarget:
+        if not tier.model:
+            raise ValueError("target.model must be a non-empty string")
+        return tier
+
+    @field_validator("executor", "advisor")
+    @classmethod
+    def _target_format_supported(cls, tier: LlmTarget, info: ValidationInfo) -> LlmTarget:
+        if tier.format == BackendFormat.RESPONSES:
+            raise ValueError(
+                f"{info.field_name}.format 'responses' is not supported by the advisor "
+                "profile (the loop is Chat-shaped); use 'openai' or 'anthropic'"
+            )
+        return tier
+
+    @field_validator("gate_trigger_pattern")
+    @classmethod
+    def _pattern_compiles(cls, value: str) -> str:
+        if value:
+            try:
+                re.compile(value)
+            except re.error as exc:
+                raise ValueError(f"gate_trigger_pattern is not a valid regex: {exc}") from exc
+        return value
+
+    @model_validator(mode="after")
+    def _pattern_trigger_requires_pattern(self) -> Self:
+        if self.gate_trigger == "pattern" and not self.gate_trigger_pattern:
+            raise ValueError(
+                "gate_trigger 'pattern' requires a non-empty gate_trigger_pattern"
+            )
+        return self
+
+__all__ = ["AdvisorConfig"]

--- a/switchyard/lib/profiles/advisor_config.py
+++ b/switchyard/lib/profiles/advisor_config.py
@@ -102,11 +102,15 @@ class AdvisorConfig(BaseModel):
         gate_trigger_pattern: (review_gate) Regex searched against the
             executor turn's text when ``gate_trigger`` is ``"pattern"``
             (e.g. ``task_complete["\\s>:]*true`` for terminus).
-        max_reviews: (review_gate) Per-session budget of advisor reviews.
-            The default (1) preserves the original once-per-session gate;
-            higher values re-review later trigger turns (e.g. a re-declared
+        max_reviews: (review_gate) Budget of advisor reviews per budget
+            scope: the caller's ``proxy_x_session_id`` header when present
+            (one evaluation/task on benchmark harnesses, sub-agents
+            included), else one scope for the whole backend instance. The
+            default (1) preserves the original once-per-task gate; higher
+            values re-review later trigger turns (e.g. a re-declared
             completion after a REDO), making the gate a sequential
-            best-of-(N+1) with the advisor as judge.
+            best-of-(N+1) with the advisor as judge. Failed advisor consults
+            do not consume the budget.
         gate_stall_turns: (review_gate) When > 0, additionally trigger a
             review (once per session, consuming review budget) at the first
             request whose conversation already carries at least this many
@@ -137,6 +141,10 @@ class AdvisorConfig(BaseModel):
             reject ``temperature``.
         transcript_max_chars: Cap on the serialized transcript handed to the
             advisor, so a long agent conversation can't blow its context.
+            The default (200k chars ≈ 50k tokens) fits comfortably in a
+            frontier advisor's window; review_gate drops the middle of an
+            over-cap conversation (task head + recent tail survive),
+            tool_call drops the oldest messages.
         fail_open: When ``True`` (default), an advisor-call failure degrades
             gracefully — the executor proceeds unadvised (tool_call) or the
             turn passes through as APPROVE (review_gate). When ``False``, the
@@ -175,7 +183,7 @@ class AdvisorConfig(BaseModel):
     seed_advice_prefix: str = SEED_ADVICE_PREFIX
     advisor_max_tokens: int = Field(default=2048, ge=1)
     advisor_temperature: float | None = None
-    transcript_max_chars: int = Field(default=24_000, ge=256)
+    transcript_max_chars: int = Field(default=200_000, ge=256)
     fail_open: bool = True
     enable_stats: bool = True
     preset: str | None = None

--- a/switchyard/lib/profiles/advisor_presets.py
+++ b/switchyard/lib/profiles/advisor_presets.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Named :class:`AdvisorConfig` presets keyed by shipping bundle.
+
+The shipping default :meth:`AdvisorPresets.opus47_exec_opus48_advisor` pairs an
+Opus 4.7 executor with an Opus 4.8 advisor, both served native Anthropic from
+NVIDIA Inference Hub. This is the proxy-side re-creation of Anthropic's
+server-side ``advisor_20260301`` beta for a gateway that cannot run it.
+``strategy`` selects how the advisor participates: ``"tool_call"`` (default)
+offers the executor a real, parameterless ``advisor`` tool it calls
+mid-generation; ``"review_gate"`` consults the advisor once per session at the
+executor's first no-tool-call turn to APPROVE or send it back (REDO).
+
+Example::
+
+    from switchyard import AdvisorPresets, AdvisorProfileConfig, ProfileSwitchyard
+
+    config = AdvisorPresets.opus47_exec_opus48_advisor(api_key=nvidia_api_key)
+    switchyard = ProfileSwitchyard(
+        AdvisorProfileConfig.from_config(config).build().with_runtime_components()
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from switchyard.lib.backends.llm_target import BackendFormat, LlmTarget
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+
+# All shipping presets route through NVIDIA Inference Hub's Anthropic Messages
+# endpoint by default; callers override with ``base_url=`` for a different gateway.
+_INFERENCE_HUB_BASE_URL = "https://inference-api.nvidia.com/v1"
+
+# Inference Hub model ids. Both tiers (Opus 4.7 executor, Opus 4.8 advisor) are
+# served native Anthropic-Messages at ``/v1/messages`` — no OpenAI translation,
+# so prompt caching survives. Both are overridable via the preset's
+# ``executor_model`` / ``advisor_model``.
+_MODEL_OPUS_4_7_EXECUTOR = "aws/anthropic/bedrock-claude-opus-4-7"
+_MODEL_OPUS_4_8_ADVISOR = "aws/anthropic/bedrock-claude-opus-4-8"
+
+
+class AdvisorPresets:
+    """Factory of pre-built :class:`AdvisorConfig` bundles."""
+
+    @staticmethod
+    def opus47_exec_opus48_advisor(
+        *,
+        api_key: str,
+        base_url: str = _INFERENCE_HUB_BASE_URL,
+        timeout_secs: float | None = 600.0,
+        executor_model: str = _MODEL_OPUS_4_7_EXECUTOR,
+        advisor_model: str = _MODEL_OPUS_4_8_ADVISOR,
+        strategy: Literal["tool_call", "review_gate"] = "tool_call",
+    ) -> AdvisorConfig:
+        """Opus 4.7 executor + Opus 4.8 advisor on NVIDIA Inference Hub.
+
+        Args:
+            api_key: Inference Hub API key, used for both tiers (one tenancy).
+            base_url: OpenAI-compatible gateway base URL.
+            timeout_secs: Per-call timeout for both tiers. Generous by default
+                because the advisor consult adds an extra round-trip inside a
+                single client request.
+            executor_model: Override the executor model id if your tenancy
+                serves Opus 4.7 under a different string.
+            advisor_model: Override the advisor model id likewise.
+            strategy: Advisor strategy — ``"tool_call"`` (default) or
+                ``"review_gate"``.
+        """
+        return AdvisorConfig(
+            executor=LlmTarget(
+                # Native Anthropic Messages (``/v1/messages``): the request passes
+                # through verbatim so the client's cache_control breakpoints reach
+                # the upstream and prompt caching is honored. Inference Hub wants
+                # Bearer auth (not Anthropic's x-api-key), so suppress x-api-key
+                # (api_key="") and carry the key in an Authorization header.
+                id="executor",
+                model=executor_model,
+                format=BackendFormat.ANTHROPIC,
+                api_key="",
+                base_url=base_url,
+                timeout_secs=timeout_secs,
+                extra_headers={"Authorization": f"Bearer {api_key}"},
+            ),
+            advisor=LlmTarget(
+                # Anthropic Messages format: consulted via ``/v1/messages`` (the
+                # advisor caller sends Bearer auth directly from ``api_key``).
+                id="advisor",
+                model=advisor_model,
+                format=BackendFormat.ANTHROPIC,
+                api_key=api_key,
+                base_url=base_url,
+                timeout_secs=timeout_secs,
+            ),
+            strategy=strategy,
+            preset="opus47_exec_opus48_advisor",
+        )
+
+
+__all__ = ["AdvisorPresets"]

--- a/switchyard/lib/profiles/advisor_prompts.py
+++ b/switchyard/lib/profiles/advisor_prompts.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Default prompts for the advisor strategies.
+
+Two strategies share this module (selected by ``AdvisorConfig.strategy``):
+
+* ``tool_call`` — the executor is offered a real, parameterless ``advisor``
+  tool it calls mid-generation (the proxy-side re-creation of Anthropic's
+  ``advisor_20260301`` server tool). ``EXECUTOR_STEERING`` and
+  ``ADVISOR_LENGTH_LINE`` are reproduced **verbatim** from Anthropic's
+  advisor-tool documentation
+  (https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool,
+  sections "Suggested system prompt for coding tasks" and "Trimming advisor
+  output length"). ``ADVISOR_SYSTEM_PROMPT`` and ``ADVISOR_TOOL_DESCRIPTION``
+  are authored here — the native tool runs the advisor server-side under
+  Anthropic-internal instructions the docs do not publish.
+
+* ``review_gate`` — the advisor is a once-per-session reviewer, not an
+  executor-triggered tool. It is consulted at the first point the executor
+  produces a no-tool-call turn — either a plan it is about to execute, or a
+  claim that the task is done — and returns ``APPROVE`` (let the executor
+  stop) or ``REDO`` + an optimized plan (send it back to keep working). This
+  preserves the executor's own test-and-iterate loop (which front-loaded
+  advice was found to suppress, causing premature convergence) and adds a
+  single quality gate on top.
+
+These are defaults; :class:`~switchyard.lib.profiles.advisor_config.AdvisorConfig`
+exposes each as an overridable field for ablation.
+"""
+
+from __future__ import annotations
+
+# Verbatim: the doc's "Timing guidance" block followed directly by the "How the
+# executor should treat the advice" block (the doc instructs placing the latter
+# "directly after the timing block"). Addresses the EXECUTOR model.
+EXECUTOR_STEERING = """\
+You have access to an `advisor` tool backed by a stronger reviewer model. It takes NO parameters — when you call advisor(), your entire conversation history is automatically forwarded. They see the task, every tool call you've made, every result you've seen.
+
+Call advisor BEFORE substantive work — before writing, before committing to an interpretation, before building on an assumption. If the task requires orientation first (finding files, fetching a source, seeing what's there), do that, then call advisor. Orientation is not substantive work. Writing, editing, and declaring an answer are.
+
+Also call advisor:
+- When you believe the task is complete. BEFORE this call, make your deliverable durable: write the file, save the result, commit the change. The advisor call takes time; if the session ends during it, a durable result persists and an unwritten one doesn't.
+- When stuck — errors recurring, approach not converging, results that don't fit.
+- When considering a change of approach.
+
+On tasks longer than a few steps, call advisor at least once before committing to an approach and once before declaring done. On short reactive tasks where the next action is dictated by tool output you just read, you don't need to keep calling — the advisor adds most of its value on the first call, before the approach crystallizes.
+
+Give the advice serious weight. If you follow a step and it fails empirically, or you have primary-source evidence that contradicts a specific claim (the file says X, the paper states Y), adapt. A passing self-test is not evidence the advice is wrong — it's evidence your test doesn't check what the advice is checking.
+
+If you've already retrieved data pointing one way and the advisor points another: don't silently switch. Surface the conflict in one more advisor call — "I found X, you suggest Y, which constraint breaks the tie?" The advisor saw your evidence but may have underweighted it; a reconcile call is cheaper than committing to the wrong branch.\
+"""
+
+# Verbatim: the doc's advisor-directed length line. The doc places it in the
+# user message because the advisor follows instructions addressed to it directly
+# far more reliably than third-person descriptions.
+ADVISOR_LENGTH_LINE = (
+    "(Advisor: please keep your guidance under 80 words — I need a focused "
+    "starting point, not a comprehensive plan.)"
+)
+
+# Authored here (the doc publishes no advisor system prompt — it is server-side
+# internal in the native tool). Tells the advisor model its role so it advises
+# rather than attempting the task itself.
+ADVISOR_SYSTEM_PROMPT = """\
+You are a higher-intelligence advisor model consulted mid-task by a faster executor model. You can see the full conversation: the task, every tool call, and every result. You do not act, write code, or call tools — you provide strategic guidance only: a focused plan or a course correction the executor will carry out. Be concrete and brief.\
+"""
+
+# Authored here (the native tool's "built-in description" is not published).
+# Description for the synthetic ``advisor`` tool offered to the executor.
+ADVISOR_TOOL_DESCRIPTION = (
+    "Consult a stronger reviewer model for strategic guidance. Takes no "
+    "parameters; your full conversation history is forwarded automatically."
+)
+
+REVIEWER_SYSTEM_PROMPT = """\
+You are a senior reviewer acting as a quality gate for a faster executor model working a coding/agent task. You are given the full transcript: the task, every action the executor took and every result it saw, and its latest message — in which it has either (a) proposed a plan before doing the work, or (b) concluded the task is complete.
+
+Decide whether to let the executor stop or send it back to keep working. Put your verdict as the FIRST word of your reply:
+
+- APPROVE — the proposed plan is sound, OR the work is genuinely complete and correct. Reply with exactly: APPROVE
+- REDO — the plan has a real flaw, OR the work is incomplete/incorrect: an unhandled edge case, an untested assumption, a subtly wrong approach, missing verification, or a stated requirement not met. Reply: REDO, then a SHORT, concrete, actionable plan naming exactly what is wrong or missing and what to do about it. No generic advice — point at the specific gap.
+
+Bias toward APPROVE when the work looks correct and complete; the executor has already done its own iteration. Use REDO specifically to catch a premature "done" on a subtly incomplete solution, or a flawed plan before it is executed. A self-claim of success is not proof — check the actual task requirements against what was actually done.
+"""
+
+#: Prepended to the advisor's REDO plan when it is injected back to the executor
+#: as a user turn, instructing it to continue rather than stop.
+REDO_FEEDBACK_PREFIX = (
+    "A senior reviewer examined your work and determined the task is NOT yet "
+    "complete or correct. Do not stop here — address the following, then keep "
+    "working until it is genuinely done:\n\n"
+)
+
+#: Prepended to the advisor's upfront plan when ``seed_plan_advice`` injects it
+#: into the session's first user message (both strategies honor the flag).
+SEED_ADVICE_PREFIX = (
+    "\n\nA senior advisor reviewed this task before you started and suggests:\n"
+)
+
+__all__ = [
+    "ADVISOR_LENGTH_LINE",
+    "ADVISOR_SYSTEM_PROMPT",
+    "ADVISOR_TOOL_DESCRIPTION",
+    "EXECUTOR_STEERING",
+    "REDO_FEEDBACK_PREFIX",
+    "REVIEWER_SYSTEM_PROMPT",
+    "SEED_ADVICE_PREFIX",
+]

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -1,0 +1,744 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the review-gate :class:`AdvisorLoopBackend` (native Anthropic).
+
+All loop tests inject a fake executor backend (returns ``ChatResponse``) and a
+fake advisor caller — no network. They cover the gate contract: tool-use turns
+pass through unreviewed; the first no-tool-use turn is reviewed once; APPROVE
+returns it; REDO re-invokes the executor to continue; the review is
+once-per-session and the session is pure passthrough afterward; fail-open
+approves. Separate tests cover the Anthropic reviewer caller (respx) and the
+pure helpers. Both streaming and completion executor responses are exercised.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import respx
+
+from switchyard.lib.backends.advisor_loop_backend import (
+    AdvisorLoopBackend,
+    _anthropic_text,
+    _AnthropicAdvisorCaller,
+    _build_advisor_caller,
+    _messages_url,
+    _OpenAiAdvisorCaller,
+    _parse_verdict,
+    _session_key,
+    _usage_tokens,
+)
+from switchyard.lib.backends.llm_target import coerce_llm_target
+from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
+from switchyard.lib.chat_response.openai_chat import ResponseStream as OpenAIResponseStream
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.stats_accumulator import StatsAccumulator
+from switchyard_rust.core import (
+    ChatRequest,
+    ChatRequestType,
+    ChatResponse,
+    ChatResponseType,
+    response_type_matches,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _completion_resp(*, text=None, tool_use=False, model="exec-model") -> ChatResponse:
+    """An Anthropic completion ChatResponse (text and/or a tool_use block)."""
+    content: list[dict] = []
+    if tool_use:
+        content.append({"type": "tool_use", "id": "t1", "name": "bash", "input": {}})
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    body = {
+        "id": "msg-x", "type": "message", "role": "assistant", "model": model,
+        "content": content,
+        "stop_reason": "tool_use" if tool_use else "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 3},
+    }
+    return ChatResponse.anthropic_completion(body)
+
+
+async def _agen(events):
+    for event in events:
+        yield event
+
+
+def _stream_resp(*, text=None, tool_use=False) -> ChatResponse:
+    """An Anthropic streaming ChatResponse (SSE event dicts)."""
+    events: list[dict] = [{"type": "message_start", "message": {"usage": {"input_tokens": 10}}}]
+    if tool_use:
+        events.append({"type": "content_block_start", "index": 0,
+                       "content_block": {"type": "tool_use", "id": "t1", "name": "bash", "input": {}}})
+        events.append({"type": "message_delta", "delta": {"stop_reason": "tool_use"},
+                       "usage": {"output_tokens": 1}})
+    else:
+        events.append({"type": "content_block_start", "index": 0,
+                       "content_block": {"type": "text", "text": ""}})
+        if text:
+            events.append({"type": "content_block_delta", "index": 0,
+                           "delta": {"type": "text_delta", "text": text}})
+        events.append({"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+                       "usage": {"output_tokens": 3}})
+    events.append({"type": "message_stop"})
+    return ChatResponse.anthropic_stream(AnthropicResponseStream(_agen(events)))
+
+
+def _exec_backend(*responses) -> MagicMock:
+    b = MagicMock()
+    b.call = AsyncMock(side_effect=list(responses))
+    b.startup = AsyncMock()
+    b.shutdown = AsyncMock()
+    return b
+
+
+def _reviewer(*verdicts: str) -> MagicMock:
+    """Fake advisor reviewer: ``advise`` yields successive ``(verdict_text, usage)``."""
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=[(v, None) for v in verdicts])
+    return c
+
+
+def _failing_reviewer(exc: Exception) -> MagicMock:
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=exc)
+    return c
+
+
+def _config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "executor": {"model": "exec-model", "base_url": "http://exec.test", "api_key": "k",
+                     "format": "anthropic"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "anthropic"},
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _backend(config, executor_backend, advisor_caller) -> AdvisorLoopBackend:
+    return AdvisorLoopBackend(
+        config, executor_backend=executor_backend, advisor_caller=advisor_caller,
+    )
+
+
+def _request(**overrides) -> ChatRequest:
+    body: dict = {"model": "incoming", "system": "sys",
+                  "messages": [{"role": "user", "content": "build X"}]}
+    body.update(overrides)
+    return ChatRequest.anthropic(body)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Gate behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_use_turn_passes_through_unreviewed() -> None:
+    """A turn with a tool_use block means the executor is working — no review."""
+    exec_b = _exec_backend(_completion_resp(text="reading", tool_use=True))
+    adv = _reviewer()
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert resp.to_body()["stop_reason"] == "tool_use"
+    assert exec_b.call.await_count == 1
+    assert adv.advise.await_count == 0  # advisor never consulted
+
+
+async def test_terminal_turn_approved_returns_as_is() -> None:
+    """First no-tool-use turn is reviewed; APPROVE returns it unchanged."""
+    exec_b = _exec_backend(_completion_resp(text="done, all good"))
+    adv = _reviewer("APPROVE")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert _anthropic_text(resp.to_body()) == "done, all good"
+    assert exec_b.call.await_count == 1
+    assert adv.advise.await_count == 1
+
+
+async def test_review_records_advisor_cost_into_stats() -> None:
+    """The advisor review's tokens are recorded into the accumulator so the run's
+    own cost output (routing_stats) includes the advisor, not just the executor."""
+    exec_b = _exec_backend(_completion_resp(text="done"))
+    adv = MagicMock()
+    adv.advise = AsyncMock(return_value=("APPROVE", {"input_tokens": 500, "output_tokens": 8}))
+    stats = MagicMock()
+    stats.record_classifier_usage = AsyncMock()
+    stats.record_success = AsyncMock()
+    backend = AdvisorLoopBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+    stats.record_classifier_usage.assert_awaited_once()
+    kw = stats.record_classifier_usage.await_args.kwargs
+    assert kw["model"] == "adv-model"
+    assert kw["prompt_tokens"] == 500
+    assert kw["completion_tokens"] == 8
+
+
+async def test_review_cost_recorded_against_real_accumulator() -> None:
+    """The mock-based test above cannot see a recording API that no longer exists:
+    ``MagicMock`` answers any attribute, so it stays green while the real call
+    raises ``AttributeError``. Drive the real accumulator so a bucket removed
+    upstream fails here instead of at the first live advisor consult."""
+    exec_b = _exec_backend(_completion_resp(text="done"))
+    adv = MagicMock()
+    adv.advise = AsyncMock(return_value=("APPROVE", {"input_tokens": 500, "output_tokens": 8}))
+    stats = StatsAccumulator()
+    backend = AdvisorLoopBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+    advisor_stats = stats.snapshot_sync()["classifier"]["models"]["adv-model"]
+    assert advisor_stats["prompt_tokens"] == 500
+    assert advisor_stats["completion_tokens"] == 8
+
+
+async def test_redo_reinvokes_executor_with_feedback() -> None:
+    """REDO feeds the plan back and re-invokes the executor to keep working."""
+    exec_b = _exec_backend(
+        _completion_resp(text="I think I'm done"),            # terminal → review
+        _completion_resp(text="continuing", tool_use=True),   # redo continuation (passthrough)
+    )
+    adv = _reviewer("REDO: you forgot the empty-input case; add a guard and test it")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 2  # original + redo re-invocation
+    redo_request = exec_b.call.await_args_list[1].args[1]
+    redo_msgs = redo_request.to_body()["messages"]
+    assert any(m.get("role") == "assistant" and m.get("content") == "I think I'm done" for m in redo_msgs)
+    assert any(m.get("role") == "user" and "empty-input case" in (m.get("content") or "") for m in redo_msgs)
+    # the returned response is the continuation (has the real tool call)
+    assert resp.to_body()["stop_reason"] == "tool_use"
+
+
+async def test_review_is_once_per_session() -> None:
+    """Two terminal turns in the same session → advisor consulted only once."""
+    exec_b = _exec_backend(_completion_resp(text="done1"), _completion_resp(text="done2"))
+    adv = _reviewer("APPROVE")  # only one verdict provided on purpose
+    backend = _backend(_config(), exec_b, adv)
+    await backend.call(ProxyContext(), _request())      # review #1
+    await backend.call(ProxyContext(), _request())      # same prefix → no review
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 2
+
+
+async def test_reviewed_session_passes_through_verbatim() -> None:
+    """After the gate fires, later turns are pure passthrough (no advisor, returned as-is)."""
+    exec_b = _exec_backend(
+        _completion_resp(text="plan"),                     # review fires here
+        _completion_resp(text="more", tool_use=True),      # passthrough verbatim
+    )
+    adv = _reviewer("APPROVE")
+    backend = _backend(_config(), exec_b, adv)
+    await backend.call(ProxyContext(), _request())
+    resp = await backend.call(ProxyContext(), _request())
+    assert adv.advise.await_count == 1
+    assert resp.to_body()["stop_reason"] == "tool_use"
+
+
+async def test_fail_open_approves_on_review_error() -> None:
+    exec_b = _exec_backend(_completion_resp(text="done"))
+    adv = _failing_reviewer(RuntimeError("advisor down"))
+    resp = await _backend(_config(fail_open=True), exec_b, adv).call(ProxyContext(), _request())
+    assert _anthropic_text(resp.to_body()) == "done"
+    assert exec_b.call.await_count == 1  # no redo
+
+
+async def test_fail_closed_propagates_review_error() -> None:
+    exec_b = _exec_backend(_completion_resp(text="done"))
+    adv = _failing_reviewer(RuntimeError("advisor down"))
+    with pytest.raises(RuntimeError, match="advisor down"):
+        await _backend(_config(fail_open=False), exec_b, adv).call(ProxyContext(), _request())
+
+
+async def test_streaming_terminal_approved_replays() -> None:
+    """Streaming no-tool-use turn → review → APPROVE → replay (one generation)."""
+    exec_b = _exec_backend(_stream_resp(text="done"))
+    adv = _reviewer("APPROVE")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request(stream=True))
+    assert exec_b.call.await_count == 1
+    assert adv.advise.await_count == 1
+    assert response_type_matches(resp, ChatResponseType.ANTHROPIC_STREAM)
+    events = [e async for e in resp.stream]
+    assert any(isinstance(e, dict) and e.get("type") == "content_block_delta" for e in events)
+
+
+async def test_streaming_tool_use_passes_through() -> None:
+    """Streaming turn with a tool_use block → pass through, no review."""
+    exec_b = _exec_backend(_stream_resp(tool_use=True))
+    adv = _reviewer()
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request(stream=True))
+    assert adv.advise.await_count == 0
+    assert response_type_matches(resp, ChatResponseType.ANTHROPIC_STREAM)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-wire gate (executor format: openai)
+# ---------------------------------------------------------------------------
+
+
+def _openai_config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "strategy": "review_gate",
+        "executor": {"model": "qwen/qwen3-max", "base_url": "http://exec.test",
+                     "api_key": "k", "format": "openai"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "anthropic"},
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _openai_completion_resp(*, text=None, tool_calls=False) -> ChatResponse:
+    message: dict = {"role": "assistant", "content": text}
+    if tool_calls:
+        message["tool_calls"] = [{"id": "b1", "type": "function",
+                                  "function": {"name": "bash", "arguments": "{}"}}]
+    body = {
+        "id": "chatcmpl-x", "object": "chat.completion", "model": "exec-model",
+        "choices": [{"index": 0, "message": message,
+                     "finish_reason": "tool_calls" if tool_calls else "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+    }
+    return ChatResponse.openai_completion(body)
+
+
+def _openai_request(**overrides) -> ChatRequest:
+    body: dict = {"model": "incoming",
+                  "messages": [{"role": "system", "content": "sys"},
+                               {"role": "user", "content": "build X"}]}
+    body.update(overrides)
+    return ChatRequest.openai_chat(body)  # type: ignore[arg-type]
+
+
+def test_openai_gate_advertises_openai_wire() -> None:
+    backend = _backend(_openai_config(), _exec_backend(), _reviewer())
+    assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+
+async def test_openai_tool_call_turn_passes_through_unreviewed() -> None:
+    exec_b = _exec_backend(_openai_completion_resp(tool_calls=True))
+    adv = _reviewer()
+    resp = await _backend(_openai_config(), exec_b, adv).call(ProxyContext(), _openai_request())
+    assert resp.to_body()["choices"][0]["finish_reason"] == "tool_calls"
+    assert adv.advise.await_count == 0
+
+
+async def test_openai_terminal_turn_approved_returns_as_is() -> None:
+    exec_b = _exec_backend(_openai_completion_resp(text="done, all good"))
+    adv = _reviewer("APPROVE")
+    resp = await _backend(_openai_config(), exec_b, adv).call(ProxyContext(), _openai_request())
+    assert resp.to_body()["choices"][0]["message"]["content"] == "done, all good"
+    assert adv.advise.await_count == 1
+
+
+async def test_openai_redo_uses_configured_prefix_and_wire() -> None:
+    exec_b = _exec_backend(
+        _openai_completion_resp(text="I think I'm done"),
+        _openai_completion_resp(text="continuing", tool_calls=True),
+    )
+    adv = _reviewer("REDO: verify the output file exists")
+    config = _openai_config(redo_feedback_prefix="REVIEWER SAYS: ")
+    resp = await _backend(config, exec_b, adv).call(ProxyContext(), _openai_request())
+
+    assert exec_b.call.await_count == 2
+    redo_request = exec_b.call.await_args_list[1].args[1]
+    assert redo_request.request_type == ChatRequestType.OPENAI_CHAT
+    redo_msgs = redo_request.to_body()["messages"]
+    assert redo_msgs[-1]["role"] == "user"
+    assert redo_msgs[-1]["content"].startswith("REVIEWER SAYS: verify the output file")
+    assert redo_msgs[-2] == {"role": "assistant", "content": "I think I'm done"}
+    assert resp.to_body()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+async def test_openai_streaming_terminal_approved_replays() -> None:
+    events = [
+        {"id": "c", "object": "chat.completion.chunk",
+         "choices": [{"index": 0, "delta": {"role": "assistant", "content": "done"},
+                      "finish_reason": None}]},
+        {"id": "c", "object": "chat.completion.chunk",
+         "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+    ]
+    exec_b = _exec_backend(
+        ChatResponse.openai_stream(OpenAIResponseStream(_agen(list(events)))),
+    )
+    adv = _reviewer("APPROVE")
+    resp = await _backend(_openai_config(), exec_b, adv).call(
+        ProxyContext(), _openai_request(stream=True),
+    )
+    assert adv.advise.await_count == 1
+    assert response_type_matches(resp, ChatResponseType.OPENAI_STREAM)
+    replayed = [e async for e in resp.stream]
+    assert replayed == events
+
+
+# ---------------------------------------------------------------------------
+# Pattern trigger (text-protocol harnesses)
+# ---------------------------------------------------------------------------
+
+
+def _pattern_config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "strategy": "review_gate",
+        "gate_trigger": "pattern",
+        "gate_trigger_pattern": r'task_complete["\s>:]*true',
+        "executor": {"model": "nvidia/nemotron-3-ultra", "base_url": "http://exec.test",
+                     "api_key": "k", "format": "openai"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "anthropic"},
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+async def test_pattern_trigger_ignores_non_matching_turns() -> None:
+    """Ordinary command turns (no marker) pass through unreviewed, even with
+    no tool calls — the whole point for text-protocol harnesses."""
+    exec_b = _exec_backend(_openai_completion_resp(text='{"commands": ["ls -la"]}'))
+    adv = _reviewer()
+    resp = await _backend(_pattern_config(), exec_b, adv).call(ProxyContext(), _openai_request())
+    assert adv.advise.await_count == 0
+    assert resp.to_body()["choices"][0]["message"]["content"] == '{"commands": ["ls -la"]}'
+
+
+async def test_pattern_trigger_gates_done_marker_and_redos() -> None:
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='All checks pass. "task_complete": true'),
+        _openai_completion_resp(text='{"commands": ["pytest tests/"]}'),
+    )
+    adv = _reviewer("REDO: the output file was never written; create it and re-verify")
+    config = _pattern_config(redo_feedback_prefix="REVIEWER: not done. ")
+    resp = await _backend(config, exec_b, adv).call(ProxyContext(), _openai_request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 2
+    redo_msgs = exec_b.call.await_args_list[1].args[1].to_body()["messages"]
+    assert redo_msgs[-1]["content"].startswith("REVIEWER: not done. the output file")
+    # The client receives the continuation turn, not the premature done-claim.
+    assert "pytest" in resp.to_body()["choices"][0]["message"]["content"]
+
+
+async def test_pattern_trigger_reviews_once_per_session() -> None:
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='"task_complete": true'),
+        _openai_completion_resp(text='<task_complete>true</task_complete>'),
+    )
+    adv = _reviewer("APPROVE")
+    backend = _backend(_pattern_config(), exec_b, adv)
+    await backend.call(ProxyContext(), _openai_request())   # gate fires
+    await backend.call(ProxyContext(), _openai_request())   # passthrough
+    assert adv.advise.await_count == 1
+
+
+def test_pattern_trigger_requires_pattern() -> None:
+    import pydantic
+    with pytest.raises(pydantic.ValidationError, match="gate_trigger_pattern"):
+        _pattern_config(gate_trigger_pattern="")
+
+
+def test_invalid_pattern_rejected() -> None:
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        _pattern_config(gate_trigger_pattern="[unclosed")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers + advisor caller
+# ---------------------------------------------------------------------------
+
+
+def test_parse_verdict() -> None:
+    assert _parse_verdict("APPROVE") == ("APPROVE", "")
+    assert _parse_verdict("approve, looks complete")[0] == "APPROVE"
+    v, plan = _parse_verdict("REDO: add a guard for empty input and re-run tests")
+    assert v == "REDO" and "add a guard" in plan
+    assert _parse_verdict("hmm not sure")[0] == "APPROVE"  # unclear → approve
+
+
+def test_session_key_stable_across_turns() -> None:
+    msgs = [{"role": "user", "content": "the task"}]
+    later = msgs + [{"role": "assistant", "content": "..."}, {"role": "user", "content": "tool result"}]
+    assert _session_key("sys", msgs) == _session_key("sys", later)
+    assert _session_key("sys", msgs) != _session_key("sys", [{"role": "user", "content": "DIFFERENT"}])
+    assert _session_key("sys", msgs) != _session_key("OTHER sys", msgs)  # system is part of the key
+
+
+def test_build_advisor_caller_is_anthropic() -> None:
+    assert isinstance(_build_advisor_caller(_config()), _AnthropicAdvisorCaller)
+
+
+def test_build_advisor_caller_dispatches_openai() -> None:
+    config = _config(advisor={"model": "deepseek/deepseek-r2", "base_url": "http://adv.test",
+                              "api_key": "k", "format": "openai"})
+    assert isinstance(_build_advisor_caller(config), _OpenAiAdvisorCaller)
+
+
+@respx.mock
+async def test_openai_advisor_hits_chat_completions_endpoint() -> None:
+    route = respx.post("https://adv.example/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json={
+            "id": "chatcmpl-x", "object": "chat.completion",
+            "choices": [{"index": 0, "finish_reason": "stop",
+                         "message": {"role": "assistant", "content": " use a heap "}}],
+            "usage": {"prompt_tokens": 42, "completion_tokens": 6},
+        })
+    )
+    target = coerce_llm_target({
+        "model": "deepseek/deepseek-r2", "base_url": "https://adv.example/v1",
+        "api_key": "secret-key", "format": "openai",
+        "extra_headers": {"X-Gateway": "test"},
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+    }, default_id="advisor")
+    caller = _OpenAiAdvisorCaller(target=target, max_tokens=256, temperature=None)
+
+    text, usage = await caller.advise(system="advise this", transcript="conversation")
+
+    assert text == "use a heap"
+    prompt_tokens, completion_tokens = _usage_tokens(usage)
+    assert (prompt_tokens, completion_tokens) == (42, 6)
+    request = route.calls.last.request
+    assert request.headers["authorization"] == "Bearer secret-key"
+    assert request.headers["x-gateway"] == "test"
+    body = json.loads(request.content)
+    assert body["messages"][0] == {"role": "system", "content": "advise this"}
+    assert body["messages"][1] == {"role": "user", "content": "conversation"}
+    assert body["max_tokens"] == 256
+    assert "temperature" not in body
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+@respx.mock
+async def test_anthropic_reviewer_hits_messages_endpoint() -> None:
+    route = respx.post("https://inference-api.nvidia.com/v1/messages").mock(
+        return_value=httpx.Response(200, json={
+            "content": [{"type": "text", "text": "APPROVE"}],
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        })
+    )
+    caller = _AnthropicAdvisorCaller(
+        api_key="secret-key", base_url="https://inference-api.nvidia.com/v1",
+        model="aws/anthropic/bedrock-claude-opus-4-8", max_tokens=256,
+        temperature=None, timeout=5.0,
+    )
+    text, usage = await caller.advise(system="review this", transcript="conversation")
+    assert text == "APPROVE"
+    assert usage["input_tokens"] == 10
+    request = route.calls.last.request
+    assert request.headers["authorization"] == "Bearer secret-key"
+    body = json.loads(request.content)
+    assert body["system"] == "review this"
+    assert "temperature" not in body
+
+
+def test_messages_url_resolution() -> None:
+    base = "https://inference-api.nvidia.com"
+    assert _messages_url(f"{base}/v1") == f"{base}/v1/messages"
+    assert _messages_url(f"{base}/v1/messages") == f"{base}/v1/messages"
+    assert _messages_url(base) == f"{base}/v1/messages"
+
+
+def test_anthropic_text_joins_text_blocks() -> None:
+    data = {"content": [{"type": "text", "text": "RE"}, {"type": "thinking", "text": "x"},
+                        {"type": "text", "text": "DO: fix it"}]}
+    assert _anthropic_text(data) == "REDO: fix it"
+
+
+# ---------------------------------------------------------------------------
+# seed_plan_advice
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_consults_once_and_injects_into_first_user_message() -> None:
+    """The session-opening request triggers one seed consult (advisor prompt,
+    not the reviewer prompt) and the advice lands in the first user message."""
+    exec_b = _exec_backend(_completion_resp(text="working", tool_use=True))
+    adv = _reviewer("1. plan the schema first")
+    config = _config(seed_plan_advice=True)
+    await _backend(config, exec_b, adv).call(ProxyContext(), _request())
+    assert adv.advise.await_count == 1
+    assert adv.advise.await_args.kwargs["system"] == config.advisor_system_prompt
+    sent = exec_b.call.await_args.args[1].to_body()
+    user = sent["messages"][0]
+    assert user["role"] == "user"
+    assert config.seed_advice_prefix.strip() in user["content"]
+    assert "1. plan the schema first" in user["content"]
+
+
+async def test_seed_reinjected_on_later_turns_without_reconsult() -> None:
+    """Later turns of the session re-inject the cached advice — one consult total."""
+    exec_b = _exec_backend(
+        _completion_resp(text="working", tool_use=True),
+        _completion_resp(text="still working", tool_use=True),
+    )
+    adv = _reviewer("1. plan")
+    backend = _backend(_config(seed_plan_advice=True), exec_b, adv)
+    await backend.call(ProxyContext(), _request())
+    await backend.call(ProxyContext(), _request(messages=[
+        {"role": "user", "content": "build X"},
+        {"role": "assistant", "content": "working"},
+        {"role": "user", "content": "output: ok"},
+    ]))
+    assert adv.advise.await_count == 1
+    second = exec_b.call.await_args_list[1].args[1].to_body()
+    assert "1. plan" in second["messages"][0]["content"]
+
+
+async def test_seed_skipped_for_session_first_seen_mid_conversation() -> None:
+    """A session whose first observed request already has assistant turns is
+    never seeded (injecting new advice mid-session would shift the prefix)."""
+    exec_b = _exec_backend(_completion_resp(text="w", tool_use=True))
+    adv = _reviewer()
+    await _backend(_config(seed_plan_advice=True), exec_b, adv).call(
+        ProxyContext(),
+        _request(messages=[
+            {"role": "user", "content": "build X"},
+            {"role": "assistant", "content": "already going"},
+            {"role": "user", "content": "go on"},
+        ]),
+    )
+    assert adv.advise.await_count == 0
+
+
+async def test_seed_fail_open_leaves_session_unseeded_without_retry() -> None:
+    """A failed seed consult proceeds unseeded and is cached — no retry storm."""
+    exec_b = _exec_backend(
+        _completion_resp(text="w", tool_use=True),
+        _completion_resp(text="w2", tool_use=True),
+    )
+    adv = _failing_reviewer(RuntimeError("advisor down"))
+    backend = _backend(_config(seed_plan_advice=True), exec_b, adv)
+    await backend.call(ProxyContext(), _request())
+    sent = exec_b.call.await_args_list[0].args[1].to_body()
+    assert "advisor reviewed" not in json.dumps(sent["messages"])
+    await backend.call(ProxyContext(), _request())
+    assert adv.advise.await_count == 1
+
+
+async def test_seed_composes_with_pattern_gate() -> None:
+    """Seed at session start + pattern gate at the done-claim, in one route:
+    first consult uses the advisor prompt, second the reviewer prompt, and the
+    REDO continuation still carries the seeded first user message."""
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='{"task_complete": true}'),
+        _openai_completion_resp(text="resumed work"),
+    )
+    adv = MagicMock()
+    adv.advise = AsyncMock(side_effect=[("1. seeded plan", None), ("REDO fix X", None)])
+    config = _pattern_config(seed_plan_advice=True)
+    resp = await _backend(config, exec_b, adv).call(ProxyContext(), _openai_request())
+    assert adv.advise.await_count == 2
+    assert adv.advise.await_args_list[0].kwargs["system"] == config.advisor_system_prompt
+    assert adv.advise.await_args_list[1].kwargs["system"] == config.reviewer_system_prompt
+    body = resp.to_body()
+    assert body["choices"][0]["message"]["content"] == "resumed work"
+    redo = exec_b.call.await_args_list[1].args[1].to_body()
+    assert "1. seeded plan" in redo["messages"][1]["content"]
+    assert redo["messages"][-1]["content"].startswith(config.redo_feedback_prefix)
+
+
+# ---------------------------------------------------------------------------
+# Review budget (max_reviews), stall checkpoint, and min-tool-results guard
+# ---------------------------------------------------------------------------
+
+
+async def test_max_reviews_budget_reviews_redeclared_completion() -> None:
+    """With max_reviews=2, a completion re-declared after a REDO is reviewed
+    again (sequential best-of-3 with the advisor as judge); the budget then
+    exhausts and later turns pass through."""
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='{"task_complete": true}'),   # req1: reviewed -> REDO
+        _openai_completion_resp(text="continuing"),                # req1: redo continuation
+        _openai_completion_resp(text='{"task_complete": true}'),   # req2: reviewed -> APPROVE
+        _openai_completion_resp(text='{"task_complete": true}'),   # req3: passthrough
+    )
+    adv = MagicMock()
+    adv.advise = AsyncMock(side_effect=[("REDO not done", None), ("APPROVE", None)])
+    config = _pattern_config(max_reviews=2)
+    backend = _backend(config, exec_b, adv)
+    later = [{"role": "user", "content": "build X"},
+             {"role": "assistant", "content": "working"},
+             {"role": "user", "content": "output"}]
+    await backend.call(ProxyContext(), _openai_request())
+    await backend.call(ProxyContext(), _openai_request(messages=list(later)))
+    await backend.call(ProxyContext(), _openai_request(messages=list(later)))
+    assert adv.advise.await_count == 2  # budget spent; third declaration unreviewed
+
+
+async def test_default_budget_keeps_once_per_session() -> None:
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='{"task_complete": true}'),
+        _openai_completion_resp(text='{"task_complete": true}'),
+    )
+    adv = _reviewer("APPROVE")
+    backend = _backend(_pattern_config(), exec_b, adv)
+    await backend.call(ProxyContext(), _openai_request())
+    await backend.call(ProxyContext(), _openai_request())
+    assert adv.advise.await_count == 1
+
+
+async def test_stall_checkpoint_reviews_mid_task_once() -> None:
+    """gate_stall_turns fires a mid-task review when the conversation has
+    grown past the threshold without the pattern ever matching — and only
+    once per session."""
+    exec_b = _exec_backend(
+        _openai_completion_resp(text='{"commands": ["make"]}'),  # stall review -> REDO
+        _openai_completion_resp(text="course-corrected"),        # redo continuation
+        _openai_completion_resp(text='{"commands": ["ls"]}'),    # no re-fire (stall spent)
+    )
+    adv = MagicMock()
+    adv.advise = AsyncMock(side_effect=[("REDO try approach B", None)])
+    config = _pattern_config(max_reviews=2, gate_stall_turns=3)
+    backend = _backend(config, exec_b, adv)
+    long_history = [{"role": "user", "content": "build X"}]
+    for i in range(3):
+        long_history += [{"role": "assistant", "content": f"cmd {i}"},
+                         {"role": "user", "content": f"out {i}"}]
+    await backend.call(ProxyContext(), _openai_request(messages=list(long_history)))
+    assert adv.advise.await_count == 1
+    await backend.call(ProxyContext(), _openai_request(messages=list(long_history)))
+    assert adv.advise.await_count == 1  # stall fired once; budget remains for the marker
+
+
+async def test_stall_disabled_by_default() -> None:
+    exec_b = _exec_backend(_openai_completion_resp(text='{"commands": ["make"]}'))
+    adv = _reviewer()
+    long_history = [{"role": "user", "content": "build X"}]
+    for i in range(10):
+        long_history += [{"role": "assistant", "content": f"c{i}"},
+                         {"role": "user", "content": f"o{i}"}]
+    await _backend(_pattern_config(), exec_b, adv).call(
+        ProxyContext(), _openai_request(messages=long_history))
+    assert adv.advise.await_count == 0
+
+
+async def test_min_tool_results_skips_early_commentary() -> None:
+    """no_tool_call trigger with gate_min_tool_results: a text-only turn
+    before any tool results is NOT reviewed; one after enough results is."""
+    exec_b = _exec_backend(
+        _completion_resp(text="here is my plan"),   # 0 tool results -> no review
+        _completion_resp(text="all done"),          # 2 tool results -> reviewed
+    )
+    adv = _reviewer("APPROVE")
+    config = _config(gate_min_tool_results=2)
+    backend = _backend(config, exec_b, adv)
+    await backend.call(ProxyContext(), _request())
+    assert adv.advise.await_count == 0
+    worked = [
+        {"role": "user", "content": "build X"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "bash", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t2", "name": "bash", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t2", "content": "ok"}]},
+    ]
+    await backend.call(ProxyContext(), _request(messages=worked))
+    assert adv.advise.await_count == 1

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -469,6 +469,39 @@ def test_session_key_stable_across_turns() -> None:
     assert _session_key("sys", msgs) != _session_key("OTHER sys", msgs)  # system is part of the key
 
 
+def test_session_key_ignores_volatile_system_tail() -> None:
+    """A harness that re-renders volatile system context must not reset the budget.
+
+    Claude Code rewrites reminders / todo state / environment into the system
+    prompt on every request. Hashing all of it minted a fresh session key per
+    turn, silently resetting ``max_reviews`` — observed as 87 advisor reviews on
+    one Terminal-Bench task instead of the configured 2. Only the client's
+    cache_control-marked prefix is stable by construction, so only it counts.
+    """
+    msgs = [{"role": "user", "content": "the task"}]
+    stable = {"type": "text", "text": "you are an agent", "cache_control": {"type": "ephemeral"}}
+    turn1 = [stable, {"type": "text", "text": "<reminder>todo: 1 of 5</reminder>"}]
+    turn2 = [stable, {"type": "text", "text": "<reminder>todo: 4 of 5</reminder>"}]
+
+    assert _session_key(turn1, msgs) == _session_key(turn2, msgs)
+
+    # A genuinely different cached prefix is still a different session.
+    other = {"type": "text", "text": "you are something else", "cache_control": {"type": "ephemeral"}}
+    assert _session_key(turn1, msgs) != _session_key([other], msgs)
+
+    # ...and a different task under the same prefix is still a different session.
+    assert _session_key(turn1, msgs) != _session_key(turn1, [{"role": "user", "content": "other task"}])
+
+
+def test_session_key_without_breakpoint_falls_back_to_first_user_message() -> None:
+    """No cache_control breakpoint -> identity rests on the stable task statement."""
+    msgs = [{"role": "user", "content": "the task"}]
+    a = [{"type": "text", "text": "volatile A"}]
+    b = [{"type": "text", "text": "volatile B"}]
+    assert _session_key(a, msgs) == _session_key(b, msgs)
+    assert _session_key(a, msgs) != _session_key(a, [{"role": "user", "content": "other task"}])
+
+
 def test_build_advisor_caller_is_anthropic() -> None:
     assert isinstance(_build_advisor_caller(_config()), _AnthropicAdvisorCaller)
 

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -228,6 +228,39 @@ async def test_review_is_once_per_session() -> None:
     assert exec_b.call.await_count == 2
 
 
+async def test_review_budget_survives_session_key_churn() -> None:
+    """A changing conversation prefix must not refill the review budget.
+
+    Real harnesses compact history and re-render system context, minting a fresh
+    session key mid-run. With a purely per-session budget the gate silently
+    refilled: one Terminal-Bench task drew 107 reviews against max_reviews=2.
+    The instance-level ceiling is what bounds it.
+    """
+    exec_b = _exec_backend(*[_completion_resp(text=f"done{i}") for i in range(6)])
+    adv = _reviewer(*["APPROVE"] * 6)
+    backend = _backend(_config(max_reviews=2), exec_b, adv)
+    # each call carries a DIFFERENT first user message -> a different session key
+    for i in range(6):
+        await backend.call(
+            ProxyContext(),
+            _request(messages=[{"role": "user", "content": f"distinct task {i}"}]),
+        )
+    assert adv.advise.await_count == 2, "instance ceiling must hold across new session keys"
+
+
+async def test_instance_budget_allows_configured_reviews() -> None:
+    """The instance ceiling must not fire early — max_reviews reviews still happen."""
+    exec_b = _exec_backend(*[_completion_resp(text=f"done{i}") for i in range(4)])
+    adv = _reviewer(*["APPROVE"] * 4)
+    backend = _backend(_config(max_reviews=2), exec_b, adv)
+    for i in range(4):
+        await backend.call(
+            ProxyContext(),
+            _request(messages=[{"role": "user", "content": f"distinct task {i}"}]),
+        )
+    assert adv.advise.await_count == 2
+
+
 async def test_reviewed_session_passes_through_verbatim() -> None:
     """After the gate fires, later turns are pure passthrough (no advisor, returned as-is)."""
     exec_b = _exec_backend(

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -494,7 +494,7 @@ def test_parse_verdict() -> None:
     assert _parse_verdict("approve, looks complete")[0] == "APPROVE"
     v, plan = _parse_verdict("REDO: add a guard for empty input and re-run tests")
     assert v == "REDO" and "add a guard" in plan
-    assert _parse_verdict("hmm not sure")[0] == "APPROVE"  # unclear → approve
+    assert _parse_verdict("hmm not sure") == ("", "")  # unclear → unparseable
 
 
 def test_session_key_stable_across_turns() -> None:
@@ -901,16 +901,73 @@ def test_advisor_usage_folds_gateway_cache_buckets() -> None:
 
 
 def test_parse_verdict_tolerates_wrappers() -> None:
-    """Markdown/prefix wrappers around the verdict must not silently APPROVE."""
+    """Markdown/label wrappers parse; prose before the verdict does not."""
     assert _parse_verdict("**REDO** add error handling")[0] == "REDO"
     assert _parse_verdict("Verdict: REDO — cover the empty-input case")[0] == "REDO"
     verdict, plan = _parse_verdict("redo:\n- fix the regex")
     assert verdict == "REDO"
     assert "fix the regex" in plan
     assert _parse_verdict("**APPROVE**") == ("APPROVE", "")
-    assert _parse_verdict("")[0] == "APPROVE"
-    # The token must appear in the head window, not buried in later prose.
-    assert _parse_verdict("x" * 100 + " REDO")[0] == "APPROVE"
+    # Anything without a LEADING verdict is unparseable — not a silent APPROVE,
+    # and crucially not an inverted one ("cannot approve ... REDO" used to
+    # parse as APPROVE under the first-match window).
+    assert _parse_verdict("") == ("", "")
+    assert _parse_verdict("x" * 100 + " REDO") == ("", "")
+    assert _parse_verdict("I cannot approve this — REDO: run the tests") == ("", "")
+
+
+async def test_unparseable_reply_refunds_budget() -> None:
+    """A hedged/malformed reviewer reply must not burn max_reviews."""
+    exec_b = _exec_backend(
+        _completion_resp(text="done"), _completion_resp(text="done again"),
+    )
+    adv = _reviewer("The transcript is truncated; I cannot evaluate this.", "APPROVE")
+    backend = _backend(_config(max_reviews=1), exec_b, adv)
+    resp = await backend.call(_ctx("ev_a"), _request())
+    assert _anthropic_text(resp.to_body()) == "done"  # turn passed through
+    await backend.call(_ctx("ev_a"), _request())      # real review still happens
+    assert adv.advise.await_count == 2
+
+
+async def test_reasoning_only_turn_reviews_reasoning_and_echoes_it_on_redo() -> None:
+    """A reasoning-only executor turn is reviewable and its redo echo is non-empty."""
+    reasoning = "I believe the task is finished because all files were written."
+    exec_b = _exec_backend(
+        ChatResponse.openai_completion({
+            "id": "chatcmpl-1", "object": "chat.completion", "model": "exec-model",
+            "choices": [{"index": 0, "finish_reason": "stop",
+                         "message": {"role": "assistant", "content": None,
+                                     "reasoning_content": reasoning}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+        }),
+        ChatResponse.openai_completion({
+            "id": "chatcmpl-2", "object": "chat.completion", "model": "exec-model",
+            "choices": [{"index": 0, "finish_reason": "stop",
+                         "message": {"role": "assistant", "content": "resumed"}}],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 2},
+        }),
+    )
+    adv = _reviewer("REDO state your results visibly and verify them")
+    config = _config(executor={
+        "model": "exec-model", "base_url": "http://exec.test", "api_key": "k",
+        "format": "openai",
+    })
+    backend = _backend(config, exec_b, adv)
+    await backend.call(
+        _ctx("ev_a"),
+        ChatRequest.openai_chat({  # type: ignore[arg-type]
+            "model": "incoming",
+            "messages": [{"role": "user", "content": "build X"}],
+        }),
+    )
+    transcript = adv.advise.await_args.kwargs["transcript"]
+    assert "internal reasoning follows" in transcript
+    assert reasoning in transcript
+    redo_body = exec_b.call.await_args_list[1].args[1].to_body()
+    assert redo_body["messages"][-2] == {"role": "assistant", "content": reasoning}
+    assert redo_body["messages"][-1]["content"].endswith(
+        "state your results visibly and verify them"
+    )
 
 
 def test_transcript_truncation_keeps_task_head_and_recent_tail() -> None:

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -605,6 +605,32 @@ async def test_anthropic_reviewer_hits_messages_endpoint() -> None:
     assert "temperature" not in body
 
 
+@respx.mock
+async def test_anthropic_reviewer_forwards_extra_body_reasoning_settings() -> None:
+    """Advisor-tier extra_body (effort/thinking) reaches the consult body."""
+    route = respx.post("https://inference-api.nvidia.com/v1/messages").mock(
+        return_value=httpx.Response(200, json={
+            "content": [{"type": "text", "text": "APPROVE"}],
+            "usage": {"input_tokens": 10, "output_tokens": 2},
+        })
+    )
+    caller = _AnthropicAdvisorCaller(
+        api_key="secret-key", base_url="https://inference-api.nvidia.com/v1",
+        model="aws/anthropic/bedrock-claude-opus-4-8", max_tokens=256,
+        temperature=None, timeout=5.0,
+        extra_body={
+            "output_config": {"effort": "high"},
+            "thinking": {"type": "adaptive"},
+            "system": "MUST NOT CLOBBER",
+        },
+    )
+    await caller.advise(system="review this", transcript="conversation")
+    body = json.loads(route.calls.last.request.content)
+    assert body["output_config"] == {"effort": "high"}
+    assert body["thinking"] == {"type": "adaptive"}
+    assert body["system"] == "review this"  # core fields protected
+
+
 def test_messages_url_resolution() -> None:
     base = "https://inference-api.nvidia.com"
     assert _messages_url(f"{base}/v1") == f"{base}/v1/messages"

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -20,6 +20,7 @@ import pytest
 import respx
 
 from switchyard.lib.backends.advisor_loop_backend import (
+    _MAX_FAILED_CONSULTS_PER_SCOPE,
     AdvisorLoopBackend,
     _anthropic_text,
     _AnthropicAdvisorCaller,
@@ -35,6 +36,7 @@ from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
 from switchyard.lib.chat_response.openai_chat import ResponseStream as OpenAIResponseStream
 from switchyard.lib.profiles.advisor_config import AdvisorConfig
 from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.request_metadata import CTX_REQUEST_METADATA, RequestMetadata
 from switchyard.lib.stats_accumulator import StatsAccumulator
 from switchyard_rust.core import (
     ChatRequest,
@@ -808,3 +810,132 @@ async def test_min_tool_results_skips_early_commentary() -> None:
     ]
     await backend.call(ProxyContext(), _request(messages=worked))
     assert adv.advise.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Budget scoping (proxy_x_session_id) and consult failures
+# ---------------------------------------------------------------------------
+
+
+def _ctx(session_id: str | None = None) -> ProxyContext:
+    """A ProxyContext optionally carrying the caller's session header identity."""
+    ctx = ProxyContext()
+    if session_id:
+        ctx.metadata[CTX_REQUEST_METADATA] = RequestMetadata(session_id=session_id)
+    return ctx
+
+
+async def test_budget_is_per_client_session_scope() -> None:
+    """Each proxy_x_session_id gets its own max_reviews budget on one instance.
+
+    On a gateway shared by many tasks (benchmark campaign topology), an
+    instance-wide cap would bound reviews for the whole run; the header scope
+    is what makes max_reviews mean "reviews for this task".
+    """
+    exec_b = _exec_backend(*[_completion_resp(text=f"done{i}") for i in range(4)])
+    adv = _reviewer(*["APPROVE"] * 4)
+    backend = _backend(_config(max_reviews=1), exec_b, adv)
+    await backend.call(_ctx("ev_a"), _request())
+    await backend.call(_ctx("ev_b"), _request())  # different task -> own budget
+    assert adv.advise.await_count == 2
+    await backend.call(_ctx("ev_a"), _request())  # ev_a spent -> passthrough
+    assert adv.advise.await_count == 2
+
+
+async def test_no_session_header_falls_back_to_instance_scope() -> None:
+    """Callers without the header share one instance-wide budget (old behavior)."""
+    exec_b = _exec_backend(*[_completion_resp(text=f"done{i}") for i in range(3)])
+    adv = _reviewer(*["APPROVE"] * 3)
+    backend = _backend(_config(max_reviews=1), exec_b, adv)
+    for i in range(3):
+        await backend.call(
+            ProxyContext(),
+            _request(messages=[{"role": "user", "content": f"distinct task {i}"}]),
+        )
+    assert adv.advise.await_count == 1
+
+
+async def test_failed_consult_refunds_budget() -> None:
+    """A fail-open advisor error is not a review — the budget must survive it."""
+    exec_b = _exec_backend(
+        _completion_resp(text="done"), _completion_resp(text="done again"),
+    )
+    adv = MagicMock()
+    adv.advise = AsyncMock(side_effect=[RuntimeError("blip"), ("APPROVE", None)])
+    backend = _backend(_config(max_reviews=1), exec_b, adv)
+    await backend.call(_ctx("ev_a"), _request())  # consult fails; budget refunded
+    await backend.call(_ctx("ev_a"), _request())  # the real review still happens
+    assert adv.advise.await_count == 2
+
+
+async def test_repeated_consult_failures_stop_attempts() -> None:
+    """A down advisor stops being consulted after the per-scope failure cap."""
+    exec_b = _exec_backend(*[_completion_resp(text=f"d{i}") for i in range(5)])
+    adv = _failing_reviewer(RuntimeError("advisor down"))
+    backend = _backend(_config(max_reviews=1), exec_b, adv)
+    for _ in range(5):
+        await backend.call(_ctx("ev_a"), _request())
+    assert adv.advise.await_count == _MAX_FAILED_CONSULTS_PER_SCOPE
+
+
+def test_parse_verdict_tolerates_wrappers() -> None:
+    """Markdown/prefix wrappers around the verdict must not silently APPROVE."""
+    assert _parse_verdict("**REDO** add error handling")[0] == "REDO"
+    assert _parse_verdict("Verdict: REDO — cover the empty-input case")[0] == "REDO"
+    verdict, plan = _parse_verdict("redo:\n- fix the regex")
+    assert verdict == "REDO"
+    assert "fix the regex" in plan
+    assert _parse_verdict("**APPROVE**") == ("APPROVE", "")
+    assert _parse_verdict("")[0] == "APPROVE"
+    # The token must appear in the head window, not buried in later prose.
+    assert _parse_verdict("x" * 100 + " REDO")[0] == "APPROVE"
+
+
+def test_transcript_truncation_keeps_task_head_and_recent_tail() -> None:
+    """Over the cap, the middle drops — the task and the newest work survive."""
+    backend = _backend(_config(transcript_max_chars=400), _exec_backend(), _reviewer())
+    messages = [{"role": "user", "content": "TASK-STATEMENT"}]
+    messages += [{"role": "assistant", "content": f"turn-{i} " + "x" * 40} for i in range(30)]
+    messages += [{"role": "assistant", "content": "NEWEST-EVIDENCE"}]
+    transcript = backend._serialize_transcript(messages, "done")
+    assert "TASK-STATEMENT" in transcript
+    assert "NEWEST-EVIDENCE" in transcript
+    assert "<middle of the conversation truncated>" in transcript
+
+
+async def test_redo_records_advisor_and_discarded_turn_in_routing_log(tmp_path) -> None:
+    """Advisor consults and the REDO-discarded executor turn reach session-stats."""
+    from switchyard.lib.processors.routing_log_response_processor import (
+        RoutingLogResponseProcessor,
+        register_routing_log_sink,
+    )
+
+    log_file = tmp_path / "routing.jsonl"
+    register_routing_log_sink(RoutingLogResponseProcessor(log_file))
+    try:
+        exec_b = _exec_backend(
+            _completion_resp(text="done"), _completion_resp(text="kept"),
+        )
+        adv = MagicMock()
+        adv.advise = AsyncMock(
+            return_value=("REDO fix it", {"input_tokens": 7, "output_tokens": 2}),
+        )
+        backend = _backend(_config(max_reviews=1), exec_b, adv)
+        await backend.call(_ctx("ev_a"), _request())
+        records = [json.loads(line) for line in log_file.read_text().splitlines()]
+        by_tier = {r["tier"]: r for r in records}
+        review = by_tier["advisor_review"]
+        assert review["model"] == "adv-model"
+        assert review["session_id"] == "ev_a"
+        assert review["prompt_tokens"] == 7
+        assert review["completion_tokens"] == 2
+        discarded = by_tier["review_gate_discarded"]
+        assert discarded["model"] == "exec-model"
+        assert discarded["session_id"] == "ev_a"
+        assert discarded["prompt_tokens"] == 10  # _completion_resp usage
+        assert discarded["completion_tokens"] == 3
+        snapshot = RoutingLogResponseProcessor(log_file).snapshot_session("ev_a")
+        assert snapshot is not None
+        assert set(snapshot["models"]) == {"adv-model", "exec-model"}
+    finally:
+        register_routing_log_sink(None)

--- a/tests/test_advisor_loop_backend.py
+++ b/tests/test_advisor_loop_backend.py
@@ -22,6 +22,7 @@ import respx
 from switchyard.lib.backends.advisor_loop_backend import (
     _MAX_FAILED_CONSULTS_PER_SCOPE,
     AdvisorLoopBackend,
+    _advisor_usage,
     _anthropic_text,
     _AnthropicAdvisorCaller,
     _build_advisor_caller,
@@ -876,6 +877,27 @@ async def test_repeated_consult_failures_stop_attempts() -> None:
     for _ in range(5):
         await backend.call(_ctx("ev_a"), _request())
     assert adv.advise.await_count == _MAX_FAILED_CONSULTS_PER_SCOPE
+
+
+def test_advisor_usage_folds_gateway_cache_buckets() -> None:
+    """Hub bedrock routes auto-cache server-side: real input lands in cache_creation."""
+    hub = {"input_tokens": 2, "output_tokens": 7,
+           "cache_creation_input_tokens": 3031, "cache_read_input_tokens": 0}
+    assert _advisor_usage(hub) == {
+        "prompt_tokens": 3033, "cached_tokens": 0,
+        "cache_creation_tokens": 3031, "completion_tokens": 7,
+    }
+    warm = {"input_tokens": 14, "output_tokens": 4,
+            "cache_creation_input_tokens": 0, "cache_read_input_tokens": 15403}
+    tokens = _advisor_usage(warm)
+    assert tokens["prompt_tokens"] == 15417
+    assert tokens["cached_tokens"] == 15403
+    openai_shape = {"prompt_tokens": 900, "completion_tokens": 30,
+                    "prompt_tokens_details": {"cached_tokens": 512}}
+    assert _advisor_usage(openai_shape) == {
+        "prompt_tokens": 900, "cached_tokens": 512,
+        "cache_creation_tokens": 0, "completion_tokens": 30,
+    }
 
 
 def test_parse_verdict_tolerates_wrappers() -> None:

--- a/tests/test_advisor_profile.py
+++ b/tests/test_advisor_profile.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wiring tests for the advisor profile, config, preset, and public exports."""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+import switchyard
+from switchyard.lib.backends.advisor_loop_backend import AdvisorLoopBackend
+from switchyard.lib.backends.advisor_tool_call_backend import AdvisorToolCallBackend
+from switchyard.lib.backends.llm_target import BackendFormat
+from switchyard.lib.processors.reasoning_effort_normalizer import (
+    ReasoningEffortNormalizer,
+)
+from switchyard.lib.processors.stats_request_processor import StatsRequestProcessor
+from switchyard.lib.processors.stats_response_processor_accumulator import (
+    StatsResponseProcessor,
+)
+from switchyard.lib.profiles import (
+    AdvisorConfig,
+    AdvisorPresets,
+    AdvisorProfileConfig,
+    ProfileSwitchyard,
+)
+from switchyard.lib.profiles.table import profile_config_type
+from switchyard.lib.stats_accumulator import StatsAccumulator
+from switchyard_rust.core import ChatRequestType
+
+
+def _config(**overrides) -> AdvisorConfig:
+    # Formats pinned so tests exercise the Anthropic wire explicitly (an
+    # omitted format coerces to openai).
+    base: dict = {
+        "executor": {"model": "exec-model", "base_url": "http://exec.test", "api_key": "k",
+                     "format": "anthropic"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "anthropic"},
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _openai_config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "executor": {"model": "qwen/qwen3-max", "base_url": "http://exec.test",
+                     "api_key": "k", "format": "openai"},
+        "advisor": {"model": "deepseek/deepseek-r2", "base_url": "http://adv.test",
+                    "api_key": "k", "format": "openai"},
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _advisor_switchyard(
+    config: AdvisorConfig,
+    *,
+    stats_accumulator: StatsAccumulator | None = None,
+) -> ProfileSwitchyard:
+    """Build the profile-backed runtime used by these tests."""
+    return ProfileSwitchyard(
+        AdvisorProfileConfig.from_config(config)
+        .build()
+        .with_runtime_components(
+            stats_accumulator=stats_accumulator,
+            enable_stats=config.enable_stats,
+        )
+    )
+
+
+class TestProfileStructure:
+    def test_registered_profile_type_is_advisor(self) -> None:
+        assert profile_config_type(AdvisorProfileConfig) == "advisor"
+
+    def test_returns_profile_backed_switchyard_adapter(self) -> None:
+        assert isinstance(_advisor_switchyard(_config()), ProfileSwitchyard)
+
+    def test_backend_defaults_to_tool_call(self) -> None:
+        cfg = _config()
+        assert cfg.strategy == "tool_call"
+        components = list(_advisor_switchyard(cfg).iter_components())
+        assert any(isinstance(c, AdvisorToolCallBackend) for c in components)
+
+    def test_review_gate_strategy_builds_loop_backend(self) -> None:
+        components = list(
+            _advisor_switchyard(_config(strategy="review_gate")).iter_components()
+        )
+        assert any(isinstance(c, AdvisorLoopBackend) for c in components)
+
+    def test_reasoning_effort_normalizer_present(self) -> None:
+        components = list(_advisor_switchyard(_config()).iter_components())
+        assert any(isinstance(c, ReasoningEffortNormalizer) for c in components)
+
+    def test_stats_processors_wired_when_enabled(self) -> None:
+        components = list(_advisor_switchyard(_config()).iter_components())
+        assert any(isinstance(c, StatsRequestProcessor) for c in components)
+        assert any(isinstance(c, StatsResponseProcessor) for c in components)
+
+    def test_stats_processors_absent_when_disabled(self) -> None:
+        components = list(
+            _advisor_switchyard(_config(enable_stats=False)).iter_components()
+        )
+        assert not any(isinstance(c, StatsRequestProcessor) for c in components)
+        assert not any(isinstance(c, StatsResponseProcessor) for c in components)
+
+    def test_runtime_attaches_accumulator_to_backend(self) -> None:
+        # The advisor backends do their own stats accounting and cannot be
+        # wrapped by StatsLlmBackend; with_runtime_components must attach the
+        # shared accumulator through the ``_stats`` compatibility hook instead.
+        stats = StatsAccumulator()
+        switchyard_adapter = _advisor_switchyard(_config(), stats_accumulator=stats)
+        backend = next(
+            c for c in switchyard_adapter.iter_components()
+            if isinstance(c, AdvisorToolCallBackend)
+        )
+        assert backend._stats is stats
+
+    def test_openai_tiers_build_tool_call_backend_on_openai_wire(self) -> None:
+        backend = next(
+            c for c in _advisor_switchyard(_openai_config()).iter_components()
+            if isinstance(c, AdvisorToolCallBackend)
+        )
+        assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+    def test_anthropic_executor_advertises_anthropic_wire(self) -> None:
+        backend = next(
+            c for c in _advisor_switchyard(_config()).iter_components()
+            if isinstance(c, AdvisorToolCallBackend)
+        )
+        assert backend.supported_request_types == [ChatRequestType.ANTHROPIC]
+
+
+class TestAdvisorConfig:
+    def test_coerces_dict_targets(self) -> None:
+        cfg = _config()
+        assert cfg.executor.model == "exec-model"
+        assert cfg.advisor.model == "adv-model"
+
+    def test_rejects_empty_target_model(self) -> None:
+        # The Rust-backed LlmTarget rejects empty model ids during coercion,
+        # before the config-level non-empty validator can fire.
+        with pytest.raises(pydantic.ValidationError, match="must not be empty"):
+            _config(executor={"model": "", "base_url": "http://e", "api_key": "k"})
+
+    def test_rejects_unknown_strategy(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            _config(strategy="both")
+
+    def test_rejects_responses_format_on_either_tier(self) -> None:
+        for tier in ("executor", "advisor"):
+            with pytest.raises(pydantic.ValidationError, match="responses"):
+                _config(**{tier: {"model": "m", "base_url": "http://t", "api_key": "k",
+                                  "format": "responses"}})
+
+    def test_review_gate_accepts_openai_executor(self) -> None:
+        components = list(
+            _advisor_switchyard(_openai_config(strategy="review_gate")).iter_components()
+        )
+        backend = next(c for c in components if isinstance(c, AdvisorLoopBackend))
+        assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+    def test_redo_feedback_prefix_is_configurable(self) -> None:
+        cfg = _config(strategy="review_gate", redo_feedback_prefix="REVIEWER SAYS: ")
+        assert cfg.redo_feedback_prefix == "REVIEWER SAYS: "
+
+    def test_tool_call_accepts_mixed_and_openai_tiers(self) -> None:
+        assert _openai_config().strategy == "tool_call"
+        mixed = _config(advisor={"model": "deepseek/deepseek-r2", "base_url": "http://adv.test",
+                                 "api_key": "k", "format": "openai"})
+        assert mixed.advisor.format == BackendFormat.OPENAI
+        assert mixed.executor.format == BackendFormat.ANTHROPIC
+
+
+class TestOpusPairPreset:
+    """Pins the validated executor+advisor pairing on the shipping default."""
+
+    def test_preset_pairs_opus_47_and_48(self) -> None:
+        cfg = AdvisorPresets.opus47_exec_opus48_advisor(api_key="nvapi-test")
+        assert cfg.executor.model == "aws/anthropic/bedrock-claude-opus-4-7"
+        assert cfg.advisor.model == "aws/anthropic/bedrock-claude-opus-4-8"
+        assert cfg.preset == "opus47_exec_opus48_advisor"
+        assert cfg.executor.endpoint.base_url == "https://inference-api.nvidia.com/v1"
+        # Both tiers are native Anthropic-Messages (no OpenAI translation →
+        # caching survives). The executor suppresses x-api-key and
+        # authenticates via Bearer.
+        assert cfg.executor.format == BackendFormat.ANTHROPIC
+        assert cfg.advisor.format == BackendFormat.ANTHROPIC
+        assert cfg.executor.endpoint.api_key == ""
+        assert cfg.executor.extra_headers == {"Authorization": "Bearer nvapi-test"}
+
+    def test_preset_defaults_to_tool_call_strategy(self) -> None:
+        cfg = AdvisorPresets.opus47_exec_opus48_advisor(api_key="k")
+        assert cfg.strategy == "tool_call"
+        gate = AdvisorPresets.opus47_exec_opus48_advisor(
+            api_key="k", strategy="review_gate",
+        )
+        assert gate.strategy == "review_gate"
+
+    def test_preset_model_overrides(self) -> None:
+        cfg = AdvisorPresets.opus47_exec_opus48_advisor(
+            api_key="k", executor_model="custom/exec", advisor_model="custom/adv",
+        )
+        assert cfg.executor.model == "custom/exec"
+        assert cfg.advisor.model == "custom/adv"
+
+
+def test_public_exports() -> None:
+    assert switchyard.AdvisorConfig is AdvisorConfig
+    assert switchyard.AdvisorPresets is AdvisorPresets
+    assert switchyard.AdvisorProfileConfig is AdvisorProfileConfig
+    for name in ("AdvisorConfig", "AdvisorPresets", "AdvisorProfileConfig"):
+        assert name in switchyard.__all__

--- a/tests/test_advisor_tool_call_backend.py
+++ b/tests/test_advisor_tool_call_backend.py
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the tool-call :class:`AdvisorToolCallBackend` (native Anthropic).
+
+All loop tests inject a fake executor backend (returns ``ChatResponse``) and a
+fake advisor caller — no network. They cover the loop contract: the advisor
+tool and steering are injected; an advisor-free turn returns verbatim; an
+advisor ``tool_use`` is intercepted, consulted, and fed back as a
+``tool_result``; ``max_uses`` returns an error result without a consult;
+fail-open marks the advisor unavailable; sibling client tool calls are dropped
+from the appended turn; the hard cap bounds a runaway loop. Both streaming
+(block reassembly + verbatim replay) and completion paths are exercised, plus
+the transcript / injection helpers.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from switchyard.lib.backends.advisor_loop_backend import _anthropic_text
+from switchyard.lib.backends.advisor_tool_call_backend import (
+    AdvisorToolCallBackend,
+    _prepend_system,
+    _with_length_line,
+)
+from switchyard.lib.chat_response.anthropic import AnthropicResponseStream
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.proxy_context import ProxyContext
+from switchyard.lib.stats_accumulator import StatsAccumulator
+from switchyard_rust.core import ChatRequest, ChatResponse, ChatResponseType
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _completion_resp(content: list[dict], *, stop_reason: str = "end_turn") -> ChatResponse:
+    """An Anthropic completion ChatResponse with the given content blocks."""
+    body = {
+        "id": "msg-x", "type": "message", "role": "assistant", "model": "exec-model",
+        "content": content,
+        "stop_reason": stop_reason,
+        "usage": {"input_tokens": 10, "output_tokens": 3, "cache_read_input_tokens": 4},
+    }
+    return ChatResponse.anthropic_completion(body)
+
+
+def _text_turn(text: str = "done") -> ChatResponse:
+    return _completion_resp([{"type": "text", "text": text}])
+
+
+def _advisor_turn(*, extra_blocks: list[dict] | None = None) -> ChatResponse:
+    """A completion turn calling the advisor (optionally with sibling blocks)."""
+    content = [
+        {"type": "text", "text": "let me ask"},
+        *(extra_blocks or []),
+        {"type": "tool_use", "id": "adv1", "name": "advisor", "input": {}},
+    ]
+    return _completion_resp(content, stop_reason="tool_use")
+
+
+async def _agen(events):
+    for event in events:
+        yield event
+
+
+def _stream_resp(events: list[dict]) -> ChatResponse:
+    return ChatResponse.anthropic_stream(AnthropicResponseStream(_agen(events)))
+
+
+def _advisor_stream_events() -> list[dict]:
+    """SSE events for a streamed turn that calls the advisor (tool input via deltas)."""
+    return [
+        {"type": "message_start",
+         "message": {"usage": {"input_tokens": 12, "cache_read_input_tokens": 5}}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0,
+         "delta": {"type": "text_delta", "text": "consulting"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "content_block_start", "index": 1,
+         "content_block": {"type": "tool_use", "id": "adv-s", "name": "advisor", "input": {}}},
+        {"type": "content_block_delta", "index": 1,
+         "delta": {"type": "input_json_delta", "partial_json": ""}},
+        {"type": "content_block_stop", "index": 1},
+        {"type": "message_delta", "delta": {"stop_reason": "tool_use"},
+         "usage": {"output_tokens": 7}},
+        {"type": "message_stop"},
+    ]
+
+
+def _terminal_stream_events() -> list[dict]:
+    return [
+        {"type": "message_start", "message": {"usage": {"input_tokens": 20}}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0,
+         "delta": {"type": "text_delta", "text": "final answer"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"},
+         "usage": {"output_tokens": 5}},
+        {"type": "message_stop"},
+    ]
+
+
+def _exec_backend(*responses) -> MagicMock:
+    b = MagicMock()
+    b.call = AsyncMock(side_effect=list(responses))
+    b.startup = AsyncMock()
+    b.shutdown = AsyncMock()
+    return b
+
+
+def _advisor(*advice: str) -> MagicMock:
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=[(a, {"input_tokens": 100, "output_tokens": 9})
+                                      for a in advice])
+    return c
+
+
+def _failing_advisor(exc: Exception) -> MagicMock:
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=exc)
+    return c
+
+
+def _config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "executor": {"model": "exec-model", "base_url": "http://exec.test", "api_key": "k",
+                     "format": "anthropic"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "anthropic"},
+        "executor_steering": "STEER",
+        "advisor_length_line": "(LENGTH)",
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _backend(config, executor_backend, advisor_caller) -> AdvisorToolCallBackend:
+    return AdvisorToolCallBackend(
+        config, executor_backend=executor_backend, advisor_caller=advisor_caller,
+    )
+
+
+def _request(**overrides) -> ChatRequest:
+    body: dict = {
+        "model": "incoming", "system": "sys",
+        "messages": [{"role": "user", "content": "build X"}],
+        "tools": [{"name": "bash", "description": "Run a shell command",
+                   "input_schema": {"type": "object"}}],
+    }
+    body.update(overrides)
+    return ChatRequest.anthropic(body)  # type: ignore[arg-type]
+
+
+def _sent_body(exec_b: MagicMock, call_index: int) -> dict:
+    return exec_b.call.await_args_list[call_index].args[1].to_body()
+
+
+# ---------------------------------------------------------------------------
+# Request shaping: tool injection + steering
+# ---------------------------------------------------------------------------
+
+
+async def test_advisor_tool_appended_to_client_tools() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(), exec_b, _advisor()).call(ProxyContext(), _request())
+    tools = _sent_body(exec_b, 0)["tools"]
+    assert [t["name"] for t in tools] == ["bash", "advisor"]
+    assert tools[-1]["input_schema"]["properties"] == {}  # parameterless
+
+
+async def test_steering_prepends_system_and_appends_length_line() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(), exec_b, _advisor()).call(ProxyContext(), _request())
+    body = _sent_body(exec_b, 0)
+    assert body["system"] == "STEER\n\nsys"
+    assert body["messages"][0]["content"] == "build X\n\n(LENGTH)"
+
+
+async def test_steering_disabled_leaves_request_untouched() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(inject_steering=False), exec_b, _advisor()).call(
+        ProxyContext(), _request(),
+    )
+    body = _sent_body(exec_b, 0)
+    assert body["system"] == "sys"
+    assert body["messages"][0]["content"] == "build X"
+    assert [t["name"] for t in body["tools"]] == ["bash", "advisor"]  # tool still offered
+
+
+# ---------------------------------------------------------------------------
+# Loop behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_advisor_free_turn_returns_without_consult() -> None:
+    exec_b = _exec_backend(_text_turn("done, all good"))
+    adv = _advisor()
+    ctx = ProxyContext()
+    resp = await _backend(_config(), exec_b, adv).call(ctx, _request())
+    assert _anthropic_text(resp.to_body()) == "done, all good"
+    assert exec_b.call.await_count == 1
+    assert adv.advise.await_count == 0
+    assert ctx.selected_model == "exec-model"
+
+
+async def test_client_tool_call_turn_returns_without_consult() -> None:
+    """A turn calling only the client's own tools is terminal — hand it back."""
+    exec_b = _exec_backend(_completion_resp(
+        [{"type": "tool_use", "id": "b1", "name": "bash", "input": {"command": "ls"}}],
+        stop_reason="tool_use",
+    ))
+    adv = _advisor()
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert resp.to_body()["stop_reason"] == "tool_use"
+    assert adv.advise.await_count == 0
+
+
+async def test_advisor_call_is_intercepted_and_fed_back() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn("informed answer"))
+    adv = _advisor("try the channel-based pattern")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 2
+    messages = _sent_body(exec_b, 1)["messages"]
+    assistant_turn = messages[-2]
+    assert assistant_turn["role"] == "assistant"
+    assert any(b.get("type") == "tool_use" and b.get("name") == "advisor"
+               for b in assistant_turn["content"])
+    result_turn = messages[-1]
+    assert result_turn["role"] == "user"
+    assert result_turn["content"] == [{
+        "type": "tool_result", "tool_use_id": "adv1",
+        "content": "try the channel-based pattern",
+    }]
+    assert _anthropic_text(resp.to_body()) == "informed answer"
+
+
+async def test_transcript_carries_tools_conversation_and_current_turn() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    transcript = adv.advise.await_args.kwargs["transcript"]
+    assert "bash" in transcript                      # tool summary
+    assert "build X" in transcript                   # conversation
+    assert "it is consulting you now" in transcript  # current-turn section
+    assert "let me ask" in transcript                # current-turn text
+    assert adv.advise.await_args.kwargs["system"] == _config().advisor_system_prompt
+
+
+async def test_max_uses_returns_error_result_without_consult() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _advisor_turn(), _text_turn())
+    adv = _advisor("first advice")  # only one consult available on purpose
+    resp = await _backend(_config(max_uses=1), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 3
+    second_result = _sent_body(exec_b, 2)["messages"][-1]["content"][0]
+    assert second_result["content"] == "[advisor unavailable: max_uses exceeded]"
+    assert _anthropic_text(resp.to_body()) == "done"
+
+
+async def test_fail_open_marks_advisor_unavailable_and_continues() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn("proceeded unadvised"))
+    adv = _failing_advisor(RuntimeError("advisor down"))
+    resp = await _backend(_config(fail_open=True), exec_b, adv).call(
+        ProxyContext(), _request(),
+    )
+    result = _sent_body(exec_b, 1)["messages"][-1]["content"][0]
+    assert result["content"] == "[advisor unavailable: RuntimeError]"
+    assert _anthropic_text(resp.to_body()) == "proceeded unadvised"
+
+
+async def test_fail_closed_raises() -> None:
+    exec_b = _exec_backend(_advisor_turn())
+    adv = _failing_advisor(RuntimeError("advisor down"))
+    with pytest.raises(RuntimeError, match="advisor down"):
+        await _backend(_config(fail_open=False), exec_b, adv).call(
+            ProxyContext(), _request(),
+        )
+
+
+async def test_sibling_tool_calls_dropped_from_appended_turn() -> None:
+    """Mixed advisor + client calls: the appended turn keeps only the advisor call."""
+    sibling = {"type": "tool_use", "id": "b9", "name": "bash", "input": {"command": "ls"}}
+    exec_b = _exec_backend(_advisor_turn(extra_blocks=[sibling]), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assistant_turn = _sent_body(exec_b, 1)["messages"][-2]
+    tool_uses = [b for b in assistant_turn["content"] if b.get("type") == "tool_use"]
+    assert [b["id"] for b in tool_uses] == ["adv1"]
+    # Non-tool blocks (the text) survive.
+    assert any(b.get("type") == "text" for b in assistant_turn["content"])
+
+
+async def test_hard_cap_returns_last_round() -> None:
+    exec_b = _exec_backend(*[_advisor_turn() for _ in range(8)])
+    adv = _advisor(*["advice"] * 8)
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert exec_b.call.await_count == 8
+    assert adv.advise.await_count == 2  # default max_uses=2; the rest get error results
+    assert resp.to_body()["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_streaming_advisor_call_reassembled_then_terminal_replayed() -> None:
+    terminal_events = _terminal_stream_events()
+    exec_b = _exec_backend(
+        _stream_resp(_advisor_stream_events()), _stream_resp(terminal_events),
+    )
+    adv = _advisor("advice")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    # The advisor call was reassembled from deltas: the fed-back tool_result
+    # targets the streamed tool_use id, and the current-turn text made it into
+    # the transcript.
+    result_turn = _sent_body(exec_b, 1)["messages"][-1]
+    assert result_turn["content"][0]["tool_use_id"] == "adv-s"
+    assert "consulting" in adv.advise.await_args.kwargs["transcript"]
+    # The terminal turn's buffered events are replayed verbatim.
+    assert resp.response_type == ChatResponseType.ANTHROPIC_STREAM
+    replayed = [event async for event in resp.stream]
+    assert replayed == terminal_events
+
+
+# ---------------------------------------------------------------------------
+# Stats accounting
+# ---------------------------------------------------------------------------
+
+
+async def test_classifier_bucket_prices_internal_turns_and_consults() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn())
+    adv = _advisor("advice")
+    stats = MagicMock()
+    stats.record_classifier_usage = AsyncMock()
+    stats.record_success = AsyncMock()
+    backend = AdvisorToolCallBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+
+    assert stats.record_classifier_usage.await_count == 2
+    by_model = {c.kwargs["model"]: c.kwargs for c in stats.record_classifier_usage.await_args_list}
+    # The intercepted executor turn (client never sees it) is priced under the
+    # executor model, cache reads included.
+    assert by_model["exec-model"]["prompt_tokens"] == 10
+    assert by_model["exec-model"]["cached_tokens"] == 4
+    # The consult is priced under the advisor model.
+    assert by_model["adv-model"]["prompt_tokens"] == 100
+    assert by_model["adv-model"]["completion_tokens"] == 9
+    stats.record_success.assert_awaited_once()
+    assert stats.record_success.await_args.args[0] == "exec-model"
+
+
+async def test_internal_turns_and_consults_recorded_against_real_accumulator() -> None:
+    """The mock-based test above cannot see a recording API that no longer exists:
+    ``MagicMock`` answers any attribute, so it stays green while the real call
+    raises ``AttributeError``. Drive the real accumulator so a bucket removed
+    upstream fails here instead of at the first live advisor consult."""
+    exec_b = _exec_backend(_advisor_turn(), _text_turn())
+    adv = _advisor("advice")
+    stats = StatsAccumulator()
+    backend = AdvisorToolCallBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+
+    models = stats.snapshot_sync()["classifier"]["models"]
+    assert models["exec-model"]["prompt_tokens"] == 10
+    assert models["exec-model"]["cached_tokens"] == 4
+    assert models["adv-model"]["prompt_tokens"] == 100
+    assert models["adv-model"]["completion_tokens"] == 9
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_transcript_drops_oldest_when_over_cap() -> None:
+    backend = _backend(_config(transcript_max_chars=300), _exec_backend(), _advisor())
+    messages = [
+        {"role": "user", "content": f"turn-{i}: " + "x" * 80} for i in range(10)
+    ]
+    transcript = backend._serialize_transcript(messages, "current", [])
+    assert "turn-9" in transcript          # newest kept
+    assert "turn-0" not in transcript      # oldest dropped
+    assert "earlier messages omitted" in transcript
+    assert transcript.endswith("current")
+
+
+def test_serialize_transcript_no_truncation_under_cap() -> None:
+    backend = _backend(_config(), _exec_backend(), _advisor())
+    messages = [{"role": "user", "content": "hello"}]
+    transcript = backend._serialize_transcript(messages, "", [])
+    assert "hello" in transcript
+    assert "omitted" not in transcript
+    assert transcript.endswith("(no text)")
+
+
+def test_prepend_system_shapes() -> None:
+    assert _prepend_system(None, "S") == "S"
+    assert _prepend_system("base", "S") == "S\n\nbase"
+    assert _prepend_system([{"type": "text", "text": "base"}], "S") == [
+        {"type": "text", "text": "S"}, {"type": "text", "text": "base"},
+    ]
+
+
+def test_with_length_line_targets_first_user_message() -> None:
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": "r"}]},
+    ]
+    out = _with_length_line(messages, "(L)")
+    assert out[0]["content"] == "first\n\n(L)"
+    assert out[2]["content"][-1]["type"] == "tool_result"  # later user turns untouched
+
+
+def test_with_length_line_block_content() -> None:
+    messages = [{"role": "user", "content": [{"type": "text", "text": "first"}]}]
+    out = _with_length_line(messages, "(L)")
+    assert out[0]["content"][-1] == {"type": "text", "text": "(L)"}

--- a/tests/test_advisor_tool_call_backend_openai.py
+++ b/tests/test_advisor_tool_call_backend_openai.py
@@ -1,0 +1,571 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :class:`AdvisorToolCallBackend` on the OpenAI-Chat wire.
+
+Mirror of ``test_advisor_tool_call_backend.py`` (the Anthropic suite) with
+OpenAI-format executors: fixtures are plain ``chat.completion`` bodies and
+``chat.completion.chunk`` dicts, matching what ``OpenAiNativeBackend``'s SSE
+parser yields. Covers the OpenAI-specific shapes — function-tool injection,
+system-message steering, ``tool_calls`` interception, ``role:"tool"``
+feedback with 1:1 ids, delta reassembly + final-usage chunk, sibling drop
+with vendor-field whitelisting — plus the format-dispatch seams (mixed tiers,
+rejected formats).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from switchyard.lib.backends.advisor_tool_call_backend import (
+    AdvisorToolCallBackend,
+    _prepend_system_message,
+)
+from switchyard.lib.chat_response.openai_chat import ResponseStream
+from switchyard.lib.profiles.advisor_config import AdvisorConfig
+from switchyard.lib.proxy_context import ProxyContext
+from switchyard_rust.core import ChatRequest, ChatRequestType, ChatResponse, ChatResponseType
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _completion_resp(
+    message: dict, *, finish_reason: str = "stop", usage: dict | None = None,
+) -> ChatResponse:
+    """An OpenAI chat.completion ChatResponse with the given assistant message."""
+    body = {
+        "id": "chatcmpl-x", "object": "chat.completion", "model": "exec-model",
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": usage if usage is not None else {
+            "prompt_tokens": 10,
+            "completion_tokens": 3,
+            "prompt_tokens_details": {"cached_tokens": 4},
+        },
+    }
+    return ChatResponse.openai_completion(body)
+
+
+def _text_turn(text: str = "done") -> ChatResponse:
+    return _completion_resp({"role": "assistant", "content": text})
+
+
+def _advisor_call(call_id: str = "adv1", *, arguments: str = "{}") -> dict:
+    return {"id": call_id, "type": "function",
+            "function": {"name": "advisor", "arguments": arguments}}
+
+
+def _advisor_turn(
+    *, extra_calls: list[dict] | None = None, finish_reason: str = "tool_calls",
+    arguments: str = "{}",
+) -> ChatResponse:
+    """A completion turn calling the advisor (optionally with sibling calls)."""
+    message = {
+        "role": "assistant",
+        "content": "let me ask",
+        "reasoning_content": "hidden chain of thought",
+        "tool_calls": [*(extra_calls or []), _advisor_call(arguments=arguments)],
+    }
+    return _completion_resp(message, finish_reason=finish_reason)
+
+
+async def _agen(events):
+    for event in events:
+        yield event
+
+
+def _stream_resp(events: list[dict]) -> ChatResponse:
+    return ChatResponse.openai_stream(ResponseStream(_agen(events)))
+
+
+def _chunk(delta: dict, *, finish_reason: str | None = None) -> dict:
+    return {
+        "id": "chatcmpl-x", "object": "chat.completion.chunk", "model": "exec-model",
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+    }
+
+
+def _usage_chunk(*, prompt: int = 12, completion: int = 7, cached: int = 5) -> dict:
+    """The final usage-only chunk stream_options.include_usage produces."""
+    return {
+        "id": "chatcmpl-x", "object": "chat.completion.chunk", "model": "exec-model",
+        "choices": [],
+        "usage": {"prompt_tokens": prompt, "completion_tokens": completion,
+                  "prompt_tokens_details": {"cached_tokens": cached}},
+    }
+
+
+def _advisor_stream_events() -> list[dict]:
+    """Chunks for a streamed advisor call: id/name first, arguments in fragments."""
+    return [
+        _chunk({"role": "assistant", "content": "consul"}),
+        _chunk({"content": "ting"}),
+        _chunk({"tool_calls": [{"index": 0, "id": "adv-s", "type": "function",
+                                "function": {"name": "advisor", "arguments": ""}}]}),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "{"}}]}),
+        _chunk({"tool_calls": [{"index": 0, "function": {"arguments": "}"}}]}),
+        _chunk({}, finish_reason="tool_calls"),
+        _usage_chunk(),
+    ]
+
+
+def _terminal_stream_events() -> list[dict]:
+    return [
+        _chunk({"role": "assistant", "content": "final"}),
+        _chunk({"content": " answer"}),
+        _chunk({}, finish_reason="stop"),
+        _usage_chunk(prompt=20, completion=5, cached=0),
+    ]
+
+
+def _exec_backend(*responses) -> MagicMock:
+    b = MagicMock()
+    b.call = AsyncMock(side_effect=list(responses))
+    b.startup = AsyncMock()
+    b.shutdown = AsyncMock()
+    return b
+
+
+def _advisor(*advice: str) -> MagicMock:
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=[(a, {"prompt_tokens": 100, "completion_tokens": 9})
+                                      for a in advice])
+    return c
+
+
+def _failing_advisor(exc: Exception) -> MagicMock:
+    c = MagicMock()
+    c.advise = AsyncMock(side_effect=exc)
+    return c
+
+
+def _config(**overrides) -> AdvisorConfig:
+    base: dict = {
+        "executor": {"model": "exec-model", "base_url": "http://exec.test", "api_key": "k",
+                     "format": "openai"},
+        "advisor": {"model": "adv-model", "base_url": "http://adv.test", "api_key": "k",
+                    "format": "openai"},
+        "executor_steering": "STEER",
+        "advisor_length_line": "(LENGTH)",
+    }
+    base.update(overrides)
+    return AdvisorConfig(**base)
+
+
+def _backend(config, executor_backend, advisor_caller) -> AdvisorToolCallBackend:
+    return AdvisorToolCallBackend(
+        config, executor_backend=executor_backend, advisor_caller=advisor_caller,
+    )
+
+
+def _request(**overrides) -> ChatRequest:
+    body: dict = {
+        "model": "incoming",
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "build X"},
+        ],
+        "tools": [{"type": "function",
+                   "function": {"name": "bash", "description": "Run a shell command",
+                                "parameters": {"type": "object"}}}],
+    }
+    body.update(overrides)
+    return ChatRequest.openai_chat(body)  # type: ignore[arg-type]
+
+
+def _sent_body(exec_b: MagicMock, call_index: int) -> dict:
+    return exec_b.call.await_args_list[call_index].args[1].to_body()
+
+
+def _content_text(body: dict) -> str:
+    return str(body["choices"][0]["message"].get("content") or "")
+
+
+# ---------------------------------------------------------------------------
+# Request shaping: tool injection + steering
+# ---------------------------------------------------------------------------
+
+
+async def test_advisor_tool_appended_in_function_shape() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(), exec_b, _advisor()).call(ProxyContext(), _request())
+    tools = _sent_body(exec_b, 0)["tools"]
+    assert [t["function"]["name"] for t in tools] == ["bash", "advisor"]
+    assert tools[-1]["type"] == "function"
+    assert tools[-1]["function"]["parameters"]["properties"] == {}  # parameterless
+
+
+async def test_steering_prepends_system_message_and_appends_length_line() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(), exec_b, _advisor()).call(ProxyContext(), _request())
+    messages = _sent_body(exec_b, 0)["messages"]
+    assert messages[0] == {"role": "system", "content": "STEER\n\nsys"}
+    assert messages[1]["content"] == "build X\n\n(LENGTH)"
+
+
+async def test_steering_inserts_system_message_when_absent() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(), exec_b, _advisor()).call(
+        ProxyContext(),
+        _request(messages=[{"role": "user", "content": "build X"}]),
+    )
+    messages = _sent_body(exec_b, 0)["messages"]
+    assert messages[0] == {"role": "system", "content": "STEER"}
+    assert messages[1]["content"] == "build X\n\n(LENGTH)"
+
+
+async def test_steering_disabled_leaves_request_untouched() -> None:
+    exec_b = _exec_backend(_text_turn())
+    await _backend(_config(inject_steering=False), exec_b, _advisor()).call(
+        ProxyContext(), _request(),
+    )
+    body = _sent_body(exec_b, 0)
+    assert body["messages"][0]["content"] == "sys"
+    assert body["messages"][1]["content"] == "build X"
+    assert [t["function"]["name"] for t in body["tools"]] == ["bash", "advisor"]
+
+
+def test_prepend_system_message_shapes() -> None:
+    assert _prepend_system_message([], "S") == [{"role": "system", "content": "S"}]
+    assert _prepend_system_message(
+        [{"role": "developer", "content": "base"}], "S",
+    ) == [{"role": "developer", "content": "S\n\nbase"}]
+    assert _prepend_system_message(
+        [{"role": "system", "content": [{"type": "text", "text": "base"}]}], "S",
+    ) == [{"role": "system", "content": [{"type": "text", "text": "S"},
+                                         {"type": "text", "text": "base"}]}]
+
+
+# ---------------------------------------------------------------------------
+# Loop behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_advisor_free_turn_returns_without_consult() -> None:
+    exec_b = _exec_backend(_text_turn("done, all good"))
+    adv = _advisor()
+    ctx = ProxyContext()
+    resp = await _backend(_config(), exec_b, adv).call(ctx, _request())
+    assert _content_text(resp.to_body()) == "done, all good"
+    assert exec_b.call.await_count == 1
+    assert adv.advise.await_count == 0
+    assert ctx.selected_model == "exec-model"
+
+
+async def test_client_tool_call_turn_returns_without_consult() -> None:
+    """A turn calling only the client's own tools is terminal — hand it back."""
+    exec_b = _exec_backend(_completion_resp(
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "b1", "type": "function",
+                         "function": {"name": "bash", "arguments": "{\"command\": \"ls\"}"}}]},
+        finish_reason="tool_calls",
+    ))
+    adv = _advisor()
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert resp.to_body()["choices"][0]["finish_reason"] == "tool_calls"
+    assert adv.advise.await_count == 0
+
+
+async def test_advisor_call_is_intercepted_and_fed_back() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn("informed answer"))
+    adv = _advisor("try the channel-based pattern")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 2
+    messages = _sent_body(exec_b, 1)["messages"]
+    assistant_turn = messages[-2]
+    assert assistant_turn["role"] == "assistant"
+    assert [tc["function"]["name"] for tc in assistant_turn["tool_calls"]] == ["advisor"]
+    result_turn = messages[-1]
+    assert result_turn == {
+        "role": "tool", "tool_call_id": "adv1",
+        "content": "try the channel-based pattern",
+    }
+    assert _content_text(resp.to_body()) == "informed answer"
+
+
+async def test_advisor_detected_even_with_stop_finish_reason() -> None:
+    """Some OSS servers mislabel tool-call turns; detection is by presence."""
+    exec_b = _exec_backend(_advisor_turn(finish_reason="stop"), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert adv.advise.await_count == 1
+
+
+async def test_parallel_advisor_calls_one_consult_fanned_results() -> None:
+    """N advisor calls in one turn → one consult, one tool message per id."""
+    message = {
+        "role": "assistant", "content": None,
+        "tool_calls": [_advisor_call("adv1"), _advisor_call("adv2")],
+    }
+    exec_b = _exec_backend(
+        _completion_resp(message, finish_reason="tool_calls"), _text_turn(),
+    )
+    adv = _advisor("shared advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    messages = _sent_body(exec_b, 1)["messages"]
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert [m["tool_call_id"] for m in tool_msgs] == ["adv1", "adv2"]
+    assert all(m["content"] == "shared advice" for m in tool_msgs)
+
+
+async def test_nonempty_arguments_round_trip_verbatim() -> None:
+    """Arguments are never parsed (the tool is parameterless) but round-trip."""
+    exec_b = _exec_backend(
+        _advisor_turn(arguments='{"question": "which approach?"}'), _text_turn(),
+    )
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assistant_turn = _sent_body(exec_b, 1)["messages"][-2]
+    assert assistant_turn["tool_calls"][0]["function"]["arguments"] == (
+        '{"question": "which approach?"}'
+    )
+
+
+async def test_transcript_carries_tools_conversation_and_current_turn() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    transcript = adv.advise.await_args.kwargs["transcript"]
+    assert "bash" in transcript                      # function-tool summary
+    assert "Run a shell command" in transcript
+    assert "build X" in transcript                   # conversation
+    assert "it is consulting you now" in transcript  # current-turn section
+    assert "let me ask" in transcript                # current-turn text
+    assert "hidden chain of thought" not in transcript  # reasoning_content excluded
+    assert adv.advise.await_args.kwargs["system"] == _config().advisor_system_prompt
+
+
+async def test_max_uses_returns_error_result_without_consult() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _advisor_turn(), _text_turn())
+    adv = _advisor("first advice")
+    resp = await _backend(_config(max_uses=1), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    assert exec_b.call.await_count == 3
+    second_result = _sent_body(exec_b, 2)["messages"][-1]
+    assert second_result["content"] == "[advisor unavailable: max_uses exceeded]"
+    assert _content_text(resp.to_body()) == "done"
+
+
+async def test_fail_open_marks_advisor_unavailable_and_continues() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn("proceeded unadvised"))
+    adv = _failing_advisor(RuntimeError("advisor down"))
+    resp = await _backend(_config(fail_open=True), exec_b, adv).call(
+        ProxyContext(), _request(),
+    )
+    result = _sent_body(exec_b, 1)["messages"][-1]
+    assert result["content"] == "[advisor unavailable: RuntimeError]"
+    assert _content_text(resp.to_body()) == "proceeded unadvised"
+
+
+async def test_fail_closed_raises() -> None:
+    exec_b = _exec_backend(_advisor_turn())
+    adv = _failing_advisor(RuntimeError("advisor down"))
+    with pytest.raises(RuntimeError, match="advisor down"):
+        await _backend(_config(fail_open=False), exec_b, adv).call(
+            ProxyContext(), _request(),
+        )
+
+
+async def test_sibling_tool_calls_dropped_and_vendor_fields_whitelisted() -> None:
+    """Mixed advisor + client calls: only the advisor call is kept, and vendor
+    fields like reasoning_content are dropped from the rebuilt turn."""
+    sibling = {"id": "b9", "type": "function",
+               "function": {"name": "bash", "arguments": "{\"command\": \"ls\"}"}}
+    exec_b = _exec_backend(_advisor_turn(extra_calls=[sibling]), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assistant_turn = _sent_body(exec_b, 1)["messages"][-2]
+    assert [tc["id"] for tc in assistant_turn["tool_calls"]] == ["adv1"]
+    assert assistant_turn["content"] == "let me ask"       # text survives
+    assert "reasoning_content" not in assistant_turn        # vendor field dropped
+    # Every kept tool_call id has exactly one tool message (OpenAI 1:1 rule).
+    tool_msgs = [m for m in _sent_body(exec_b, 1)["messages"] if m.get("role") == "tool"]
+    assert [m["tool_call_id"] for m in tool_msgs] == ["adv1"]
+
+
+async def test_hard_cap_returns_last_round() -> None:
+    exec_b = _exec_backend(*[_advisor_turn() for _ in range(8)])
+    adv = _advisor(*["advice"] * 8)
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    assert exec_b.call.await_count == 8
+    assert adv.advise.await_count == 2  # default max_uses=2; the rest get error results
+    assert resp.to_body()["choices"][0]["finish_reason"] == "tool_calls"
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_streaming_advisor_call_reassembled_then_terminal_replayed() -> None:
+    terminal_events = _terminal_stream_events()
+    exec_b = _exec_backend(
+        _stream_resp(_advisor_stream_events()), _stream_resp(terminal_events),
+    )
+    adv = _advisor("advice")
+    resp = await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+
+    assert adv.advise.await_count == 1
+    # Reassembled from deltas: the fed-back tool message targets the streamed
+    # id, the fragmented arguments merged, and the streamed text reached the
+    # transcript.
+    messages = _sent_body(exec_b, 1)["messages"]
+    assert messages[-1] == {"role": "tool", "tool_call_id": "adv-s", "content": "advice"}
+    assert messages[-2]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert "consulting" in adv.advise.await_args.kwargs["transcript"]
+    # The terminal turn's buffered events are replayed verbatim.
+    assert resp.response_type == ChatResponseType.OPENAI_STREAM
+    replayed = [event async for event in resp.stream]
+    assert replayed == terminal_events
+
+
+async def test_streaming_missing_tool_call_id_is_synthesized() -> None:
+    events = [
+        _chunk({"role": "assistant",
+                "tool_calls": [{"index": 0,
+                                "function": {"name": "advisor", "arguments": ""}}]}),
+        _chunk({}, finish_reason="tool_calls"),
+    ]
+    exec_b = _exec_backend(_stream_resp(events), _text_turn())
+    adv = _advisor("advice")
+    await _backend(_config(), exec_b, adv).call(ProxyContext(), _request())
+    result = _sent_body(exec_b, 1)["messages"][-1]
+    assert result["tool_call_id"] == "call_switchyard_0"
+
+
+# ---------------------------------------------------------------------------
+# Stats accounting
+# ---------------------------------------------------------------------------
+
+
+async def test_classifier_bucket_prices_internal_turns_and_consults() -> None:
+    exec_b = _exec_backend(_advisor_turn(), _text_turn())
+    adv = _advisor("advice")
+    stats = MagicMock()
+    stats.record_classifier_usage = AsyncMock()
+    stats.record_success = AsyncMock()
+    backend = AdvisorToolCallBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+
+    assert stats.record_classifier_usage.await_count == 2
+    by_model = {c.kwargs["model"]: c.kwargs for c in stats.record_classifier_usage.await_args_list}
+    # The intercepted executor turn is priced under the executor model, with
+    # OpenAI cached tokens read from prompt_tokens_details.
+    assert by_model["exec-model"]["prompt_tokens"] == 10
+    assert by_model["exec-model"]["cached_tokens"] == 4
+    assert by_model["adv-model"]["prompt_tokens"] == 100
+    assert by_model["adv-model"]["completion_tokens"] == 9
+    stats.record_success.assert_awaited_once()
+
+
+async def test_missing_usage_records_zeros() -> None:
+    exec_b = _exec_backend(
+        _completion_resp(
+            {"role": "assistant", "content": None, "tool_calls": [_advisor_call()]},
+            finish_reason="tool_calls", usage={},
+        ),
+        _text_turn(),
+    )
+    adv = _advisor("advice")
+    stats = MagicMock()
+    stats.record_classifier_usage = AsyncMock()
+    stats.record_success = AsyncMock()
+    backend = AdvisorToolCallBackend(
+        _config(), stats_accumulator=stats, executor_backend=exec_b, advisor_caller=adv,
+    )
+    await backend.call(ProxyContext(), _request())
+    internal = stats.record_classifier_usage.await_args_list[0].kwargs
+    assert internal["prompt_tokens"] == 0
+    assert internal["cached_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Format dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_openai_executor_advertises_openai_chat() -> None:
+    backend = _backend(_config(), _exec_backend(), _advisor())
+    assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+
+def test_mixed_tiers_follow_executor_wire() -> None:
+    anthropic_advisor = {"model": "claude-opus-4-8", "base_url": "http://adv.test",
+                         "api_key": "k", "format": "anthropic"}
+    backend = _backend(
+        _config(advisor=anthropic_advisor), _exec_backend(), _advisor(),
+    )
+    assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+    openai_advisor = {"model": "deepseek/deepseek-r2", "base_url": "http://adv.test",
+                      "api_key": "k", "format": "openai"}
+    anthropic_exec = {"model": "claude-opus-4-7", "base_url": "http://exec.test",
+                      "api_key": "k", "format": "anthropic"}
+    backend = _backend(
+        _config(executor=anthropic_exec, advisor=openai_advisor),
+        _exec_backend(), _advisor(),
+    )
+    assert backend.supported_request_types == [ChatRequestType.ANTHROPIC]
+
+
+def test_auto_format_with_injected_backend_raises() -> None:
+    auto_exec = {"model": "m", "base_url": "http://exec.test", "api_key": "k",
+                 "format": "auto"}
+    with pytest.raises(ValueError, match="pin format"):
+        _backend(_config(executor=auto_exec), _exec_backend(), _advisor())
+
+
+# ---------------------------------------------------------------------------
+# seed_plan_advice
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_consults_before_first_executor_turn_and_injects() -> None:
+    """Seed advice is fetched before the executor runs and lands in the first
+    user message, ahead of the steering length line."""
+    exec_b = _exec_backend(_text_turn())
+    adv = _advisor("1. read the docs first")
+    config = _config(seed_plan_advice=True)
+    await _backend(config, exec_b, adv).call(ProxyContext(), _request())
+    assert adv.advise.await_count == 1
+    assert adv.advise.await_args.kwargs["system"] == config.advisor_system_prompt
+    user = _sent_body(exec_b, 0)["messages"][1]
+    assert user["role"] == "user"
+    assert config.seed_advice_prefix.strip() in user["content"]
+    assert "1. read the docs first" in user["content"]
+    assert "(LENGTH)" in user["content"]  # steering still applied after the seed
+
+
+async def test_seed_cached_for_later_turns_of_the_session() -> None:
+    """The second request of a session re-injects the cached advice without a
+    fresh consult; the advisor tool loop still works on top."""
+    exec_b = _exec_backend(_text_turn(), _text_turn())
+    adv = _advisor("1. plan")
+    backend = _backend(_config(seed_plan_advice=True), exec_b, adv)
+    await backend.call(ProxyContext(), _request())
+    await backend.call(ProxyContext(), _request(messages=[
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "build X"},
+        {"role": "assistant", "content": "working on it"},
+        {"role": "user", "content": "tool output: ok"},
+    ]))
+    assert adv.advise.await_count == 1
+    assert "1. plan" in str(_sent_body(exec_b, 1)["messages"][1]["content"])
+
+
+async def test_seed_fail_open_proceeds_unseeded() -> None:
+    exec_b = _exec_backend(_text_turn())
+    adv = _failing_advisor(RuntimeError("advisor down"))
+    config = _config(seed_plan_advice=True)
+    resp = await _backend(config, exec_b, adv).call(ProxyContext(), _request())
+    assert _content_text(resp.to_body()) == "done"
+    user = _sent_body(exec_b, 0)["messages"][1]
+    assert "advisor reviewed" not in str(user["content"])

--- a/tests/test_route_bundle.py
+++ b/tests/test_route_bundle.py
@@ -1174,6 +1174,152 @@ class TestStageRouterRouteType:
         assert snapshot["routing_decisions"]["stage_router"]["llm-classifier"] == 1
 
 
+class TestAdvisorRouteType:
+    """`type: advisor` wires the executor + advisor chain via YAML (strategy-selected)."""
+
+    def _bundle(self) -> dict:
+        return {
+            "routes": {
+                "myrouter/advisor": {
+                    "type": "advisor",
+                    "executor": {
+                        "model": "aws/anthropic/bedrock-claude-opus-4-7",
+                        "api_key": "",
+                        "base_url": "https://exec.invalid/v1",
+                        "format": "anthropic",
+                        "extra_headers": {"Authorization": "Bearer sk-exec"},
+                    },
+                    "advisor": {
+                        "model": "aws/anthropic/bedrock-claude-opus-4-8",
+                        "api_key": "sk-adv",
+                        "base_url": "https://adv.invalid/v1",
+                        "format": "anthropic",
+                    },
+                },
+            },
+        }
+
+    def test_registers_under_route_key(self):
+        table = build_route_bundle_table(self._bundle())
+        assert table.registered_models() == ["myrouter/advisor"]
+
+    def test_metadata_records_advisor_profile(self):
+        table = build_route_bundle_table(self._bundle())
+        _, _, metadata = next(iter(table.items()))
+        assert metadata["switchyard"]["profile"] == "advisor"
+
+    def test_backend_defaults_to_tool_call(self):
+        from switchyard.lib.backends.advisor_tool_call_backend import (
+            AdvisorToolCallBackend,
+        )
+
+        table = build_route_bundle_table(self._bundle())
+        components = list(table.iter_components())
+        assert any(isinstance(c, AdvisorToolCallBackend) for c in components)
+
+    def test_review_gate_strategy_selects_loop_backend(self):
+        from switchyard.lib.backends.advisor_loop_backend import AdvisorLoopBackend
+
+        bundle = self._bundle()
+        bundle["routes"]["myrouter/advisor"]["strategy"] = "review_gate"
+        table = build_route_bundle_table(bundle)
+        components = list(table.iter_components())
+        assert any(isinstance(c, AdvisorLoopBackend) for c in components)
+
+    def test_review_gate_on_openai_wire_with_custom_redo_prefix(self):
+        from switchyard.lib.backends.advisor_loop_backend import AdvisorLoopBackend
+        from switchyard_rust.core import ChatRequestType
+
+        bundle = {
+            "routes": {
+                "myrouter/advisor-gate-oss": {
+                    "type": "advisor",
+                    "strategy": "review_gate",
+                    "redo_feedback_prefix": "REVIEWER SAYS: ",
+                    "executor": {
+                        "model": "qwen/qwen3-max",
+                        "api_key": "sk-exec",
+                        "base_url": "https://exec.invalid/v1",
+                        "format": "openai",
+                    },
+                    "advisor": {
+                        "model": "aws/anthropic/bedrock-claude-opus-4-8",
+                        "api_key": "sk-adv",
+                        "base_url": "https://adv.invalid/v1",
+                        "format": "anthropic",
+                    },
+                },
+            },
+        }
+        table = build_route_bundle_table(bundle)
+        backend = next(
+            c for c in table.iter_components() if isinstance(c, AdvisorLoopBackend)
+        )
+        assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+        assert backend._config.redo_feedback_prefix == "REVIEWER SAYS: "
+
+    def test_rejects_unknown_route_key(self):
+        bundle = self._bundle()
+        bundle["routes"]["myrouter/advisor"]["bogus_field"] = 1
+        with pytest.raises(RouteBundleConfigError) as exc:
+            build_route_bundle_table(bundle)
+        assert "bogus_field" in str(exc.value)
+
+    def test_enable_stats_false_disables_stats_processors(self):
+        from switchyard.lib.processors.stats_request_processor import (
+            StatsRequestProcessor,
+        )
+        from switchyard.lib.processors.stats_response_processor_accumulator import (
+            StatsResponseProcessor,
+        )
+
+        bundle = self._bundle()
+        bundle["routes"]["myrouter/advisor"]["enable_stats"] = False
+        table = build_route_bundle_table(bundle)
+        components = list(table.iter_components())
+        assert not any(isinstance(c, StatsRequestProcessor) for c in components)
+        assert not any(isinstance(c, StatsResponseProcessor) for c in components)
+
+    def test_openai_tiers_build_on_openai_wire(self):
+        """OSS executor + advisor pairs (format: openai) are first-class."""
+        from switchyard.lib.backends.advisor_tool_call_backend import (
+            AdvisorToolCallBackend,
+        )
+        from switchyard_rust.core import ChatRequestType
+
+        bundle = {
+            "routes": {
+                "myrouter/advisor-oss": {
+                    "type": "advisor",
+                    "executor": {
+                        "model": "qwen/qwen3-max",
+                        "api_key": "sk-exec",
+                        "base_url": "https://exec.invalid/v1",
+                        "format": "openai",
+                    },
+                    "advisor": {
+                        "model": "deepseek/deepseek-r2",
+                        "api_key": "sk-adv",
+                        "base_url": "https://adv.invalid/v1",
+                        "format": "openai",
+                    },
+                },
+            },
+        }
+        table = build_route_bundle_table(bundle)
+        backend = next(
+            c for c in table.iter_components()
+            if isinstance(c, AdvisorToolCallBackend)
+        )
+        assert backend.supported_request_types == [ChatRequestType.OPENAI_CHAT]
+
+    def test_responses_format_rejected(self):
+        bundle = self._bundle()
+        bundle["routes"]["myrouter/advisor"]["executor"]["format"] = "responses"
+        with pytest.raises(Exception, match="responses"):
+            build_route_bundle_table(bundle)
+
+
 def test_stage_router_route_hydrates_tier_catalogs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

Ports the **advisor strategy** from the internal dev repo (`advisor-strategy` branch, including its final in-flight state) into this repo's profiles architecture, and generalizes the shipping `tool_call` strategy into a **wire-format-agnostic performance gear** — it works with any Chat-shaped executor/advisor pair, not just Anthropic:

- **`type: advisor` route / `AdvisorProfileConfig`** — pairs a faster **executor** with a stronger **advisor** model. Each tier's `format` selects its wire independently and tiers mix freely:
  - `anthropic` — served native Anthropic Messages (`/v1/messages`); the executor call is delegated **verbatim** to `AnthropicNativeBackend`, so the client's `cache_control` breakpoints survive and prompt caching is honored.
  - `openai` — served OpenAI Chat Completions (`/chat/completions`) via `OpenAiNativeBackend`, covering OSS models (Qwen, DeepSeek on vLLM/NIM) and OpenAI. The loop runs natively on OpenAI wire: function-shaped advisor tool, `tool_calls` interception, `role:"tool"` feedback (1:1 with tool_call ids), delta reassembly + final-usage chunk, verbatim stream replay.
  - `responses` targets are rejected at config validation (the loop is Chat-shaped); `format: auto` resolves at build time.
- `AdvisorConfig.strategy` selects the design:
  - **`tool_call` (shipping default, any wire)** — `AdvisorToolCallBackend`: a proxy-side re-creation of Anthropic's `advisor_20260301` server tool for gateways/models that cannot run it server-side. A real, parameterless `advisor` tool is injected; each advisor call is intercepted before it reaches the client, the advisor model is consulted on the transcript, and the advice loops back as the tool result (up to `max_uses`, hard cap 8 executor turns). Wire specifics live in two small private dialect objects (`_AnthropicDialect` / `_OpenAiDialect`); the loop itself is format-independent.
  - **`review_gate` (any wire, like tool_call)** — `AdvisorLoopBackend`: no tool injected; at the executor's first no-tool-call turn (a plan, or a claim of "done") the advisor reviews **once per session** → APPROVE (return as-is) or REDO (feed the optimized plan back and re-invoke). Preserved for A/B comparison.
- The **advisor caller** likewise dispatches on `advisor.format`: Anthropic Messages (httpx, Bearer) or OpenAI Chat Completions (`OpenAILLMClient`, `max_retries=0` so failures fall through to the loop's own `fail_open`); target `extra_headers`/`extra_body` are forwarded so gateway auth and vLLM chat-template hints work.
- **Rust: native-Anthropic verbatim passthrough** (`AnthropicNativeBackend::outbound_body`) — a native Anthropic request is now forwarded byte-faithful (only the model id is rewritten + operator `extra_body` merged). The strip/normalize/sanitize steps now apply only to the translated (OpenAI/Responses→Anthropic) path. This preserves `context_management`, signed thinking blocks, mid-conversation system turns, client tool ids — and, critically, `cache_control` breakpoints.
- Claude Opus 4.8 pricing in `cost_estimator.py` (3 id variants), public exports (`AdvisorConfig`, `AdvisorPresets`, `AdvisorProfileConfig`), an advisor row in `switchyard-lib-core`'s Quick Reference, and AGENTS.md structure sync.

Port mapping (dev repo → here): `lib/factories/advisor/{config,factory,advisor_presets,prompts}.py` + `SwitchyardRecipes.advisor_recipe` → `lib/profiles/advisor{_config,,_presets,_prompts}.py`, per this repo's profile-owned-construction contract (no factories/recipes/registries). The internal benchmark runbook skill intentionally stays in the internal repo.

## Why

This migrates the complete advisor line of work — code and the design rationale behind it — so it ships from this repo, and makes it usable across every endpoint family Switchyard fronts. Condensed design history:

**v1 — executor-triggered tool loop**: a mostly spec-faithful re-creation of Anthropic's advisor tool. Trace analysis showed front-loaded advice **suppressed the executor's own test-and-iterate loop** — it trusted the plan, one-shot it, and declared done prematurely, losing tasks the unadvised baseline solved by iterating. Retired in favor of:

**v2 — once-per-session review gate**: the executor works with its own tools; its first no-tool-call turn is reviewed once → APPROVE/REDO. A near-superset of solo behavior (identical until "done", plus one quality gate), so it is downside-protected while catching premature convergence.

**v3 — native Anthropic everywhere**: the cost lever. Serving the executor through OpenAI-Chat translation strips `cache_control` (the OpenAI schema has no such field), so upstream prompt caching never engages and all input bills at the full rate — on agentic workloads (~95% input tokens) that was roughly a **7× cost difference** vs the cached path. Both tiers therefore run native `/v1/messages`, and the executor call is delegated verbatim to `AnthropicNativeBackend` (this PR's Rust change) so the client's breakpoints reach the upstream. For gateways that authenticate `/v1/messages` with `Authorization: Bearer` rather than Anthropic's `x-api-key`, the preset sets `api_key: ""` (suppresses x-api-key) and carries the key in `extra_headers`.

**Benchmark outcome (internal coding-agent benchmark, review-gate arm vs executor-solo, both native-Anthropic on a healthy cluster):** the gate **edged the solo baseline directionally but not statistically significantly** — it rescued more tasks than it regressed (premature-convergence losses recovered via REDO), at a small cost and latency premium. Earlier runs suggesting the advisor lost were traced to an infrastructure incident and discarded.

**v4 — advisor-as-tool-call restored as the shipping default**: ship the strategy that matches the public product surface (Anthropic's `advisor_20260301`; OpenRouter's analogous `openrouter:advisor`), keeping the gate selectable for A/B. The rebuilt `AdvisorToolCallBackend` fixes the v1 deviations found by auditing against Anthropic's advisor-tool doc:

1. The advisor now sees **the executor's current-turn text** (the doc forwards "the text the executor has produced so far in this turn"; v1 consulted before appending it), plus a compact summary of the executor's tools.
2. Transcript truncation is **tail-keep** — the oldest turns drop first (v1 kept the head, discarding the consult-relevant recent turns).
3. `max_uses` follows the spec's semantics: over-cap calls receive a `max_uses exceeded` **tool result** and the executor continues (v1 withdrew the tool, which the Anthropic wire format rejects once history contains `tool_use` blocks).
4. Steering is injected **cache-stably**: system-prompt prepend + the doc's length line on the **first** user message. The doc places the length line on the *latest* user message, but the client never sees this injection — re-injecting per turn would shift the upstream cache prefix on every turn. The same placement holds on the OpenAI wire, where vLLM/OpenAI automatic prefix caching also wants a stable prefix.

One v1 behavior kept deliberately: a turn mixing advisor + client tool calls is regenerated with the sibling client calls dropped (they are re-issued advice-informed on the next iteration). The native API pauses with the client calls pending; a proxy cannot — it can neither execute the client's tools nor return a turn containing a tool the client was never offered.

**v5 — generic wire formats (this PR's final shape)**: Switchyard users front OSS models (Qwen, DeepSeek) on OpenAI-compatible endpoints alongside commercial Claude/OpenAI, and want the advisor as a generic model-performance gear rather than an Anthropic-only feature. This is also where the feature most plausibly pays off: Anthropic's published guidance puts tool-call lifts on **weaker executors** (strong executors tend to over-call), which is exactly the OSS-executor + strong-advisor pairing. The loop was refactored behind a private wire-dialect seam — the Anthropic dialect delegates to the pre-existing helpers (the original Anthropic test suite passes **unmodified**, which is the byte-for-byte regression proof), and the OpenAI dialect adds Chat-wire handling with OSS-endpoint hardening: advisor detection by tool-call presence (never `finish_reason`, which some servers mislabel), synthesized ids for servers that omit them in stream deltas, `"{}"` for empty arguments, vendor fields (`reasoning_content`) whitelisted out of rebuilt turns so strict endpoints accept the replayed history, and missing-usage tolerance.

Cost accounting: advisor consults **and** the intercepted executor turns (which the client never sees, so the outer stats processor cannot count them) are priced into the stats planner bucket (OpenAI cached tokens read from `prompt_tokens_details`); each consult emits an `advisor_call={…}` audit line (`advisor_review={…}` on the gate arm).

Open follow-ups carried from the dev discussion: (a) verify end-to-end that planner-bucket advisor cost lands in the deployed cost output; (b) request-declared advisor (parsing/stripping a client-sent advisor tools entry, with an opt-in route mode) was scoped but not built — today the advisor is route-configured, always-on, and invisible to the API contract.

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean (strict)
- [x] `uv run pytest tests/` — **2070 passed** (100 advisor tests: the Anthropic tool-call suite — unmodified across the format generalization — plus its OpenAI mirror, review-gate contract, both advisor callers via respx, profile wiring + format validation, route-bundle `type: advisor` incl. OSS-tier and rejected-format cases, presets, exports)
- [x] `cargo test -p switchyard-components` (246 tests, incl. the rewritten native-passthrough adversarial suite), `cargo clippy` clean, `cargo fmt --check` clean
- [ ] Live e2e not run from this host (no credentials); the Anthropic chain was exercised live during the internal benchmark runs summarized above

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` (`AdvisorConfig`, `AdvisorPresets`, `AdvisorProfileConfig`).
- [x] Unit tests added for new components.
- [x] Skills synced (`switchyard-lib-core` advisor row); AGENTS.md backends list updated.
- [x] Commits signed off per the DCO.

## Notes for reviewers

- **The Rust passthrough change is a behavior change** for every native-Anthropic route, not just advisor ones: fields the old path stripped from real Anthropic clients (`reasoning_effort`, `context_management`, unsigned thinking blocks, message-level system turns, unsanitized tool ids) now forward verbatim, and the upstream API decides what to accept. The adversarial tests were rewritten to pin the new contract; translated-path (OpenAI/Responses→Anthropic) stripping is unchanged.
- Route YAMLs should **pin `strategy:` explicitly** — the config default is `tool_call`, so an unpinned `type: advisor` route means the tool-call arm. `review_gate` is wire-generic too: it dispatches on `executor.format`, its REDO feedback prefix is configurable (`redo_feedback_prefix`), and its proxy-side trigger makes it the recommended strategy for weak executors that rarely call tools.
- `AdvisorToolCallBackend.supported_request_types` follows the **executor's** wire; the chain's TranslationEngine normalizes any inbound client format (OpenAI Chat, Anthropic Messages, Responses) to it once, so e.g. Claude Code can front a Qwen executor and an OpenAI SDK client can front a Claude executor.
- Both advisor backends are Python multi-call backends that do their own stats accounting (like `LatencyServiceLLMBackend`): do **not** wrap them in `StatsLlmBackend`; `with_runtime_components` attaches the shared accumulator via the `_stats` hook (covered by a test).
- Example OSS route (Qwen executor + DeepSeek advisor):
  ```yaml
  routes:
    my-model:
      type: advisor
      strategy: tool_call
      executor: {model: qwen/qwen3-max, base_url: https://exec.example/v1, api_key: "${KEY}", format: openai}
      advisor:  {model: deepseek/deepseek-r2, base_url: https://adv.example/v1, api_key: "${KEY}", format: openai}
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update 2026-07-22 — judge-side controls and session seeding

Two commits add YAML-tunable advisor controls, all default-off and backward compatible:

- `seed_plan_advice` + `seed_advice_prefix` (both strategies): consult the advisor once at each session-opening request and re-inject its plan into the first user message on every turn (stable cache prefix; fail-open; `advisor_seed=` audit line).
- `max_reviews` (review_gate): per-session review budget — re-declared completions after a REDO are re-verified (sequential best-of-N with the advisor as judge).
- `gate_stall_turns` (review_gate): once-per-session mid-task checkpoint when the conversation exceeds N assistant turns without the completion trigger firing.
- `gate_min_tool_results` (review_gate, `no_tool_call` trigger): only review no-tool-call turns after real work exists — skips early commentary turns on chatty harnesses.
- benchmark runner: env-gated `SWITCHYARD_DOCKER_NETWORK_MODE=host` for hosts whose Docker bridge cannot route to the upstream.

In our evaluation, the review-budget configuration produced the strongest results of the strategies tested; upfront seeding measured neutral-to-slightly-negative and ships as ablation surface. Validation: full test suite, ruff, and mypy green (new failing-first unit tests cover seeding, budgets, stall checkpoint, and the trigger guard).
