### PR TITLE
feat(libsy): add pluggable routing affinity

### DIFF
--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -40,6 +40,33 @@ println!("answer: {}", completion_text(&response.llm_response.into_agg().await?)
 
 Runnable: [`research_agent`](examples/research_agent.rs)
 
+## Sub-agent affinity
+
+Compose `AffinityRouter` as both the first classifier and a processor. On a child
+agent's first turn it abstains, the random fallback chooses a target, and the
+processor retains that decision. Later turns from the same `(session_id, agent_id)`
+short-circuit to the retained target. Root-agent traffic continues through the
+fallback on every turn.
+
+```rust
+use switchyard_libsy::{
+    algorithms::{AffinityRouter, FallThrough, RandomClassifier},
+    Algorithm, Classifier, Processor,
+};
+use std::sync::Arc;
+
+let affinity = Arc::new(AffinityRouter::for_subagents());
+let algo: Arc<dyn Algorithm> = Arc::new(
+    FallThrough::new(targets)
+        .with_processor(affinity.clone() as Arc<dyn Processor>)
+        .with_classifier(affinity as Arc<dyn Classifier>)
+        .with_classifier(Arc::new(RandomClassifier::new(["frontier", "fast"]))),
+);
+```
+
+Request identity comes from `switchyard_protocol::Metadata`; HTTP integrations can
+normalize supported harness headers with `Metadata::from_headers` before routing.
+
 ## Requests & responses
 
 ```rust

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -11,9 +11,11 @@ pub mod fall_through;
 pub mod llm_class;
 pub mod noop;
 pub mod rand;
+pub mod random_classifier;
 
 pub use affinity::AffinityRouter;
 pub use fall_through::{FallThrough, FallThroughDecision};
 pub use llm_class::{ClassifierDecision, ClassifierTier, LlmClassifier};
 pub use noop::{Noop, NoopDecision};
 pub use rand::{Random, RandomDecision};
+pub use random_classifier::RandomClassifier;

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -6,11 +6,13 @@
 //! Reach for them by name — `use switchyard_libsy::algorithms::Random` — rather than through the
 //! per-algorithm submodules.
 
+pub mod affinity;
 pub mod fall_through;
 pub mod llm_class;
 pub mod noop;
 pub mod rand;
 
+pub use affinity::AffinityRouter;
 pub use fall_through::{FallThrough, FallThroughDecision};
 pub use llm_class::{ClassifierDecision, ClassifierTier, LlmClassifier};
 pub use noop::{Noop, NoopDecision};

--- a/crates/libsy/src/algorithms/affinity.rs
+++ b/crates/libsy/src/algorithms/affinity.rs
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Model affinity as a single SDK component.
+//!
+//! [`AffinityRouter`] retains the first model chosen for a request's stable identity and
+//! forces that model on later requests sharing the identity. It is one object that plays
+//! both SDK roles, so registering it as a processor and a classifier cannot drift apart:
+//!
+//! - As a [`Processor`] it *writes* the assignment: it captures the request's identity on
+//!   [`Event::Request`] and binds it to the chosen model on [`Event::Decision`], the first
+//!   assignment for an identity winning.
+//! - As a [`Classifier`] it *reads* the assignment: it scores the retained model with
+//!   confidence `1.0`, or returns no scores to abstain.
+//!
+//! Identity is derived from correlation metadata: by default, a request is keyed by its
+//! session, and a sub-agent is keyed more finely by `session + agent` — a subset of its
+//! session. [`AffinityRouter::for_subagents`] narrows affinity to explicitly identified
+//! child agents, leaving root traffic to later classifiers on every turn.
+
+use std::collections::{HashMap, HashSet};
+
+use async_trait::async_trait;
+use switchyard_protocol::Request;
+
+use crate::{Classification, Classifier, Event, Processor, Score, State};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Upper bound on retained assignments, keeping the process-local map from growing
+/// without limit; the oldest entry is evicted once the bound is reached.
+const MAX_ASSIGNMENTS: usize = 4096;
+
+/// The stable identity a model assignment is retained against.
+///
+/// A sub-agent request is keyed by `session + agent` and a root request by session alone,
+/// so a sub-agent's assignment is scoped within — but distinct from — its session's.
+#[derive(Clone, Hash, PartialEq, Eq)]
+enum AffinityKey {
+    /// One model per session, for root-agent traffic.
+    Session(String),
+    /// One model per identified child agent within a session.
+    Subagent { session: String, agent: String },
+}
+
+/// The affinity memory folded into [`State`]: the retained model per identity, plus the
+/// key captured from the current turn's request while its decision is pending.
+#[derive(Default)]
+struct AffinityAssignments {
+    /// Identity → retained model, first assignment winning.
+    assignments: HashMap<AffinityKey, String>,
+    /// Key captured on this turn's [`Event::Request`], consumed by its [`Event::Decision`].
+    pending: Option<AffinityKey>,
+}
+
+/// Retains a model per request identity and forces it on later matching requests.
+///
+/// Register the same instance as both a processor and a classifier; the two roles share
+/// the retained assignments through [`State`]. Because a decision event carries only the
+/// chosen model, the request's identity is captured first (on [`Event::Request`]) and
+/// consumed when the decision arrives — this assumes a turn's request is observed before
+/// its decision on the same [`State`], as the driving algorithm folds a turn in order.
+///
+/// [`with_latch_only`](Self::with_latch_only) narrows *which* models are retained — a
+/// decision for any other model routes normally but is not latched (the escalation latch:
+/// retain only the strong tier, never the weak one).
+#[derive(Default)]
+pub struct AffinityRouter {
+    /// When set, only these models are retained; a decision for any other model is not latched.
+    latch_only: Option<HashSet<String>>,
+    /// Whether root-session requests should abstain instead of being retained.
+    subagents_only: bool,
+}
+
+impl AffinityRouter {
+    /// Creates a router that latches every decision.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a router that retains assignments only for explicitly identified child agents.
+    ///
+    /// Root-agent requests always abstain, so a later classifier selects them on every turn.
+    pub fn for_subagents() -> Self {
+        Self {
+            subagents_only: true,
+            ..Self::default()
+        }
+    }
+
+    /// Restricts latching to `models`; a decision for any other model routes but is not
+    /// retained.
+    pub fn with_latch_only(mut self, models: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.latch_only = Some(models.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Whether a decision for `model` should be retained.
+    fn should_latch(&self, model: &str) -> bool {
+        self.latch_only
+            .as_ref()
+            .is_none_or(|set| set.contains(model))
+    }
+
+    /// Derives the stable identity this router should retain for `request`.
+    fn affinity_key(&self, request: &Request) -> Option<AffinityKey> {
+        let metadata = request.metadata.as_ref()?;
+        let session = metadata.session_id.clone()?;
+        if metadata.is_subagent {
+            Some(AffinityKey::Subagent {
+                session,
+                agent: metadata.agent_id.clone()?,
+            })
+        } else if self.subagents_only {
+            None
+        } else {
+            Some(AffinityKey::Session(session))
+        }
+    }
+}
+
+#[async_trait]
+impl Processor for AffinityRouter {
+    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
+        match event {
+            // Capture the identity now; the model it maps to is only known at the decision.
+            Event::Request(request) => {
+                state
+                    .entry_or_insert_with(AffinityAssignments::default)
+                    .pending = self.affinity_key(request);
+            }
+            // Bind the captured identity to the chosen model, keeping any earlier winner.
+            Event::Decision(decision) => {
+                let model = decision.selected_model();
+                let fact = state.entry_or_insert_with(AffinityAssignments::default);
+                let Some(key) = fact.pending.take() else {
+                    return Ok(());
+                };
+                // Latch only permitted models; others consume `pending` but are not retained.
+                if self.should_latch(model) && !fact.assignments.contains_key(&key) {
+                    evict_if_full(&mut fact.assignments);
+                    fact.assignments.insert(key, model.to_string());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Classifier for AffinityRouter {
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &Request,
+        _driver: Option<&crate::Driver>,
+    ) -> Result<Classification, BoxErr> {
+        let Some(key) = self.affinity_key(request) else {
+            return Ok(Classification::Scores(Vec::new()));
+        };
+        let assigned = state
+            .get::<AffinityAssignments>()
+            .and_then(|fact| fact.assignments.get(&key).cloned());
+        Ok(Classification::Scores(match assigned {
+            Some(target) => vec![Score {
+                confidence: 1.0,
+                target,
+            }],
+            None => Vec::new(),
+        }))
+    }
+}
+
+/// Evicts one arbitrary assignment when the map has reached [`MAX_ASSIGNMENTS`].
+fn evict_if_full(assignments: &mut HashMap<AffinityKey, String>) {
+    if assignments.len() >= MAX_ASSIGNMENTS {
+        if let Some(evicted) = assignments.keys().next().cloned() {
+            assignments.remove(&evicted);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use switchyard_protocol::{text_request, Decision, Metadata};
+
+    /// A decision that reports a fixed selected model.
+    struct FixedDecision(&'static str);
+
+    impl Decision for FixedDecision {
+        fn selected_model(&self) -> &str {
+            self.0
+        }
+
+        fn reasoning(&self) -> Option<&str> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn request(metadata: Metadata) -> Request {
+        Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: Some(metadata),
+        }
+    }
+
+    fn session(session_id: &str, agent_id: &str) -> Metadata {
+        Metadata {
+            session_id: Some(session_id.to_string()),
+            agent_id: Some(agent_id.to_string()),
+            ..Metadata::default()
+        }
+    }
+
+    fn subagent(agent_id: &str, task_id: &str) -> Metadata {
+        Metadata {
+            session_id: Some("session-1".to_string()),
+            agent_id: Some(agent_id.to_string()),
+            task_id: Some(task_id.to_string()),
+            is_subagent: true,
+            ..Metadata::default()
+        }
+    }
+
+    /// Folds a request and its decision through the router, retaining `model`.
+    async fn retain(
+        router: &AffinityRouter,
+        state: &mut State,
+        request: &Request,
+        model: &'static str,
+    ) -> Result<(), BoxErr> {
+        router.process(state, Event::Request(request)).await?;
+        router
+            .process(state, Event::Decision(&FixedDecision(model)))
+            .await
+    }
+
+    /// Scores through the definitive classification variant used by affinity.
+    async fn scores(
+        classifier: &dyn Classifier,
+        state: &mut State,
+        request: &Request,
+    ) -> Result<Vec<Score>, BoxErr> {
+        match classifier.score(state, request, None).await? {
+            Classification::Scores(scores) => Ok(scores),
+            Classification::Ambiguous(_) => Err("affinity never returns ambiguous scores".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_retains_first_model_across_requests() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let first = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &first, "model-a").await?;
+
+        // A different agent in the same session is scored onto the retained model.
+        let second = request(session("session-1", "agent-b"));
+        let scores = scores(&router, &mut state, &second).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].confidence, 1.0);
+        assert_eq!(scores[0].target, "model-a");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_only_retains_children_without_latching_root_traffic() -> Result<(), BoxErr> {
+        let router = AffinityRouter::for_subagents();
+        let mut state = State::default();
+
+        let root = request(session("session-1", "root-agent"));
+        retain(&router, &mut state, &root, "model-a").await?;
+        assert!(scores(&router, &mut state, &root).await?.is_empty());
+
+        let first_child_turn = request(subagent("child-1", "task-1"));
+        retain(&router, &mut state, &first_child_turn, "model-b").await?;
+        let later_child_turn = request(subagent("child-1", "task-2"));
+        let scores = scores(&router, &mut state, &later_child_turn).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-b")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn first_decision_wins() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let req = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &req, "model-a").await?;
+        // A later decision for the same identity must not overwrite the first.
+        retain(&router, &mut state, &req, "model-b").await?;
+
+        let scores = scores(&router, &mut state, &req).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_is_keyed_by_agent_not_task() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let first = request(subagent("child-1", "task-1"));
+        retain(&router, &mut state, &first, "model-a").await?;
+
+        // Same child, different task: still scored onto the retained model.
+        let second = request(subagent("child-1", "task-2"));
+        let scores = scores(&router, &mut state, &second).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_subagents_are_assigned_independently() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // One child in the session is pinned...
+        retain(
+            &router,
+            &mut state,
+            &request(subagent("child-1", "task-1")),
+            "model-a",
+        )
+        .await?;
+
+        // ...a sibling child in the same session has no assignment of its own yet.
+        let sibling = request(subagent("child-2", "task-1"));
+        assert!(scores(&router, &mut state, &sibling).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_does_not_inherit_session_assignment() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // The session root is pinned, but a sub-agent is keyed separately...
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-1", "root-1")),
+            "model-a",
+        )
+        .await?;
+
+        // ...so the sub-agent abstains until it is assigned in its own right.
+        let child = request(subagent("child-1", "task-1"));
+        assert!(scores(&router, &mut state, &child).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn classifier_abstains_without_a_session() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // No session id at all: nothing to key on.
+        let req = request(Metadata::default());
+        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn one_router_serves_both_roles() -> Result<(), BoxErr> {
+        // The same instance is registered under both SDK roles; a decision folded in via
+        // the processor handle is read back via the classifier handle.
+        let router = Arc::new(AffinityRouter::new());
+        let processor: Arc<dyn Processor> = router.clone();
+        let classifier: Arc<dyn Classifier> = router;
+        let mut state = State::default();
+
+        let first = request(session("session-1", "agent-a"));
+        processor
+            .process(&mut state, Event::Request(&first))
+            .await?;
+        processor
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let second = request(session("session-1", "agent-b"));
+        let scores = scores(classifier.as_ref(), &mut state, &second).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_without_a_request_is_ignored() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // A decision with no captured identity (no prior request) stores nothing.
+        router
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let req = request(session("session-1", "agent-a"));
+        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unrelated_events_preserve_the_pending_identity() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let req = request(session("session-1", "agent-a"));
+        router.process(&mut state, Event::Request(&req)).await?;
+        // A stray signal between the request and its decision must not drop the captured
+        // identity, nor create an assignment of its own.
+        router
+            .process(&mut state, Event::Signal(&crate::Signals {}))
+            .await?;
+        router
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let scores = scores(&router, &mut state, &req).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_sessions_are_assigned_independently() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-1", "agent-a")),
+            "model-a",
+        )
+        .await?;
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-2", "agent-a")),
+            "model-b",
+        )
+        .await?;
+
+        let first = scores(&router, &mut state, &request(session("session-1", "other"))).await?;
+        let second = scores(&router, &mut state, &request(session("session-2", "other"))).await?;
+        assert_eq!(
+            first.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        assert_eq!(
+            second.first().map(|score| score.target.as_str()),
+            Some("model-b")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_without_an_agent_id_is_not_keyed() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // The sub-agent flag is set but no agent id is present, so no key can be formed;
+        // the request is neither retained nor scored.
+        let metadata = Metadata {
+            session_id: Some("session-1".to_string()),
+            is_subagent: true,
+            ..Metadata::default()
+        };
+        let req = request(metadata);
+        retain(&router, &mut state, &req, "model-a").await?;
+        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn assignments_are_bounded_by_the_cap() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // One distinct session past the cap forces exactly one eviction.
+        for index in 0..=MAX_ASSIGNMENTS {
+            let session_id = format!("session-{index}");
+            retain(
+                &router,
+                &mut state,
+                &request(session(&session_id, "agent-a")),
+                "model-a",
+            )
+            .await?;
+        }
+
+        let len = state
+            .get::<AffinityAssignments>()
+            .map(|fact| fact.assignments.len());
+        assert_eq!(len, Some(MAX_ASSIGNMENTS));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn latch_only_retains_matching_models() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new().with_latch_only(["strong"]);
+        let mut state = State::default();
+        let req = request(session("session-1", "agent-a"));
+
+        // A "weak" decision is not retained — a later turn is not latched.
+        retain(&router, &mut state, &req, "weak").await?;
+        assert!(scores(&router, &mut state, &req).await?.is_empty());
+
+        // A "strong" decision is retained — later turns latch onto it.
+        retain(&router, &mut state, &req, "strong").await?;
+        assert_eq!(
+            scores(&router, &mut state, &req)
+                .await?
+                .first()
+                .map(|s| s.target.as_str()),
+            Some("strong")
+        );
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -142,6 +142,7 @@ impl Algorithm for FallThrough {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::algorithms::AffinityRouter;
     use crate::core::Classification;
 
     use switchyard_protocol::{
@@ -235,17 +236,25 @@ mod tests {
         }
     }
 
-    /// Drives a shared router through one turn, returning the completion text + trace.
-    async fn run_turn(
+    /// Drives a request through a shared router, returning the completion text + trace.
+    async fn run_request(
         router: &Arc<FallThrough>,
+        request: Request,
     ) -> Result<(String, Vec<Arc<dyn Decision>>), BoxErr> {
-        let (trace, response) = router.clone().run(Context::default(), request()).await?;
+        let (trace, response) = router.clone().run(Context::default(), request).await?;
         let text = response
             .llm_response
             .into_agg()
             .await
             .map(|agg| completion_text(&agg))?;
         Ok((text, trace))
+    }
+
+    /// Drives a shared router through one default root-agent turn.
+    async fn run_turn(
+        router: &Arc<FallThrough>,
+    ) -> Result<(String, Vec<Arc<dyn Decision>>), BoxErr> {
+        run_request(router, request()).await
     }
 
     /// Drives a fresh router through one turn.
@@ -409,6 +418,63 @@ mod tests {
         assert_eq!(turn1, "weak"); // count 1 — below threshold
         assert_eq!(turn2, "strong"); // count 2 — state carried over from turn 1
         assert_eq!(turn3, "strong"); // count 3 — still above threshold
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_affinity_latches_children_but_root_traffic_falls_through(
+    ) -> Result<(), BoxErr> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct AlternatingClassifier(AtomicUsize);
+
+        #[async_trait]
+        impl Classifier for AlternatingClassifier {
+            async fn score(
+                &self,
+                _state: &mut State,
+                _request: &Request,
+                _driver: Option<&Driver>,
+            ) -> Result<Classification, BoxErr> {
+                let target = if self.0.fetch_add(1, Ordering::SeqCst).is_multiple_of(2) {
+                    "strong"
+                } else {
+                    "weak"
+                };
+                Ok(Classification::Scores(vec![score(target, 1.0)]))
+            }
+        }
+
+        let classifier = Arc::new(AlternatingClassifier(AtomicUsize::new(0)));
+        let affinity = Arc::new(AffinityRouter::for_subagents());
+        let router = Arc::new(
+            FallThrough::new(target_set(&["strong", "weak"]))
+                .with_processor(affinity.clone() as Arc<dyn Processor>)
+                .with_classifier(affinity as Arc<dyn Classifier>)
+                .with_classifier(classifier.clone()),
+        );
+
+        let (root_turn_1, _) = run_turn(&router).await?;
+        let (root_turn_2, _) = run_turn(&router).await?;
+        assert_eq!(
+            (root_turn_1.as_str(), root_turn_2.as_str()),
+            ("strong", "weak")
+        );
+
+        let mut child = request();
+        child.metadata = Some(Metadata {
+            session_id: Some("session-1".to_string()),
+            agent_id: Some("child-1".to_string()),
+            is_subagent: true,
+            ..Metadata::default()
+        });
+        let (child_turn_1, _) = run_request(&router, child.clone()).await?;
+        let (child_turn_2, _) = run_request(&router, child).await?;
+        assert_eq!(
+            (child_turn_1.as_str(), child_turn_2.as_str()),
+            ("strong", "strong")
+        );
+        assert_eq!(classifier.0.load(Ordering::SeqCst), 3);
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/random_classifier.rs
+++ b/crates/libsy/src/algorithms/random_classifier.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Uniform random selection as a composable [`Classifier`].
+
+use async_trait::async_trait;
+use rand::seq::SliceRandom;
+use switchyard_protocol::Request;
+
+use crate::{Classification, Classifier, Score, State};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Selects one configured routing target uniformly at random.
+///
+/// Place this classifier after classifiers that may abstain, such as
+/// [`crate::algorithms::AffinityRouter`], to provide a guaranteed local fallback.
+pub struct RandomClassifier {
+    targets: Vec<String>,
+}
+
+impl RandomClassifier {
+    /// Creates a random classifier over the provided target names.
+    pub fn new(targets: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            targets: targets.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Chooses one target, avoiding random-number generation for a singleton set.
+    fn choose_target(&self) -> Result<String, BoxErr> {
+        match self.targets.as_slice() {
+            [] => Err("random classifier: no targets available".into()),
+            [target] => Ok(target.clone()),
+            targets => targets
+                .choose(&mut rand::thread_rng())
+                .cloned()
+                .ok_or_else(|| "random classifier: no targets available".into()),
+        }
+    }
+}
+
+#[async_trait]
+impl Classifier for RandomClassifier {
+    async fn score(
+        &self,
+        _state: &mut State,
+        _request: &Request,
+        _driver: Option<&crate::Driver>,
+    ) -> Result<Classification, BoxErr> {
+        Ok(Classification::Scores(vec![Score {
+            confidence: 1.0,
+            target: self.choose_target()?,
+        }]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use switchyard_protocol::{text_request, Request};
+
+    fn request() -> Request {
+        Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn singleton_target_is_selected() -> Result<(), BoxErr> {
+        let classifier = RandomClassifier::new(["only"]);
+        let classification = classifier
+            .score(&mut State::default(), &request(), None)
+            .await?;
+        let scores = match classification {
+            Classification::Scores(scores) => scores,
+            Classification::Ambiguous(_) => {
+                return Err("random classifier returned ambiguity".into())
+            }
+        };
+
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "only");
+        assert_eq!(scores[0].confidence, 1.0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn selected_target_belongs_to_the_configured_set() -> Result<(), BoxErr> {
+        let targets = ["a", "b", "c"];
+        let classifier = RandomClassifier::new(targets);
+        let mut state = State::default();
+
+        for _ in 0..50 {
+            let classification = classifier.score(&mut state, &request(), None).await?;
+            let selected = classification
+                .argmax(false)?
+                .ok_or("random classifier abstained")?;
+            assert!(targets.contains(&selected.target.as_str()));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_target_set_errors() {
+        let classifier = RandomClassifier::new(Vec::<String>::new());
+        assert!(classifier
+            .score(&mut State::default(), &request(), None)
+            .await
+            .is_err());
+    }
+}

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -58,6 +58,9 @@
 //!
 //! [`algorithms::Random`] provides uniform random routing.
 //!
+//! [`algorithms::RandomClassifier`] provides the same selection policy inside a
+//! classifier cascade.
+//!
 //! [`algorithms::LlmClassifier`] classifies with one model, then routes to a strong/weak
 //! model depending on the classifier's choice.
 


### PR DESCRIPTION
## Why

Sub-agent routing should be an optional persistence policy, not a separate routing algorithm. A normal algorithm should select a target on the first eligible request, then reuse that selection for the same stable identity. Root-agent traffic and algorithms without affinity must preserve their existing behavior.

## What

- replace the classifier-specific `AgentAwareOrchAlgo` POC with a public, reusable `Affinity` trait
- add process-local `SessionAffinity` and `SubAgentAffinity` policies with bounded first-writer-wins state
- add explicit `AgentContext::is_subagent` metadata
- normalize Codex, NeMo Relay, Dynamo, and explicit `x-switchyard-*` lineage headers without adding a runtime dependency
- let `RandomAlgo` optionally retain its final selection through any `Affinity` implementation
- keep root-agent requests random per turn when `SubAgentAffinity` is enabled
- fast-path a single configured random-routing target and retain it for subsequent child-agent turns
- keep `NoopAlgo` unchanged because it does not select a routable model
- update the libsy proxy demo, public docs, and focused tests

The affinity state is bounded to 4,096 process-local assignments. `SubAgentAffinity` keys by `(session_id, agent_id)` and intentionally excludes `task_id`, so one child remains on the same model as its task/turn metadata changes.

## How

`Affinity` owns only request eligibility, stable key construction, and retained state. Algorithms remain responsible for model selection. On an affinity miss, `RandomAlgo` runs its normal selection, atomically retains the first winner, and routes to the canonical retained target. On a hit, it bypasses reselection. Requests the policy cannot key continue through ordinary random routing.

`AffinityKey` is namespaced and public, while `AffinityState` provides the reusable bounded storage. The integration contract test implements a custom task-based affinity policy outside the `libsy` crate to verify the extension point is usable by downstream libraries.

Header normalization remains a separate adapter. Explicit `x-switchyard-*` headers take precedence; Codex, Relay, and Dynamo headers are converted into neutral libsy metadata. No direct NeMo Relay dependency is required.

### Try it

Start the buffered demo against NVIDIA Inference Hub:

```bash
export INFERENCE_HUB_SY_API_KEY="nvapi-..."
ANTHROPIC_API_KEY="$INFERENCE_HUB_SY_API_KEY" cargo run -p libsy-proxy
```

Send the first turn for a child agent:

```bash
curl -i http://127.0.0.1:4000/v1/chat/completions \
  -H 'content-type: application/json' \
  -H 'session-id: root-session-1' \
  -H 'thread-id: child-thread-1' \
  -H 'x-codex-parent-thread-id: root-thread-1' \
  -H 'x-openai-subagent: collab_spawn' \
  -H 'x-switchyard-task-id: task-1' \
  -H 'x-codex-turn-metadata: {"session_id":"root-session-1","thread_id":"child-thread-1","parent_thread_id":"root-thread-1","turn_id":"turn-1","subagent_kind":"collab_spawn"}' \
  -d '{"model":"libsy-random-affinity","messages":[{"role":"user","content":"Reply with exactly AFFINITY_E2E_OK"}],"stream":false}'
```

The first response reports the provider model and a rationale like:

```text
x-model-router-selected-model: <provider-model-id>
x-model-router-selected-tier: <logical-target>
x-model-router-version: libsy-random-affinity-v1
x-model-router-rationale: random routing selected and retained target '<logical-target>'
```

Repeat the request with the same `session-id` and `thread-id`, but change `x-switchyard-task-id` to `task-2` and the turn metadata to `turn-2`. The response should use the same model and report:

```text
x-model-router-rationale: affinity reused target '<logical-target>'
```

The demo currently requires `"stream": false`; adapting an unmodified streaming Codex CLI remains outside this focused change.

## Where to Start Review

1. `crates/libsy/src/affinity.rs` — public trait, state, built-in policies, and header normalization
2. `crates/libsy/src/algorithms/rand.rs` — optional affinity at the final selection point
3. `crates/libsy/tests/affinity.rs` — downstream custom-policy contract
4. `demo/libsy-proxy/src/main.rs` — live HTTP/provider wiring
5. `crates/libsy-protocol/src/envelope.rs` — explicit child-agent signal

## Test Plan

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace` — pass
- `uv run ruff check .` — pass
- focused live NVIDIA Inference Hub e2e through `libsy-proxy` — pass:
  - turn 1 returned HTTP 200 and reported `random routing selected and retained`
  - turn 2 used the same provider model across changed task/turn metadata and reported `affinity reused`
- broad `tests/e2e/` run — incomplete: 17 passed, then 5 setup errors reached `--maxfail=5`; 21 tests did not run because the existing passthrough fixture invokes the removed `switchyard passthrough` CLI command

The single-target behavior is covered by `single_target_subagent_is_retained_without_reselection`; the live demo currently uses its two configured provider targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `RandomClassifier` for randomly selecting among configured routing targets.
  * Added sub-agent affinity routing, allowing child-agent requests to remain assigned to the same target across turns.
  * Root-agent requests continue to use fallback routing behavior.
* **Documentation**
  * Added guidance and examples for configuring sub-agent affinity and normalizing request metadata for HTTP integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->