### PR TITLE
fix(cli): restore first-run launcher setup

### DIFF
--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -266,6 +266,9 @@ def maybe_bootstrap_launch_config(
         provider=connectivity.provider,
         base_url=connectivity.base_url,
         api_key=args.api_key,
+        routing_profiles=getattr(args, "routing_profiles", None),
+        skill_distillation=None,
+        disable_skill_distillation=False,
         prompt_default_api_key=resolved_api_key,
         prompt_default_api_key_source=_api_key_prompt_default_source(
             args=args,

--- a/tests/test_launch_claude.py
+++ b/tests/test_launch_claude.py
@@ -83,6 +83,9 @@ def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path
     monkeypatch.setenv("NVIDIA_BASE_URL", "https://nvidia.test/v1")
     monkeypatch.setattr("switchyard.cli.launch_command.is_interactive_terminal", lambda: True)
     monkeypatch.setattr("switchyard.cli.launch_command.load_secrets", lambda: {})
+    monkeypatch.setattr(
+        "switchyard.cli.configure_command.is_interactive_terminal", lambda: False
+    )
 
     args = argparse.Namespace(
         reconfigure=True,

--- a/tests/test_launch_claude.py
+++ b/tests/test_launch_claude.py
@@ -62,6 +62,10 @@ def test_random_routing_virtual_model_id_is_client_neutral() -> None:
 
 
 def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path) -> None:
+    from switchyard.cli.config.user_config import (
+        load_user_config,
+        load_user_credentials,
+    )
     from switchyard.cli.launch_command import maybe_bootstrap_launch_config
 
     monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
@@ -79,11 +83,6 @@ def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path
     monkeypatch.setenv("NVIDIA_BASE_URL", "https://nvidia.test/v1")
     monkeypatch.setattr("switchyard.cli.launch_command.is_interactive_terminal", lambda: True)
     monkeypatch.setattr("switchyard.cli.launch_command.load_secrets", lambda: {})
-    captured: dict[str, argparse.Namespace] = {}
-    monkeypatch.setattr(
-        "switchyard.cli.launch_command.cmd_configure",
-        lambda configure_args: captured.setdefault("args", configure_args),
-    )
 
     args = argparse.Namespace(
         reconfigure=True,
@@ -106,11 +105,13 @@ def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path
         ),
     )
 
-    configure_args = captured["args"]
-    assert configure_args.provider == "nvidia"
-    assert configure_args.base_url == "https://nvidia.test/v1"
-    assert configure_args.prompt_default_api_key == "nvidia-key"  # pragma: allowlist secret
-    assert configure_args.prompt_default_api_key_source == "$NVIDIA_API_KEY"
+    config = load_user_config()
+    credentials = load_user_credentials()
+    assert config.default_provider == "nvidia"
+    assert config.provider("nvidia").base_url == "https://nvidia.test/v1"
+    assert config.launch_target("claude").effective_route().model == "nvidia/model"
+    assert credentials.api_key("nvidia") == "nvidia-key"  # pragma: allowlist secret
+    assert args.api_key == "nvidia-key"  # pragma: allowlist secret
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Populate the first-run launcher's synthetic configure arguments with the routing-profile and skill-distillation defaults expected by `cmd_configure`.
- Make the bootstrap regression test execute the real configure path and verify that provider, model, and credentials are persisted.

## Why

First-run launcher setup crashes with `AttributeError` because its hand-built `argparse.Namespace` does not satisfy the configure command's argument contract. The skill-distillation fields trigger the reported failure, and the missing `routing_profiles` field would fail next.

Closes #60

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green
- [ ] Manual smoke (not run; it would spawn an external agent CLI and use live provider credentials)

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (No classes added.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (No public symbols added.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (No documented interface changed.)
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

`maybe_bootstrap_launch_config` is shared by Claude, Codex, and OpenClaw. The focused test exercises that shared helper through the Claude first-run path without making live provider calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bootstrap configuration now preserves routing profile selections and skill-distillation settings.
  * Launch configuration correctly persists the selected provider, base URL, target model, and API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->