### PR TITLE
chore(switchyard-server): Output /v1/messages and /v1/responses sample curl

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -594,18 +594,26 @@ fn startup_banner(options: &ServerRunOptions, registry: &ProfileRegistry) -> Str
     push_line(&mut output, format!("    curl -s {local_url}/health"));
     push_line(&mut output, format!("    curl -s {local_url}/v1/models"));
     if let Some(entry) = entries.first() {
-        let payload = json!({
+        let chat_payload = json!({
             "model": entry.id.as_str(),
-            "messages": [{"role": "user", "content": "Say ok"}],
+            "messages": [{"role": "user", "content": "Say OK"}],
             "max_tokens": 256, // Space for thinking tokens
         });
         push_line(
             &mut output,
-            format!(
-                "    curl -s {local_url}/v1/chat/completions -H 'content-type: application/json' -d '{}'",
-                payload
-            ),
+            format!("    curl -s {local_url}/v1/chat/completions -H 'content-type: application/json' -d '{chat_payload}'")
         );
+        push_line(
+            &mut output,
+            format!("    curl -s {local_url}/v1/messages -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -d '{chat_payload}'")
+        );
+
+        let responses_payload = json!({
+            "model": entry.id.as_str(),
+            "max_output_tokens": 256,
+            "input": "Say OK",
+        });
+        push_line(&mut output, format!("    curl -s {local_url}/v1/responses -H 'content-type: application/json' -d '{responses_payload}'"));
     }
     if options.is_tls() {
         push_line(


### PR DESCRIPTION
I was trying to test a previous PR and didn't have a handy copy-paste
command for those two.

Also shows our translation layer a little.

Looks like this now - notice the extra two `curl` lines at the bottom:
<img width="2066" height="700" alt="Screenshot from 2026-07-14 12-58-04" src="https://github.com/user-attachments/assets/6318f813-9961-4ae4-8a9d-fd66da195b57" />

Signed-off-by: Graham King <grahamk@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the startup banner’s example commands to demonstrate chat, messages, and responses endpoints.
  * Added endpoint-specific request formats and required headers for clearer API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->