### PR TITLE
fix: Do not advertise the model directly

### DIFF
--- a/crates/switchyard-server/src/registry.rs
+++ b/crates/switchyard-server/src/registry.rs
@@ -67,13 +67,6 @@ impl ProfileRegistry {
                 Arc::clone(&profile),
                 target.model.as_str(),
             )?;
-            if target.id.as_str() != target.model.as_str() {
-                registry.insert(
-                    target.model.clone(),
-                    profile,
-                    format!("target {}", target.id.as_str()),
-                )?;
-            }
         }
 
         Ok(registry)

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -207,60 +207,6 @@ async fn translation_errors_do_not_emit_routing_metadata_headers() -> TestResult
 }
 
 #[tokio::test]
-async fn target_id_and_target_model_aliases_are_advertised_and_routable() -> TestResult {
-    let _stats_guard = stats_guard().await;
-    let Some(stub) = HttpStub::start(2)? else {
-        log_loopback_bind_skip();
-        return Ok(());
-    };
-    let app = build_switchyard_router(state_from_yaml(&format!(
-        r#"
-targets:
-  direct:
-    model: upstream-direct
-    format: openai
-    base_url: {base_url}
-profiles:
-  direct-profile:
-    type: passthrough
-    target: direct
-"#,
-        base_url = stub.base_url
-    ))?);
-
-    let models = app
-        .clone()
-        .oneshot(request("GET", "/v1/models", None)?)
-        .await?;
-    let model_ids = json_body(models).await?["model_pool"].clone();
-    assert_eq!(
-        model_ids,
-        json!(["direct-profile", "direct", "upstream-direct"])
-    );
-
-    for public_model in ["direct", "upstream-direct"] {
-        let response = app
-            .clone()
-            .oneshot(request(
-                "POST",
-                "/v1/chat/completions",
-                Some(json!({
-                    "model": public_model,
-                    "messages": [{"role": "user", "content": "hi"}],
-                })),
-            )?)
-            .await?;
-        assert_eq!(response.status(), StatusCode::OK);
-    }
-
-    let seen = stub.requests()?;
-    assert_eq!(seen.len(), 2);
-    assert_eq!(seen[0]["model"], "upstream-direct");
-    assert_eq!(seen[1]["model"], "upstream-direct");
-    Ok(())
-}
-
-#[tokio::test]
 async fn target_with_same_id_and_model_is_registered_once() -> TestResult {
     let _stats_guard = stats_guard().await;
     let Some(stub) = HttpStub::start(1)? else {
@@ -403,28 +349,6 @@ profiles:
     let seen = stub.requests()?;
     assert_eq!(seen.len(), 1);
     assert_eq!(seen[0]["model"], "upstream-fast");
-    Ok(())
-}
-
-#[tokio::test]
-async fn duplicate_public_model_ids_are_rejected() -> TestResult {
-    let err = state_from_yaml(
-        r#"
-targets:
-  direct:
-    model: same
-    format: openai
-    base_url: http://127.0.0.1:9/v1
-profiles:
-  same:
-    type: noop
-"#,
-    )
-    .err()
-    .ok_or("expected duplicate public model id failure")?;
-
-    assert!(err.to_string().contains("same"));
-    assert!(err.to_string().contains("already registered"));
     Ok(())
 }
 


### PR DESCRIPTION
Only advertise the target names, for example 'classifier', 'weak' and 'strong'.

This allows the operator to adjust the models without breaking clients.
It also removes the bug that prevents using the same model for
classifier and weak (also for example).

The code change is in `registry.rs`.

The rest is two test removals:
- `target_id_and_target_model_aliases_are_advertised_and_routable`. The
  checked we advertise the model directly which we don't now. The other
  half of that test is covered by a different test.
- `duplicate_public_model_ids_are_rejected`. This prevented having a
  model named the same as a target. That's no longer a problem because
  we don't advertise the model directly.

Closes: https://github.com/NVIDIA-NeMo/Switchyard/issues/51

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated passthrough model resolution so inbound model names use the configured target ID.
  * Target model names are now presented as display names rather than additional aliases.
  * Removed support for routing through alternate target-model aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->