### PR TITLE
feat: noop algorithm for libsy

### DIFF
--- a/crates/libsy-protocol/src/envelope.rs
+++ b/crates/libsy-protocol/src/envelope.rs
@@ -46,6 +46,12 @@ pub struct Request {
     pub metadata: Option<Metadata>,
 }
 
+impl Request {
+    pub fn requested_model(&self) -> Option<&str> {
+        self.llm_request.model.as_deref()
+    }
+}
+
 /// A response an algorithm returns: the [`LlmResponse`] (streamed or aggregate) plus
 /// optional correlation [`Metadata`].
 ///
@@ -55,4 +61,10 @@ pub struct Response {
     pub llm_response: LlmResponse,
     /// Correlation metadata carried through the response.
     pub metadata: Option<Metadata>,
+}
+
+impl Response {
+    pub fn selected_model(&self) -> Option<&str> {
+        self.llm_response.selected_model()
+    }
 }

--- a/crates/libsy-protocol/src/stream.rs
+++ b/crates/libsy-protocol/src/stream.rs
@@ -61,6 +61,14 @@ impl LlmResponse {
             }
         }
     }
+
+    pub fn selected_model(&self) -> Option<&str> {
+        match self {
+            LlmResponse::Agg(agg) => agg.model.as_deref(),
+            // TODO: How do we get the model name on a stream?
+            LlmResponse::Stream(_) => None,
+        }
+    }
 }
 
 /// One provider-neutral streaming event — the normalized counterpart to

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod noop;

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -6,9 +6,11 @@
 
 use std::{error::Error, sync::Arc};
 
-use switchyard_protocol::{Request, Response};
+use switchyard_protocol::{
+    AggLlmResponse, ContentBlock, LlmResponse, Request, Response, ResponseOutput, Role, StopReason,
+};
 
-use crate::{Algorithm, Context, Decision, Driver, LlmResponse, Signals};
+use crate::{Algorithm, Context, Decision, Driver, Signals};
 
 /// A routing algorithm that does not route. It returns a hard-coded response.
 pub struct NoopAlgo {}
@@ -48,33 +50,18 @@ impl Algorithm for NoopAlgo {
         });
         driver.info(ctx, decision.clone()).await?;
 
-        let json = serde_json::json!({
-            "id": "switchyard-noop",
-            "model": model,
-            "outputs": [{
-                "role": "Assistant",
-                "content": [{
-                    "Text": {
-                        "text": "OK"
-                    }
+        let llm_response = LlmResponse::Agg(AggLlmResponse {
+            id: Some("switchyard-noop".to_string()),
+            model: Some(model),
+            outputs: vec![ResponseOutput {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Text {
+                    text: "OK".to_string(),
                 }],
-                "stop_reason": "EndTurn"
+                stop_reason: Some(StopReason::EndTurn),
             }],
-            "usage": {
-                "input_tokens": null,
-                "output_tokens": null,
-                "total_tokens": null,
-                "reasoning_tokens": null
-            },
-            "extensions": {
-                "fields": {}
-            },
-            "preservation": {
-                "requests": {},
-                "responses": {}
-        }});
-
-        let llm_response: LlmResponse = serde_json::from_value(json)?;
+            ..Default::default()
+        });
         let response = Response {
             llm_response,
             metadata: request.metadata.clone(),
@@ -115,7 +102,7 @@ mod tests {
             panic!("Expected exactly one Decision");
         };
         assert_eq!(decision.selected_model(), TEST_MODEL);
-        assert_eq!(response.model(), Some(TEST_MODEL));
+        assert_eq!(response.selected_model(), Some(TEST_MODEL));
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! No-op router. Always returns a hard coded response. Does not route to a backend.
+//! For testing.
+
+use std::{error::Error, sync::Arc};
+
+use switchyard_protocol::{Request, Response};
+
+use crate::{Algorithm, Context, Decision, Driver, LlmResponse, Signals};
+
+pub struct NoopAlgo {}
+
+pub struct NoopDecision {
+    model: String,
+}
+
+impl Decision for NoopDecision {
+    fn selected_model(&self) -> &str {
+        &self.model
+    }
+    fn reasoning(&self) -> Option<&str> {
+        None
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl Algorithm for NoopAlgo {
+    async fn create_run_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Response, Box<dyn Error + Send + Sync>> {
+        let model = request
+            .requested_model()
+            .unwrap_or("switchyard/noop")
+            .to_string();
+        let decision: Arc<dyn Decision> = Arc::new(NoopDecision {
+            model: model.clone(),
+        });
+        driver.info(ctx, decision.clone()).await?;
+
+        let json = serde_json::json!({
+            "id": "switchyard-noop",
+            "model": model,
+            "outputs": [{
+                "role": "Assistant",
+                "content": [{
+                    "Text": {
+                        "text": "OK"
+                    }
+                }],
+                "stop_reason": "EndTurn"
+            }],
+            "usage": {
+                "input_tokens": null,
+                "output_tokens": null,
+                "total_tokens": null,
+                "reasoning_tokens": null
+            },
+            "extensions": {
+                "fields": {}
+            },
+            "preservation": {
+                "requests": {},
+                "responses": {}
+        }});
+
+        let llm_response: LlmResponse = serde_json::from_value(json)?;
+        let response = Response {
+            llm_response,
+            metadata: request.metadata.clone(),
+        };
+        Ok(response)
+    }
+
+    async fn process_signals(
+        self: Arc<Self>,
+        _signals: Signals,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use switchyard_protocol::{LlmRequest, Message, Role};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_noop_algo() -> Result<(), Box<dyn Error + Send + Sync>> {
+        const TEST_MODEL: &str = "test_noop_algo";
+        let request = Request {
+            llm_request: LlmRequest {
+                model: Some(TEST_MODEL.to_string()),
+                messages: vec![Message::text(Role::User, "hi")],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        };
+
+        let a: Arc<dyn Algorithm> = Arc::new(NoopAlgo {});
+        let (decisions, response) = a.run(Context::default(), request).await?;
+        let Some(decision) = decisions.first() else {
+            panic!("Expected exactly one Decision");
+        };
+        assert_eq!(decision.selected_model(), TEST_MODEL);
+        assert_eq!(response.model(), Some(TEST_MODEL));
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -10,8 +10,11 @@ use switchyard_protocol::{Request, Response};
 
 use crate::{Algorithm, Context, Decision, Driver, LlmResponse, Signals};
 
+/// A routing algorithm that does not route. It returns a hard-coded response.
 pub struct NoopAlgo {}
 
+/// How [`NoopAlgo`] records which model it chose. This will be the model on the Request if any,
+/// otherwise a hard coded placeholder. Neither is actually used.
 pub struct NoopDecision {
     model: String,
 }

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -57,6 +57,9 @@
 //! Worked implementations — a random router, an LLM classifier, and a stateful
 //! ensemble — plus runnable agents live in the `libsy-examples` crate.
 
+mod algorithms;
+pub use algorithms::noop::{NoopAlgo, NoopDecision};
+
 mod driver;
 
 use std::{error::Error, pin::Pin, sync::Arc};


### PR DESCRIPTION
Mirrors the switchyard-components-v2 version. Learning the libsy API.

The noop algo returns a hard-coded response without calling the driver or backend. This would be useful for performance testing just the switchyard layer, or for integration testing.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a no-operation routing algorithm that selects a model, records it in the decision, and returns a predictable assistant response.
  * Added convenience accessors to retrieve the requested model from requests and the selected model from responses.
  * Exposed the no-operation algorithm and its decision type as public APIs.
* **Tests**
  * Added coverage verifying model selection, decision reporting, and response generation for the no-operation algorithm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->