### PR TITLE
chore: Provide a default impl for `process_signals`.

### DIFF
--- a/crates/libsy-examples/src/ensemble.rs
+++ b/crates/libsy-examples/src/ensemble.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response, Signals};
+use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response};
 use switchyard_protocol::{completion_text, prompt_text, text_request};
 
 /// Which step of the ensemble flow produced a decision.
@@ -390,20 +390,12 @@ impl Algorithm for EnsembleOrchAlgo {
         }
         Ok(response)
     }
-
-    async fn process_signals(
-        self: Arc<Self>,
-        _signals: Signals,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        // Success is measured by the judge, not agent-system signals.
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libsy::{LlmClient, LlmResponse, LlmTarget, Response, RoutedRequest};
+    use libsy::{LlmClient, LlmResponse, LlmTarget, Response, RoutedRequest, Signals};
     use std::sync::Mutex as StdMutex;
     use switchyard_protocol::text_response;
 

--- a/crates/libsy-examples/src/llm_class.rs
+++ b/crates/libsy-examples/src/llm_class.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response, Signals};
+use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response};
 use switchyard_protocol::{completion_text, prompt_text, text_request};
 
 /// Preamble prepended to the user prompt when asking the classifier target for a
@@ -169,14 +169,6 @@ impl Algorithm for LlmClassifierOrchAlgo {
         driver
             .call_llm_target(ctx, &routed_target, routed_request, route_decision)
             .await
-    }
-
-    async fn process_signals(
-        self: Arc<Self>,
-        _signals: Signals,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        // Stateless classification; agent-system signals are ignored.
-        Ok(())
     }
 }
 

--- a/crates/libsy-examples/src/rand.rs
+++ b/crates/libsy-examples/src/rand.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use rand::seq::SliceRandom;
 
-use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response, Signals};
+use libsy::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response};
 
 /// Decision produced by [`RandomOrchAlgo`]: which target was chosen and why.
 pub struct RandomDecision {
@@ -85,20 +85,12 @@ impl Algorithm for RandomOrchAlgo {
             .call_llm_target(ctx, &target, request, decision)
             .await
     }
-
-    async fn process_signals(
-        self: Arc<Self>,
-        _signals: Signals,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        // Random routing is stateless, so agent-system signals are ignored.
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libsy::{LlmClient, LlmResponse, LlmTarget, Response, RoutedRequest};
+    use libsy::{LlmClient, LlmResponse, LlmTarget, Response, RoutedRequest, Signals};
     use std::collections::HashSet;
     use switchyard_protocol::{completion_text, text_request, text_response};
 

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -10,7 +10,7 @@ use switchyard_protocol::{
     AggLlmResponse, ContentBlock, LlmResponse, Request, Response, ResponseOutput, Role, StopReason,
 };
 
-use crate::{Algorithm, Context, Decision, Driver, Signals};
+use crate::{Algorithm, Context, Decision, Driver};
 
 /// A routing algorithm that does not route. It returns a hard-coded response.
 pub struct NoopAlgo {}
@@ -67,13 +67,6 @@ impl Algorithm for NoopAlgo {
             metadata: request.metadata.clone(),
         };
         Ok(response)
-    }
-
-    async fn process_signals(
-        self: Arc<Self>,
-        _signals: Signals,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        Ok(())
     }
 }
 

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -369,10 +369,13 @@ pub trait Algorithm: Send + Sync + 'static {
     /// Feed the algorithm agentic-stack events (tool results, budgets, etc.). The
     /// reference algorithms ignore signals; a stateful algorithm updates its own
     /// (interior-mutable) state. Takes `self: Arc<Self>` like the other run methods.
+    #[allow(unused_variables)]
     async fn process_signals(
         self: Arc<Self>,
         signals: Signals,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
 
     /// Run one request as a stream of [`Step`]s (provided). The algorithm runs on its
     /// own task; drive the stream: serve each [`Step::CallLlm`] (via its
@@ -534,13 +537,6 @@ mod tests {
             driver
                 .call_llm_target(ctx, &target, request, decision)
                 .await
-        }
-
-        async fn process_signals(
-            self: Arc<Self>,
-            _signals: Signals,
-        ) -> Result<(), Box<dyn Error + Send + Sync>> {
-            Ok(())
         }
     }
 
@@ -947,13 +943,6 @@ mod tests {
                     llm_response: LlmResponse::Agg(text_response(None, "done".to_string())),
                     metadata: None,
                 })
-            }
-
-            async fn process_signals(
-                self: Arc<Self>,
-                _signals: Signals,
-            ) -> Result<(), Box<dyn Error + Send + Sync>> {
-                Ok(())
             }
         }
 


### PR DESCRIPTION
All the current users are a noop, so this simplifies.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Signal processing is now optional for algorithms, with a default no-op behavior.
  * Simplified algorithm implementations no longer need to define unused signal-handling logic.
  * Existing examples and tests continue to compile with the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->