### PR TITLE
feat: libsy components

### DIFF
--- a/crates/libsy-protocol/src/envelope.rs
+++ b/crates/libsy-protocol/src/envelope.rs
@@ -4,7 +4,7 @@
 //! The request/response envelope: the normalized [`LlmRequest`]/[`LlmResponse`] paired
 //! with the original provider payload and correlation [`Metadata`].
 
-use crate::{LlmRequest, LlmResponse, WireFormat};
+use crate::{LlmRequest, LlmResponse, Metadata};
 use std::collections::HashMap;
 
 /// Per-request state threaded to an algorithm alongside a request. A placeholder
@@ -13,29 +13,6 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Context {
     pub values: HashMap<String, String>,
-}
-
-/// Correlation and routing metadata attached to a request or response.
-///
-/// All fields are optional; algorithms and observers use whichever are present
-/// (e.g. to key per-session state or emit correlated telemetry). `extra_metadata`
-/// is a free-form escape hatch for host-specific keys.
-#[derive(Clone)]
-pub struct Metadata {
-    /// Stable id for a multi-request session/conversation.
-    pub session_id: Option<String>,
-    /// Id of the agent making the request.
-    pub agent_id: Option<String>,
-    /// Id of the task the request belongs to.
-    pub task_id: Option<String>,
-    /// External trace/request id for joining with the host's telemetry.
-    pub correlation_id: Option<String>,
-    /// Arbitrary host-defined key/value metadata.
-    pub extra_metadata: Option<std::collections::BTreeMap<String, String>>,
-    /// HTTP headers to attach when forwarding the request/response, if any.
-    pub http_headers: Option<std::collections::BTreeMap<String, String>>,
-    /// The wire format the request/response was originally encoded in, if known.
-    pub wire_format: Option<WireFormat>,
 }
 
 /// A request an algorithm routes: the normalized [`LlmRequest`] plus the original

--- a/crates/libsy-protocol/src/lib.rs
+++ b/crates/libsy-protocol/src/lib.rs
@@ -24,12 +24,14 @@ pub mod client;
 pub mod envelope;
 pub mod format;
 pub mod llm;
+pub mod metadata;
 pub mod stream;
 
 pub use client::*;
 pub use envelope::*;
 pub use format::*;
 pub use llm::*;
+pub use metadata::*;
 pub use stream::*;
 
 /// Build a single-turn request: one user message carrying `prompt`, for `model`.

--- a/crates/libsy-protocol/src/metadata.rs
+++ b/crates/libsy-protocol/src/metadata.rs
@@ -67,9 +67,10 @@ impl Metadata {
     /// child agent (its parent inferred to be the session when not stated). Subagent
     /// status is taken from an explicit `x-switchyard-is-subagent` header when
     /// present, and otherwise inferred from any parent/child lineage header.
-    pub fn from_headers(headers: &BTreeMap<String, Vec<String>>) -> Self {
+    pub fn from_headers(headers: &BTreeMap<String, String>) -> Self {
+        let headers = &normalize_headers(headers);
         let codex = header(headers, CODEX_TURN_METADATA_HEADER)
-            .and_then(|value| serde_json::from_str::<CodexTurnMetadata>(&value).ok())
+            .and_then(|value| serde_json::from_str::<CodexTurnMetadata>(value).ok())
             .unwrap_or_default();
 
         let switchyard_parent = header(headers, "x-switchyard-parent-agent-id");
@@ -88,9 +89,7 @@ impl Metadata {
             (Some(agent), Some(session)) if agent != session
         );
         let claude_parent = claude_subagent
-            .then(|| {
-                header(headers, "x-claude-code-parent-agent-id").or_else(|| claude_session.clone())
-            })
+            .then(|| header(headers, "x-claude-code-parent-agent-id").or(claude_session))
             .flatten();
 
         // OpenCode carries a session id and an optional parent session; the parent
@@ -110,53 +109,59 @@ impl Metadata {
             || claude_subagent
             || opencode_parent.is_some();
         let is_subagent = header(headers, "x-switchyard-is-subagent")
-            .as_deref()
             .and_then(parse_bool)
             .unwrap_or(inferred_subagent);
 
         Metadata {
-            session_id: first_some([
+            session_id: first_some(&[
                 header(headers, "x-switchyard-session-id"),
                 claude_session,
                 header(headers, "x-nemo-relay-session-id"),
                 opencode_session,
-                codex.session_id,
+                codex.session_id.as_deref(),
                 header(headers, "session-id"),
             ]),
-            agent_id: first_some([
+            agent_id: first_some(&[
                 header(headers, "x-switchyard-agent-id"),
                 claude_agent,
                 relay_subagent,
                 header(headers, "x-dynamo-session-id"),
-                codex.thread_id,
+                codex.thread_id.as_deref(),
                 header(headers, "thread-id"),
             ]),
-            parent_agent_id: first_some([
+            parent_agent_id: first_some(&[
                 switchyard_parent,
                 dynamo_parent,
-                codex.parent_thread_id,
+                codex.parent_thread_id.as_deref(),
                 codex_parent,
                 claude_parent,
                 opencode_parent,
             ]),
             is_subagent,
-            agent_kind: first_some([
+            agent_kind: first_some(&[
                 header(headers, "x-switchyard-agent-kind"),
-                codex.subagent_kind,
+                codex.subagent_kind.as_deref(),
                 openai_subagent,
             ]),
-            agent_role: first_some([header(headers, "x-switchyard-agent-role"), codex.agent_role]),
-            task_id: first_some([
+            agent_role: first_some(&[
+                header(headers, "x-switchyard-agent-role"),
+                codex.agent_role.as_deref(),
+            ]),
+            task_id: first_some(&[
                 header(headers, "x-switchyard-task-id"),
-                codex.task_id,
+                codex.task_id.as_deref(),
                 header(headers, "x-task-id"),
             ]),
-            task_kind: first_some([header(headers, "x-switchyard-task-kind"), codex.task_kind]),
-            turn_id: first_some([header(headers, "x-switchyard-turn-id"), codex.turn_id]),
-            session_final: header(headers, "x-dynamo-session-final")
-                .as_deref()
-                .and_then(parse_bool),
-            correlation_id: first_some([
+            task_kind: first_some(&[
+                header(headers, "x-switchyard-task-kind"),
+                codex.task_kind.as_deref(),
+            ]),
+            turn_id: first_some(&[
+                header(headers, "x-switchyard-turn-id"),
+                codex.turn_id.as_deref(),
+            ]),
+            session_final: header(headers, "x-dynamo-session-final").and_then(parse_bool),
+            correlation_id: first_some(&[
                 header(headers, "x-request-id"),
                 header(headers, "x-client-request-id"),
             ]),
@@ -178,15 +183,6 @@ struct CodexTurnMetadata {
     task_kind: Option<String>,
 }
 
-/// Returns the first non-empty, trimmed value for a case-insensitive header name.
-fn header(headers: &BTreeMap<String, Vec<String>>, name: &str) -> Option<String> {
-    headers
-        .iter()
-        .find(|(key, _)| key.eq_ignore_ascii_case(name))
-        .and_then(|(_, values)| values.iter().find(|value| !value.trim().is_empty()))
-        .map(|value| value.trim().to_string())
-}
-
 /// Parses the common textual spellings of a boolean header value.
 fn parse_bool(value: &str) -> Option<bool> {
     match value.trim().to_ascii_lowercase().as_str() {
@@ -196,35 +192,45 @@ fn parse_bool(value: &str) -> Option<bool> {
     }
 }
 
-/// Returns the first present value in preference order.
-fn first_some<const N: usize>(values: [Option<String>; N]) -> Option<String> {
-    values.into_iter().flatten().next()
+/// Lowercases header names and keeps the first non-empty, trimmed value per name.
+fn normalize_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut normalized = BTreeMap::new();
+    for (key, value) in headers {
+        let lower_key = key.to_ascii_lowercase();
+        let trimmed_value = value.trim();
+        if !normalized.contains_key(&lower_key) && !trimmed_value.is_empty() {
+            normalized.insert(lower_key, trimmed_value.to_string());
+        }
+    }
+
+    normalized
+}
+
+fn header<'a>(headers: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    let lower_key = key.to_ascii_lowercase();
+    headers.get(&lower_key).map(|s| s.as_str())
+}
+
+fn first_some(options: &[Option<&str>]) -> Option<String> {
+    options.iter().find_map(|opt| opt.map(|s| s.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Builds a single-valued header map from `(name, value)` pairs.
-    fn headers(pairs: &[(&str, &str)]) -> BTreeMap<String, Vec<String>> {
-        pairs
-            .iter()
-            .map(|(name, value)| (name.to_string(), vec![value.to_string()]))
-            .collect()
-    }
-
     #[test]
     fn normalizes_codex_child_metadata() {
         let headers = BTreeMap::from([(
             CODEX_TURN_METADATA_HEADER.to_string(),
-            vec![serde_json::json!({
+            serde_json::json!({
                 "session_id": "root-session",
                 "thread_id": "child-agent",
                 "parent_thread_id": "root-agent",
                 "turn_id": "turn-7",
                 "subagent_kind": "collab_spawn",
             })
-            .to_string()],
+            .to_string(),
         )]);
 
         let metadata = Metadata::from_headers(&headers);
@@ -238,12 +244,12 @@ mod tests {
     fn root_codex_metadata_is_not_inferred_as_a_subagent() {
         let headers = BTreeMap::from([(
             CODEX_TURN_METADATA_HEADER.to_string(),
-            vec![serde_json::json!({
+            serde_json::json!({
                 "session_id": "root-session",
                 "thread_id": "root-agent",
                 "turn_id": "turn-1",
             })
-            .to_string()],
+            .to_string(),
         )]);
 
         let metadata = Metadata::from_headers(&headers);
@@ -253,13 +259,10 @@ mod tests {
     #[test]
     fn explicit_switchyard_subagent_flag_overrides_inference() {
         let headers = BTreeMap::from([
-            (
-                "x-switchyard-is-subagent".to_string(),
-                vec!["false".to_string()],
-            ),
+            ("x-switchyard-is-subagent".to_string(), "false".to_string()),
             (
                 "x-switchyard-parent-agent-id".to_string(),
-                vec!["parent".to_string()],
+                "parent".to_string(),
             ),
         ]);
 
@@ -273,7 +276,7 @@ mod tests {
         // affinity keys on it so a whole CLI session pins to one tier.
         let headers = BTreeMap::from([(
             "x-claude-code-session-id".to_string(),
-            vec!["fb46caae-eac6-4f5f-83fd-8fc8f5743abb".to_string()],
+            "fb46caae-eac6-4f5f-83fd-8fc8f5743abb".to_string(),
         )]);
 
         let metadata = Metadata::from_headers(&headers);
@@ -288,15 +291,15 @@ mod tests {
         let headers = BTreeMap::from([
             (
                 "x-nemo-relay-session-id".to_string(),
-                vec!["relay-session".to_string()],
+                "relay-session".to_string(),
             ),
             (
                 "x-nemo-relay-subagent-id".to_string(),
-                vec!["relay-child".to_string()],
+                "relay-child".to_string(),
             ),
             (
                 "x-dynamo-parent-session-id".to_string(),
-                vec!["relay-parent".to_string()],
+                "relay-parent".to_string(),
             ),
         ]);
 
@@ -310,9 +313,15 @@ mod tests {
     fn claude_code_agent_lineage_marks_subagent_and_infers_parent() {
         // A distinct agent id under a session is a child agent; with no explicit
         // parent header its parent is inferred to be the session it was spawned under.
-        let metadata = Metadata::from_headers(&headers(&[
-            ("x-claude-code-session-id", "claude-session"),
-            ("x-claude-code-agent-id", "claude-agent"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            (
+                "x-claude-code-session-id".to_string(),
+                "claude-session".to_string(),
+            ),
+            (
+                "x-claude-code-agent-id".to_string(),
+                "claude-agent".to_string(),
+            ),
         ]));
         assert_eq!(metadata.session_id.as_deref(), Some("claude-session"));
         assert_eq!(metadata.agent_id.as_deref(), Some("claude-agent"));
@@ -322,10 +331,19 @@ mod tests {
 
     #[test]
     fn explicit_claude_parent_agent_overrides_inferred_session() {
-        let metadata = Metadata::from_headers(&headers(&[
-            ("x-claude-code-session-id", "claude-session"),
-            ("x-claude-code-agent-id", "claude-agent"),
-            ("x-claude-code-parent-agent-id", "claude-parent-agent"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            (
+                "x-claude-code-session-id".to_string(),
+                "claude-session".to_string(),
+            ),
+            (
+                "x-claude-code-agent-id".to_string(),
+                "claude-agent".to_string(),
+            ),
+            (
+                "x-claude-code-parent-agent-id".to_string(),
+                "claude-parent-agent".to_string(),
+            ),
         ]));
         assert_eq!(
             metadata.parent_agent_id.as_deref(),
@@ -337,9 +355,15 @@ mod tests {
     fn claude_root_agent_without_distinct_child_is_not_a_subagent() {
         // Session but no distinct agent id: a root agent. A stray parent-agent header
         // is only meaningful for a distinct child, so it must not leak in.
-        let metadata = Metadata::from_headers(&headers(&[
-            ("x-claude-code-session-id", "claude-session"),
-            ("x-claude-code-parent-agent-id", "claude-parent-agent"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            (
+                "x-claude-code-session-id".to_string(),
+                "claude-session".to_string(),
+            ),
+            (
+                "x-claude-code-parent-agent-id".to_string(),
+                "claude-parent-agent".to_string(),
+            ),
         ]));
         assert_eq!(metadata.session_id.as_deref(), Some("claude-session"));
         assert_eq!(metadata.agent_id, None);
@@ -349,9 +373,12 @@ mod tests {
 
     #[test]
     fn opencode_parent_session_marks_subagent() {
-        let metadata = Metadata::from_headers(&headers(&[
-            ("x-session-id", "opencode-run"),
-            ("x-parent-session-id", "opencode-parent"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            ("x-session-id".to_string(), "opencode-run".to_string()),
+            (
+                "x-parent-session-id".to_string(),
+                "opencode-parent".to_string(),
+            ),
         ]));
         assert_eq!(metadata.session_id.as_deref(), Some("opencode-run"));
         assert!(metadata.is_subagent);
@@ -362,9 +389,12 @@ mod tests {
     fn opencode_parent_ignored_without_opencode_session() {
         // The OpenCode parent header only applies with OpenCode's own session header;
         // next to a Codex `session-id` it must not surface as a parent.
-        let metadata = Metadata::from_headers(&headers(&[
-            ("session-id", "codex-run"),
-            ("x-parent-session-id", "stray-parent"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            ("session-id".to_string(), "codex-run".to_string()),
+            (
+                "x-parent-session-id".to_string(),
+                "stray-parent".to_string(),
+            ),
         ]));
         assert_eq!(metadata.session_id.as_deref(), Some("codex-run"));
         assert!(!metadata.is_subagent);
@@ -373,25 +403,31 @@ mod tests {
 
     #[test]
     fn dynamo_session_final_is_captured() {
-        let metadata = Metadata::from_headers(&headers(&[
-            ("x-dynamo-session-id", "generic-run"),
-            ("x-dynamo-parent-session-id", "generic-parent"),
-            ("x-dynamo-session-final", "true"),
+        let metadata = Metadata::from_headers(&BTreeMap::from([
+            ("x-dynamo-session-id".to_string(), "generic-run".to_string()),
+            (
+                "x-dynamo-parent-session-id".to_string(),
+                "generic-parent".to_string(),
+            ),
+            ("x-dynamo-session-final".to_string(), "true".to_string()),
         ]));
         assert_eq!(metadata.agent_id.as_deref(), Some("generic-run"));
         assert_eq!(metadata.parent_agent_id.as_deref(), Some("generic-parent"));
         assert_eq!(metadata.session_final, Some(true));
 
-        let not_final = Metadata::from_headers(&headers(&[
-            ("x-dynamo-session-id", "generic-run"),
-            ("x-dynamo-session-final", "false"),
+        let not_final = Metadata::from_headers(&BTreeMap::from([
+            ("x-dynamo-session-id".to_string(), "generic-run".to_string()),
+            ("x-dynamo-session-final".to_string(), "false".to_string()),
         ]));
         assert_eq!(not_final.session_final, Some(false));
     }
 
     #[test]
     fn codex_session_header_is_case_insensitive() {
-        let metadata = Metadata::from_headers(&headers(&[("Session-ID", "codex-run")]));
+        let metadata = Metadata::from_headers(&BTreeMap::from([(
+            "Session-ID".to_string(),
+            "codex-run".to_string(),
+        )]));
         assert_eq!(metadata.session_id.as_deref(), Some("codex-run"));
     }
 }

--- a/crates/libsy-protocol/src/metadata.rs
+++ b/crates/libsy-protocol/src/metadata.rs
@@ -1,0 +1,397 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Correlation metadata and harness header normalization.
+//!
+//! [`Metadata`] is the correlation/routing envelope carried alongside a request or
+//! response. [`Metadata::from_headers`] normalizes the harness-specific HTTP headers
+//! that Claude Code, Codex, NeMo Relay, and Dynamo attach into that neutral shape.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::WireFormat;
+
+/// Header carrying Codex's structured turn metadata as a JSON object.
+const CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
+
+/// Correlation and routing metadata attached to a request or response.
+///
+/// All fields are optional (or default-empty); algorithms and observers use whichever
+/// are present (e.g. to key per-session state or emit correlated telemetry). The
+/// agent-lineage fields (`parent_agent_id`, `is_subagent`, `agent_kind`, `agent_role`,
+/// `task_kind`, `turn_id`, `session_final`) are populated for requests from a coding
+/// agent. `extra_metadata` is a free-form escape hatch for host-specific keys.
+#[derive(Clone, Default)]
+pub struct Metadata {
+    /// Stable id for a multi-request session/conversation.
+    pub session_id: Option<String>,
+    /// Id of the agent making the request.
+    pub agent_id: Option<String>,
+    /// Id of the parent agent, when this request comes from a child agent.
+    pub parent_agent_id: Option<String>,
+    /// Whether the harness identified this request as coming from a child agent.
+    pub is_subagent: bool,
+    /// Harness-defined kind of agent call, such as `collab_spawn` or `review`.
+    pub agent_kind: Option<String>,
+    /// Semantic agent role, such as `explorer`, `worker`, or `reviewer`.
+    pub agent_role: Option<String>,
+    /// Id of the task the request belongs to.
+    pub task_id: Option<String>,
+    /// Semantic task class supplied by the harness.
+    pub task_kind: Option<String>,
+    /// Id of the current agent turn.
+    pub turn_id: Option<String>,
+    /// Whether the harness signalled this is the session's final request (e.g. the
+    /// host may evict per-session state). `None` when the harness said nothing.
+    pub session_final: Option<bool>,
+    /// External trace/request id for joining with the host's telemetry.
+    pub correlation_id: Option<String>,
+    /// Arbitrary host-defined key/value metadata.
+    pub extra_metadata: Option<BTreeMap<String, String>>,
+    /// HTTP headers to attach when forwarding the request/response, if any.
+    pub http_headers: Option<BTreeMap<String, String>>,
+    /// The wire format the request/response was originally encoded in, if known.
+    pub wire_format: Option<WireFormat>,
+}
+
+impl Metadata {
+    /// Normalizes harness-specific request headers into correlation metadata.
+    ///
+    /// Explicit `x-switchyard-*` headers win. NeMo Relay and Dynamo correlation
+    /// headers are accepted without linking either runtime. Codex's structured turn
+    /// metadata is preferred over its compatibility projections. Claude Code and
+    /// OpenCode carry their agent lineage in native headers: a Claude Code request
+    /// naming a distinct `x-claude-code-agent-id` under its session is treated as a
+    /// child agent (its parent inferred to be the session when not stated). Subagent
+    /// status is taken from an explicit `x-switchyard-is-subagent` header when
+    /// present, and otherwise inferred from any parent/child lineage header.
+    pub fn from_headers(headers: &BTreeMap<String, Vec<String>>) -> Self {
+        let codex = header(headers, CODEX_TURN_METADATA_HEADER)
+            .and_then(|value| serde_json::from_str::<CodexTurnMetadata>(&value).ok())
+            .unwrap_or_default();
+
+        let switchyard_parent = header(headers, "x-switchyard-parent-agent-id");
+        let relay_subagent = header(headers, "x-nemo-relay-subagent-id");
+        let dynamo_parent = header(headers, "x-dynamo-parent-session-id");
+        let codex_parent = header(headers, "x-codex-parent-thread-id");
+        let openai_subagent = header(headers, "x-openai-subagent");
+
+        // Claude Code names a session and, for a spawned child, a distinct agent id.
+        // A child whose agent id differs from the session is a sub-agent; its parent is
+        // the explicit parent-agent header, else the session id it was spawned under.
+        let claude_session = header(headers, "x-claude-code-session-id");
+        let claude_agent = header(headers, "x-claude-code-agent-id");
+        let claude_subagent = matches!(
+            (&claude_agent, &claude_session),
+            (Some(agent), Some(session)) if agent != session
+        );
+        let claude_parent = claude_subagent
+            .then(|| {
+                header(headers, "x-claude-code-parent-agent-id").or_else(|| claude_session.clone())
+            })
+            .flatten();
+
+        // OpenCode carries a session id and an optional parent session; the parent
+        // header is only meaningful alongside OpenCode's own session header.
+        let opencode_session = header(headers, "x-session-id");
+        let opencode_parent = opencode_session
+            .as_ref()
+            .and_then(|_| header(headers, "x-parent-session-id"));
+
+        let inferred_subagent = switchyard_parent.is_some()
+            || relay_subagent.is_some()
+            || dynamo_parent.is_some()
+            || codex.parent_thread_id.is_some()
+            || codex.subagent_kind.is_some()
+            || codex_parent.is_some()
+            || openai_subagent.is_some()
+            || claude_subagent
+            || opencode_parent.is_some();
+        let is_subagent = header(headers, "x-switchyard-is-subagent")
+            .as_deref()
+            .and_then(parse_bool)
+            .unwrap_or(inferred_subagent);
+
+        Metadata {
+            session_id: first_some([
+                header(headers, "x-switchyard-session-id"),
+                claude_session,
+                header(headers, "x-nemo-relay-session-id"),
+                opencode_session,
+                codex.session_id,
+                header(headers, "session-id"),
+            ]),
+            agent_id: first_some([
+                header(headers, "x-switchyard-agent-id"),
+                claude_agent,
+                relay_subagent,
+                header(headers, "x-dynamo-session-id"),
+                codex.thread_id,
+                header(headers, "thread-id"),
+            ]),
+            parent_agent_id: first_some([
+                switchyard_parent,
+                dynamo_parent,
+                codex.parent_thread_id,
+                codex_parent,
+                claude_parent,
+                opencode_parent,
+            ]),
+            is_subagent,
+            agent_kind: first_some([
+                header(headers, "x-switchyard-agent-kind"),
+                codex.subagent_kind,
+                openai_subagent,
+            ]),
+            agent_role: first_some([header(headers, "x-switchyard-agent-role"), codex.agent_role]),
+            task_id: first_some([
+                header(headers, "x-switchyard-task-id"),
+                codex.task_id,
+                header(headers, "x-task-id"),
+            ]),
+            task_kind: first_some([header(headers, "x-switchyard-task-kind"), codex.task_kind]),
+            turn_id: first_some([header(headers, "x-switchyard-turn-id"), codex.turn_id]),
+            session_final: header(headers, "x-dynamo-session-final")
+                .as_deref()
+                .and_then(parse_bool),
+            correlation_id: first_some([
+                header(headers, "x-request-id"),
+                header(headers, "x-client-request-id"),
+            ]),
+            ..Metadata::default()
+        }
+    }
+}
+
+/// Codex's structured turn metadata, carried as JSON in [`CODEX_TURN_METADATA_HEADER`].
+#[derive(Default, Deserialize)]
+struct CodexTurnMetadata {
+    session_id: Option<String>,
+    thread_id: Option<String>,
+    parent_thread_id: Option<String>,
+    turn_id: Option<String>,
+    subagent_kind: Option<String>,
+    agent_role: Option<String>,
+    task_id: Option<String>,
+    task_kind: Option<String>,
+}
+
+/// Returns the first non-empty, trimmed value for a case-insensitive header name.
+fn header(headers: &BTreeMap<String, Vec<String>>, name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .and_then(|(_, values)| values.iter().find(|value| !value.trim().is_empty()))
+        .map(|value| value.trim().to_string())
+}
+
+/// Parses the common textual spellings of a boolean header value.
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Returns the first present value in preference order.
+fn first_some<const N: usize>(values: [Option<String>; N]) -> Option<String> {
+    values.into_iter().flatten().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a single-valued header map from `(name, value)` pairs.
+    fn headers(pairs: &[(&str, &str)]) -> BTreeMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(name, value)| (name.to_string(), vec![value.to_string()]))
+            .collect()
+    }
+
+    #[test]
+    fn normalizes_codex_child_metadata() {
+        let headers = BTreeMap::from([(
+            CODEX_TURN_METADATA_HEADER.to_string(),
+            vec![serde_json::json!({
+                "session_id": "root-session",
+                "thread_id": "child-agent",
+                "parent_thread_id": "root-agent",
+                "turn_id": "turn-7",
+                "subagent_kind": "collab_spawn",
+            })
+            .to_string()],
+        )]);
+
+        let metadata = Metadata::from_headers(&headers);
+        assert_eq!(metadata.session_id.as_deref(), Some("root-session"));
+        assert_eq!(metadata.agent_id.as_deref(), Some("child-agent"));
+        assert!(metadata.is_subagent);
+        assert_eq!(metadata.parent_agent_id.as_deref(), Some("root-agent"));
+    }
+
+    #[test]
+    fn root_codex_metadata_is_not_inferred_as_a_subagent() {
+        let headers = BTreeMap::from([(
+            CODEX_TURN_METADATA_HEADER.to_string(),
+            vec![serde_json::json!({
+                "session_id": "root-session",
+                "thread_id": "root-agent",
+                "turn_id": "turn-1",
+            })
+            .to_string()],
+        )]);
+
+        let metadata = Metadata::from_headers(&headers);
+        assert!(!metadata.is_subagent);
+    }
+
+    #[test]
+    fn explicit_switchyard_subagent_flag_overrides_inference() {
+        let headers = BTreeMap::from([
+            (
+                "x-switchyard-is-subagent".to_string(),
+                vec!["false".to_string()],
+            ),
+            (
+                "x-switchyard-parent-agent-id".to_string(),
+                vec!["parent".to_string()],
+            ),
+        ]);
+
+        let metadata = Metadata::from_headers(&headers);
+        assert!(!metadata.is_subagent);
+    }
+
+    #[test]
+    fn normalizes_claude_code_session_header() {
+        // Claude Code identifies a session with `x-claude-code-session-id`; session
+        // affinity keys on it so a whole CLI session pins to one tier.
+        let headers = BTreeMap::from([(
+            "x-claude-code-session-id".to_string(),
+            vec!["fb46caae-eac6-4f5f-83fd-8fc8f5743abb".to_string()],
+        )]);
+
+        let metadata = Metadata::from_headers(&headers);
+        assert_eq!(
+            metadata.session_id.as_deref(),
+            Some("fb46caae-eac6-4f5f-83fd-8fc8f5743abb")
+        );
+    }
+
+    #[test]
+    fn normalizes_relay_and_dynamo_child_headers() {
+        let headers = BTreeMap::from([
+            (
+                "x-nemo-relay-session-id".to_string(),
+                vec!["relay-session".to_string()],
+            ),
+            (
+                "x-nemo-relay-subagent-id".to_string(),
+                vec!["relay-child".to_string()],
+            ),
+            (
+                "x-dynamo-parent-session-id".to_string(),
+                vec!["relay-parent".to_string()],
+            ),
+        ]);
+
+        let metadata = Metadata::from_headers(&headers);
+        assert_eq!(metadata.session_id.as_deref(), Some("relay-session"));
+        assert_eq!(metadata.agent_id.as_deref(), Some("relay-child"));
+        assert!(metadata.is_subagent);
+    }
+
+    #[test]
+    fn claude_code_agent_lineage_marks_subagent_and_infers_parent() {
+        // A distinct agent id under a session is a child agent; with no explicit
+        // parent header its parent is inferred to be the session it was spawned under.
+        let metadata = Metadata::from_headers(&headers(&[
+            ("x-claude-code-session-id", "claude-session"),
+            ("x-claude-code-agent-id", "claude-agent"),
+        ]));
+        assert_eq!(metadata.session_id.as_deref(), Some("claude-session"));
+        assert_eq!(metadata.agent_id.as_deref(), Some("claude-agent"));
+        assert!(metadata.is_subagent);
+        assert_eq!(metadata.parent_agent_id.as_deref(), Some("claude-session"));
+    }
+
+    #[test]
+    fn explicit_claude_parent_agent_overrides_inferred_session() {
+        let metadata = Metadata::from_headers(&headers(&[
+            ("x-claude-code-session-id", "claude-session"),
+            ("x-claude-code-agent-id", "claude-agent"),
+            ("x-claude-code-parent-agent-id", "claude-parent-agent"),
+        ]));
+        assert_eq!(
+            metadata.parent_agent_id.as_deref(),
+            Some("claude-parent-agent")
+        );
+    }
+
+    #[test]
+    fn claude_root_agent_without_distinct_child_is_not_a_subagent() {
+        // Session but no distinct agent id: a root agent. A stray parent-agent header
+        // is only meaningful for a distinct child, so it must not leak in.
+        let metadata = Metadata::from_headers(&headers(&[
+            ("x-claude-code-session-id", "claude-session"),
+            ("x-claude-code-parent-agent-id", "claude-parent-agent"),
+        ]));
+        assert_eq!(metadata.session_id.as_deref(), Some("claude-session"));
+        assert_eq!(metadata.agent_id, None);
+        assert!(!metadata.is_subagent);
+        assert_eq!(metadata.parent_agent_id, None);
+    }
+
+    #[test]
+    fn opencode_parent_session_marks_subagent() {
+        let metadata = Metadata::from_headers(&headers(&[
+            ("x-session-id", "opencode-run"),
+            ("x-parent-session-id", "opencode-parent"),
+        ]));
+        assert_eq!(metadata.session_id.as_deref(), Some("opencode-run"));
+        assert!(metadata.is_subagent);
+        assert_eq!(metadata.parent_agent_id.as_deref(), Some("opencode-parent"));
+    }
+
+    #[test]
+    fn opencode_parent_ignored_without_opencode_session() {
+        // The OpenCode parent header only applies with OpenCode's own session header;
+        // next to a Codex `session-id` it must not surface as a parent.
+        let metadata = Metadata::from_headers(&headers(&[
+            ("session-id", "codex-run"),
+            ("x-parent-session-id", "stray-parent"),
+        ]));
+        assert_eq!(metadata.session_id.as_deref(), Some("codex-run"));
+        assert!(!metadata.is_subagent);
+        assert_eq!(metadata.parent_agent_id, None);
+    }
+
+    #[test]
+    fn dynamo_session_final_is_captured() {
+        let metadata = Metadata::from_headers(&headers(&[
+            ("x-dynamo-session-id", "generic-run"),
+            ("x-dynamo-parent-session-id", "generic-parent"),
+            ("x-dynamo-session-final", "true"),
+        ]));
+        assert_eq!(metadata.agent_id.as_deref(), Some("generic-run"));
+        assert_eq!(metadata.parent_agent_id.as_deref(), Some("generic-parent"));
+        assert_eq!(metadata.session_final, Some(true));
+
+        let not_final = Metadata::from_headers(&headers(&[
+            ("x-dynamo-session-id", "generic-run"),
+            ("x-dynamo-session-final", "false"),
+        ]));
+        assert_eq!(not_final.session_final, Some(false));
+    }
+
+    #[test]
+    fn codex_session_header_is_case_insensitive() {
+        let metadata = Metadata::from_headers(&headers(&[("Session-ID", "codex-run")]));
+        assert_eq!(metadata.session_id.as_deref(), Some("codex-run"));
+    }
+}

--- a/crates/libsy-protocol/src/metadata.rs
+++ b/crates/libsy-protocol/src/metadata.rs
@@ -16,6 +16,48 @@ use crate::WireFormat;
 /// Header carrying Codex's structured turn metadata as a JSON object.
 const CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
 
+// Explicit Switchyard override headers; these take precedence over harness-native headers.
+const SWITCHYARD_SESSION_ID_HEADER: &str = "x-switchyard-session-id";
+const SWITCHYARD_AGENT_ID_HEADER: &str = "x-switchyard-agent-id";
+const SWITCHYARD_PARENT_AGENT_ID_HEADER: &str = "x-switchyard-parent-agent-id";
+const SWITCHYARD_IS_SUBAGENT_HEADER: &str = "x-switchyard-is-subagent";
+const SWITCHYARD_AGENT_KIND_HEADER: &str = "x-switchyard-agent-kind";
+const SWITCHYARD_AGENT_ROLE_HEADER: &str = "x-switchyard-agent-role";
+const SWITCHYARD_TASK_ID_HEADER: &str = "x-switchyard-task-id";
+const SWITCHYARD_TASK_KIND_HEADER: &str = "x-switchyard-task-kind";
+const SWITCHYARD_TURN_ID_HEADER: &str = "x-switchyard-turn-id";
+
+// NeMo Relay correlation headers.
+const RELAY_SESSION_ID_HEADER: &str = "x-nemo-relay-session-id";
+const RELAY_SUBAGENT_ID_HEADER: &str = "x-nemo-relay-subagent-id";
+
+// Dynamo correlation headers.
+const DYNAMO_SESSION_ID_HEADER: &str = "x-dynamo-session-id";
+const DYNAMO_PARENT_SESSION_ID_HEADER: &str = "x-dynamo-parent-session-id";
+const DYNAMO_SESSION_FINAL_HEADER: &str = "x-dynamo-session-final";
+
+// Codex compatibility projection of its parent thread id.
+const CODEX_PARENT_THREAD_ID_HEADER: &str = "x-codex-parent-thread-id";
+
+// OpenAI subagent marker.
+const OPENAI_SUBAGENT_HEADER: &str = "x-openai-subagent";
+
+// Claude Code agent-lineage headers.
+const CLAUDE_SESSION_ID_HEADER: &str = "x-claude-code-session-id";
+const CLAUDE_AGENT_ID_HEADER: &str = "x-claude-code-agent-id";
+const CLAUDE_PARENT_AGENT_ID_HEADER: &str = "x-claude-code-parent-agent-id";
+
+// OpenCode session headers.
+const OPENCODE_SESSION_ID_HEADER: &str = "x-session-id";
+const OPENCODE_PARENT_SESSION_ID_HEADER: &str = "x-parent-session-id";
+
+// Generic Codex-compatible correlation headers.
+const SESSION_ID_HEADER: &str = "session-id";
+const THREAD_ID_HEADER: &str = "thread-id";
+const TASK_ID_HEADER: &str = "x-task-id";
+const REQUEST_ID_HEADER: &str = "x-request-id";
+const CLIENT_REQUEST_ID_HEADER: &str = "x-client-request-id";
+
 /// Correlation and routing metadata attached to a request or response.
 ///
 /// All fields are optional (or default-empty); algorithms and observers use whichever
@@ -73,31 +115,31 @@ impl Metadata {
             .and_then(|value| serde_json::from_str::<CodexTurnMetadata>(value).ok())
             .unwrap_or_default();
 
-        let switchyard_parent = header(headers, "x-switchyard-parent-agent-id");
-        let relay_subagent = header(headers, "x-nemo-relay-subagent-id");
-        let dynamo_parent = header(headers, "x-dynamo-parent-session-id");
-        let codex_parent = header(headers, "x-codex-parent-thread-id");
-        let openai_subagent = header(headers, "x-openai-subagent");
+        let switchyard_parent = header(headers, SWITCHYARD_PARENT_AGENT_ID_HEADER);
+        let relay_subagent = header(headers, RELAY_SUBAGENT_ID_HEADER);
+        let dynamo_parent = header(headers, DYNAMO_PARENT_SESSION_ID_HEADER);
+        let codex_parent = header(headers, CODEX_PARENT_THREAD_ID_HEADER);
+        let openai_subagent = header(headers, OPENAI_SUBAGENT_HEADER);
 
         // Claude Code names a session and, for a spawned child, a distinct agent id.
         // A child whose agent id differs from the session is a sub-agent; its parent is
         // the explicit parent-agent header, else the session id it was spawned under.
-        let claude_session = header(headers, "x-claude-code-session-id");
-        let claude_agent = header(headers, "x-claude-code-agent-id");
+        let claude_session = header(headers, CLAUDE_SESSION_ID_HEADER);
+        let claude_agent = header(headers, CLAUDE_AGENT_ID_HEADER);
         let claude_subagent = matches!(
             (&claude_agent, &claude_session),
             (Some(agent), Some(session)) if agent != session
         );
         let claude_parent = claude_subagent
-            .then(|| header(headers, "x-claude-code-parent-agent-id").or(claude_session))
+            .then(|| header(headers, CLAUDE_PARENT_AGENT_ID_HEADER).or(claude_session))
             .flatten();
 
         // OpenCode carries a session id and an optional parent session; the parent
         // header is only meaningful alongside OpenCode's own session header.
-        let opencode_session = header(headers, "x-session-id");
+        let opencode_session = header(headers, OPENCODE_SESSION_ID_HEADER);
         let opencode_parent = opencode_session
             .as_ref()
-            .and_then(|_| header(headers, "x-parent-session-id"));
+            .and_then(|_| header(headers, OPENCODE_PARENT_SESSION_ID_HEADER));
 
         let inferred_subagent = switchyard_parent.is_some()
             || relay_subagent.is_some()
@@ -108,26 +150,26 @@ impl Metadata {
             || openai_subagent.is_some()
             || claude_subagent
             || opencode_parent.is_some();
-        let is_subagent = header(headers, "x-switchyard-is-subagent")
+        let is_subagent = header(headers, SWITCHYARD_IS_SUBAGENT_HEADER)
             .and_then(parse_bool)
             .unwrap_or(inferred_subagent);
 
         Metadata {
             session_id: first_some(&[
-                header(headers, "x-switchyard-session-id"),
+                header(headers, SWITCHYARD_SESSION_ID_HEADER),
                 claude_session,
-                header(headers, "x-nemo-relay-session-id"),
+                header(headers, RELAY_SESSION_ID_HEADER),
                 opencode_session,
                 codex.session_id.as_deref(),
-                header(headers, "session-id"),
+                header(headers, SESSION_ID_HEADER),
             ]),
             agent_id: first_some(&[
-                header(headers, "x-switchyard-agent-id"),
+                header(headers, SWITCHYARD_AGENT_ID_HEADER),
                 claude_agent,
                 relay_subagent,
-                header(headers, "x-dynamo-session-id"),
+                header(headers, DYNAMO_SESSION_ID_HEADER),
                 codex.thread_id.as_deref(),
-                header(headers, "thread-id"),
+                header(headers, THREAD_ID_HEADER),
             ]),
             parent_agent_id: first_some(&[
                 switchyard_parent,
@@ -139,31 +181,31 @@ impl Metadata {
             ]),
             is_subagent,
             agent_kind: first_some(&[
-                header(headers, "x-switchyard-agent-kind"),
+                header(headers, SWITCHYARD_AGENT_KIND_HEADER),
                 codex.subagent_kind.as_deref(),
                 openai_subagent,
             ]),
             agent_role: first_some(&[
-                header(headers, "x-switchyard-agent-role"),
+                header(headers, SWITCHYARD_AGENT_ROLE_HEADER),
                 codex.agent_role.as_deref(),
             ]),
             task_id: first_some(&[
-                header(headers, "x-switchyard-task-id"),
+                header(headers, SWITCHYARD_TASK_ID_HEADER),
                 codex.task_id.as_deref(),
-                header(headers, "x-task-id"),
+                header(headers, TASK_ID_HEADER),
             ]),
             task_kind: first_some(&[
-                header(headers, "x-switchyard-task-kind"),
+                header(headers, SWITCHYARD_TASK_KIND_HEADER),
                 codex.task_kind.as_deref(),
             ]),
             turn_id: first_some(&[
-                header(headers, "x-switchyard-turn-id"),
+                header(headers, SWITCHYARD_TURN_ID_HEADER),
                 codex.turn_id.as_deref(),
             ]),
-            session_final: header(headers, "x-dynamo-session-final").and_then(parse_bool),
+            session_final: header(headers, DYNAMO_SESSION_FINAL_HEADER).and_then(parse_bool),
             correlation_id: first_some(&[
-                header(headers, "x-request-id"),
-                header(headers, "x-client-request-id"),
+                header(headers, REQUEST_ID_HEADER),
+                header(headers, CLIENT_REQUEST_ID_HEADER),
             ]),
             ..Metadata::default()
         }

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod core;
+pub mod metadata_processor;
 pub mod noop;
 pub mod rand;

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod affinity;
 pub mod core;
 pub mod metadata_processor;
 pub mod noop;

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -6,3 +6,4 @@ pub mod core;
 pub mod metadata_processor;
 pub mod noop;
 pub mod rand;
+pub mod staged;

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -3,8 +3,11 @@
 
 pub mod affinity;
 pub mod core;
+pub mod escalation;
+pub mod fall_through;
 pub mod llm_classifier;
 pub mod metadata_processor;
 pub mod noop;
 pub mod rand;
 pub mod staged;
+pub mod turn_gate;

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -3,6 +3,7 @@
 
 pub mod affinity;
 pub mod core;
+pub mod llm_classifier;
 pub mod metadata_processor;
 pub mod noop;
 pub mod rand;

--- a/crates/libsy/src/algorithms/affinity.rs
+++ b/crates/libsy/src/algorithms/affinity.rs
@@ -16,7 +16,7 @@
 //! Identity is derived from correlation metadata: a request is keyed by its session, and a
 //! sub-agent is keyed more finely by `session + agent` — a subset of its session.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use switchyard_protocol::Request;
@@ -74,17 +74,38 @@ struct AffinityAssignments {
 /// chosen model, the request's identity is captured first (on [`Event::Request`]) and
 /// consumed when the decision arrives — this assumes a turn's request is observed before
 /// its decision on the same [`State`], as the driving algorithm folds a turn in order.
+///
+/// [`with_latch_only`](Self::with_latch_only) narrows *which* models are retained — a
+/// decision for any other model routes normally but is not latched (the escalation latch:
+/// retain only the strong tier, never the weak one).
 #[derive(Default)]
-pub struct AffinityRouter;
+pub struct AffinityRouter {
+    /// When set, only these models are retained; a decision for any other model is not latched.
+    latch_only: Option<HashSet<String>>,
+}
 
 impl AffinityRouter {
-    /// Creates a router with empty assignments.
+    /// Creates a router that latches every decision.
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Restricts latching to `models`; a decision for any other model routes but is not
+    /// retained.
+    pub fn with_latch_only(mut self, models: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.latch_only = Some(models.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Whether a decision for `model` should be retained.
+    fn should_latch(&self, model: &str) -> bool {
+        self.latch_only
+            .as_ref()
+            .is_none_or(|set| set.contains(model))
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Processor for AffinityRouter {
     async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
         match event {
@@ -96,14 +117,15 @@ impl Processor for AffinityRouter {
             }
             // Bind the captured identity to the chosen model, keeping any earlier winner.
             Event::Decision(decision) => {
+                let model = decision.selected_model();
                 let fact = state.entry_or_insert_with(AffinityAssignments::default);
                 let Some(key) = fact.pending.take() else {
                     return Ok(());
                 };
-                if !fact.assignments.contains_key(&key) {
+                // Latch only permitted models; others consume `pending` but are not retained.
+                if self.should_latch(model) && !fact.assignments.contains_key(&key) {
                     evict_if_full(&mut fact.assignments);
-                    fact.assignments
-                        .insert(key, decision.selected_model().to_string());
+                    fact.assignments.insert(key, model.to_string());
                 }
             }
             _ => {}
@@ -114,7 +136,12 @@ impl Processor for AffinityRouter {
 
 #[async_trait]
 impl Classifier for AffinityRouter {
-    async fn score(&self, state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &Request,
+        _driver: Option<&crate::Driver>,
+    ) -> Result<Vec<Score>, BoxErr> {
         let Some(key) = affinity_key(request) else {
             return Ok(Vec::new());
         };
@@ -214,7 +241,7 @@ mod tests {
 
         // A different agent in the same session is scored onto the retained model.
         let second = request(session("session-1", "agent-b"));
-        let scores = router.score(&mut state, &second).await?;
+        let scores = router.score(&mut state, &second, None).await?;
         assert_eq!(scores.len(), 1);
         assert_eq!(scores[0].confidence, 1.0);
         assert_eq!(scores[0].target, "model-a");
@@ -231,7 +258,7 @@ mod tests {
         // A later decision for the same identity must not overwrite the first.
         retain(&router, &mut state, &req, "model-b").await?;
 
-        let scores = router.score(&mut state, &req).await?;
+        let scores = router.score(&mut state, &req, None).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -249,7 +276,7 @@ mod tests {
 
         // Same child, different task: still scored onto the retained model.
         let second = request(subagent("child-1", "task-2"));
-        let scores = router.score(&mut state, &second).await?;
+        let scores = router.score(&mut state, &second, None).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -273,7 +300,7 @@ mod tests {
 
         // ...a sibling child in the same session has no assignment of its own yet.
         let sibling = request(subagent("child-2", "task-1"));
-        assert!(router.score(&mut state, &sibling).await?.is_empty());
+        assert!(router.score(&mut state, &sibling, None).await?.is_empty());
         Ok(())
     }
 
@@ -293,7 +320,7 @@ mod tests {
 
         // ...so the sub-agent abstains until it is assigned in its own right.
         let child = request(subagent("child-1", "task-1"));
-        assert!(router.score(&mut state, &child).await?.is_empty());
+        assert!(router.score(&mut state, &child, None).await?.is_empty());
         Ok(())
     }
 
@@ -304,7 +331,7 @@ mod tests {
 
         // No session id at all: nothing to key on.
         let req = request(Metadata::default());
-        assert!(router.score(&mut state, &req).await?.is_empty());
+        assert!(router.score(&mut state, &req, None).await?.is_empty());
         Ok(())
     }
 
@@ -326,7 +353,7 @@ mod tests {
             .await?;
 
         let second = request(session("session-1", "agent-b"));
-        let scores = classifier.score(&mut state, &second).await?;
+        let scores = classifier.score(&mut state, &second, None).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -345,7 +372,7 @@ mod tests {
             .await?;
 
         let req = request(session("session-1", "agent-a"));
-        assert!(router.score(&mut state, &req).await?.is_empty());
+        assert!(router.score(&mut state, &req, None).await?.is_empty());
         Ok(())
     }
 
@@ -365,7 +392,7 @@ mod tests {
             .process(&mut state, Event::Decision(&FixedDecision("model-a")))
             .await?;
 
-        let scores = router.score(&mut state, &req).await?;
+        let scores = router.score(&mut state, &req, None).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -394,10 +421,10 @@ mod tests {
         .await?;
 
         let first = router
-            .score(&mut state, &request(session("session-1", "other")))
+            .score(&mut state, &request(session("session-1", "other")), None)
             .await?;
         let second = router
-            .score(&mut state, &request(session("session-2", "other")))
+            .score(&mut state, &request(session("session-2", "other")), None)
             .await?;
         assert_eq!(
             first.first().map(|score| score.target.as_str()),
@@ -424,7 +451,7 @@ mod tests {
         };
         let req = request(metadata);
         retain(&router, &mut state, &req, "model-a").await?;
-        assert!(router.score(&mut state, &req).await?.is_empty());
+        assert!(router.score(&mut state, &req, None).await?.is_empty());
         Ok(())
     }
 
@@ -449,6 +476,29 @@ mod tests {
             .get::<AffinityAssignments>()
             .map(|fact| fact.assignments.len());
         assert_eq!(len, Some(MAX_ASSIGNMENTS));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn latch_only_retains_matching_models() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new().with_latch_only(["strong"]);
+        let mut state = State::default();
+        let req = request(session("session-1", "agent-a"));
+
+        // A "weak" decision is not retained — a later turn is not latched.
+        retain(&router, &mut state, &req, "weak").await?;
+        assert!(router.score(&mut state, &req, None).await?.is_empty());
+
+        // A "strong" decision is retained — later turns latch onto it.
+        retain(&router, &mut state, &req, "strong").await?;
+        assert_eq!(
+            router
+                .score(&mut state, &req, None)
+                .await?
+                .first()
+                .map(|s| s.target.as_str()),
+            Some("strong")
+        );
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/affinity.rs
+++ b/crates/libsy/src/algorithms/affinity.rs
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Model affinity as a single SDK component.
+//!
+//! [`AffinityRouter`] retains the first model chosen for a request's stable identity and
+//! forces that model on later requests sharing the identity. It is one object that plays
+//! both SDK roles, so registering it as a processor and a classifier cannot drift apart:
+//!
+//! - As a [`Processor`] it *writes* the assignment: it captures the request's identity on
+//!   [`Event::Request`] and binds it to the chosen model on [`Event::Decision`], the first
+//!   assignment for an identity winning.
+//! - As a [`Classifier`] it *reads* the assignment: it scores the retained model with
+//!   confidence `1.0`, or returns no scores to abstain.
+//!
+//! Identity is derived from correlation metadata: a request is keyed by its session, and a
+//! sub-agent is keyed more finely by `session + agent` — a subset of its session.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use switchyard_protocol::Request;
+
+use super::core::{Classifier, Event, Processor, Score, State};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Upper bound on retained assignments, keeping the process-local map from growing
+/// without limit; the oldest entry is evicted once the bound is reached.
+const MAX_ASSIGNMENTS: usize = 4096;
+
+/// The stable identity a model assignment is retained against.
+///
+/// A sub-agent request is keyed by `session + agent` and a root request by session alone,
+/// so a sub-agent's assignment is scoped within — but distinct from — its session's.
+#[derive(Clone, Hash, PartialEq, Eq)]
+enum AffinityKey {
+    /// One model per session, for root-agent traffic.
+    Session(String),
+    /// One model per identified child agent within a session.
+    Subagent { session: String, agent: String },
+}
+
+/// Derives the affinity identity for a request, or `None` when it cannot be keyed
+/// (no session id, or a sub-agent without an agent id).
+fn affinity_key(request: &Request) -> Option<AffinityKey> {
+    let metadata = request.metadata.as_ref()?;
+    let session = metadata.session_id.clone()?;
+    if metadata.is_subagent {
+        Some(AffinityKey::Subagent {
+            session,
+            agent: metadata.agent_id.clone()?,
+        })
+    } else {
+        Some(AffinityKey::Session(session))
+    }
+}
+
+/// The affinity memory folded into [`State`]: the retained model per identity, plus the
+/// key captured from the current turn's request while its decision is pending.
+#[derive(Default)]
+struct AffinityAssignments {
+    /// Identity → retained model, first assignment winning.
+    assignments: HashMap<AffinityKey, String>,
+    /// Key captured on this turn's [`Event::Request`], consumed by its [`Event::Decision`].
+    pending: Option<AffinityKey>,
+}
+
+/// Retains a model per request identity and forces it on later matching requests.
+///
+/// Register the same instance as both a processor and a classifier; the two roles share
+/// the retained assignments through [`State`]. Because a decision event carries only the
+/// chosen model, the request's identity is captured first (on [`Event::Request`]) and
+/// consumed when the decision arrives — this assumes a turn's request is observed before
+/// its decision on the same [`State`], as the driving algorithm folds a turn in order.
+#[derive(Default)]
+pub struct AffinityRouter;
+
+impl AffinityRouter {
+    /// Creates a router with empty assignments.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait(?Send)]
+impl Processor for AffinityRouter {
+    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
+        match event {
+            // Capture the identity now; the model it maps to is only known at the decision.
+            Event::Request(request) => {
+                state
+                    .entry_or_insert_with(AffinityAssignments::default)
+                    .pending = affinity_key(request);
+            }
+            // Bind the captured identity to the chosen model, keeping any earlier winner.
+            Event::Decision(decision) => {
+                let fact = state.entry_or_insert_with(AffinityAssignments::default);
+                let Some(key) = fact.pending.take() else {
+                    return Ok(());
+                };
+                if !fact.assignments.contains_key(&key) {
+                    evict_if_full(&mut fact.assignments);
+                    fact.assignments
+                        .insert(key, decision.selected_model().to_string());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Classifier for AffinityRouter {
+    async fn score(&self, state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
+        let Some(key) = affinity_key(request) else {
+            return Ok(Vec::new());
+        };
+        let assigned = state
+            .get::<AffinityAssignments>()
+            .and_then(|fact| fact.assignments.get(&key).cloned());
+        Ok(match assigned {
+            Some(target) => vec![Score {
+                confidence: 1.0,
+                target,
+            }],
+            None => Vec::new(),
+        })
+    }
+}
+
+/// Evicts one arbitrary assignment when the map has reached [`MAX_ASSIGNMENTS`].
+fn evict_if_full(assignments: &mut HashMap<AffinityKey, String>) {
+    if assignments.len() >= MAX_ASSIGNMENTS {
+        if let Some(evicted) = assignments.keys().next().cloned() {
+            assignments.remove(&evicted);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use switchyard_protocol::{text_request, Decision, Metadata};
+
+    /// A decision that reports a fixed selected model.
+    struct FixedDecision(&'static str);
+
+    impl Decision for FixedDecision {
+        fn selected_model(&self) -> &str {
+            self.0
+        }
+
+        fn reasoning(&self) -> Option<&str> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn request(metadata: Metadata) -> Request {
+        Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: Some(metadata),
+        }
+    }
+
+    fn session(session_id: &str, agent_id: &str) -> Metadata {
+        Metadata {
+            session_id: Some(session_id.to_string()),
+            agent_id: Some(agent_id.to_string()),
+            ..Metadata::default()
+        }
+    }
+
+    fn subagent(agent_id: &str, task_id: &str) -> Metadata {
+        Metadata {
+            session_id: Some("session-1".to_string()),
+            agent_id: Some(agent_id.to_string()),
+            task_id: Some(task_id.to_string()),
+            is_subagent: true,
+            ..Metadata::default()
+        }
+    }
+
+    /// Folds a request and its decision through the router, retaining `model`.
+    async fn retain(
+        router: &AffinityRouter,
+        state: &mut State,
+        request: &Request,
+        model: &'static str,
+    ) -> Result<(), BoxErr> {
+        router.process(state, Event::Request(request)).await?;
+        router
+            .process(state, Event::Decision(&FixedDecision(model)))
+            .await
+    }
+
+    #[tokio::test]
+    async fn session_retains_first_model_across_requests() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let first = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &first, "model-a").await?;
+
+        // A different agent in the same session is scored onto the retained model.
+        let second = request(session("session-1", "agent-b"));
+        let scores = router.score(&mut state, &second).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].confidence, 1.0);
+        assert_eq!(scores[0].target, "model-a");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn first_decision_wins() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let req = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &req, "model-a").await?;
+        // A later decision for the same identity must not overwrite the first.
+        retain(&router, &mut state, &req, "model-b").await?;
+
+        let scores = router.score(&mut state, &req).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_is_keyed_by_agent_not_task() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let first = request(subagent("child-1", "task-1"));
+        retain(&router, &mut state, &first, "model-a").await?;
+
+        // Same child, different task: still scored onto the retained model.
+        let second = request(subagent("child-1", "task-2"));
+        let scores = router.score(&mut state, &second).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_subagents_are_assigned_independently() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // One child in the session is pinned...
+        retain(
+            &router,
+            &mut state,
+            &request(subagent("child-1", "task-1")),
+            "model-a",
+        )
+        .await?;
+
+        // ...a sibling child in the same session has no assignment of its own yet.
+        let sibling = request(subagent("child-2", "task-1"));
+        assert!(router.score(&mut state, &sibling).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_does_not_inherit_session_assignment() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // The session root is pinned, but a sub-agent is keyed separately...
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-1", "root-1")),
+            "model-a",
+        )
+        .await?;
+
+        // ...so the sub-agent abstains until it is assigned in its own right.
+        let child = request(subagent("child-1", "task-1"));
+        assert!(router.score(&mut state, &child).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn classifier_abstains_without_a_session() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // No session id at all: nothing to key on.
+        let req = request(Metadata::default());
+        assert!(router.score(&mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn one_router_serves_both_roles() -> Result<(), BoxErr> {
+        // The same instance is registered under both SDK roles; a decision folded in via
+        // the processor handle is read back via the classifier handle.
+        let router = Arc::new(AffinityRouter::new());
+        let processor: Arc<dyn Processor> = router.clone();
+        let classifier: Arc<dyn Classifier> = router;
+        let mut state = State::default();
+
+        let first = request(session("session-1", "agent-a"));
+        processor
+            .process(&mut state, Event::Request(&first))
+            .await?;
+        processor
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let second = request(session("session-1", "agent-b"));
+        let scores = classifier.score(&mut state, &second).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_without_a_request_is_ignored() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // A decision with no captured identity (no prior request) stores nothing.
+        router
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let req = request(session("session-1", "agent-a"));
+        assert!(router.score(&mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unrelated_events_preserve_the_pending_identity() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        let req = request(session("session-1", "agent-a"));
+        router.process(&mut state, Event::Request(&req)).await?;
+        // A stray signal between the request and its decision must not drop the captured
+        // identity, nor create an assignment of its own.
+        router
+            .process(&mut state, Event::Signal(&crate::Signals {}))
+            .await?;
+        router
+            .process(&mut state, Event::Decision(&FixedDecision("model-a")))
+            .await?;
+
+        let scores = router.score(&mut state, &req).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_sessions_are_assigned_independently() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-1", "agent-a")),
+            "model-a",
+        )
+        .await?;
+        retain(
+            &router,
+            &mut state,
+            &request(session("session-2", "agent-a")),
+            "model-b",
+        )
+        .await?;
+
+        let first = router
+            .score(&mut state, &request(session("session-1", "other")))
+            .await?;
+        let second = router
+            .score(&mut state, &request(session("session-2", "other")))
+            .await?;
+        assert_eq!(
+            first.first().map(|score| score.target.as_str()),
+            Some("model-a")
+        );
+        assert_eq!(
+            second.first().map(|score| score.target.as_str()),
+            Some("model-b")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn subagent_without_an_agent_id_is_not_keyed() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // The sub-agent flag is set but no agent id is present, so no key can be formed;
+        // the request is neither retained nor scored.
+        let metadata = Metadata {
+            session_id: Some("session-1".to_string()),
+            is_subagent: true,
+            ..Metadata::default()
+        };
+        let req = request(metadata);
+        retain(&router, &mut state, &req, "model-a").await?;
+        assert!(router.score(&mut state, &req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn assignments_are_bounded_by_the_cap() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new();
+        let mut state = State::default();
+
+        // One distinct session past the cap forces exactly one eviction.
+        for index in 0..=MAX_ASSIGNMENTS {
+            let session_id = format!("session-{index}");
+            retain(
+                &router,
+                &mut state,
+                &request(session(&session_id, "agent-a")),
+                "model-a",
+            )
+            .await?;
+        }
+
+        let len = state
+            .get::<AffinityAssignments>()
+            .map(|fact| fact.assignments.len());
+        assert_eq!(len, Some(MAX_ASSIGNMENTS));
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/core.rs
+++ b/crates/libsy/src/algorithms/core.rs
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+use crate::Signals;
+use switchyard_protocol::{Decision, Request, Response};
+
+#[derive(Default)]
+pub struct State {
+    items: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl State {
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
+        self.items.get(&TypeId::of::<T>())?.downcast_ref::<T>()
+    }
+
+    pub fn get_mut<T: Any + Send + Sync>(&mut self) -> Option<&mut T> {
+        self.items.get_mut(&TypeId::of::<T>())?.downcast_mut::<T>()
+    }
+
+    pub fn insert<T: Any + Send + Sync>(&mut self, item: T) {
+        self.items.insert(TypeId::of::<T>(), Box::new(item));
+    }
+
+    pub fn entry_or_insert_with<T: Any + Send + Sync>(&mut self, f: impl FnOnce() -> T) -> &mut T {
+        match self
+            .items
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(f()))
+            .downcast_mut::<T>()
+        {
+            Some(value) => value,
+            // The TypeId key guarantees the stored box holds a T.
+            None => unreachable!("State key TypeId matches the stored value type"),
+        }
+    }
+}
+
+pub enum Event<'a> {
+    Request(&'a Request),
+    Signal(&'a Signals),
+    Decision(&'a dyn Decision),
+    ModelRequest(&'a Request),
+    ModelResponse(&'a Response),
+}
+
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Processor mutates state given an event
+// `Event` can carry a `&Response`, whose streaming body is `!Sync`, so the returned
+// future cannot be `Send`; opt out of async_trait's default `Send` bound.
+#[async_trait(?Send)]
+pub trait Processor: Send + Sync {
+    /// Process an event, mutating the state and returning a result.
+    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr>;
+}
+
+pub struct Score {
+    /// [0.0, 1.0] confidence score
+    pub confidence: f64,
+    pub target: String,
+}
+
+#[async_trait]
+pub trait Classifier: Send + Sync {
+    async fn score(&self, state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A couple of unrelated concrete state items so we can prove the bag keys by type.
+    #[derive(Debug, PartialEq)]
+    struct Counter(u32);
+
+    #[derive(Debug, PartialEq)]
+    struct Label(String);
+
+    #[test]
+    fn get_returns_none_when_absent() {
+        let state = State::default();
+        assert!(state.get::<Counter>().is_none());
+    }
+
+    #[test]
+    fn insert_then_get_returns_value() {
+        let mut state = State::default();
+        state.insert(Counter(7));
+        assert_eq!(state.get::<Counter>(), Some(&Counter(7)));
+    }
+
+    #[test]
+    fn insert_replaces_existing_item_of_same_type() {
+        let mut state = State::default();
+        state.insert(Counter(1));
+        state.insert(Counter(2));
+        assert_eq!(state.get::<Counter>(), Some(&Counter(2)));
+    }
+
+    #[test]
+    fn get_mut_mutates_in_place() {
+        let mut state = State::default();
+        state.insert(Counter(0));
+        let Some(counter) = state.get_mut::<Counter>() else {
+            panic!("expected a Counter to be present");
+        };
+        counter.0 += 5;
+        assert_eq!(state.get::<Counter>(), Some(&Counter(5)));
+    }
+
+    #[test]
+    fn get_mut_returns_none_when_absent() {
+        let mut state = State::default();
+        assert!(state.get_mut::<Counter>().is_none());
+    }
+
+    #[test]
+    fn distinct_types_coexist_keyed_by_type() {
+        let mut state = State::default();
+        state.insert(Counter(3));
+        state.insert(Label("hello".to_string()));
+        assert_eq!(state.get::<Counter>(), Some(&Counter(3)));
+        assert_eq!(state.get::<Label>(), Some(&Label("hello".to_string())));
+    }
+
+    #[test]
+    fn entry_or_insert_with_inserts_default_when_absent() {
+        let mut state = State::default();
+        let counter = state.entry_or_insert_with(|| Counter(42));
+        assert_eq!(*counter, Counter(42));
+    }
+
+    #[test]
+    fn entry_or_insert_with_returns_existing_without_calling_default() {
+        let mut state = State::default();
+        state.insert(Counter(1));
+        // The default closure must not run when an item is already present.
+        let counter =
+            state.entry_or_insert_with::<Counter>(|| panic!("default should not be called"));
+        assert_eq!(*counter, Counter(1));
+    }
+
+    #[test]
+    fn entry_or_insert_with_yields_mutable_handle() {
+        let mut state = State::default();
+        *state.entry_or_insert_with(|| Counter(10)) = Counter(11);
+        assert_eq!(state.get::<Counter>(), Some(&Counter(11)));
+    }
+}

--- a/crates/libsy/src/algorithms/core.rs
+++ b/crates/libsy/src/algorithms/core.rs
@@ -8,6 +8,11 @@ use std::collections::HashMap;
 use crate::Signals;
 use switchyard_protocol::{Decision, Request, Response};
 
+/// The per-request accumulator shared across an algorithm's components.
+///
+/// The [`Processor`] chain runs first and *writes* facts into it (keyed by type); the
+/// [`Classifier`] cascade runs next and *reads* those facts to decide. One `State` is
+/// threaded through a single request's whole processor→classifier run.
 #[derive(Default)]
 pub struct State {
     items: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
@@ -50,21 +55,36 @@ pub enum Event<'a> {
 
 type BoxErr = Box<dyn std::error::Error + Send + Sync>;
 
-/// Processor mutates state given an event
+/// Head-of-algorithm state collection.
+///
+/// Processors run first, one after another, before any classifier. Each does *lightweight*
+/// work — read an [`Event`] and accumulate facts into the shared [`State`] — so later
+/// classifiers can key off it. Heavy work (LLM calls, scoring) belongs in a [`Classifier`],
+/// not here.
 // `Event` can carry a `&Response`, whose streaming body is `!Sync`, so the returned
 // future cannot be `Send`; opt out of async_trait's default `Send` bound.
 #[async_trait(?Send)]
 pub trait Processor: Send + Sync {
-    /// Process an event, mutating the state and returning a result.
+    /// Process an event, accumulating facts into `state`.
     async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr>;
 }
 
+/// One classifier's recommendation of a routing `target`, with a `[0.0, 1.0]` confidence.
 pub struct Score {
-    /// [0.0, 1.0] confidence score
+    /// `[0.0, 1.0]` confidence in `target`.
     pub confidence: f64,
+    /// The target (model / tier) being recommended.
     pub target: String,
 }
 
+/// A classification stage in the cascade that runs after the [`Processor`] chain.
+///
+/// Classifiers are tried in turn — ideally cheapest first (e.g. a heuristic `StagedRouter`),
+/// falling back to heavier ones (e.g. an LLM-backed classifier). Each [`score`](Self::score)
+/// call reads the accumulated [`State`] and the request, does its (possibly expensive)
+/// classification, and returns a [`Score`] per recommended `target`. Returning an **empty**
+/// vec **abstains**, deferring to the next classifier; the first classifier to return a
+/// non-empty result decides.
 #[async_trait]
 pub trait Classifier: Send + Sync {
     async fn score(&self, state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr>;

--- a/crates/libsy/src/algorithms/core.rs
+++ b/crates/libsy/src/algorithms/core.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
-use crate::Signals;
-use switchyard_protocol::{Decision, Request, Response};
+use crate::{Driver, Signals};
+use switchyard_protocol::{AggLlmResponse, Decision, Request};
 
 /// The per-request accumulator shared across an algorithm's components.
 ///
@@ -45,12 +45,15 @@ impl State {
     }
 }
 
+/// An event fed to the [`Processor`] chain. Every variant is `Send` so the chain can run
+/// inside an algorithm's `Send` run task; a response-side processor therefore observes the
+/// *buffered* [`AggLlmResponse`], since a live response stream cannot cross that boundary.
 pub enum Event<'a> {
     Request(&'a Request),
     Signal(&'a Signals),
     Decision(&'a dyn Decision),
     ModelRequest(&'a Request),
-    ModelResponse(&'a Response),
+    ModelResponse(&'a AggLlmResponse),
 }
 
 type BoxErr = Box<dyn std::error::Error + Send + Sync>;
@@ -61,9 +64,10 @@ type BoxErr = Box<dyn std::error::Error + Send + Sync>;
 /// work — read an [`Event`] and accumulate facts into the shared [`State`] — so later
 /// classifiers can key off it. Heavy work (LLM calls, scoring) belongs in a [`Classifier`],
 /// not here.
-// `Event` can carry a `&Response`, whose streaming body is `!Sync`, so the returned
-// future cannot be `Send`; opt out of async_trait's default `Send` bound.
-#[async_trait(?Send)]
+///
+/// `process` returns a `Send` future so a processor chain can run inside an algorithm's
+/// `Send` run task — which is why every [`Event`] variant is `Send`.
+#[async_trait]
 pub trait Processor: Send + Sync {
     /// Process an event, accumulating facts into `state`.
     async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr>;
@@ -85,9 +89,18 @@ pub struct Score {
 /// classification, and returns a [`Score`] per recommended `target`. Returning an **empty**
 /// vec **abstains**, deferring to the next classifier; the first classifier to return a
 /// non-empty result decides.
+///
+/// `driver` offloads any model call the classifier itself needs (e.g. an LLM-backed
+/// classifier's own call). It is `None` when the classifier is scored outside an algorithm
+/// run; a classifier that requires it returns an error rather than assuming one is present.
 #[async_trait]
 pub trait Classifier: Send + Sync {
-    async fn score(&self, state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr>;
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &Request,
+        driver: Option<&Driver>,
+    ) -> Result<Vec<Score>, BoxErr>;
 }
 
 #[cfg(test)]

--- a/crates/libsy/src/algorithms/escalation.rs
+++ b/crates/libsy/src/algorithms/escalation.rs
@@ -1,0 +1,522 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Escalation routing, assembled from existing components.
+//!
+//! Escalation routing starts a conversation on the cheap `weak` tier and moves it to `strong`
+//! when an LLM judge sees the run is in recoverable trouble; once escalated, it **latches** to
+//! `strong` for the rest of the session. It is a [`FallThroughClassification`] over:
+//!
+//! - a **latch** ([`AffinityRouter`] retaining only the strong tier) — as a processor it pins
+//!   the session on a strong decision; as the first classifier it short-circuits a latched
+//!   session to `strong` without calling the judge;
+//! - a **[`TurnGate`]** routing `weak` before `min_turn` (too little trajectory to judge);
+//! - a **judge** — an [`LlmClassifier`] over `{strong, weak}` with the escalation rubric that
+//!   scores `strong` high to escalate, failing open to `weak`.
+//!
+//! With `confirmations = 1` (this build) the persisted [`State`](super::core::State) latch is
+//! all the cross-turn memory needed: a strong decision pins the session, and later turns latch.
+//! Multi-verdict confirmation is a later addition.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::affinity::AffinityRouter;
+use super::core::{Classifier, Processor, Score, State};
+use super::fall_through::FallThroughClassification;
+use super::llm_classifier::LlmClassifier;
+use super::turn_gate::TurnGate;
+use crate::{Driver, LlmTarget, LlmTargetSet, Request};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// System prompt for the escalation judge. Condensed from the reference
+/// `escalation_judge.md`, reframed for the per-target score tool: `strong` high = escalate.
+pub const ESCALATION_JUDGE_SYSTEM_PROMPT: &str = "You are an escalation judge for an LLM proxy \
+running a multi-turn agent that started on the cheaper `weak` tier. Judge the recent \
+trajectory — is the agent making real progress toward the stated task, not how hard the task \
+looks — and decide whether the run is in trouble a more capable model would fix. Call the \
+route-selection tool exactly once, scoring `strong` high to escalate and `weak` high to stay. \
+Escalate only on a clear PATTERN of trouble, never a single failed command: the same command \
+or edit failing repeatedly with the same error; near-identical tool calls or file re-reads that \
+gain no new information; claiming success while the latest output shows failure; finishing \
+without the verification the task requires; drifting to unrelated work while the task is \
+unstarted; or desperation (giving up, destructive flailing). Hold `weak` on the healthy \
+friction the cheaper tier works through on its own: a test written to fail first, an error \
+fixed on the next turn, early exploration dead-ends, adaptively handling a missing tool, trying \
+a different approach after one fails, a slow command that has not finished, routine planning, \
+and clean zero-count summaries (\"0 failed\"). When the evidence is thin or ambiguous, score \
+`weak` high. Escalation is one-way and expensive.";
+
+/// Trailing-message window shown to the judge — wider than the classifier default, because
+/// loop detection must see the repeats. Mirrors the reference `recent_turn_window`.
+pub const ESCALATION_JUDGE_TURN_WINDOW: usize = 14;
+
+/// The per-session escalation streak, held in the router's [`State`].
+///
+/// Because a `FallThroughClassification`'s `State` persists for one session, this is a plain
+/// counter — no session keying, unlike the reference's process-global streak store.
+#[derive(Default)]
+struct EscalationStreak {
+    /// Consecutive escalate verdicts (reset by a confirming route or an aged-out decline).
+    escalates: u32,
+    /// Escalate-free judged turns since the last escalate verdict.
+    declines: u32,
+}
+
+/// Requires repeated escalate verdicts before an escalation takes effect.
+///
+/// Wraps a judge [`Classifier`] over `{escalate_target, hold_target}`. Each turn it reads the
+/// judge's top vote and updates the session streak: it routes `escalate_target` only once
+/// `confirmations` escalate verdicts have accrued (within `confirmation_window` — how many
+/// judged turns an escalate verdict stays live across intervening declines); otherwise it
+/// routes `hold_target`. `confirmations = 1` (the default) escalates on the first verdict,
+/// reproducing an unwrapped judge.
+pub struct ConfirmingJudge {
+    judge: Arc<dyn Classifier>,
+    escalate_target: String,
+    hold_target: String,
+    confirmations: u32,
+    confirmation_window: u32,
+}
+
+impl ConfirmingJudge {
+    /// Wraps `judge`, confirming an escalation to `escalate_target` after `confirmations`
+    /// verdicts (minimum 1); other turns route `hold_target`. Window defaults to 1.
+    pub fn new(
+        judge: Arc<dyn Classifier>,
+        escalate_target: impl Into<String>,
+        hold_target: impl Into<String>,
+        confirmations: u32,
+    ) -> Self {
+        Self {
+            judge,
+            escalate_target: escalate_target.into(),
+            hold_target: hold_target.into(),
+            confirmations: confirmations.max(1),
+            confirmation_window: 1,
+        }
+    }
+
+    /// Sets how many judged turns an escalate verdict stays live for confirmation. `1` (the
+    /// default) makes any decline reset the streak; `N` tolerates `N - 1` intervening declines.
+    pub fn with_confirmation_window(mut self, window: u32) -> Self {
+        self.confirmation_window = window.max(1);
+        self
+    }
+}
+
+/// The highest-confidence target in a score set, or `None` when empty.
+fn top_target(scores: &[Score]) -> Option<&str> {
+    scores
+        .iter()
+        .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
+        .map(|score| score.target.as_str())
+}
+
+#[async_trait]
+impl Classifier for ConfirmingJudge {
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &Request,
+        driver: Option<&Driver>,
+    ) -> Result<Vec<Score>, BoxErr> {
+        let scores = self.judge.score(state, request, driver).await?;
+        // The judge abstained — abstain too, deferring to the next classifier.
+        let Some(top) = top_target(&scores) else {
+            return Ok(Vec::new());
+        };
+        let escalated = top == self.escalate_target;
+
+        // Update the session streak and decide whether the escalation is confirmed.
+        let confirmed = {
+            let streak = state.entry_or_insert_with(EscalationStreak::default);
+            if escalated {
+                streak.escalates += 1;
+                streak.declines = 0;
+                streak.escalates >= self.confirmations
+            } else {
+                streak.declines += 1;
+                if streak.declines >= self.confirmation_window {
+                    *streak = EscalationStreak::default();
+                }
+                false
+            }
+        };
+
+        let target = if confirmed {
+            self.escalate_target.clone()
+        } else {
+            self.hold_target.clone()
+        };
+        Ok(vec![Score {
+            confidence: 1.0,
+            target,
+        }])
+    }
+}
+
+/// Builds an escalation router: start on `weak`, let the `judge` model escalate to `strong`
+/// from `min_turn` on (after `confirmations` escalate verdicts), and latch `strong` for the
+/// rest of the session.
+///
+/// `strong` / `weak` are the routed tiers (their `semantic_name`s key the latch, gate, and
+/// judge); `judge` names the model that scores the trajectory. `confirmations` is the number
+/// of escalate verdicts required before escalating (`1` escalates on the first). Wire real
+/// clients onto the targets (or serve the offloaded calls yourself when driving the step
+/// stream).
+pub fn escalation_router(
+    strong: LlmTarget,
+    weak: LlmTarget,
+    judge: LlmTarget,
+    min_turn: usize,
+    confirmations: u32,
+) -> FallThroughClassification {
+    let strong_name = strong.semantic_name.clone();
+    let weak_name = weak.semantic_name.clone();
+
+    // The latch retains only the strong tier: once escalated, later turns stay strong.
+    let latch = Arc::new(AffinityRouter::new().with_latch_only([strong_name.clone()]));
+
+    // The judge scores {strong, weak}; the confirmation gate holds weak until enough escalate
+    // verdicts accrue, then routes strong (which the latch pins).
+    let judge: Arc<dyn Classifier> = Arc::new(
+        LlmClassifier::new(judge, vec![strong_name.clone(), weak_name.clone()])
+            .with_system_prompt(ESCALATION_JUDGE_SYSTEM_PROMPT)
+            .with_recent_turn_window(ESCALATION_JUDGE_TURN_WINDOW)
+            .with_fail_open(weak_name.clone()),
+    );
+    let judge = Arc::new(ConfirmingJudge::new(
+        judge,
+        strong_name,
+        weak_name.clone(),
+        confirmations,
+    ));
+
+    FallThroughClassification::new(LlmTargetSet::new(vec![strong, weak]))
+        .with_processor(latch.clone() as Arc<dyn Processor>)
+        .with_classifier(latch as Arc<dyn Classifier>)
+        .with_classifier(Arc::new(TurnGate::new(weak_name, min_turn)))
+        .with_classifier(judge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use serde_json::json;
+    use switchyard_protocol::{
+        completion_text, AggLlmResponse, ContentBlock, LlmRequest, Message, Metadata,
+        ResponseOutput, Role, ToolCall,
+    };
+
+    use crate::{Algorithm, Context, Decision, LlmResponse, Response, RoutedLlmClient};
+
+    /// A judge stub that votes a scripted target per call (last vote repeats).
+    struct ScriptedJudge {
+        votes: Vec<&'static str>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Classifier for ScriptedJudge {
+        async fn score(
+            &self,
+            _state: &mut State,
+            _request: &Request,
+            _driver: Option<&Driver>,
+        ) -> Result<Vec<Score>, BoxErr> {
+            let index = self
+                .calls
+                .fetch_add(1, Ordering::SeqCst)
+                .min(self.votes.len() - 1);
+            Ok(vec![Score {
+                confidence: 1.0,
+                target: self.votes[index].to_string(),
+            }])
+        }
+    }
+
+    /// Runs one `ConfirmingJudge` turn over shared state, returning the routed target.
+    async fn confirm_turn(gate: &ConfirmingJudge, state: &mut State) -> Result<String, BoxErr> {
+        let scores = gate.score(state, &request(1), None).await?;
+        Ok(scores[0].target.clone())
+    }
+
+    #[tokio::test]
+    async fn confirmations_hold_weak_until_the_streak_is_met() -> Result<(), BoxErr> {
+        // confirmations=2: the first escalate holds weak, the second confirms strong.
+        let gate = ConfirmingJudge::new(
+            Arc::new(ScriptedJudge {
+                votes: vec!["strong"],
+                calls: AtomicUsize::new(0),
+            }),
+            "strong",
+            "weak",
+            2,
+        );
+        let mut state = State::default();
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak");
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "strong");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_decline_resets_the_streak_with_window_one() -> Result<(), BoxErr> {
+        // strong, weak, strong, strong — the decline (window=1) resets, so it takes two more
+        // escalates to confirm.
+        let gate = ConfirmingJudge::new(
+            Arc::new(ScriptedJudge {
+                votes: vec!["strong", "weak", "strong", "strong"],
+                calls: AtomicUsize::new(0),
+            }),
+            "strong",
+            "weak",
+            2,
+        );
+        let mut state = State::default();
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak"); // esc streak 1
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak"); // decline resets
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak"); // esc streak 1 again
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "strong"); // esc streak 2 → confirm
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_wider_window_survives_an_intervening_decline() -> Result<(), BoxErr> {
+        // strong, weak, strong with window=2 — the escalate survives one decline and confirms.
+        let gate = ConfirmingJudge::new(
+            Arc::new(ScriptedJudge {
+                votes: vec!["strong", "weak", "strong"],
+                calls: AtomicUsize::new(0),
+            }),
+            "strong",
+            "weak",
+            2,
+        )
+        .with_confirmation_window(2);
+        let mut state = State::default();
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak"); // esc streak 1
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "weak"); // decline kept (window 2)
+        assert_eq!(confirm_turn(&gate, &mut state).await?, "strong"); // esc streak 2 → confirm
+        Ok(())
+    }
+
+    /// Echoes the routed model name back as the completion (for the strong/weak tiers).
+    struct EchoClient;
+
+    #[async_trait]
+    impl RoutedLlmClient for EchoClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> Result<Response, BoxErr> {
+            Ok(Response {
+                llm_response: LlmResponse::Agg(switchyard_protocol::text_response(
+                    None,
+                    decision.selected_model().to_string(),
+                )),
+                metadata: None,
+            })
+        }
+    }
+
+    /// The judge model: returns a `select_route` tool call, escalating on its first call and
+    /// holding `weak` after — and counts how many times it was consulted.
+    struct JudgeClient(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl RoutedLlmClient for JudgeClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            _decision: Arc<dyn Decision>,
+        ) -> Result<Response, BoxErr> {
+            let (strong, weak) = if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                (0.9, 0.1) // escalate
+            } else {
+                (0.1, 0.9) // hold weak
+            };
+            Ok(Response {
+                llm_response: LlmResponse::Agg(AggLlmResponse {
+                    outputs: vec![ResponseOutput {
+                        role: Role::Assistant,
+                        content: vec![ContentBlock::ToolCall(ToolCall {
+                            id: "call-1".to_string(),
+                            name: crate::DEFAULT_TOOL_NAME.to_string(),
+                            arguments: json!({ "strong": strong, "weak": weak }),
+                        })],
+                        stop_reason: None,
+                    }],
+                    ..AggLlmResponse::default()
+                }),
+                metadata: None,
+            })
+        }
+    }
+
+    fn target(name: &str, client: Arc<dyn RoutedLlmClient>) -> LlmTarget {
+        LlmTarget {
+            semantic_name: name.to_string(),
+            llm_client: Some(client),
+        }
+    }
+
+    /// A same-session request with `user_turns` user messages (each with an assistant reply).
+    fn request(user_turns: usize) -> Request {
+        let mut messages = Vec::new();
+        for index in 0..user_turns {
+            messages.push(Message::text(Role::User, format!("turn {index}")));
+            messages.push(Message::text(Role::Assistant, "working"));
+        }
+        Request {
+            llm_request: LlmRequest {
+                model: Some("auto".to_string()),
+                messages,
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: Some(Metadata {
+                session_id: Some("sess-1".to_string()),
+                ..Metadata::default()
+            }),
+        }
+    }
+
+    /// Runs one turn through the shared router, returning the served completion text.
+    async fn run_turn(
+        router: &Arc<FallThroughClassification>,
+        req: Request,
+    ) -> Result<String, BoxErr> {
+        let (_, response) = router.clone().run(Context::default(), req).await?;
+        response
+            .llm_response
+            .into_agg()
+            .await
+            .map(|agg| completion_text(&agg))
+    }
+
+    #[tokio::test]
+    async fn escalates_then_latches_strong() -> Result<(), BoxErr> {
+        let judge_calls = Arc::new(AtomicUsize::new(0));
+        let echo = Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>;
+        let router = Arc::new(escalation_router(
+            target("strong", echo.clone()),
+            target("weak", echo),
+            target("judge", Arc::new(JudgeClient(judge_calls.clone()))),
+            3,
+            1,
+        ));
+
+        // Turn 1: before min_turn, the gate routes weak and the judge is never called.
+        assert_eq!(run_turn(&router, request(1)).await?, "weak");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 0);
+
+        // Turn 3: the judge runs, escalates, and the strong decision pins the session.
+        assert_eq!(run_turn(&router, request(3)).await?, "strong");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 1);
+
+        // Later turn: the latch routes strong and short-circuits the judge (its call count is
+        // unchanged even though it would now hold weak).
+        assert_eq!(run_turn(&router, request(3)).await?, "strong");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn judge_failure_holds_weak_without_latching() -> Result<(), BoxErr> {
+        /// A judge whose call always fails.
+        struct FailingJudge;
+
+        #[async_trait]
+        impl RoutedLlmClient for FailingJudge {
+            async fn call(
+                &self,
+                _ctx: Context,
+                _request: Request,
+                _decision: Arc<dyn Decision>,
+            ) -> Result<Response, BoxErr> {
+                Err("judge upstream failed".into())
+            }
+        }
+
+        let echo = Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>;
+        let router = Arc::new(escalation_router(
+            target("strong", echo.clone()),
+            target("weak", echo),
+            target("judge", Arc::new(FailingJudge)),
+            3,
+            1,
+        ));
+
+        // Judge fails → fail open to weak, and no strong pin is created...
+        assert_eq!(run_turn(&router, request(3)).await?, "weak");
+        // ...so the next judged turn still routes weak (the session did not latch).
+        assert_eq!(run_turn(&router, request(3)).await?, "weak");
+        Ok(())
+    }
+
+    /// A judge model whose call always escalates; counts how many times it was consulted.
+    struct AlwaysEscalate(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl RoutedLlmClient for AlwaysEscalate {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            _decision: Arc<dyn Decision>,
+        ) -> Result<Response, BoxErr> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(Response {
+                llm_response: LlmResponse::Agg(AggLlmResponse {
+                    outputs: vec![ResponseOutput {
+                        role: Role::Assistant,
+                        content: vec![ContentBlock::ToolCall(ToolCall {
+                            id: "c".to_string(),
+                            name: crate::DEFAULT_TOOL_NAME.to_string(),
+                            arguments: json!({ "strong": 0.9, "weak": 0.1 }),
+                        })],
+                        stop_reason: None,
+                    }],
+                    ..AggLlmResponse::default()
+                }),
+                metadata: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn two_confirmations_escalate_on_the_second_verdict() -> Result<(), BoxErr> {
+        let judge_calls = Arc::new(AtomicUsize::new(0));
+        let echo = Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>;
+        let router = Arc::new(escalation_router(
+            target("strong", echo.clone()),
+            target("weak", echo),
+            target("judge", Arc::new(AlwaysEscalate(judge_calls.clone()))),
+            3,
+            2, // require two escalate verdicts
+        ));
+
+        // First judged turn: escalate verdict #1 holds weak (pending confirmation).
+        assert_eq!(run_turn(&router, request(3)).await?, "weak");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 1);
+
+        // Second judged turn: escalate verdict #2 confirms → strong, and pins the session.
+        assert_eq!(run_turn(&router, request(3)).await?, "strong");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 2);
+
+        // Latched: strong without consulting the judge again.
+        assert_eq!(run_turn(&router, request(3)).await?, "strong");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/escalation.rs
+++ b/crates/libsy/src/algorithms/escalation.rs
@@ -11,12 +11,14 @@
 //!   the session on a strong decision; as the first classifier it short-circuits a latched
 //!   session to `strong` without calling the judge;
 //! - a **[`TurnGate`]** routing `weak` before `min_turn` (too little trajectory to judge);
+//! - optionally a cheap **[`StagedRouter`]** heuristic (see [`escalation_router_with_staged`])
+//!   that decides confident turns for free and defers ambiguous ones to the judge;
 //! - a **judge** — an [`LlmClassifier`] over `{strong, weak}` with the escalation rubric that
-//!   scores `strong` high to escalate, failing open to `weak`.
+//!   scores `strong` high to escalate, failing open to `weak`, wrapped in a [`ConfirmingJudge`]
+//!   that holds `weak` until `confirmations` escalate verdicts accrue.
 //!
-//! With `confirmations = 1` (this build) the persisted [`State`](super::core::State) latch is
-//! all the cross-turn memory needed: a strong decision pins the session, and later turns latch.
-//! Multi-verdict confirmation is a later addition.
+//! The persisted [`State`](super::core::State) is the cross-turn memory: it carries the latch
+//! and the confirmation streak across a session's turns.
 
 use std::sync::Arc;
 
@@ -26,6 +28,7 @@ use super::affinity::AffinityRouter;
 use super::core::{Classifier, Processor, Score, State};
 use super::fall_through::FallThroughClassification;
 use super::llm_classifier::LlmClassifier;
+use super::staged::StagedRouter;
 use super::turn_gate::TurnGate;
 use crate::{Driver, LlmTarget, LlmTargetSet, Request};
 
@@ -175,6 +178,38 @@ pub fn escalation_router(
     min_turn: usize,
     confirmations: u32,
 ) -> FallThroughClassification {
+    build(strong, weak, judge, min_turn, confirmations, None)
+}
+
+/// Like [`escalation_router`], with a cheap [`StagedRouter`] heuristic layer inserted before
+/// the judge.
+///
+/// The staged classifier scores the turn's tool-result signals for free: a confident verdict
+/// (magnitude past `staged_confidence_threshold`) decides the turn — escalating `strong`
+/// (which the latch pins) or holding `weak` — while an ambiguous one abstains and the LLM
+/// judge runs. This is the "cheap heuristic → expensive judge" cascade, so the judge is only
+/// paid for on turns the heuristic cannot call. `StagedRouter` is classifier-only (it extracts
+/// its signals inside `score`), so no extra processor is needed.
+pub fn escalation_router_with_staged(
+    strong: LlmTarget,
+    weak: LlmTarget,
+    judge: LlmTarget,
+    min_turn: usize,
+    confirmations: u32,
+    staged_confidence_threshold: f64,
+) -> FallThroughClassification {
+    build(strong, weak, judge, min_turn, confirmations, Some(staged_confidence_threshold))
+}
+
+/// Shared assembly for the escalation router, optionally inserting a staged heuristic layer.
+fn build(
+    strong: LlmTarget,
+    weak: LlmTarget,
+    judge: LlmTarget,
+    min_turn: usize,
+    confirmations: u32,
+    staged_confidence_threshold: Option<f64>,
+) -> FallThroughClassification {
     let strong_name = strong.semantic_name.clone();
     let weak_name = weak.semantic_name.clone();
 
@@ -183,24 +218,33 @@ pub fn escalation_router(
 
     // The judge scores {strong, weak}; the confirmation gate holds weak until enough escalate
     // verdicts accrue, then routes strong (which the latch pins).
-    let judge: Arc<dyn Classifier> = Arc::new(
+    let judge_llm: Arc<dyn Classifier> = Arc::new(
         LlmClassifier::new(judge, vec![strong_name.clone(), weak_name.clone()])
             .with_system_prompt(ESCALATION_JUDGE_SYSTEM_PROMPT)
             .with_recent_turn_window(ESCALATION_JUDGE_TURN_WINDOW)
             .with_fail_open(weak_name.clone()),
     );
     let judge = Arc::new(ConfirmingJudge::new(
-        judge,
-        strong_name,
+        judge_llm,
+        strong_name.clone(),
         weak_name.clone(),
         confirmations,
     ));
 
-    FallThroughClassification::new(LlmTargetSet::new(vec![strong, weak]))
+    let mut router = FallThroughClassification::new(LlmTargetSet::new(vec![strong, weak]))
         .with_processor(latch.clone() as Arc<dyn Processor>)
         .with_classifier(latch as Arc<dyn Classifier>)
-        .with_classifier(Arc::new(TurnGate::new(weak_name, min_turn)))
-        .with_classifier(judge)
+        .with_classifier(Arc::new(TurnGate::new(weak_name.clone(), min_turn)));
+
+    // Optional cheap heuristic layer between the gate and the judge: staged maps its capable
+    // tier to `strong` and efficient to `weak`, or abstains in its ambiguous band.
+    if let Some(threshold) = staged_confidence_threshold {
+        let staged =
+            StagedRouter::new(strong_name, weak_name).with_confidence_threshold(threshold);
+        router = router.with_classifier(Arc::new(staged));
+    }
+
+    router.with_classifier(judge)
 }
 
 #[cfg(test)]
@@ -212,7 +256,7 @@ mod tests {
     use serde_json::json;
     use switchyard_protocol::{
         completion_text, AggLlmResponse, ContentBlock, LlmRequest, Message, Metadata,
-        ResponseOutput, Role, ToolCall,
+        ResponseOutput, Role, ToolCall, ToolResult,
     };
 
     use crate::{Algorithm, Context, Decision, LlmResponse, Response, RoutedLlmClient};
@@ -517,6 +561,77 @@ mod tests {
         // Latched: strong without consulting the judge again.
         assert_eq!(run_turn(&router, request(3)).await?, "strong");
         assert_eq!(judge_calls.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+
+    // --- staged heuristic layer --------------------------------------------------------
+
+    /// A past-min_turn request whose last tool result is a critical error — the staged
+    /// heuristic reads this as a hard escalation signal.
+    fn troubled_request() -> Request {
+        let messages = vec![
+            Message::text(Role::User, "do the task"),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolCall(ToolCall {
+                    id: "c".to_string(),
+                    name: "Bash".to_string(),
+                    arguments: json!({ "command": "make" }),
+                })],
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult(ToolResult {
+                    tool_call_id: "c".to_string(),
+                    content: vec![ContentBlock::Text { text: "fatal: out of memory".to_string() }],
+                    is_error: None,
+                })],
+            },
+            Message::text(Role::User, "continue"),
+        ];
+        Request {
+            llm_request: LlmRequest { model: Some("auto".to_string()), messages, ..LlmRequest::default() },
+            raw_request: None,
+            metadata: Some(Metadata { session_id: Some("sess-1".to_string()), ..Metadata::default() }),
+        }
+    }
+
+    #[tokio::test]
+    async fn staged_heuristic_escalates_before_the_judge() -> Result<(), BoxErr> {
+        // The staged layer sees a critical error, escalates strong for free, and the judge is
+        // never consulted.
+        let judge_calls = Arc::new(AtomicUsize::new(0));
+        let echo = Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>;
+        let router = Arc::new(escalation_router_with_staged(
+            target("strong", echo.clone()),
+            target("weak", echo),
+            target("judge", Arc::new(JudgeClient(judge_calls.clone()))),
+            3,
+            1,
+            0.75,
+        ));
+
+        assert_eq!(run_turn(&router, troubled_request()).await?, "strong");
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ambiguous_turn_falls_through_the_staged_layer_to_the_judge() -> Result<(), BoxErr> {
+        // A benign turn carries no strong staged signal, so staged abstains and the judge runs.
+        let judge_calls = Arc::new(AtomicUsize::new(0));
+        let echo = Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>;
+        let router = Arc::new(escalation_router_with_staged(
+            target("strong", echo.clone()),
+            target("weak", echo),
+            target("judge", Arc::new(JudgeClient(judge_calls.clone()))),
+            3,
+            1,
+            0.75,
+        ));
+
+        assert_eq!(run_turn(&router, request(3)).await?, "strong"); // judge escalates
+        assert_eq!(judge_calls.load(Ordering::SeqCst), 1); // staged abstained → judge ran
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fall-through classification: a processor chain, then a classifier cascade.
+//!
+//! [`FallThroughClassification`] is the shared routing skeleton. For each request it:
+//!
+//! 1. runs its [`Processor`] chain over [`Event::Request`], accumulating facts into a shared
+//!    [`State`];
+//! 2. tries each [`Classifier`] in turn — the first to return a non-empty score set decides,
+//!    by argmax over that set's [`Score`]s;
+//! 3. resolves the winning target in the [`LlmTargetSet`], publishes the [`Decision`], and
+//!    replays it to the processors over [`Event::Decision`] so stateful ones (session latch /
+//!    affinity) can bind it;
+//! 4. dispatches the routed model call through the [`Driver`].
+//!
+//! Different component lists express different routers over the one skeleton:
+//!
+//! - `[LlmClassifier]` → LLM-classifier routing;
+//! - `[StagedRouter, fallback]` → staged routing (staged abstains in its band; the fallback
+//!   decides);
+//! - `[latch, turn-gate, judge]` (with a latch processor) → escalation routing.
+//!
+//! A classifier that offloads its own model call (e.g. [`LlmClassifier`]) receives the
+//! per-request [`Driver`] through [`Classifier::score`]; classifiers that decide locally
+//! ignore it. Every classifier is a shared instance.
+//!
+//! ## Session state
+//!
+//! The [`State`] is **owned by the router and persists for its lifetime** — one
+//! `FallThroughClassification` is one session, and its `State` carries facts across turns.
+//! That is what lets a stateful component (a session latch / [`AffinityRouter`]) remember a
+//! decision from an earlier turn. The `State` sits behind a lock held for the whole
+//! request→decision fold of a turn (so a turn's fact accumulation is atomic and turns are
+//! serialized), then released before the routed model call.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use super::core::{Classifier, Event, Processor, Score, State};
+use crate::{Algorithm, Context, Decision, Driver, LlmTargetSet, Request, Response};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// The decision a fall-through run produces: the selected model plus a human-readable reason.
+struct RoutedDecision {
+    model: String,
+    reason: String,
+}
+
+impl Decision for RoutedDecision {
+    fn selected_model(&self) -> &str {
+        &self.model
+    }
+
+    fn reasoning(&self) -> Option<&str> {
+        Some(&self.reason)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Processor chain → classifier cascade → routed model call. See the [module docs](self).
+///
+/// Holds the session [`State`], so one instance is one session (see the module docs).
+pub struct FallThroughClassification {
+    processors: Vec<Arc<dyn Processor>>,
+    classifiers: Vec<Arc<dyn Classifier>>,
+    targets: LlmTargetSet,
+    /// Session state, persisted across turns and shared under a lock (see the module docs).
+    state: Mutex<State>,
+}
+
+impl FallThroughClassification {
+    /// Creates an empty router over `targets`; add components with the `with_*` builders.
+    pub fn new(targets: LlmTargetSet) -> Self {
+        Self {
+            processors: Vec::new(),
+            classifiers: Vec::new(),
+            targets,
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    /// Appends a processor to the head-of-request chain.
+    pub fn with_processor(mut self, processor: Arc<dyn Processor>) -> Self {
+        self.processors.push(processor);
+        self
+    }
+
+    /// Appends a classifier to the cascade.
+    pub fn with_classifier(mut self, classifier: Arc<dyn Classifier>) -> Self {
+        self.classifiers.push(classifier);
+        self
+    }
+}
+
+/// The highest-confidence score, or `None` when the set is empty (the classifier abstained).
+/// Ties keep the first — cascade order is the tie-break.
+fn argmax(scores: Vec<Score>) -> Option<Score> {
+    scores.into_iter().reduce(|best, next| {
+        if next.confidence > best.confidence {
+            next
+        } else {
+            best
+        }
+    })
+}
+
+#[async_trait]
+impl Algorithm for FallThroughClassification {
+    async fn create_run_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Response, BoxErr> {
+        // Hold the session state for the whole request→decision fold, so a turn's fact
+        // accumulation is atomic and concurrent turns serialize on it.
+        let mut state = self.state.lock().await;
+
+        // 1. Processor chain accumulates request-side facts into the session State.
+        for processor in &self.processors {
+            processor
+                .process(&mut state, Event::Request(&request))
+                .await?;
+        }
+
+        // 2. Fall through the cascade: the first classifier to score decides (argmax). The
+        //    per-request driver is offered to each — driver-backed classifiers use it.
+        let mut winner: Option<Score> = None;
+        for classifier in &self.classifiers {
+            let scores = classifier
+                .score(&mut state, &request, Some(&driver))
+                .await?;
+            if let Some(score) = argmax(scores) {
+                winner = Some(score);
+                break;
+            }
+        }
+        let Some(winner) = winner else {
+            return Err("fall-through: every classifier abstained".into());
+        };
+
+        // 3. Resolve the target and publish the decision.
+        let target = self.targets.get_target(&winner.target)?;
+        let decision: Arc<dyn Decision> = Arc::new(RoutedDecision {
+            model: winner.target.clone(),
+            reason: format!(
+                "fall-through selected {} (confidence {:.3})",
+                winner.target, winner.confidence
+            ),
+        });
+        driver.info(ctx.clone(), decision.clone()).await?;
+
+        // 4. Replay the decision to the processors so stateful ones (latch / affinity) bind
+        //    it into the session State.
+        for processor in &self.processors {
+            processor
+                .process(&mut state, Event::Decision(decision.as_ref()))
+                .await?;
+        }
+
+        // 5. Release the session state before the (long) routed model call.
+        drop(state);
+        driver
+            .call_llm_target(ctx, &target, request, decision)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use switchyard_protocol::{
+        completion_text, text_response, LlmRequest, Message, Metadata, Role,
+    };
+
+    use crate::{AffinityRouter, LlmResponse, LlmTarget, RoutedLlmClient};
+
+    // --- fixtures ----------------------------------------------------------------------
+
+    /// A client that echoes the routed model name back as the completion.
+    struct EchoClient;
+
+    #[async_trait]
+    impl RoutedLlmClient for EchoClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> Result<Response, BoxErr> {
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(
+                    None,
+                    decision.selected_model().to_string(),
+                )),
+                metadata: None,
+            })
+        }
+    }
+
+    /// A target set whose targets all serve via [`EchoClient`].
+    fn target_set(names: &[&str]) -> LlmTargetSet {
+        LlmTargetSet::new(
+            names
+                .iter()
+                .map(|name| LlmTarget {
+                    semantic_name: name.to_string(),
+                    llm_client: Some(Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>),
+                })
+                .collect(),
+        )
+    }
+
+    /// A classifier that emits fixed scores (empty = abstain).
+    struct FixedClassifier(Vec<Score>);
+
+    #[async_trait]
+    impl Classifier for FixedClassifier {
+        async fn score(
+            &self,
+            _state: &mut State,
+            _request: &Request,
+            _driver: Option<&Driver>,
+        ) -> Result<Vec<Score>, BoxErr> {
+            Ok(self
+                .0
+                .iter()
+                .map(|s| Score {
+                    confidence: s.confidence,
+                    target: s.target.clone(),
+                })
+                .collect())
+        }
+    }
+
+    fn score(target: &str, confidence: f64) -> Score {
+        Score {
+            confidence,
+            target: target.to_string(),
+        }
+    }
+
+    fn fixed(scores: Vec<Score>) -> Arc<dyn Classifier> {
+        Arc::new(FixedClassifier(scores))
+    }
+
+    fn request() -> Request {
+        Request {
+            llm_request: LlmRequest {
+                model: Some("auto".to_string()),
+                messages: vec![Message::text(Role::User, "hi")],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: Some(Metadata {
+                session_id: Some("session-1".to_string()),
+                ..Metadata::default()
+            }),
+        }
+    }
+
+    /// Drives a shared router through one turn, returning the completion text + trace.
+    async fn run_turn(
+        router: &Arc<FallThroughClassification>,
+    ) -> Result<(String, Vec<Arc<dyn Decision>>), BoxErr> {
+        let (trace, response) = router.clone().run(Context::default(), request()).await?;
+        let text = response
+            .llm_response
+            .into_agg()
+            .await
+            .map(|agg| completion_text(&agg))?;
+        Ok((text, trace))
+    }
+
+    /// Drives a fresh router through one turn.
+    async fn run(
+        router: FallThroughClassification,
+    ) -> Result<(String, Vec<Arc<dyn Decision>>), BoxErr> {
+        run_turn(&Arc::new(router)).await
+    }
+
+    // --- tests -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn argmax_picks_the_highest_confidence_target() -> Result<(), BoxErr> {
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_classifier(fixed(vec![score("weak", 0.2), score("strong", 0.9)]));
+        let (model, trace) = run(router).await?;
+        assert_eq!(model, "strong");
+        assert_eq!(trace.len(), 1);
+        assert_eq!(trace[0].selected_model(), "strong");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn falls_through_the_first_abstaining_classifier() -> Result<(), BoxErr> {
+        // First classifier abstains (empty); the second decides.
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_classifier(fixed(vec![]))
+            .with_classifier(fixed(vec![score("weak", 1.0)]));
+        let (model, _) = run(router).await?;
+        assert_eq!(model, "weak");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn first_deciding_classifier_wins_the_cascade() -> Result<(), BoxErr> {
+        // The first classifier decides; the second is never consulted.
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_classifier(fixed(vec![score("strong", 0.6)]))
+            .with_classifier(fixed(vec![score("weak", 1.0)]));
+        let (model, _) = run(router).await?;
+        assert_eq!(model, "strong");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn all_abstaining_is_an_error() -> Result<(), BoxErr> {
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_classifier(fixed(vec![]));
+        assert!(run(router).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn classifiers_receive_the_per_request_driver() -> Result<(), BoxErr> {
+        // A classifier that only decides when handed a driver — proving the cascade offers
+        // the per-request driver to every classifier (driver-backed ones need it).
+        struct NeedsDriver;
+
+        #[async_trait]
+        impl Classifier for NeedsDriver {
+            async fn score(
+                &self,
+                _state: &mut State,
+                _request: &Request,
+                driver: Option<&Driver>,
+            ) -> Result<Vec<Score>, BoxErr> {
+                match driver {
+                    Some(_) => Ok(vec![score("strong", 1.0)]),
+                    None => Err("expected a driver".into()),
+                }
+            }
+        }
+
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_classifier(Arc::new(NeedsDriver));
+        let (model, _) = run(router).await?;
+        assert_eq!(model, "strong");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn processor_observes_request_and_decision() -> Result<(), BoxErr> {
+        use std::sync::Mutex;
+
+        // Records which event kinds it saw, proving the request-then-decision replay.
+        struct RecordingProcessor(Arc<Mutex<Vec<&'static str>>>);
+
+        #[async_trait]
+        impl Processor for RecordingProcessor {
+            async fn process(&self, _state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
+                let kind = match event {
+                    Event::Request(_) => "request",
+                    Event::Decision(_) => "decision",
+                    _ => "other",
+                };
+                self.0.lock().map_err(|_| "lock poisoned")?.push(kind);
+                Ok(())
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let router = FallThroughClassification::new(target_set(&["strong", "weak"]))
+            .with_processor(Arc::new(RecordingProcessor(seen.clone())))
+            .with_classifier(fixed(vec![score("strong", 1.0)]));
+        run(router).await?;
+
+        assert_eq!(
+            *seen.lock().map_err(|_| "lock poisoned")?,
+            vec!["request", "decision"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_state_persists_the_latch_across_turns() -> Result<(), BoxErr> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Picks "strong" on the first call and "weak" thereafter — so a second turn that
+        // still routes "strong" can only be the affinity latch, held in the persistent State.
+        struct StrongThenWeak(AtomicUsize);
+
+        #[async_trait]
+        impl Classifier for StrongThenWeak {
+            async fn score(
+                &self,
+                _state: &mut State,
+                _request: &Request,
+                _driver: Option<&Driver>,
+            ) -> Result<Vec<Score>, BoxErr> {
+                let tier = if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                    "strong"
+                } else {
+                    "weak"
+                };
+                Ok(vec![score(tier, 1.0)])
+            }
+        }
+
+        // AffinityRouter plays both roles; its assignment map lives in the router's State.
+        let affinity = Arc::new(AffinityRouter::new());
+        let router = Arc::new(
+            FallThroughClassification::new(target_set(&["strong", "weak"]))
+                .with_processor(affinity.clone() as Arc<dyn Processor>)
+                .with_classifier(affinity as Arc<dyn Classifier>)
+                .with_classifier(Arc::new(StrongThenWeak(AtomicUsize::new(0)))),
+        );
+
+        // Turn 1: affinity abstains, the fallback picks "strong", the decision pins it.
+        let (turn1, _) = run_turn(&router).await?;
+        assert_eq!(turn1, "strong");
+
+        // Turn 2: the fallback would now pick "weak", but the persisted latch wins — proving
+        // State survives across turns.
+        let (turn2, _) = run_turn(&router).await?;
+        assert_eq!(turn2, "strong");
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/llm_classifier.rs
+++ b/crates/libsy/src/algorithms/llm_classifier.rs
@@ -132,10 +132,10 @@ impl Decision for ClassifierCall {
 /// LLM-backed [`Classifier`]: scores each routing target with one offloaded, tool-calling
 /// model call.
 ///
-/// Holds the [`Driver`] to offload that call (constructor-injected, since only LLM-backed
-/// classifiers need one) and the classifier [`LlmTarget`] naming the scoring model.
+/// The call is offloaded through the [`Driver`] passed to [`score`](Classifier::score); a
+/// [`None`] driver is an error (this classifier cannot decide without one). Holds the
+/// classifier [`LlmTarget`] naming the scoring model.
 pub struct LlmClassifier {
-    driver: Driver,
     classifier_target: LlmTarget,
     /// The target `semantic_name`s to score, one [`Score`] emitted per entry.
     targets: Vec<String>,
@@ -148,11 +148,11 @@ pub struct LlmClassifier {
 }
 
 impl LlmClassifier {
-    /// Creates a classifier that offloads its call through `driver`, scores with
-    /// `classifier_target`, and emits a [`Score`] for each name in `targets`.
-    pub fn new(driver: Driver, classifier_target: LlmTarget, targets: Vec<String>) -> Self {
+    /// Creates a classifier that scores with `classifier_target` and emits a [`Score`] for
+    /// each name in `targets`. Its call is offloaded through the driver given to
+    /// [`score`](Classifier::score).
+    pub fn new(classifier_target: LlmTarget, targets: Vec<String>) -> Self {
         Self {
-            driver,
             classifier_target,
             targets,
             system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
@@ -200,15 +200,19 @@ impl LlmClassifier {
         self
     }
 
-    /// Offloads the tool-calling classification and returns the parsed per-target score map.
-    async fn classify(&self, request: &Request) -> Result<HashMap<String, f64>, BoxErr> {
+    /// Offloads the tool-calling classification through `driver` and returns the parsed
+    /// per-target score map.
+    async fn classify(
+        &self,
+        request: &Request,
+        driver: &Driver,
+    ) -> Result<HashMap<String, f64>, BoxErr> {
         let classify_request =
             self.build_request(summarize_request(request, self.recent_turn_window));
         let decision: Arc<dyn Decision> = Arc::new(ClassifierCall {
             model: self.classifier_target.semantic_name.clone(),
         });
-        let response = self
-            .driver
+        let response = driver
             .call_llm_target(
                 Context::default(),
                 &self.classifier_target,
@@ -229,12 +233,19 @@ impl LlmClassifier {
                 model: Some(self.classifier_target.semantic_name.clone()),
                 instructions: vec![InstructionBlock {
                     role: Role::System,
-                    content: vec![ContentBlock::Text { text: self.system_prompt.clone() }],
+                    content: vec![ContentBlock::Text {
+                        text: self.system_prompt.clone(),
+                    }],
                 }],
                 messages: vec![Message::text(Role::User, summary)],
                 tools: vec![self.route_tool()],
-                tool_choice: Some(ToolChoice::Tool { name: self.tool_name.clone() }),
-                sampling: SamplingParams { temperature: Some(0.0), ..SamplingParams::default() },
+                tool_choice: Some(ToolChoice::Tool {
+                    name: self.tool_name.clone(),
+                }),
+                sampling: SamplingParams {
+                    temperature: Some(0.0),
+                    ..SamplingParams::default()
+                },
                 output: OutputParams {
                     max_output_tokens: Some(self.max_tokens),
                     ..OutputParams::default()
@@ -253,8 +264,11 @@ impl LlmClassifier {
             .iter()
             .map(|name| (name.clone(), json!({ "type": "number" })))
             .collect();
-        let required: Vec<Value> =
-            self.targets.iter().map(|name| Value::String(name.clone())).collect();
+        let required: Vec<Value> = self
+            .targets
+            .iter()
+            .map(|name| Value::String(name.clone()))
+            .collect();
         ToolDefinition {
             name: self.tool_name.clone(),
             description: Some(
@@ -285,15 +299,20 @@ impl LlmClassifier {
 
 #[async_trait]
 impl Classifier for LlmClassifier {
-    async fn score(&self, _state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
-        match self.classify(request).await {
+    async fn score(
+        &self,
+        _state: &mut State,
+        request: &Request,
+        driver: Option<&Driver>,
+    ) -> Result<Vec<Score>, BoxErr> {
+        // The classifier cannot decide without a driver to offload its call.
+        let driver = driver.ok_or("LlmClassifier requires a driver to offload its call")?;
+        match self.classify(request, driver).await {
             // Missing targets score 0.0.
             Ok(parsed) => Ok(self.scores_by(|name| parsed.get(name).copied().unwrap_or(0.0))),
             // On failure, fail open to the configured default target, or propagate.
             Err(err) => match &self.fail_open_target {
-                Some(target) => {
-                    Ok(self.scores_by(|name| if name == target { 1.0 } else { 0.0 }))
-                }
+                Some(target) => Ok(self.scores_by(|name| if name == target { 1.0 } else { 0.0 })),
                 None => Err(err),
             },
         }
@@ -366,7 +385,10 @@ fn summarize_request(request: &Request, recent_turn_window: usize) -> String {
 /// Keeps the routing-signal slice of the conversation: the first user message plus the last
 /// `recent_turn_window` messages (or, with window `0`, just the last user message).
 fn trim_messages(messages: &[Message], recent_turn_window: usize) -> Vec<Value> {
-    let Some(first_user) = messages.iter().position(|message| message.role == Role::User) else {
+    let Some(first_user) = messages
+        .iter()
+        .position(|message| message.role == Role::User)
+    else {
         return Vec::new();
     };
     let mut out = vec![render_message(&messages[first_user])];
@@ -453,7 +475,10 @@ mod tests {
     }
 
     fn target(name: &str) -> LlmTarget {
-        LlmTarget { semantic_name: name.to_string(), llm_client: None }
+        LlmTarget {
+            semantic_name: name.to_string(),
+            llm_client: None,
+        }
     }
 
     fn request(prompt: &str) -> Request {
@@ -476,12 +501,18 @@ mod tests {
                 name: DEFAULT_TOOL_NAME.to_string(),
                 arguments: arguments.clone(),
             })],
-            ModelReply::NoToolCall => vec![ContentBlock::Text { text: "no tool".to_string() }],
+            ModelReply::NoToolCall => vec![ContentBlock::Text {
+                text: "no tool".to_string(),
+            }],
             ModelReply::Error => return Err("classifier upstream failed".into()),
         };
         Ok(Response {
             llm_response: LlmResponse::Agg(AggLlmResponse {
-                outputs: vec![ResponseOutput { role: Role::Assistant, content, stop_reason: None }],
+                outputs: vec![ResponseOutput {
+                    role: Role::Assistant,
+                    content,
+                    stop_reason: None,
+                }],
                 ..AggLlmResponse::default()
             }),
             metadata: None,
@@ -489,17 +520,20 @@ mod tests {
     }
 
     /// Runs a classifier's `score` against a stubbed reply, returning the scores and the
-    /// classifier requests it offloaded.
+    /// classifier requests it offloaded. Builds a driver and serves the one offloaded call.
     async fn run_score(
         classifier: LlmClassifier,
-        driver: Driver,
         request: Request,
         reply: ModelReply,
     ) -> Result<(Vec<Score>, Vec<Request>), BoxErr> {
+        let driver = Driver::new();
         let stream = driver.stream();
+        let task_driver = driver.clone();
         let handle = tokio::spawn(async move {
             let mut state = State::default();
-            classifier.score(&mut state, &request).await
+            classifier
+                .score(&mut state, &request, Some(&task_driver))
+                .await
         });
 
         let mut seen = Vec::new();
@@ -514,10 +548,9 @@ mod tests {
         handle.await?.map(|scores| (scores, seen))
     }
 
-    /// A classifier over `["strong", "weak"]` sharing `driver`.
-    fn classifier(driver: &Driver) -> LlmClassifier {
+    /// A classifier over `["strong", "weak"]`.
+    fn classifier() -> LlmClassifier {
         LlmClassifier::new(
-            driver.clone(),
             target("classifier-model"),
             vec!["strong".to_string(), "weak".to_string()],
         )
@@ -525,10 +558,8 @@ mod tests {
 
     #[tokio::test]
     async fn scores_each_target_from_the_tool_call() -> Result<(), BoxErr> {
-        let driver = Driver::new();
         let (scores, _) = run_score(
-            classifier(&driver),
-            driver.clone(),
+            classifier(),
             request("solve this proof"),
             ModelReply::ToolCall(json!({ "strong": 0.9, "weak": 0.2 })),
         )
@@ -544,10 +575,8 @@ mod tests {
     #[tokio::test]
     async fn tool_call_arguments_as_json_string_are_parsed() -> Result<(), BoxErr> {
         // Some formats deliver `arguments` as a JSON string rather than an object.
-        let driver = Driver::new();
         let (scores, _) = run_score(
-            classifier(&driver),
-            driver.clone(),
+            classifier(),
             request("hi"),
             ModelReply::ToolCall(Value::String(r#"{"strong": 0.4, "weak": 0.6}"#.to_string())),
         )
@@ -559,10 +588,8 @@ mod tests {
 
     #[tokio::test]
     async fn missing_target_scores_zero_and_out_of_range_is_clamped() -> Result<(), BoxErr> {
-        let driver = Driver::new();
         let (scores, _) = run_score(
-            classifier(&driver),
-            driver.clone(),
+            classifier(),
             request("hi"),
             ModelReply::ToolCall(json!({ "strong": 1.5 })),
         )
@@ -575,33 +602,22 @@ mod tests {
 
     #[tokio::test]
     async fn missing_tool_call_without_fail_open_errors() -> Result<(), BoxErr> {
-        let driver = Driver::new();
-        let result = run_score(
-            classifier(&driver),
-            driver.clone(),
-            request("hi"),
-            ModelReply::NoToolCall,
-        )
-        .await;
+        let result = run_score(classifier(), request("hi"), ModelReply::NoToolCall).await;
         assert!(result.is_err());
         Ok(())
     }
 
     #[tokio::test]
     async fn call_error_without_fail_open_propagates() -> Result<(), BoxErr> {
-        let driver = Driver::new();
-        let result =
-            run_score(classifier(&driver), driver.clone(), request("hi"), ModelReply::Error).await;
+        let result = run_score(classifier(), request("hi"), ModelReply::Error).await;
         assert!(result.is_err());
         Ok(())
     }
 
     #[tokio::test]
     async fn fail_open_routes_to_the_default_target() -> Result<(), BoxErr> {
-        let driver = Driver::new();
         let (scores, _) = run_score(
-            classifier(&driver).with_fail_open("weak"),
-            driver.clone(),
+            classifier().with_fail_open("weak"),
             request("hi"),
             ModelReply::Error,
         )
@@ -615,10 +631,8 @@ mod tests {
 
     #[tokio::test]
     async fn classifier_call_forces_the_strict_route_tool() -> Result<(), BoxErr> {
-        let driver = Driver::new();
         let (_, seen) = run_score(
-            classifier(&driver),
-            driver.clone(),
+            classifier(),
             request("prove it"),
             ModelReply::ToolCall(json!({ "strong": 0.9, "weak": 0.1 })),
         )
@@ -626,7 +640,12 @@ mod tests {
         assert_eq!(seen.len(), 1);
         let llm = &seen[0].llm_request;
         // Forced strict tool with a required number property per target.
-        assert_eq!(llm.tool_choice, Some(ToolChoice::Tool { name: DEFAULT_TOOL_NAME.to_string() }));
+        assert_eq!(
+            llm.tool_choice,
+            Some(ToolChoice::Tool {
+                name: DEFAULT_TOOL_NAME.to_string()
+            })
+        );
         assert_eq!(llm.sampling.temperature, Some(0.0));
         assert_eq!(llm.output.max_output_tokens, Some(DEFAULT_MAX_TOKENS));
         let tool = &llm.tools[0];
@@ -645,10 +664,8 @@ mod tests {
 
     #[tokio::test]
     async fn policy_selects_the_traffic_tuned_system_prompt() -> Result<(), BoxErr> {
-        let driver = Driver::new();
         let (_, seen) = run_score(
-            classifier(&driver).with_policy(Policy::CodingAgent),
-            driver.clone(),
+            classifier().with_policy(Policy::CodingAgent),
             request("refactor auth"),
             ModelReply::ToolCall(json!({ "strong": 0.8, "weak": 0.2 })),
         )
@@ -657,15 +674,23 @@ mod tests {
             .llm_request
             .instructions
             .iter()
-            .find_map(|instruction| instruction.content.iter().find_map(|block| match block {
-                ContentBlock::Text { text } => Some(text.clone()),
-                _ => None,
-            }))
+            .find_map(|instruction| {
+                instruction.content.iter().find_map(|block| match block {
+                    ContentBlock::Text { text } => Some(text.clone()),
+                    _ => None,
+                })
+            })
             .unwrap_or_default();
         assert!(system.contains("coding-agent harness"));
         // The three policies carry distinct rubrics.
-        assert_ne!(Policy::General.system_prompt(), Policy::CodingAgent.system_prompt());
-        assert_ne!(Policy::CodingAgent.system_prompt(), Policy::OpenClaw.system_prompt());
+        assert_ne!(
+            Policy::General.system_prompt(),
+            Policy::CodingAgent.system_prompt()
+        );
+        assert_ne!(
+            Policy::CodingAgent.system_prompt(),
+            Policy::OpenClaw.system_prompt()
+        );
         // General is the default.
         assert_eq!(Policy::default(), Policy::General);
         assert_eq!(DEFAULT_SYSTEM_PROMPT, Policy::General.system_prompt());
@@ -680,7 +705,14 @@ mod tests {
             messages.push(Message::text(Role::Assistant, format!("turn {index}")));
         }
         let summary = summarize_request(
-            &Request { llm_request: LlmRequest { messages, ..LlmRequest::default() }, raw_request: None, metadata: None },
+            &Request {
+                llm_request: LlmRequest {
+                    messages,
+                    ..LlmRequest::default()
+                },
+                raw_request: None,
+                metadata: None,
+            },
             4,
         );
         assert!(summary.contains("FIRST")); // first-user anchor kept

--- a/crates/libsy/src/algorithms/llm_classifier.rs
+++ b/crates/libsy/src/algorithms/llm_classifier.rs
@@ -1,0 +1,691 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LLM-classifier routing as a single SDK component.
+//!
+//! [`LlmClassifier`] is the **heavy fallback stage** of a classifier cascade: it runs after
+//! cheaper classifiers (e.g. [`StagedRouter`](super::staged::StagedRouter)) have abstained.
+//! It asks an LLM to score the routing targets, then emits one [`Score`] per target — keyed
+//! by the target's `semantic_name` (`"strong"`, `"weak"`, …), the same name the algorithm's
+//! processors and classifiers route by. An orchestrator picks the argmax.
+//!
+//! The classifier call mirrors the components-v2 `llm_routing` profile's "judge" call:
+//!
+//! - a **forced, strict tool call** (`tool_choice` pins one function, `strict: true`, a
+//!   closed JSON schema) is how the model returns structured output — read from the response
+//!   tool call, not from free-form text. The only departure from v2's schema is the tool's
+//!   parameters: instead of v2's `recommended_tier` + feature fields, they are one number per
+//!   candidate target, so the reply is a per-target score map;
+//! - the user message is a **trimmed conversation summary** — system, tool names and
+//!   descriptions, the first user message, and the last `recent_turn_window` messages, as
+//!   JSON capped at 16k — the port of v2's `summarize_request` / `condense_body` /
+//!   `trim_messages`;
+//! - `temperature: 0` and a `max_tokens` cap, as in v2.
+//!
+//! v2's tier machinery — `RouteSignals` feature schema, the `policy_tier()` variants, tier
+//! mapping, confidence floor, alignment bump, tool-planning escalation — is intentionally
+//! dropped: the LLM scores the targets directly, so none of it is needed here. v2's three
+//! profiles survive as [`Policy`] presets that only swap the system-prompt rubric (the
+//! traffic-specific routing guidance that lived in v2's `policy_tier` weights); the LLM call,
+//! schema, and per-target output are identical across them.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{json, Map, Value};
+use switchyard_protocol::{
+    AggLlmResponse, ContentBlock, Context, Decision, InstructionBlock, LlmRequest, Message,
+    OutputParams, Request, Role, SamplingParams, ToolChoice, ToolDefinition,
+};
+
+use super::core::{Classifier, Score, State};
+use crate::{Driver, LlmTarget};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// A traffic-tuned classifier policy. Selects the system-prompt rubric the classifier scores
+/// by — the per-target equivalent of components-v2's `general` / `coding_agent` / `openclaw`
+/// profiles, whose behavior lived in `policy_tier` weights and now lives in the prompt.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Policy {
+    /// Mixed general traffic (chat, summarization, extraction, generic coding).
+    #[default]
+    General,
+    /// Coding-agent harness turns (Claude Code, Codex, Cursor).
+    CodingAgent,
+    /// OpenClaw personal-assistant channels.
+    OpenClaw,
+}
+
+impl Policy {
+    /// The default system-prompt rubric for this policy.
+    pub fn system_prompt(self) -> &'static str {
+        match self {
+            Policy::General => GENERAL_SYSTEM_PROMPT,
+            Policy::CodingAgent => CODING_AGENT_SYSTEM_PROMPT,
+            Policy::OpenClaw => OPENCLAW_SYSTEM_PROMPT,
+        }
+    }
+}
+
+/// Rubric for mixed general traffic.
+pub const GENERAL_SYSTEM_PROMPT: &str = "You are a model-routing classifier for an LLM proxy. \
+Call the route-selection tool exactly once, scoring each candidate model in [0, 1] for how \
+well suited it is to the next turn (higher = better). \
+Favor a more capable candidate for complex or multi-step reasoning, math or algorithmic work, \
+careful debugging, high-precision or high-stakes output, structured-output formats, and \
+tool- or planning-heavy turns. Favor a cheaper, faster candidate for simple Q&A, chit-chat, \
+short lookups, summarization, and straightforward edits.";
+
+/// Rubric for coding-agent harness turns.
+pub const CODING_AGENT_SYSTEM_PROMPT: &str = "You are a model-routing classifier inside a \
+coding-agent harness. Call the route-selection tool exactly once, scoring each candidate model \
+in [0, 1] for how well suited it is to the next turn (higher = better). \
+Favor a more capable candidate for planning and debugging turns, multi-file or cross-module \
+changes, and genuine multi-step tool orchestration that modifies code. Favor a cheaper, faster \
+candidate for chit-chat and clarifications, exploration and file reads, explanations, and small \
+single-file or single-line edits.";
+
+/// Rubric for OpenClaw personal-assistant channels.
+pub const OPENCLAW_SYSTEM_PROMPT: &str = "You are a model-routing classifier inside an OpenClaw \
+personal-assistant agent. Call the route-selection tool exactly once, scoring each candidate \
+model in [0, 1] for how well suited it is to the next message (higher = better). \
+Favor a more capable candidate for tool orchestration and irreversible external actions \
+(especially high-precision ones), heavy memory recall, ambiguous requests, and deliberate \
+channels. Favor a cheaper, faster candidate for casual chit-chat, quick lookups, simple memory \
+recall, and clarifications on casual channels.";
+
+/// Default classifier system prompt — the [`Policy::General`] rubric.
+pub const DEFAULT_SYSTEM_PROMPT: &str = GENERAL_SYSTEM_PROMPT;
+
+/// Default tool name the classifier is forced to call. Mirrors v2's `select_route`.
+pub const DEFAULT_TOOL_NAME: &str = "select_route";
+
+/// Default `max_tokens` for the classifier call. Mirrors v2's `DEFAULT_CLASSIFIER_MAX_TOKENS`.
+pub const DEFAULT_MAX_TOKENS: u64 = 4096;
+
+/// Default trailing-turn window kept in the summary. Mirrors v2's `default_recent_turn_window`.
+pub const DEFAULT_RECENT_TURN_WINDOW: usize = 4;
+
+/// The routing [`Decision`] behind the classifier's own model call: it names the classifier
+/// model so [`Driver::call_llm_target`] hits it.
+struct ClassifierCall {
+    model: String,
+}
+
+impl Decision for ClassifierCall {
+    fn selected_model(&self) -> &str {
+        &self.model
+    }
+
+    fn reasoning(&self) -> Option<&str> {
+        None
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// LLM-backed [`Classifier`]: scores each routing target with one offloaded, tool-calling
+/// model call.
+///
+/// Holds the [`Driver`] to offload that call (constructor-injected, since only LLM-backed
+/// classifiers need one) and the classifier [`LlmTarget`] naming the scoring model.
+pub struct LlmClassifier {
+    driver: Driver,
+    classifier_target: LlmTarget,
+    /// The target `semantic_name`s to score, one [`Score`] emitted per entry.
+    targets: Vec<String>,
+    system_prompt: String,
+    tool_name: String,
+    max_tokens: u64,
+    recent_turn_window: usize,
+    /// On a classifier failure, the target to route to at confidence `1.0`; `None` propagates.
+    fail_open_target: Option<String>,
+}
+
+impl LlmClassifier {
+    /// Creates a classifier that offloads its call through `driver`, scores with
+    /// `classifier_target`, and emits a [`Score`] for each name in `targets`.
+    pub fn new(driver: Driver, classifier_target: LlmTarget, targets: Vec<String>) -> Self {
+        Self {
+            driver,
+            classifier_target,
+            targets,
+            system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
+            tool_name: DEFAULT_TOOL_NAME.to_string(),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            recent_turn_window: DEFAULT_RECENT_TURN_WINDOW,
+            fail_open_target: None,
+        }
+    }
+
+    /// Selects a traffic-tuned [`Policy`], setting its system-prompt rubric.
+    pub fn with_policy(mut self, policy: Policy) -> Self {
+        self.system_prompt = policy.system_prompt().to_string();
+        self
+    }
+
+    /// Overrides the classifier system prompt (takes precedence over [`with_policy`]).
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = prompt.into();
+        self
+    }
+
+    /// Overrides the forced tool name.
+    pub fn with_tool_name(mut self, name: impl Into<String>) -> Self {
+        self.tool_name = name.into();
+        self
+    }
+
+    /// Sets the classifier call's `max_tokens` cap.
+    pub fn with_max_tokens(mut self, max_tokens: u64) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Sets how many trailing messages the request summary keeps.
+    pub fn with_recent_turn_window(mut self, window: usize) -> Self {
+        self.recent_turn_window = window;
+        self
+    }
+
+    /// Routes to `target` at confidence `1.0` when the classifier call/parse fails, instead
+    /// of propagating the error.
+    pub fn with_fail_open(mut self, target: impl Into<String>) -> Self {
+        self.fail_open_target = Some(target.into());
+        self
+    }
+
+    /// Offloads the tool-calling classification and returns the parsed per-target score map.
+    async fn classify(&self, request: &Request) -> Result<HashMap<String, f64>, BoxErr> {
+        let classify_request =
+            self.build_request(summarize_request(request, self.recent_turn_window));
+        let decision: Arc<dyn Decision> = Arc::new(ClassifierCall {
+            model: self.classifier_target.semantic_name.clone(),
+        });
+        let response = self
+            .driver
+            .call_llm_target(
+                Context::default(),
+                &self.classifier_target,
+                classify_request,
+                decision,
+            )
+            .await?;
+        let aggregate = response.llm_response.into_agg().await?;
+        tool_call_scores(&aggregate, &self.tool_name)
+            .ok_or_else(|| "classifier did not return the route-selection tool call".into())
+    }
+
+    /// Builds the classifier's own request: system prompt, the summary, the forced strict
+    /// route-selection tool, and `temperature: 0` + `max_tokens`.
+    fn build_request(&self, summary: String) -> Request {
+        Request {
+            llm_request: LlmRequest {
+                model: Some(self.classifier_target.semantic_name.clone()),
+                instructions: vec![InstructionBlock {
+                    role: Role::System,
+                    content: vec![ContentBlock::Text { text: self.system_prompt.clone() }],
+                }],
+                messages: vec![Message::text(Role::User, summary)],
+                tools: vec![self.route_tool()],
+                tool_choice: Some(ToolChoice::Tool { name: self.tool_name.clone() }),
+                sampling: SamplingParams { temperature: Some(0.0), ..SamplingParams::default() },
+                output: OutputParams {
+                    max_output_tokens: Some(self.max_tokens),
+                    ..OutputParams::default()
+                },
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        }
+    }
+
+    /// The strict route-selection tool: one required `number` property per candidate target.
+    fn route_tool(&self) -> ToolDefinition {
+        let properties: Map<String, Value> = self
+            .targets
+            .iter()
+            .map(|name| (name.clone(), json!({ "type": "number" })))
+            .collect();
+        let required: Vec<Value> =
+            self.targets.iter().map(|name| Value::String(name.clone())).collect();
+        ToolDefinition {
+            name: self.tool_name.clone(),
+            description: Some(
+                "Score each candidate model in [0, 1] for how well it can handle the next turn."
+                    .to_string(),
+            ),
+            parameters: json!({
+                "type": "object",
+                "properties": Value::Object(properties),
+                "required": required,
+                "additionalProperties": false,
+            }),
+            strict: Some(true),
+        }
+    }
+
+    /// Emits one clamped [`Score`] per target, scored by `confidence`.
+    fn scores_by(&self, confidence: impl Fn(&str) -> f64) -> Vec<Score> {
+        self.targets
+            .iter()
+            .map(|name| Score {
+                confidence: confidence(name).clamp(0.0, 1.0),
+                target: name.clone(),
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Classifier for LlmClassifier {
+    async fn score(&self, _state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
+        match self.classify(request).await {
+            // Missing targets score 0.0.
+            Ok(parsed) => Ok(self.scores_by(|name| parsed.get(name).copied().unwrap_or(0.0))),
+            // On failure, fail open to the configured default target, or propagate.
+            Err(err) => match &self.fail_open_target {
+                Some(target) => {
+                    Ok(self.scores_by(|name| if name == target { 1.0 } else { 0.0 }))
+                }
+                None => Err(err),
+            },
+        }
+    }
+}
+
+// --- classifier output ----------------------------------------------------------------
+
+/// Reads the forced tool call's arguments as a `{target: score}` map, or `None` when the
+/// response carries no such tool call or its arguments are not a JSON object.
+fn tool_call_scores(response: &AggLlmResponse, tool_name: &str) -> Option<HashMap<String, f64>> {
+    let arguments = response
+        .outputs
+        .iter()
+        .flat_map(|output| &output.content)
+        .find_map(|block| match block {
+            ContentBlock::ToolCall(call) if call.name == tool_name => Some(&call.arguments),
+            _ => None,
+        })?;
+    // Arguments arrive as a parsed object on some formats, a JSON string on others.
+    let value = match arguments {
+        Value::String(raw) => serde_json::from_str::<Value>(raw).ok()?,
+        other => other.clone(),
+    };
+    Some(
+        value
+            .as_object()?
+            .iter()
+            .filter_map(|(name, score)| score.as_f64().map(|score| (name.clone(), score)))
+            .collect(),
+    )
+}
+
+// --- request summary (port of v2 summarize_request / condense_body / trim_messages) ----
+
+/// Serializes a trimmed JSON summary of the request for the classifier, capped at 16k chars.
+/// Keeps the model, system instructions, tool names + descriptions, and the trimmed messages.
+fn summarize_request(request: &Request, recent_turn_window: usize) -> String {
+    let llm_request = &request.llm_request;
+    let system: Vec<String> = llm_request
+        .instructions
+        .iter()
+        .filter_map(|instruction| join_text_blocks(&instruction.content))
+        .collect();
+    let messages = trim_messages(&llm_request.messages, recent_turn_window);
+    let tools: Vec<Value> = llm_request
+        .tools
+        .iter()
+        .map(|tool| json!({ "name": tool.name, "description": tool.description }))
+        .collect();
+    let payload = json!({
+        "model": llm_request.model,
+        "system": system,
+        "messages": messages,
+        "tools": tools,
+    });
+
+    const MAX_CHARS: usize = 16_000;
+    let text = payload.to_string();
+    if text.len() <= MAX_CHARS {
+        return text;
+    }
+    let mut end = MAX_CHARS.saturating_sub(15).min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...<truncated>", &text[..end])
+}
+
+/// Keeps the routing-signal slice of the conversation: the first user message plus the last
+/// `recent_turn_window` messages (or, with window `0`, just the last user message).
+fn trim_messages(messages: &[Message], recent_turn_window: usize) -> Vec<Value> {
+    let Some(first_user) = messages.iter().position(|message| message.role == Role::User) else {
+        return Vec::new();
+    };
+    let mut out = vec![render_message(&messages[first_user])];
+    let tail = &messages[first_user + 1..];
+    if recent_turn_window == 0 {
+        if let Some(last_user) = tail.iter().rev().find(|message| message.role == Role::User) {
+            out.push(render_message(last_user));
+        }
+    } else {
+        let start = tail.len().saturating_sub(recent_turn_window);
+        out.extend(tail[start..].iter().map(render_message));
+    }
+    out
+}
+
+/// Renders one message as `{role, content}`, content condensed to text + tool markers.
+fn render_message(message: &Message) -> Value {
+    json!({ "role": role_str(message.role), "content": message_content_summary(&message.content) })
+}
+
+/// Condenses a message's content to one line: text verbatim, tool calls as `<tool_use:name>`,
+/// tool results as a truncated `<tool_result:...>` snippet.
+fn message_content_summary(content: &[ContentBlock]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for block in content {
+        match block {
+            ContentBlock::Text { text } => parts.push(text.clone()),
+            ContentBlock::ToolCall(call) => parts.push(format!("<tool_use:{}>", call.name)),
+            ContentBlock::ToolResult(result) => {
+                let inner = join_text_blocks(&result.content).unwrap_or_default();
+                let snippet: String = inner.chars().take(120).collect();
+                parts.push(format!("<tool_result:{snippet}>"));
+            }
+            _ => {}
+        }
+    }
+    parts.join(" ")
+}
+
+/// Joins the text blocks of a content list, or `None` when it has no text.
+fn join_text_blocks(content: &[ContentBlock]) -> Option<String> {
+    let parts: Vec<&str> = content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+/// The wire-level role name for a normalized [`Role`].
+fn role_str(role: Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::Developer => "developer",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::StreamExt;
+    use switchyard_protocol::{LlmResponse, Response, ResponseOutput, ToolCall};
+
+    use crate::Step;
+
+    /// How the (stubbed) classifier model replies to the offloaded tool-calling call.
+    enum ModelReply {
+        /// Return a `select_route` tool call whose arguments are this JSON value.
+        ToolCall(Value),
+        /// Return an assistant message with no tool call.
+        NoToolCall,
+        /// Fail the model call.
+        Error,
+    }
+
+    fn target(name: &str) -> LlmTarget {
+        LlmTarget { semantic_name: name.to_string(), llm_client: None }
+    }
+
+    fn request(prompt: &str) -> Request {
+        Request {
+            llm_request: LlmRequest {
+                model: Some("auto".to_string()),
+                messages: vec![Message::text(Role::User, prompt)],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        }
+    }
+
+    /// Builds the aggregate response for a stubbed reply.
+    fn reply_response(reply: &ModelReply) -> Result<Response, BoxErr> {
+        let content = match reply {
+            ModelReply::ToolCall(arguments) => vec![ContentBlock::ToolCall(ToolCall {
+                id: "call-1".to_string(),
+                name: DEFAULT_TOOL_NAME.to_string(),
+                arguments: arguments.clone(),
+            })],
+            ModelReply::NoToolCall => vec![ContentBlock::Text { text: "no tool".to_string() }],
+            ModelReply::Error => return Err("classifier upstream failed".into()),
+        };
+        Ok(Response {
+            llm_response: LlmResponse::Agg(AggLlmResponse {
+                outputs: vec![ResponseOutput { role: Role::Assistant, content, stop_reason: None }],
+                ..AggLlmResponse::default()
+            }),
+            metadata: None,
+        })
+    }
+
+    /// Runs a classifier's `score` against a stubbed reply, returning the scores and the
+    /// classifier requests it offloaded.
+    async fn run_score(
+        classifier: LlmClassifier,
+        driver: Driver,
+        request: Request,
+        reply: ModelReply,
+    ) -> Result<(Vec<Score>, Vec<Request>), BoxErr> {
+        let stream = driver.stream();
+        let handle = tokio::spawn(async move {
+            let mut state = State::default();
+            classifier.score(&mut state, &request).await
+        });
+
+        let mut seen = Vec::new();
+        tokio::pin!(stream);
+        while let Some(step) = stream.next().await {
+            if let Step::CallLlm(call) = step? {
+                seen.push(call.get_request().clone());
+                call.respond(reply_response(&reply))?;
+                break;
+            }
+        }
+        handle.await?.map(|scores| (scores, seen))
+    }
+
+    /// A classifier over `["strong", "weak"]` sharing `driver`.
+    fn classifier(driver: &Driver) -> LlmClassifier {
+        LlmClassifier::new(
+            driver.clone(),
+            target("classifier-model"),
+            vec!["strong".to_string(), "weak".to_string()],
+        )
+    }
+
+    #[tokio::test]
+    async fn scores_each_target_from_the_tool_call() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let (scores, _) = run_score(
+            classifier(&driver),
+            driver.clone(),
+            request("solve this proof"),
+            ModelReply::ToolCall(json!({ "strong": 0.9, "weak": 0.2 })),
+        )
+        .await?;
+        assert_eq!(scores.len(), 2);
+        assert_eq!(scores[0].target, "strong");
+        assert!((scores[0].confidence - 0.9).abs() < 1e-9);
+        assert_eq!(scores[1].target, "weak");
+        assert!((scores[1].confidence - 0.2).abs() < 1e-9);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tool_call_arguments_as_json_string_are_parsed() -> Result<(), BoxErr> {
+        // Some formats deliver `arguments` as a JSON string rather than an object.
+        let driver = Driver::new();
+        let (scores, _) = run_score(
+            classifier(&driver),
+            driver.clone(),
+            request("hi"),
+            ModelReply::ToolCall(Value::String(r#"{"strong": 0.4, "weak": 0.6}"#.to_string())),
+        )
+        .await?;
+        assert!((scores[0].confidence - 0.4).abs() < 1e-9);
+        assert!((scores[1].confidence - 0.6).abs() < 1e-9);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_target_scores_zero_and_out_of_range_is_clamped() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let (scores, _) = run_score(
+            classifier(&driver),
+            driver.clone(),
+            request("hi"),
+            ModelReply::ToolCall(json!({ "strong": 1.5 })),
+        )
+        .await?;
+        assert_eq!(scores[0].confidence, 1.0); // clamped
+        assert_eq!(scores[1].target, "weak");
+        assert_eq!(scores[1].confidence, 0.0); // missing → 0.0
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_tool_call_without_fail_open_errors() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let result = run_score(
+            classifier(&driver),
+            driver.clone(),
+            request("hi"),
+            ModelReply::NoToolCall,
+        )
+        .await;
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn call_error_without_fail_open_propagates() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let result =
+            run_score(classifier(&driver), driver.clone(), request("hi"), ModelReply::Error).await;
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fail_open_routes_to_the_default_target() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let (scores, _) = run_score(
+            classifier(&driver).with_fail_open("weak"),
+            driver.clone(),
+            request("hi"),
+            ModelReply::Error,
+        )
+        .await?;
+        assert_eq!(scores[0].target, "strong");
+        assert_eq!(scores[0].confidence, 0.0);
+        assert_eq!(scores[1].target, "weak");
+        assert_eq!(scores[1].confidence, 1.0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn classifier_call_forces_the_strict_route_tool() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let (_, seen) = run_score(
+            classifier(&driver),
+            driver.clone(),
+            request("prove it"),
+            ModelReply::ToolCall(json!({ "strong": 0.9, "weak": 0.1 })),
+        )
+        .await?;
+        assert_eq!(seen.len(), 1);
+        let llm = &seen[0].llm_request;
+        // Forced strict tool with a required number property per target.
+        assert_eq!(llm.tool_choice, Some(ToolChoice::Tool { name: DEFAULT_TOOL_NAME.to_string() }));
+        assert_eq!(llm.sampling.temperature, Some(0.0));
+        assert_eq!(llm.output.max_output_tokens, Some(DEFAULT_MAX_TOKENS));
+        let tool = &llm.tools[0];
+        assert_eq!(tool.strict, Some(true));
+        assert!(tool.parameters["properties"]["strong"].is_object());
+        assert!(tool.parameters["properties"]["weak"].is_object());
+        // The trimmed summary carries the user turn.
+        let user_text = llm
+            .messages
+            .iter()
+            .find_map(|message| message.text_content("\n"))
+            .unwrap_or_default();
+        assert!(user_text.contains("prove it"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn policy_selects_the_traffic_tuned_system_prompt() -> Result<(), BoxErr> {
+        let driver = Driver::new();
+        let (_, seen) = run_score(
+            classifier(&driver).with_policy(Policy::CodingAgent),
+            driver.clone(),
+            request("refactor auth"),
+            ModelReply::ToolCall(json!({ "strong": 0.8, "weak": 0.2 })),
+        )
+        .await?;
+        let system = seen[0]
+            .llm_request
+            .instructions
+            .iter()
+            .find_map(|instruction| instruction.content.iter().find_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            }))
+            .unwrap_or_default();
+        assert!(system.contains("coding-agent harness"));
+        // The three policies carry distinct rubrics.
+        assert_ne!(Policy::General.system_prompt(), Policy::CodingAgent.system_prompt());
+        assert_ne!(Policy::CodingAgent.system_prompt(), Policy::OpenClaw.system_prompt());
+        // General is the default.
+        assert_eq!(Policy::default(), Policy::General);
+        assert_eq!(DEFAULT_SYSTEM_PROMPT, Policy::General.system_prompt());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn summary_trims_to_first_user_and_recent_window() -> Result<(), BoxErr> {
+        // 1 first user + 8 assistant turns; window keeps the first user + last 4 messages.
+        let mut messages = vec![Message::text(Role::User, "FIRST")];
+        for index in 0..8 {
+            messages.push(Message::text(Role::Assistant, format!("turn {index}")));
+        }
+        let summary = summarize_request(
+            &Request { llm_request: LlmRequest { messages, ..LlmRequest::default() }, raw_request: None, metadata: None },
+            4,
+        );
+        assert!(summary.contains("FIRST")); // first-user anchor kept
+        assert!(summary.contains("turn 7")); // last turn kept
+        assert!(!summary.contains("turn 2")); // middle dropped by the window
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/metadata_processor.rs
+++ b/crates/libsy/src/algorithms/metadata_processor.rs
@@ -17,7 +17,7 @@ type BoxErr = Box<dyn std::error::Error + Send + Sync>;
 /// with any metadata already attached to the request, and stores the result in [`State`].
 pub struct MetadataProcessor;
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Processor for MetadataProcessor {
     async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
         // Only the inbound request carries the harness headers we normalize.

--- a/crates/libsy/src/algorithms/metadata_processor.rs
+++ b/crates/libsy/src/algorithms/metadata_processor.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Processor that folds a request's harness HTTP headers into correlation [`Metadata`]
+//! and records the merged envelope in [`State`] for later processors and classifiers.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use switchyard_protocol::Metadata;
+
+use super::core::{Event, Processor, State};
+
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Derives correlation [`Metadata`] from the inbound request's HTTP headers, merges it
+/// with any metadata already attached to the request, and stores the result in [`State`].
+pub struct MetadataProcessor;
+
+#[async_trait(?Send)]
+impl Processor for MetadataProcessor {
+    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
+        // Only the inbound request carries the harness headers we normalize.
+        let Event::Request(request) = event else {
+            return Ok(());
+        };
+
+        // Normalize whatever harness headers the request carries into a neutral envelope.
+        let empty = BTreeMap::new();
+        let headers = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.http_headers.as_ref())
+            .unwrap_or(&empty);
+        let derived = Metadata::from_headers(headers);
+
+        // Merge the request's existing metadata over the header-derived envelope; explicit
+        // request metadata wins field-by-field, header-derived values fill any gaps.
+        let merged = match request.metadata.as_ref() {
+            Some(existing) => merge(existing, derived),
+            None => derived,
+        };
+
+        state.insert(merged);
+        Ok(())
+    }
+}
+
+/// Merges `overlay` beneath `base`: each field takes `base`'s value when present and
+/// falls back to `overlay` otherwise. `is_subagent` is a plain flag, so it is true when
+/// either source flags it.
+fn merge(base: &Metadata, overlay: Metadata) -> Metadata {
+    Metadata {
+        session_id: base.session_id.clone().or(overlay.session_id),
+        agent_id: base.agent_id.clone().or(overlay.agent_id),
+        parent_agent_id: base.parent_agent_id.clone().or(overlay.parent_agent_id),
+        is_subagent: base.is_subagent || overlay.is_subagent,
+        agent_kind: base.agent_kind.clone().or(overlay.agent_kind),
+        agent_role: base.agent_role.clone().or(overlay.agent_role),
+        task_id: base.task_id.clone().or(overlay.task_id),
+        task_kind: base.task_kind.clone().or(overlay.task_kind),
+        turn_id: base.turn_id.clone().or(overlay.turn_id),
+        session_final: base.session_final.or(overlay.session_final),
+        correlation_id: base.correlation_id.clone().or(overlay.correlation_id),
+        extra_metadata: base.extra_metadata.clone().or(overlay.extra_metadata),
+        http_headers: base.http_headers.clone().or(overlay.http_headers),
+        wire_format: base.wire_format.or(overlay.wire_format),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use switchyard_protocol::{LlmRequest, Request};
+
+    /// Builds a request carrying `metadata`, with no LLM payload of interest.
+    fn request(metadata: Option<Metadata>) -> Request {
+        Request {
+            llm_request: LlmRequest::default(),
+            raw_request: None,
+            metadata,
+        }
+    }
+
+    /// A metadata envelope whose only content is the given HTTP headers.
+    fn metadata_with_headers(pairs: &[(&str, &str)]) -> Metadata {
+        Metadata {
+            http_headers: Some(
+                pairs
+                    .iter()
+                    .map(|(name, value)| (name.to_string(), value.to_string()))
+                    .collect(),
+            ),
+            ..Metadata::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn stores_metadata_derived_from_request_headers() -> Result<(), BoxErr> {
+        let request = request(Some(metadata_with_headers(&[(
+            "x-switchyard-session-id",
+            "sess-1",
+        )])));
+
+        let mut state = State::default();
+        MetadataProcessor
+            .process(&mut state, Event::Request(&request))
+            .await?;
+
+        let Some(stored) = state.get::<Metadata>() else {
+            panic!("expected merged metadata to be stored in state");
+        };
+        assert_eq!(stored.session_id.as_deref(), Some("sess-1"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_request_metadata_wins_and_headers_fill_gaps() -> Result<(), BoxErr> {
+        // The request already names a session; a header names a different one and also
+        // supplies an agent id the request lacks.
+        let mut metadata = metadata_with_headers(&[
+            ("x-switchyard-session-id", "from-header"),
+            ("x-switchyard-agent-id", "agent-from-header"),
+        ]);
+        metadata.session_id = Some("explicit-session".to_string());
+        let request = request(Some(metadata));
+
+        let mut state = State::default();
+        MetadataProcessor
+            .process(&mut state, Event::Request(&request))
+            .await?;
+
+        let Some(stored) = state.get::<Metadata>() else {
+            panic!("expected merged metadata to be stored in state");
+        };
+        // Explicit request value wins over the header-derived one.
+        assert_eq!(stored.session_id.as_deref(), Some("explicit-session"));
+        // The header-only field fills the gap the request left.
+        assert_eq!(stored.agent_id.as_deref(), Some("agent-from-header"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_without_metadata_stores_header_derived_only() -> Result<(), BoxErr> {
+        let request = request(None);
+
+        let mut state = State::default();
+        MetadataProcessor
+            .process(&mut state, Event::Request(&request))
+            .await?;
+
+        let Some(stored) = state.get::<Metadata>() else {
+            panic!("expected metadata to be stored in state");
+        };
+        assert_eq!(stored.session_id, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ignores_non_request_events() -> Result<(), BoxErr> {
+        let signals = crate::Signals {};
+
+        let mut state = State::default();
+        MetadataProcessor
+            .process(&mut state, Event::Signal(&signals))
+            .await?;
+
+        assert!(state.get::<Metadata>().is_none());
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/staged.rs
+++ b/crates/libsy/src/algorithms/staged.rs
@@ -3,24 +3,26 @@
 
 //! Staged (cascade) routing as an SDK component.
 //!
-//! [`StagedRouter`] recreates the reference cascade router's first, heuristic stage over
-//! libsy's normalized conversation model. It plays both SDK roles over shared [`State`]:
+//! [`StagedRouter`] is the **cheap first stage** of a classifier cascade: a heuristic
+//! [`Classifier`] that decides confidently-shaped turns for free and abstains on the rest,
+//! deferring to a heavier classifier (e.g. an LLM-backed one). It recreates the reference
+//! cascade router's first, heuristic stage over libsy's normalized conversation model. All
+//! of the per-request work happens in [`score`](Classifier::score), which
 //!
-//! - As a [`Processor`] it extracts a [`ToolResultSignal`] from the request's conversation
-//!   history — the tool calls and tool results already accumulated over the session — and
-//!   stashes it in [`State`]. This is the port of the cascade router's request-side
-//!   dimension collection; it reads the conversation, not correlation metadata.
-//! - As a [`Classifier`] it performs the per-request heuristic scoring: apply hard
-//!   overrides, then a weighted linear score over normalized dimensions. The signed
-//!   `[-1, 1]` score is reranged to a `[0, 1]` capability confidence
-//!   (`confidence = (score + 1) / 2`; `0.0` = strongly efficient, `1.0` = strongly
-//!   capable). A confident score yields one [`Score`] for the winning tier's model; a
-//!   score in the ambiguous band yields no scores, deferring to the next cascade stage.
+//! 1. extracts a [`ToolResultSignal`] from the request's conversation history — the tool
+//!    calls and tool results already accumulated over the session (the port of the cascade
+//!    router's dimension collection; it reads the conversation, not correlation metadata);
+//! 2. applies hard overrides, then a weighted linear score over the normalized dimensions.
+//!
+//! The signed `[-1, 1]` score is reranged to a `[0, 1]` capability confidence
+//! (`confidence = (score + 1) / 2`; `0.0` = strongly efficient, `1.0` = strongly capable). A
+//! confident score yields one [`Score`] for the winning tier's model; a score in the
+//! ambiguous band yields no scores, deferring to the next cascade stage.
 
 use async_trait::async_trait;
 use switchyard_protocol::{ContentBlock, Request, Role};
 
-use super::core::{Classifier, Event, Processor, Score, State};
+use super::core::{Classifier, Score, State};
 
 /// Boxed, thread-safe error type used across the SDK.
 type BoxErr = Box<dyn std::error::Error + Send + Sync>;
@@ -580,8 +582,8 @@ fn apply_overrides(signal: &ToolResultSignal) -> Option<Tier> {
 
 /// Heuristic first stage of a two-tier cascade router.
 ///
-/// Register the same instance as both a processor and a classifier; the processor extracts
-/// the signal and the classifier scores it, sharing [`State`].
+/// A pure [`Classifier`]: [`score`](Classifier::score) extracts the tool-result signal from
+/// the request and scores it in one pass, with no cross-component [`State`].
 pub struct StagedRouter {
     capable_model: String,
     efficient_model: String,
@@ -623,29 +625,16 @@ impl StagedRouter {
     }
 }
 
-#[async_trait(?Send)]
-impl Processor for StagedRouter {
-    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
-        // Extract the tool-result signal from the request's history and stash it for the
-        // classifier. The metadata processor's Metadata fact is left untouched.
-        if let Event::Request(request) = event {
-            state.insert(extract_tool_signals(request));
-        }
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl Classifier for StagedRouter {
-    async fn score(&self, state: &mut State, _request: &Request) -> Result<Vec<Score>, BoxErr> {
-        let Some(signal) = state.get::<ToolResultSignal>() else {
-            // No signal extracted yet: abstain.
-            return Ok(Vec::new());
-        };
+    async fn score(&self, _state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
+        // Extract the tool-result signal from the request's conversation history, then score
+        // it — all the heuristic work happens here, in the classifier.
+        let signal = extract_tool_signals(request);
 
         // Hard overrides jump to the extremes of the capability axis:
         // capable → 1.0, efficient → 0.0.
-        if let Some(tier) = apply_overrides(signal) {
+        if let Some(tier) = apply_overrides(&signal) {
             let confidence = match tier {
                 Tier::Capable => 1.0,
                 Tier::Efficient => 0.0,
@@ -656,7 +645,7 @@ impl Classifier for StagedRouter {
         // Rerange the signed [-1, 1] weighted score onto the [0, 1] capability
         // confidence, then compare it directly against the threshold band. Capable
         // above `threshold`, efficient below `1 - threshold`, abstain in between.
-        let confidence = (weighted_score(&dimensions(signal)) + 1.0) / 2.0;
+        let confidence = (weighted_score(&dimensions(&signal)) + 1.0) / 2.0;
         if confidence >= self.confidence_threshold {
             Ok(self.tier_score(Tier::Capable, confidence))
         } else if confidence <= 1.0 - self.confidence_threshold {
@@ -790,18 +779,17 @@ mod tests {
         assert_eq!(signal.recent_write_count, DEFAULT_RECENT_WINDOW as u32);
     }
 
-    // --- routing (processor + classifier) ----------------------------------------------
+    // --- routing (classifier) ----------------------------------------------------------
 
     async fn route(router: &StagedRouter, request: &Request) -> Result<Vec<Score>, BoxErr> {
         let mut state = State::default();
-        router.process(&mut state, Event::Request(request)).await?;
         router.score(&mut state, request).await
     }
 
     #[tokio::test]
-    async fn no_signal_abstains() -> Result<(), BoxErr> {
-        let mut state = State::default();
-        let scores = router().score(&mut state, &request_from(vec![])).await?;
+    async fn empty_request_abstains() -> Result<(), BoxErr> {
+        // No conversation history: a neutral signal scores to the ambiguous band → abstain.
+        let scores = route(&router(), &request_from(vec![])).await?;
         assert!(scores.is_empty());
         Ok(())
     }
@@ -850,21 +838,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn one_router_serves_both_roles() -> Result<(), BoxErr> {
-        let router = Arc::new(router());
-        let processor: Arc<dyn Processor> = router.clone();
-        let classifier: Arc<dyn Classifier> = router;
+    async fn shared_classifier_scores_via_trait_object() -> Result<(), BoxErr> {
+        // The router is used behind an `Arc<dyn Classifier>`, as an orchestrator would hold it.
+        let classifier: Arc<dyn Classifier> = Arc::new(router());
         let mut state = State::default();
-
         let request = request_from(vec![user(vec![tool_result("out of memory")])]);
-        processor
-            .process(&mut state, Event::Request(&request))
-            .await?;
         let scores = classifier.score(&mut state, &request).await?;
-        assert_eq!(
-            scores.first().map(|score| score.target.as_str()),
-            Some("capable-model")
-        );
+        assert_eq!(scores.first().map(|score| score.target.as_str()), Some("capable-model"));
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/staged.rs
+++ b/crates/libsy/src/algorithms/staged.rs
@@ -627,7 +627,12 @@ impl StagedRouter {
 
 #[async_trait]
 impl Classifier for StagedRouter {
-    async fn score(&self, _state: &mut State, request: &Request) -> Result<Vec<Score>, BoxErr> {
+    async fn score(
+        &self,
+        _state: &mut State,
+        request: &Request,
+        _driver: Option<&crate::Driver>,
+    ) -> Result<Vec<Score>, BoxErr> {
         // Extract the tool-result signal from the request's conversation history, then score
         // it — all the heuristic work happens here, in the classifier.
         let signal = extract_tool_signals(request);
@@ -783,7 +788,7 @@ mod tests {
 
     async fn route(router: &StagedRouter, request: &Request) -> Result<Vec<Score>, BoxErr> {
         let mut state = State::default();
-        router.score(&mut state, request).await
+        router.score(&mut state, request, None).await
     }
 
     #[tokio::test]
@@ -843,8 +848,11 @@ mod tests {
         let classifier: Arc<dyn Classifier> = Arc::new(router());
         let mut state = State::default();
         let request = request_from(vec![user(vec![tool_result("out of memory")])]);
-        let scores = classifier.score(&mut state, &request).await?;
-        assert_eq!(scores.first().map(|score| score.target.as_str()), Some("capable-model"));
+        let scores = classifier.score(&mut state, &request, None).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("capable-model")
+        );
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/staged.rs
+++ b/crates/libsy/src/algorithms/staged.rs
@@ -1,0 +1,1225 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Staged (cascade) routing as an SDK component.
+//!
+//! [`StagedRouter`] recreates the reference cascade router's first, heuristic stage over
+//! libsy's normalized conversation model. It plays both SDK roles over shared [`State`]:
+//!
+//! - As a [`Processor`] it extracts a [`ToolResultSignal`] from the request's conversation
+//!   history — the tool calls and tool results already accumulated over the session — and
+//!   stashes it in [`State`]. This is the port of the cascade router's request-side
+//!   dimension collection; it reads the conversation, not correlation metadata.
+//! - As a [`Classifier`] it performs the per-request heuristic scoring: apply hard
+//!   overrides, then a weighted linear score over normalized dimensions. The signed
+//!   `[-1, 1]` score is reranged to a `[0, 1]` capability confidence
+//!   (`confidence = (score + 1) / 2`; `0.0` = strongly efficient, `1.0` = strongly
+//!   capable). A confident score yields one [`Score`] for the winning tier's model; a
+//!   score in the ambiguous band yields no scores, deferring to the next cascade stage.
+
+use async_trait::async_trait;
+use switchyard_protocol::{ContentBlock, Request, Role};
+
+use super::core::{Classifier, Event, Processor, Score, State};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Default confidence threshold, in reranged `[0, 1]` confidence units: the heuristic
+/// routes capable at `confidence >= threshold`, efficient at `confidence <= 1 - threshold`,
+/// and defers to the next cascade stage inside the `[1 - threshold, threshold]` band.
+/// `0.75` is the rerange of the reference's `0.5` magnitude threshold (`(0.5 + 1) / 2`).
+pub const DEFAULT_CONFIDENCE_THRESHOLD: f64 = 0.75;
+
+/// Number of most-recent tool calls the `recent_*` counters window over.
+pub const DEFAULT_RECENT_WINDOW: usize = 3;
+
+/// Minimum turn depth for the "clean tests, run settled" efficient override.
+const CLEAN_TESTS_MIN_TURN_DEPTH: u32 = 10;
+/// Maximum writes for the "clean tests, run settled" efficient override.
+const CLEAN_TESTS_MAX_WRITES: u32 = 1;
+/// Half-saturation point for the pure-bash streak intensity.
+const PURE_BASH_NORM: f64 = 8.0;
+
+// --- Signal extraction (port of dimension_collector::tool_signals) --------------------
+
+/// Soft/hard/critical severities on the `[0, 1]` scale.
+const SOFT: f32 = 0.3;
+const HARD: f32 = 0.7;
+const CRITICAL: f32 = 1.0;
+
+/// Error-pattern table: `(name, severity, substrings)`. A tool result trips a pattern
+/// when it contains any of the substrings (case-insensitive); its severity is the max.
+static ERROR_PATTERNS: &[(&str, f32, &[&str])] = &[
+    (
+        "oom",
+        CRITICAL,
+        &["out of memory", "memoryerror", "cannot allocate memory"],
+    ),
+    (
+        "connection_refused",
+        CRITICAL,
+        &[
+            "connection refused",
+            "connectionrefusederror",
+            "econnrefused",
+        ],
+    ),
+    ("traceback", HARD, &["traceback (most recent call last)"]),
+    (
+        "import_error",
+        HARD,
+        &["modulenotfounderror:", "importerror:", "no module named "],
+    ),
+    (
+        "cmd_not_found",
+        HARD,
+        &["command not found", "not found\n", "/usr/bin/env: "],
+    ),
+    ("assertion", HARD, &["assertionerror"]),
+    ("value_error", HARD, &["valueerror:"]),
+    ("syntax_error", HARD, &["syntaxerror:"]),
+    (
+        "timeout",
+        HARD,
+        &[
+            "timed out",
+            "timeouterror",
+            "timeout expired",
+            "deadline exceeded",
+        ],
+    ),
+    (
+        "no_such_file",
+        HARD,
+        &["filenotfounderror:", "no such file or directory"],
+    ),
+    (
+        "exit_nonzero",
+        SOFT,
+        &[
+            "exit code 1",
+            "exit code 2",
+            "exit status 1",
+            "returned non-zero",
+            "exited with code",
+        ],
+    ),
+];
+
+static EDIT_TOOL_NAMES: &[&str] = &[
+    "edit",
+    "multiedit",
+    "notebookedit",
+    "str_replace",
+    "str_replace_based_edit_tool",
+    "text_editor",
+];
+static WRITE_TOOL_NAMES: &[&str] = &["write", "create_file", "new_file"];
+static READ_TOOL_NAMES: &[&str] = &["read", "view"];
+static PLAN_TOOL_NAMES: &[&str] = &["todowrite", "todo_write", "todo", "update_plan"];
+static BASH_TOOL_NAMES: &[&str] = &["bash", "shell_command", "shell", "local_shell_call"];
+
+static BASH_WRITE_PATTERNS: &[&str] = &[
+    "cat >",
+    "cat >>",
+    "echo >",
+    "echo >>",
+    "tee ",
+    "printf >",
+    "printf >>",
+    "> /",
+    ">> /",
+    "<< 'eof'",
+    "<<eof",
+    "<<'eof'",
+    "<< eof",
+];
+static BASH_EDIT_PATTERNS: &[&str] = &[
+    "sed -i",
+    "sed --in-place",
+    "awk -i inplace",
+    "awk 'inplace=1'",
+    "patch ",
+    "patch -p",
+    "perl -i",
+    "perl -p -i",
+    "perl -pi",
+];
+static BASH_READ_PATTERNS: &[&str] = &[
+    "cat /", "cat ./", "cat ../", "grep ", "ls ", "ls -", "find ", "head ", "tail ", "wc ",
+    "diff ", "which ", "ps ", "df ", "du ", "stat ", "file ", "less ", "more ",
+];
+
+static TEST_PASS_PHRASES: &[&str] = &[
+    " passed",
+    "passed in",
+    "tests passed",
+    "all tests passed",
+    "test ok",
+    "test result: ok",
+    "passed.\n",
+    "tests pass",
+    "\nok ",
+    "✓ ",
+];
+static TEST_FAILURE_LITERAL: &[&str] = &["✗ ", "fatal:", "assertionerror", "error:"];
+static NUMERIC_FAILURE_KEYWORDS: &[&str] = &["failed", "failure", "failures", "errors", "error"];
+
+/// A normalized snapshot of coding-agent state extracted from a conversation, the input to
+/// the heuristic score. Mirrors the reference `ToolResultSignal`.
+#[derive(Clone, Debug, Default)]
+pub struct ToolResultSignal {
+    /// Severity of the latest tool result, in `[0, 1]`; `1.0` is critical.
+    pub severity: f32,
+    /// Names of the error patterns the latest tool result tripped.
+    pub patterns: Vec<String>,
+    /// Consecutive clean tool results, counted back from the most recent.
+    pub no_error_streak: u32,
+    /// Cumulative edit/write/read/plan tool-call counts.
+    pub edit_count: u32,
+    pub write_count: u32,
+    pub read_count: u32,
+    pub todowrite_count: u32,
+    /// The same counts restricted to the most recent [`DEFAULT_RECENT_WINDOW`] calls.
+    pub recent_edit_count: u32,
+    pub recent_write_count: u32,
+    pub recent_read_count: u32,
+    pub recent_todowrite_count: u32,
+    /// Trailing run of uncategorized (bash-ish) tool calls.
+    pub pure_bash_streak: u32,
+    /// Whether a recent tool result reads as a passing test run.
+    pub tests_passed: bool,
+    /// Number of messages in the conversation.
+    pub turn_depth: u32,
+    /// Character length of the last user message's text.
+    pub prompt_char_count: u32,
+}
+
+/// A tool call observed in the conversation: its name and (for bash) its command string.
+struct ObservedToolCall {
+    name: String,
+    command: Option<String>,
+}
+
+/// The write/edit/read/plan class a tool call falls into.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ToolCategory {
+    Write,
+    Edit,
+    Read,
+    Plan,
+    Other,
+}
+
+/// Classifies a tool result's text: the max severity over the patterns it trips, plus
+/// their names in table order.
+fn classify_text(text: &str) -> (f32, Vec<String>) {
+    let lower = text.to_lowercase();
+    let mut patterns = Vec::new();
+    let mut severity: f32 = 0.0;
+    for (name, sev, substrings) in ERROR_PATTERNS {
+        if substrings.iter().any(|sub| lower.contains(sub)) {
+            patterns.push((*name).to_string());
+            severity = severity.max(*sev);
+        }
+    }
+    (severity, patterns)
+}
+
+/// Classifies a tool call by name, consulting the command for bash-family tools.
+fn classify_tool_call(name: &str, command: Option<&str>) -> ToolCategory {
+    let lower = name.to_lowercase();
+    if WRITE_TOOL_NAMES.contains(&lower.as_str()) {
+        return ToolCategory::Write;
+    }
+    if EDIT_TOOL_NAMES.contains(&lower.as_str()) {
+        return ToolCategory::Edit;
+    }
+    if READ_TOOL_NAMES.contains(&lower.as_str()) {
+        return ToolCategory::Read;
+    }
+    if PLAN_TOOL_NAMES.contains(&lower.as_str()) {
+        return ToolCategory::Plan;
+    }
+    if BASH_TOOL_NAMES.contains(&lower.as_str()) {
+        if let Some(cmd) = command {
+            // Redirection (write) trumps in-place edit trumps read inspection.
+            if BASH_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
+                return ToolCategory::Write;
+            }
+            if BASH_EDIT_PATTERNS.iter().any(|p| cmd.contains(p)) {
+                return ToolCategory::Edit;
+            }
+            if BASH_READ_PATTERNS.iter().any(|p| cmd.contains(p)) {
+                return ToolCategory::Read;
+            }
+        }
+    }
+    ToolCategory::Other
+}
+
+/// Consecutive clean (severity-zero) tool results, counted back from the most recent.
+fn compute_no_error_streak(tool_texts: &[String]) -> u32 {
+    let mut streak = 0u32;
+    for text in tool_texts.iter().rev() {
+        let (sev, _) = classify_text(text);
+        if sev > 0.0 {
+            break;
+        }
+        streak += 1;
+    }
+    streak
+}
+
+/// Whether any of the last up-to-three tool results reads as a passing test run.
+fn detect_tests_passed(tool_texts: &[String]) -> bool {
+    let recent = if tool_texts.len() > 3 {
+        &tool_texts[tool_texts.len() - 3..]
+    } else {
+        tool_texts
+    };
+    recent.iter().any(|text| {
+        let lower = text.to_lowercase();
+        TEST_PASS_PHRASES.iter().any(|p| lower.contains(p))
+            && !TEST_FAILURE_LITERAL.iter().any(|p| lower.contains(p))
+            && !has_nonzero_failure_count(&lower)
+    })
+}
+
+/// Whether the text contains a nonzero failure/error count like "1 failed" (but not
+/// "0 failed" or "errored").
+fn has_nonzero_failure_count(lower: &str) -> bool {
+    for kw in NUMERIC_FAILURE_KEYWORDS {
+        let mut cursor = 0usize;
+        while let Some(rel) = lower[cursor..].find(kw) {
+            let kw_start = cursor + rel;
+            let kw_end = kw_start + kw.len();
+            // Require a word boundary after the keyword so "errored" doesn't match "error".
+            let boundary_after = lower[kw_end..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_ascii_alphanumeric());
+            if boundary_after {
+                let prefix = &lower[..kw_start];
+                let trimmed = prefix.trim_end_matches(char::is_whitespace);
+                let digits_rev: String = trimmed
+                    .chars()
+                    .rev()
+                    .take_while(char::is_ascii_digit)
+                    .collect();
+                if !digits_rev.is_empty() && digits_rev.chars().any(|d| d != '0') {
+                    return true;
+                }
+            }
+            cursor = kw_start + kw.len();
+        }
+    }
+    false
+}
+
+/// Joins the text blocks of a tool result's content, or `None` when it has no text.
+fn content_to_text(content: &[ContentBlock]) -> Option<String> {
+    let parts: Vec<&str> = content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+/// Extracts a [`ToolResultSignal`] from a request's conversation history, windowing the
+/// `recent_*` counters over the last `recent_window` tool calls.
+fn extract_tool_signals_with_window(request: &Request, recent_window: usize) -> ToolResultSignal {
+    let messages = &request.llm_request.messages;
+    let mut tool_texts: Vec<String> = Vec::new();
+    let mut tool_calls: Vec<ObservedToolCall> = Vec::new();
+    let mut prompt_char_count = 0u32;
+
+    for message in messages {
+        let is_user = matches!(message.role, Role::User);
+        let mut user_text_len = 0u32;
+        for block in &message.content {
+            match block {
+                ContentBlock::ToolCall(call) => {
+                    let command = call
+                        .arguments
+                        .get("command")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_lowercase);
+                    tool_calls.push(ObservedToolCall {
+                        name: call.name.clone(),
+                        command,
+                    });
+                }
+                ContentBlock::ToolResult(result) => {
+                    if let Some(text) = content_to_text(&result.content) {
+                        tool_texts.push(text);
+                    }
+                }
+                ContentBlock::Text { text } if is_user => {
+                    user_text_len += text.len() as u32;
+                }
+                _ => {}
+            }
+        }
+        if is_user && user_text_len > 0 {
+            prompt_char_count = user_text_len;
+        }
+    }
+
+    let turn_depth = messages.len() as u32;
+    build_signal(
+        &tool_texts,
+        &tool_calls,
+        turn_depth,
+        prompt_char_count,
+        recent_window,
+    )
+}
+
+/// Extracts a [`ToolResultSignal`] using the default recent window.
+fn extract_tool_signals(request: &Request) -> ToolResultSignal {
+    extract_tool_signals_with_window(request, DEFAULT_RECENT_WINDOW)
+}
+
+/// Assembles a [`ToolResultSignal`] from collected tool texts and calls.
+fn build_signal(
+    tool_texts: &[String],
+    tool_calls: &[ObservedToolCall],
+    turn_depth: u32,
+    prompt_char_count: u32,
+    recent_window: usize,
+) -> ToolResultSignal {
+    let (severity, patterns) = tool_texts
+        .last()
+        .map(|text| classify_text(text))
+        .unwrap_or((0.0, Vec::new()));
+    let no_error_streak = compute_no_error_streak(tool_texts);
+
+    // Single reverse pass: cumulative + windowed counts, and the trailing bash streak.
+    let recent_start = tool_calls.len().saturating_sub(recent_window);
+    let mut signal = ToolResultSignal {
+        severity,
+        patterns,
+        no_error_streak,
+        turn_depth,
+        prompt_char_count,
+        tests_passed: detect_tests_passed(tool_texts),
+        ..ToolResultSignal::default()
+    };
+    let mut streak_open = true;
+    for (index, call) in tool_calls.iter().enumerate().rev() {
+        let category = classify_tool_call(&call.name, call.command.as_deref());
+        if streak_open {
+            if matches!(category, ToolCategory::Other) {
+                signal.pure_bash_streak += 1;
+            } else {
+                streak_open = false;
+            }
+        }
+        let recent = index >= recent_start;
+        match category {
+            ToolCategory::Write => {
+                signal.write_count += 1;
+                signal.recent_write_count += u32::from(recent);
+            }
+            ToolCategory::Edit => {
+                signal.edit_count += 1;
+                signal.recent_edit_count += u32::from(recent);
+            }
+            ToolCategory::Read => {
+                signal.read_count += 1;
+                signal.recent_read_count += u32::from(recent);
+            }
+            ToolCategory::Plan => {
+                signal.todowrite_count += 1;
+                signal.recent_todowrite_count += u32::from(recent);
+            }
+            ToolCategory::Other => {}
+        }
+    }
+    signal
+}
+
+// --- Heuristic scoring (port of stage_router scorer + overrides) ----------------------
+
+/// The two model tiers the cascade routes between.
+#[derive(Clone, Copy)]
+enum Tier {
+    /// The stronger, more expensive model.
+    Capable,
+    /// The cheaper, faster model.
+    Efficient,
+}
+
+/// Weighted linear coefficients over [`Dimensions`]. Positive pushes toward capable,
+/// negative toward efficient; magnitudes are calibrated so one high-impact axis clears
+/// the default confidence threshold.
+struct Weights {
+    severity: f64,
+    no_error_streak_intensity: f64,
+    write_intensity: f64,
+    edit_intensity: f64,
+    recent_write_intensity: f64,
+    planning_active: f64,
+    pure_bash_intensity: f64,
+    stuck_exploring: f64,
+    no_progress: f64,
+    tests_passed: f64,
+}
+
+/// Default scorer weights, mirroring the reference stage_router calibration.
+const DEFAULT_WEIGHTS: Weights = Weights {
+    severity: 0.80,
+    stuck_exploring: 0.70,
+    no_progress: 0.60,
+    tests_passed: -0.80,
+    planning_active: -0.70,
+    write_intensity: -0.40,
+    edit_intensity: -0.30,
+    recent_write_intensity: -0.30,
+    pure_bash_intensity: -0.30,
+    no_error_streak_intensity: -0.20,
+};
+
+/// The scorer-ready projection of a [`ToolResultSignal`], every field in `[0, 1]`.
+struct Dimensions {
+    severity: f64,
+    no_error_streak_intensity: f64,
+    write_intensity: f64,
+    edit_intensity: f64,
+    recent_write_intensity: f64,
+    planning_active: f64,
+    pure_bash_intensity: f64,
+    stuck_exploring: f64,
+    no_progress: f64,
+    tests_passed: f64,
+}
+
+/// Maps a nonnegative count into `[0, 1)`; `scale` is the half-saturation point.
+fn saturating(x: f64, scale: f64) -> f64 {
+    if x <= 0.0 {
+        0.0
+    } else {
+        1.0 - (-x / scale).exp()
+    }
+}
+
+/// Fraction of `numerator` in `denominator`, or `0.0` when there is nothing to divide.
+fn ratio(numerator: f64, denominator: f64) -> f64 {
+    if denominator > 0.0 {
+        numerator / denominator
+    } else {
+        0.0
+    }
+}
+
+/// Projects a signal onto the normalized dimension space the scorer reads.
+fn dimensions(signal: &ToolResultSignal) -> Dimensions {
+    let total_tool_ops = f64::from(signal.write_count + signal.edit_count + signal.read_count);
+    let recent_tool_ops =
+        f64::from(signal.recent_write_count + signal.recent_edit_count + signal.recent_read_count);
+    // A deep turn with many reads but almost no writes reads as stuck exploration.
+    let stuck = signal.turn_depth >= 8 && signal.write_count <= 1 && signal.read_count >= 5;
+    let no_progress = signal.turn_depth > 60 && signal.write_count == 0;
+    Dimensions {
+        severity: f64::from(signal.severity),
+        no_error_streak_intensity: saturating(f64::from(signal.no_error_streak), 3.0),
+        write_intensity: ratio(f64::from(signal.write_count), total_tool_ops),
+        edit_intensity: ratio(f64::from(signal.edit_count), total_tool_ops),
+        recent_write_intensity: ratio(f64::from(signal.recent_write_count), recent_tool_ops),
+        planning_active: f64::from(signal.recent_todowrite_count > 0),
+        pure_bash_intensity: saturating(f64::from(signal.pure_bash_streak), PURE_BASH_NORM),
+        stuck_exploring: f64::from(stuck),
+        no_progress: f64::from(no_progress),
+        // Treat passing tests as confirmatory only once real changes have been made;
+        // early runs against an unmodified tree are exploratory, not settled.
+        tests_passed: f64::from(signal.tests_passed && signal.write_count >= 3),
+    }
+}
+
+/// Weighted linear score in `[-1, +1]`: positive favors capable, negative favors
+/// efficient. Callers rerange this onto the `[0, 1]` capability confidence via
+/// `(score + 1) / 2`.
+fn weighted_score(dimensions: &Dimensions) -> f64 {
+    let w = &DEFAULT_WEIGHTS;
+    let raw = dimensions.severity * w.severity
+        + dimensions.no_error_streak_intensity * w.no_error_streak_intensity
+        + dimensions.write_intensity * w.write_intensity
+        + dimensions.edit_intensity * w.edit_intensity
+        + dimensions.recent_write_intensity * w.recent_write_intensity
+        + dimensions.planning_active * w.planning_active
+        + dimensions.pure_bash_intensity * w.pure_bash_intensity
+        + dimensions.stuck_exploring * w.stuck_exploring
+        + dimensions.no_progress * w.no_progress
+        + dimensions.tests_passed * w.tests_passed;
+    raw.clamp(-1.0, 1.0)
+}
+
+/// Non-negotiable, signal-derived shortcuts that bypass the scorer entirely.
+fn apply_overrides(signal: &ToolResultSignal) -> Option<Tier> {
+    if signal.severity >= CRITICAL {
+        return Some(Tier::Capable);
+    }
+    // Passing tests after a settled run (deep enough, few writes) is a strong efficient cue.
+    if signal.tests_passed
+        && signal.turn_depth >= CLEAN_TESTS_MIN_TURN_DEPTH
+        && signal.write_count <= CLEAN_TESTS_MAX_WRITES
+    {
+        return Some(Tier::Efficient);
+    }
+    None
+}
+
+/// Heuristic first stage of a two-tier cascade router.
+///
+/// Register the same instance as both a processor and a classifier; the processor extracts
+/// the signal and the classifier scores it, sharing [`State`].
+pub struct StagedRouter {
+    capable_model: String,
+    efficient_model: String,
+    confidence_threshold: f64,
+}
+
+impl StagedRouter {
+    /// Creates a router between `capable_model` and `efficient_model` at the default
+    /// confidence threshold.
+    pub fn new(capable_model: impl Into<String>, efficient_model: impl Into<String>) -> Self {
+        Self {
+            capable_model: capable_model.into(),
+            efficient_model: efficient_model.into(),
+            confidence_threshold: DEFAULT_CONFIDENCE_THRESHOLD,
+        }
+    }
+
+    /// Sets the confidence bound at which the heuristic decides rather than defers. The
+    /// abstain band is symmetric around the `0.5` neutral point: `[1 - threshold, threshold]`.
+    pub fn with_confidence_threshold(mut self, threshold: f64) -> Self {
+        self.confidence_threshold = threshold;
+        self
+    }
+
+    /// The model name for a tier.
+    fn model_for(&self, tier: Tier) -> &str {
+        match tier {
+            Tier::Capable => &self.capable_model,
+            Tier::Efficient => &self.efficient_model,
+        }
+    }
+
+    /// One score for the given tier's model at `confidence`.
+    fn tier_score(&self, tier: Tier, confidence: f64) -> Vec<Score> {
+        vec![Score {
+            confidence,
+            target: self.model_for(tier).to_string(),
+        }]
+    }
+}
+
+#[async_trait(?Send)]
+impl Processor for StagedRouter {
+    async fn process(&self, state: &mut State, event: Event<'_>) -> Result<(), BoxErr> {
+        // Extract the tool-result signal from the request's history and stash it for the
+        // classifier. The metadata processor's Metadata fact is left untouched.
+        if let Event::Request(request) = event {
+            state.insert(extract_tool_signals(request));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Classifier for StagedRouter {
+    async fn score(&self, state: &mut State, _request: &Request) -> Result<Vec<Score>, BoxErr> {
+        let Some(signal) = state.get::<ToolResultSignal>() else {
+            // No signal extracted yet: abstain.
+            return Ok(Vec::new());
+        };
+
+        // Hard overrides jump to the extremes of the capability axis:
+        // capable → 1.0, efficient → 0.0.
+        if let Some(tier) = apply_overrides(signal) {
+            let confidence = match tier {
+                Tier::Capable => 1.0,
+                Tier::Efficient => 0.0,
+            };
+            return Ok(self.tier_score(tier, confidence));
+        }
+
+        // Rerange the signed [-1, 1] weighted score onto the [0, 1] capability
+        // confidence, then compare it directly against the threshold band. Capable
+        // above `threshold`, efficient below `1 - threshold`, abstain in between.
+        let confidence = (weighted_score(&dimensions(signal)) + 1.0) / 2.0;
+        if confidence >= self.confidence_threshold {
+            Ok(self.tier_score(Tier::Capable, confidence))
+        } else if confidence <= 1.0 - self.confidence_threshold {
+            Ok(self.tier_score(Tier::Efficient, confidence))
+        } else {
+            // Ambiguous band: defer to the next cascade stage.
+            Ok(Vec::new())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use switchyard_protocol::{
+        ContentBlock, LlmRequest, Message, Request, Role, ToolCall, ToolResult,
+    };
+
+    fn tool_call(name: &str, command: Option<&str>) -> ContentBlock {
+        let arguments = match command {
+            Some(command) => serde_json::json!({ "command": command }),
+            None => serde_json::Value::Null,
+        };
+        ContentBlock::ToolCall(ToolCall {
+            id: "call".to_string(),
+            name: name.to_string(),
+            arguments,
+        })
+    }
+
+    fn tool_result(text: &str) -> ContentBlock {
+        ContentBlock::ToolResult(ToolResult {
+            tool_call_id: "call".to_string(),
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+            is_error: None,
+        })
+    }
+
+    fn assistant(content: Vec<ContentBlock>) -> Message {
+        Message {
+            role: Role::Assistant,
+            content,
+        }
+    }
+
+    fn user(content: Vec<ContentBlock>) -> Message {
+        Message {
+            role: Role::User,
+            content,
+        }
+    }
+
+    fn request_from(messages: Vec<Message>) -> Request {
+        Request {
+            llm_request: LlmRequest {
+                model: Some("auto".to_string()),
+                messages,
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        }
+    }
+
+    fn router() -> StagedRouter {
+        StagedRouter::new("capable-model", "efficient-model")
+    }
+
+    // --- extraction --------------------------------------------------------------------
+
+    #[test]
+    fn categorizes_tool_calls_including_bash_commands() {
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![
+            tool_call("Write", None),
+            tool_call("Edit", None),
+            tool_call("Read", None),
+            tool_call("TodoWrite", None),
+            tool_call("Bash", Some("sed -i 's/a/b/' file")),
+            tool_call("Bash", Some("grep foo file")),
+        ])]));
+        assert_eq!(signal.write_count, 1);
+        assert_eq!(signal.edit_count, 2); // Edit tool + `sed -i` bash edit
+        assert_eq!(signal.read_count, 2); // Read tool + `grep` bash read
+        assert_eq!(signal.todowrite_count, 1);
+    }
+
+    #[test]
+    fn severity_and_patterns_come_from_the_last_tool_result() {
+        let signal = extract_tool_signals(&request_from(vec![
+            user(vec![tool_result("all good here")]),
+            user(vec![tool_result("Traceback (most recent call last):")]),
+        ]));
+        assert_eq!(signal.severity, HARD);
+        assert!(signal.patterns.iter().any(|p| p == "traceback"));
+    }
+
+    #[test]
+    fn no_error_streak_counts_trailing_clean_results() {
+        let signal = extract_tool_signals(&request_from(vec![
+            user(vec![tool_result("out of memory")]),
+            user(vec![tool_result("ok")]),
+            user(vec![tool_result("done")]),
+        ]));
+        assert_eq!(signal.no_error_streak, 2);
+    }
+
+    #[test]
+    fn detects_passing_and_failing_test_runs() {
+        let passed = extract_tool_signals(&request_from(vec![user(vec![tool_result(
+            "test result: ok. 5 passed",
+        )])]));
+        assert!(passed.tests_passed);
+
+        let failed = extract_tool_signals(&request_from(vec![user(vec![tool_result(
+            "test result: FAILED. 1 failed, 4 passed",
+        )])]));
+        assert!(!failed.tests_passed);
+    }
+
+    #[test]
+    fn recent_window_bounds_the_recent_counts() {
+        // Five writes, default window of three: only the last three count as recent.
+        let calls: Vec<ContentBlock> = (0..5).map(|_| tool_call("Write", None)).collect();
+        let signal = extract_tool_signals(&request_from(vec![assistant(calls)]));
+        assert_eq!(signal.write_count, 5);
+        assert_eq!(signal.recent_write_count, DEFAULT_RECENT_WINDOW as u32);
+    }
+
+    // --- routing (processor + classifier) ----------------------------------------------
+
+    async fn route(router: &StagedRouter, request: &Request) -> Result<Vec<Score>, BoxErr> {
+        let mut state = State::default();
+        router.process(&mut state, Event::Request(request)).await?;
+        router.score(&mut state, request).await
+    }
+
+    #[tokio::test]
+    async fn no_signal_abstains() -> Result<(), BoxErr> {
+        let mut state = State::default();
+        let scores = router().score(&mut state, &request_from(vec![])).await?;
+        assert!(scores.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn critical_error_routes_capable() -> Result<(), BoxErr> {
+        let request = request_from(vec![user(vec![tool_result("fatal: out of memory")])]);
+        let scores = route(&router(), &request).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "capable-model");
+        assert_eq!(scores[0].confidence, 1.0); // capable override sits at the capable extreme
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn planning_activity_routes_efficient() -> Result<(), BoxErr> {
+        let request = request_from(vec![assistant(vec![tool_call("TodoWrite", None)])]);
+        let scores = route(&router(), &request).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "efficient-model");
+        // planning_active=1.0 · -0.70 → raw -0.70 → confidence (−0.70 + 1)/2 = 0.15.
+        assert!((scores[0].confidence - 0.15).abs() < 1e-9);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stuck_exploration_routes_capable() -> Result<(), BoxErr> {
+        // Eight read-only turns: deep, many reads, no writes → stuck exploration.
+        let messages: Vec<Message> = (0..8)
+            .map(|_| assistant(vec![tool_call("Read", None)]))
+            .collect();
+        let scores = route(&router(), &request_from(messages)).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "capable-model");
+        // stuck_exploring=1.0 · 0.70 → raw 0.70 → confidence (0.70 + 1)/2 = 0.85.
+        assert!((scores[0].confidence - 0.85).abs() < 1e-9);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read_only_activity_is_ambiguous() -> Result<(), BoxErr> {
+        // A single read carries no weighted signal: defer to the next stage.
+        let request = request_from(vec![assistant(vec![tool_call("Read", None)])]);
+        assert!(route(&router(), &request).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn one_router_serves_both_roles() -> Result<(), BoxErr> {
+        let router = Arc::new(router());
+        let processor: Arc<dyn Processor> = router.clone();
+        let classifier: Arc<dyn Classifier> = router;
+        let mut state = State::default();
+
+        let request = request_from(vec![user(vec![tool_result("out of memory")])]);
+        processor
+            .process(&mut state, Event::Request(&request))
+            .await?;
+        let scores = classifier.score(&mut state, &request).await?;
+        assert_eq!(
+            scores.first().map(|score| score.target.as_str()),
+            Some("capable-model")
+        );
+        Ok(())
+    }
+
+    // --- classify_text (port of tool_signals.rs) ---------------------------------------
+    // Reference: crates/switchyard-components/src/dimension_collector/tool_signals.rs
+
+    #[test]
+    fn clean_text_has_zero_severity() {
+        let (sev, patterns) = classify_text("everything went fine");
+        assert_eq!(sev, 0.0);
+        assert!(patterns.is_empty());
+    }
+
+    #[test]
+    fn traceback_is_hard() {
+        let (sev, patterns) = classify_text("Traceback (most recent call last):\n  ValueError");
+        assert_eq!(sev, HARD);
+        assert!(patterns.contains(&"traceback".to_string()));
+    }
+
+    #[test]
+    fn oom_is_critical() {
+        let (sev, _) = classify_text("Out of memory: kill process 1234");
+        assert_eq!(sev, CRITICAL);
+    }
+
+    #[test]
+    fn severity_is_max_across_patterns() {
+        // exit_nonzero (SOFT) + traceback (HARD) → HARD.
+        let (sev, _) = classify_text("exit code 1\nTraceback (most recent call last):");
+        assert_eq!(sev, HARD);
+    }
+
+    #[test]
+    fn no_error_streak_all_clean() {
+        let texts = vec!["ok".to_string(), "all good".to_string()];
+        assert_eq!(compute_no_error_streak(&texts), 2);
+    }
+
+    #[test]
+    fn no_error_streak_stops_at_error() {
+        let texts = vec![
+            "Traceback (most recent call last):".to_string(),
+            "ok".to_string(),
+            "ok".to_string(),
+        ];
+        assert_eq!(compute_no_error_streak(&texts), 2);
+    }
+
+    // --- classify_tool_call (port of tool_signals.rs) ----------------------------------
+    // Reference: crates/switchyard-components/src/dimension_collector/tool_signals.rs
+
+    #[test]
+    fn todowrite_and_update_plan_classify_as_plan() {
+        assert_eq!(classify_tool_call("TodoWrite", None), ToolCategory::Plan);
+        assert_eq!(classify_tool_call("todo_write", None), ToolCategory::Plan);
+        // `update_plan` is codex's equivalent of `todowrite`.
+        assert_eq!(classify_tool_call("update_plan", None), ToolCategory::Plan);
+    }
+
+    #[test]
+    fn codex_shell_command_runs_bash_pattern_match() {
+        // shell_command + heredoc -> Write.
+        assert_eq!(
+            classify_tool_call("shell_command", Some("cat > /app/foo.py <<'eof'\nx=1\neof")),
+            ToolCategory::Write,
+        );
+        // shell_command + read-like inspection -> Read.
+        assert_eq!(
+            classify_tool_call("shell_command", Some("ls /app")),
+            ToolCategory::Read
+        );
+        // shell_command without matching patterns -> Other.
+        assert_eq!(
+            classify_tool_call("shell_command", Some("./run_tests.sh")),
+            ToolCategory::Other
+        );
+    }
+
+    #[test]
+    fn read_tool_and_bash_reads_classify_as_read() {
+        assert_eq!(classify_tool_call("Read", None), ToolCategory::Read);
+        assert_eq!(classify_tool_call("View", None), ToolCategory::Read);
+        for cmd in [
+            "cat /etc/passwd",
+            "grep foo bar.txt",
+            "ls /app",
+            "find . -name '*.py'",
+        ] {
+            assert_eq!(
+                classify_tool_call("Bash", Some(cmd)),
+                ToolCategory::Read,
+                "expected Read for {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn bash_write_precedence_over_read() {
+        // `cat /file > /out` contains both `cat /` (read) and `> /` (write);
+        // write redirection must win.
+        assert_eq!(
+            classify_tool_call("Bash", Some("cat /etc/hosts > /tmp/out")),
+            ToolCategory::Write,
+        );
+    }
+
+    // --- bash-command bucketing (port of tool_signals.rs) ------------------------------
+    // Reference: crates/switchyard-components/src/dimension_collector/tool_signals.rs
+
+    #[test]
+    fn bash_heredoc_counts_as_write() {
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![tool_call(
+            "Bash",
+            Some("cat > /tmp/test.py <<'EOF'\nprint(1)\nEOF"),
+        )])]));
+        assert_eq!(
+            signal.write_count, 1,
+            "Bash heredoc should bucket into write_count"
+        );
+        assert_eq!(signal.edit_count, 0);
+    }
+
+    #[test]
+    fn bash_sed_inplace_counts_as_edit() {
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![tool_call(
+            "Bash",
+            Some("sed -i 's/foo/bar/g' /app/file.py"),
+        )])]));
+        assert_eq!(
+            signal.edit_count, 1,
+            "Bash sed -i should bucket into edit_count"
+        );
+        assert_eq!(signal.write_count, 0);
+    }
+
+    #[test]
+    fn bash_non_mutating_does_not_count() {
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![
+            tool_call("Bash", Some("ls -la /app")),
+            tool_call("Bash", Some("cat /app/main.py")),
+        ])]));
+        assert_eq!(signal.write_count, 0);
+        assert_eq!(signal.edit_count, 0);
+    }
+
+    #[test]
+    fn pure_bash_streak_counts_trailing_other() {
+        // 5 trailing non-classified Bash calls → streak == 5.
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![
+            tool_call("Bash", Some("make")),
+            tool_call("Bash", Some("./configure")),
+            tool_call("Bash", Some("make install")),
+            tool_call("Bash", Some("./run.sh")),
+            tool_call("Bash", Some("./test")),
+        ])]));
+        assert_eq!(signal.pure_bash_streak, 5);
+        assert_eq!(signal.write_count, 0);
+        assert_eq!(signal.read_count, 0);
+    }
+
+    #[test]
+    fn pure_bash_streak_resets_on_write() {
+        // A trailing Write closes the streak, even after a bash `make`.
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![
+            tool_call("Bash", Some("make")),
+            tool_call("Write", None),
+        ])]));
+        assert_eq!(signal.pure_bash_streak, 0);
+        assert_eq!(signal.write_count, 1);
+    }
+
+    #[test]
+    fn recent_window_tracks_todowrite_and_read() {
+        // Final 3 tool calls: TodoWrite, Read, TodoWrite (preceded by a bash `make`).
+        let signal = extract_tool_signals(&request_from(vec![assistant(vec![
+            tool_call("Bash", Some("make")),
+            tool_call("TodoWrite", None),
+            tool_call("Read", None),
+            tool_call("TodoWrite", None),
+        ])]));
+        assert_eq!(signal.todowrite_count, 2);
+        assert_eq!(signal.recent_todowrite_count, 2);
+        assert_eq!(signal.read_count, 1);
+        assert_eq!(signal.recent_read_count, 1);
+    }
+
+    #[test]
+    fn recent_window_size_is_caller_overridable() {
+        // 5 writes then 1 edit. window=3 → recent_writes=2; window=6 → recent_writes=5.
+        let mut calls: Vec<ContentBlock> = (0..5).map(|_| tool_call("Write", None)).collect();
+        calls.push(tool_call("Edit", None));
+        let request = request_from(vec![assistant(calls)]);
+
+        let narrow = extract_tool_signals_with_window(&request, 3);
+        assert_eq!(narrow.recent_write_count, 2);
+        assert_eq!(narrow.recent_edit_count, 1);
+
+        let wide = extract_tool_signals_with_window(&request, 6);
+        assert_eq!(wide.recent_write_count, 5);
+        assert_eq!(wide.recent_edit_count, 1);
+    }
+
+    // --- tests_passed detection (port of tool_signals.rs) ------------------------------
+    // Reference: crates/switchyard-components/src/dimension_collector/tool_signals.rs
+    // Guards `has_nonzero_failure_count`: "0 failed" / "0 errors" clean summaries must
+    // not be misread as failures, while a nonzero count before the keyword must.
+
+    #[test]
+    fn tests_passed_accepts_cargo_clean_summary() {
+        assert!(detect_tests_passed(&[
+            "running 3 tests\ntest result: ok. 3 passed; 0 failed; 0 ignored".to_string()
+        ]));
+    }
+
+    #[test]
+    fn tests_passed_rejects_cargo_real_failure() {
+        assert!(!detect_tests_passed(&[
+            "running 3 tests\ntest result: FAILED. 2 passed; 1 failed; 0 ignored".to_string()
+        ]));
+    }
+
+    #[test]
+    fn tests_passed_accepts_go_clean_summary() {
+        assert!(detect_tests_passed(&[
+            "ok  github.com/foo/bar\t0.012s (5 passed, 0 errors)".to_string()
+        ]));
+    }
+
+    #[test]
+    fn tests_passed_accepts_pytest_zero_errors() {
+        assert!(detect_tests_passed(&[
+            "5 passed, 0 errors in 0.30s".to_string()
+        ]));
+    }
+
+    #[test]
+    fn tests_passed_detects_diy_checkmark() {
+        assert!(detect_tests_passed(&["✓ all checks passed".to_string()]));
+    }
+
+    #[test]
+    fn tests_passed_ignores_partial_failures() {
+        assert!(!detect_tests_passed(&[
+            "2 failed, 5 passed in 0.56s".to_string()
+        ]));
+    }
+
+    // --- scorer (port of scorer.py / test_stage_router_scorer.py) ----------------------
+    // Reference: switchyard/lib/processors/stage_router/scorer.py
+    //            tests/test_stage_router_scorer.py
+
+    fn zero_dimensions() -> Dimensions {
+        Dimensions {
+            severity: 0.0,
+            no_error_streak_intensity: 0.0,
+            write_intensity: 0.0,
+            edit_intensity: 0.0,
+            recent_write_intensity: 0.0,
+            planning_active: 0.0,
+            pure_bash_intensity: 0.0,
+            stuck_exploring: 0.0,
+            no_progress: 0.0,
+            tests_passed: 0.0,
+        }
+    }
+
+    #[test]
+    fn zero_dimensions_score_to_zero() {
+        assert_eq!(weighted_score(&zero_dimensions()), 0.0);
+    }
+
+    #[test]
+    fn critical_severity_pushes_toward_capable() {
+        let dims = Dimensions {
+            severity: 1.0,
+            ..zero_dimensions()
+        };
+        assert!(weighted_score(&dims) > 0.0);
+    }
+
+    #[test]
+    fn tests_passed_pushes_toward_efficient() {
+        let dims = Dimensions {
+            tests_passed: 1.0,
+            ..zero_dimensions()
+        };
+        assert!(weighted_score(&dims) < 0.0);
+    }
+
+    #[test]
+    fn score_is_clamped_to_unit_interval() {
+        // Positive axes sum past +1 (0.80 + 0.70 + 0.60 = 2.10) → clamp to +1.
+        let capable = Dimensions {
+            severity: 1.0,
+            stuck_exploring: 1.0,
+            no_progress: 1.0,
+            ..zero_dimensions()
+        };
+        assert_eq!(weighted_score(&capable), 1.0);
+        // Negative axes sum past -1 → clamp to -1.
+        let efficient = Dimensions {
+            tests_passed: 1.0,
+            planning_active: 1.0,
+            write_intensity: 1.0,
+            edit_intensity: 1.0,
+            recent_write_intensity: 1.0,
+            pure_bash_intensity: 1.0,
+            no_error_streak_intensity: 1.0,
+            ..zero_dimensions()
+        };
+        assert_eq!(weighted_score(&efficient), -1.0);
+    }
+
+    #[test]
+    fn dimensions_normalise_a_real_extracted_signal() {
+        // End-to-end: extraction → ToolResultSignal → Dimensions, all in [0, 1].
+        // Port of test_stage_router_scorer.py::test_from_signal_normalises_real_extracted_signal.
+        let signal = extract_tool_signals(&request_from(vec![
+            assistant(vec![tool_call("Write", None)]),
+            user(vec![tool_result("ok")]),
+            user(vec![ContentBlock::Text {
+                text: "next".to_string(),
+            }]),
+        ]));
+        let dims = dimensions(&signal);
+        assert!((0.0..=1.0).contains(&dims.severity));
+        assert!((0.0..=1.0).contains(&dims.write_intensity));
+        assert!(dims.write_intensity > 0.0); // we issued one Write call
+    }
+
+    // --- routing overrides (port of test_stage_router_pickers.py) ----------------------
+    // Reference: tests/test_stage_router_pickers.py
+    // NOTE: the reference pickers fall open to a default tier (capable-first /
+    // efficient-first) or an LLM classifier on low-confidence turns; StagedRouter
+    // instead abstains (empty scores) to defer to the next cascade stage, so only the
+    // override / confident-score paths are portable here.
+
+    #[tokio::test]
+    async fn tests_passed_after_settled_run_routes_efficient() -> Result<(), BoxErr> {
+        // 3 edits + 3 "all tests passed" results + 12 user turns: tests_passed, deep,
+        // no writes → the settled-tests override forces EFFICIENT.
+        let mut messages: Vec<Message> = (0..3)
+            .map(|_| assistant(vec![tool_call("Edit", None)]))
+            .collect();
+        messages.extend((0..3).map(|_| user(vec![tool_result("all tests passed")])));
+        messages.extend((0..12).map(|_| {
+            user(vec![ContentBlock::Text {
+                text: "ok continue".to_string(),
+            }])
+        }));
+        let scores = route(&router(), &request_from(messages)).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "efficient-model");
+        assert_eq!(scores[0].confidence, 0.0); // efficient override sits at the efficient extreme
+        Ok(())
+    }
+}

--- a/crates/libsy/src/algorithms/turn_gate.rs
+++ b/crates/libsy/src/algorithms/turn_gate.rs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Early-turn gate: route a fixed target for the opening turns of a conversation.
+//!
+//! [`TurnGate`] scores a fixed `target` at confidence `1.0` while the conversation is younger
+//! than `min_turn`, and abstains afterwards. In the escalation cascade it sits ahead of the
+//! judge so early turns route to the cheap tier **without** paying for a judge call — there is
+//! too little trajectory to assess yet.
+
+use async_trait::async_trait;
+use switchyard_protocol::{Request, Role};
+
+use super::core::{Classifier, Score, State};
+
+/// Boxed, thread-safe error type used across the SDK.
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// The conversation's turn number: the count of user-role messages so far.
+pub fn conversation_turn(request: &Request) -> usize {
+    request
+        .llm_request
+        .messages
+        .iter()
+        .filter(|message| message.role == Role::User)
+        .count()
+}
+
+/// Routes `target` while the conversation turn is `< min_turn`, then abstains.
+pub struct TurnGate {
+    target: String,
+    min_turn: usize,
+}
+
+impl TurnGate {
+    /// Creates a gate that routes `target` until the conversation reaches `min_turn`.
+    pub fn new(target: impl Into<String>, min_turn: usize) -> Self {
+        Self {
+            target: target.into(),
+            min_turn,
+        }
+    }
+}
+
+#[async_trait]
+impl Classifier for TurnGate {
+    async fn score(
+        &self,
+        _state: &mut State,
+        request: &Request,
+        _driver: Option<&crate::Driver>,
+    ) -> Result<Vec<Score>, BoxErr> {
+        if conversation_turn(request) < self.min_turn {
+            Ok(vec![Score {
+                confidence: 1.0,
+                target: self.target.clone(),
+            }])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use switchyard_protocol::{LlmRequest, Message};
+
+    /// A request with `user_turns` user messages, each followed by an assistant reply.
+    fn request(user_turns: usize) -> Request {
+        let mut messages = Vec::new();
+        for index in 0..user_turns {
+            messages.push(Message::text(Role::User, format!("turn {index}")));
+            messages.push(Message::text(Role::Assistant, "ok"));
+        }
+        Request {
+            llm_request: LlmRequest {
+                messages,
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn conversation_turn_counts_user_messages() {
+        assert_eq!(conversation_turn(&request(0)), 0);
+        assert_eq!(conversation_turn(&request(3)), 3);
+    }
+
+    #[tokio::test]
+    async fn routes_the_target_before_min_turn() -> Result<(), BoxErr> {
+        let gate = TurnGate::new("weak", 3);
+        let scores = gate.score(&mut State::default(), &request(2), None).await?;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].target, "weak");
+        assert_eq!(scores[0].confidence, 1.0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn abstains_at_and_after_min_turn() -> Result<(), BoxErr> {
+        let gate = TurnGate::new("weak", 3);
+        // At the threshold the judge should run, so the gate abstains.
+        assert!(gate
+            .score(&mut State::default(), &request(3), None)
+            .await?
+            .is_empty());
+        assert!(gate
+            .score(&mut State::default(), &request(5), None)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+}

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -59,6 +59,7 @@
 //! agents, live in the `libsy-examples` crate.
 
 mod algorithms;
+pub use algorithms::metadata_processor::MetadataProcessor;
 pub use algorithms::noop::{NoopAlgo, NoopDecision};
 pub use algorithms::rand::{RandomAlgo, RandomDecision};
 

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -61,6 +61,11 @@
 mod algorithms;
 pub use algorithms::affinity::AffinityRouter;
 pub use algorithms::core::{Classifier, Event, Processor, Score, State};
+pub use algorithms::escalation::{
+    escalation_router, ConfirmingJudge, ESCALATION_JUDGE_SYSTEM_PROMPT,
+    ESCALATION_JUDGE_TURN_WINDOW,
+};
+pub use algorithms::fall_through::FallThroughClassification;
 pub use algorithms::llm_classifier::{
     LlmClassifier, Policy, CODING_AGENT_SYSTEM_PROMPT, DEFAULT_MAX_TOKENS,
     DEFAULT_RECENT_TURN_WINDOW, DEFAULT_SYSTEM_PROMPT, DEFAULT_TOOL_NAME, GENERAL_SYSTEM_PROMPT,
@@ -70,6 +75,7 @@ pub use algorithms::metadata_processor::MetadataProcessor;
 pub use algorithms::noop::{NoopAlgo, NoopDecision};
 pub use algorithms::rand::{RandomAlgo, RandomDecision};
 pub use algorithms::staged::{StagedRouter, ToolResultSignal};
+pub use algorithms::turn_gate::{conversation_turn, TurnGate};
 
 mod driver;
 

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -64,6 +64,7 @@ pub use algorithms::core::{Classifier, Event, Processor, Score, State};
 pub use algorithms::metadata_processor::MetadataProcessor;
 pub use algorithms::noop::{NoopAlgo, NoopDecision};
 pub use algorithms::rand::{RandomAlgo, RandomDecision};
+pub use algorithms::staged::{StagedRouter, ToolResultSignal};
 
 mod driver;
 

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -61,6 +61,11 @@
 mod algorithms;
 pub use algorithms::affinity::AffinityRouter;
 pub use algorithms::core::{Classifier, Event, Processor, Score, State};
+pub use algorithms::llm_classifier::{
+    LlmClassifier, Policy, CODING_AGENT_SYSTEM_PROMPT, DEFAULT_MAX_TOKENS,
+    DEFAULT_RECENT_TURN_WINDOW, DEFAULT_SYSTEM_PROMPT, DEFAULT_TOOL_NAME, GENERAL_SYSTEM_PROMPT,
+    OPENCLAW_SYSTEM_PROMPT,
+};
 pub use algorithms::metadata_processor::MetadataProcessor;
 pub use algorithms::noop::{NoopAlgo, NoopDecision};
 pub use algorithms::rand::{RandomAlgo, RandomDecision};

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -59,6 +59,8 @@
 //! agents, live in the `libsy-examples` crate.
 
 mod algorithms;
+pub use algorithms::affinity::AffinityRouter;
+pub use algorithms::core::{Classifier, Event, Processor, Score, State};
 pub use algorithms::metadata_processor::MetadataProcessor;
 pub use algorithms::noop::{NoopAlgo, NoopDecision};
 pub use algorithms::rand::{RandomAlgo, RandomDecision};

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -62,8 +62,8 @@ mod algorithms;
 pub use algorithms::affinity::AffinityRouter;
 pub use algorithms::core::{Classifier, Event, Processor, Score, State};
 pub use algorithms::escalation::{
-    escalation_router, ConfirmingJudge, ESCALATION_JUDGE_SYSTEM_PROMPT,
-    ESCALATION_JUDGE_TURN_WINDOW,
+    escalation_router, escalation_router_with_staged, ConfirmingJudge,
+    ESCALATION_JUDGE_SYSTEM_PROMPT, ESCALATION_JUDGE_TURN_WINDOW,
 };
 pub use algorithms::fall_through::FallThroughClassification;
 pub use algorithms::llm_classifier::{


### PR DESCRIPTION
# libsy: composable routing components

Adds a small SDK for LLM traffic routing to `libsy`, built from two roles —
**`Processor`** (lightweight, accumulates session `State`) and **`Classifier`**
(scores routing targets, possibly via its own LLM call) — plus a shared
orchestrator that runs them. Every router in this PR is a *configuration* of the
same pieces rather than a bespoke implementation.

## Core

- **`Processor` / `Classifier` / `State` / `Score`** (`core.rs`) — the role
  traits. Processors run first and write facts into a shared, per-session
  `State`; classifiers then run in a cascade, each returning a `Score` per
  target or an empty vec to **abstain** (defer to the next, heavier classifier).
- **`FallThroughClassification`** (`fall_through.rs`) — the orchestrator
  (`Algorithm`). Runs the processor chain, falls through the classifier cascade
  (first non-empty result wins, by argmax), dispatches the routed call via the
  `Driver`, then replays the decision to the processors so stateful ones bind
  it. **Owns the session `State`** (persists across turns behind a lock).

## Components

- **`StagedRouter`** — heuristic per-turn router ported from the cascade
  router's dimension collector + scorer (tool-result signals → capable/efficient,
  reranged to a `[0,1]` capability confidence; abstains in an ambiguous band).
- **`LlmClassifier`** — LLM-backed classifier that offloads one **strict
  tool-call** through the `Driver` and emits a score per target. Trimmed request
  summary, `temperature 0` + `max_tokens`, optional fail-open. Three `Policy`
  prompt presets (general / coding-agent / openclaw).
- **`AffinityRouter`** — session latch (retain a model per identity);
  `with_latch_only` restricts *which* models latch.
- **`TurnGate`** — routes a fixed target before `min_turn`, then abstains.
- **`MetadataProcessor`** + `Metadata::from_headers` — normalizes harness
  headers into correlation metadata in `State`.

## Composed routers (all one skeleton)

| Router | Cascade |
|---|---|
| LLM classifier | `[LlmClassifier]` |
| Staged | `[StagedRouter, fallback]` |
| Escalation | `[latch, TurnGate, ConfirmingJudge(LlmClassifier)]` + latch processor |
| Escalation + staged | `…, TurnGate, StagedRouter, judge]` |

`escalation_router(...)` / `escalation_router_with_staged(...)` assemble the
judge-latched escalation flow: start `weak`, escalate to `strong` when the judge
(or the cheap staged heuristic) sees trouble, then latch. `ConfirmingJudge`
requires N escalate verdicts before latching — trivial here because `State` is
per-session (the reference needs a keyed streak store).

## Notes

- `Classifier::score` takes an optional `&Driver` (driver-backed classifiers use
  it, error on `None`; local ones ignore it).
- Chain-shape changes required to run processors inside a `Send` algorithm
  future: `Processor` now yields `Send` futures, and `Event::ModelResponse`
  carries the buffered `&AggLlmResponse` (a live stream can't cross the spawn).

## Testing

121 unit/integration tests, `cargo clippy` clean. Ports the reference test
suites (signal extraction, scorer, tier selection) and covers the cascade,
latch persistence, confirmations, and end-to-end escalation with a stubbed
judge over the driver stream.
## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class.
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use.
- [ ] Unit tests added for new components / bug fixes.
- [ ] README / `--help` updated if customer-facing surface changed.
- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

Anything reviewers should pay extra attention to — risky paths, follow-up tickets, intentional trade-offs.
