### PR TITLE
fix(cli): make configure inputs a typed request so first-run setup can't crash

### DIFF
--- a/switchyard/cli/command_utils.py
+++ b/switchyard/cli/command_utils.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import argparse
 import getpass
 import logging
 import sys
@@ -53,10 +52,10 @@ def is_interactive_terminal() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-def build_launch_config_wizard(args: argparse.Namespace) -> LaunchConfigWizard:
+def build_launch_config_wizard(no_tui: bool) -> LaunchConfigWizard:
     return LaunchConfigWizard(
         session=TuiSession.from_current_terminal(
-            force_plain=bool(getattr(args, "no_tui", False)),
+            force_plain=no_tui,
             input_fn=input,
             secret_fn=getpass.getpass,
             output_fn=print,

--- a/switchyard/cli/configure_command.py
+++ b/switchyard/cli/configure_command.py
@@ -3,7 +3,6 @@
 
 """Implementation of ``switchyard configure``."""
 
-import argparse
 import json
 import logging
 from collections.abc import Iterable
@@ -38,6 +37,7 @@ from switchyard.cli.config.user_config import (
     save_user_config,
     save_user_credentials,
 )
+from switchyard.cli.configure_request import ConfigureRequest
 from switchyard.cli.launchers.claude_alias import claude_alias_for
 from switchyard.cli.model_catalog.model_discovery import (
     choose_default_claude_model,
@@ -56,42 +56,42 @@ from switchyard.server.server_util import load_secrets
 logger = logging.getLogger(__name__)
 
 
-def _skill_distillation_args_present(args: argparse.Namespace) -> bool:
-    return bool(args.disable_skill_distillation) or args.skill_distillation is not None
+def _skill_distillation_args_present(request: ConfigureRequest) -> bool:
+    return bool(request.disable_skill_distillation) or request.skill_distillation is not None
 
 
-def _provider_or_launcher_args_present(args: argparse.Namespace) -> bool:
+def _provider_or_launcher_args_present(request: ConfigureRequest) -> bool:
     return any(
         value
         for value in (
-            args.api_key,
-            args.base_url,
-            args.claude_model,
-            args.claude_base_url,
-            args.claude_api_key,
-            args.codex_model,
-            args.codex_base_url,
-            args.codex_api_key,
-            args.openclaw_model,
-            args.openclaw_base_url,
-            args.openclaw_api_key,
+            request.api_key,
+            request.base_url,
+            request.claude_model,
+            request.claude_base_url,
+            request.claude_api_key,
+            request.codex_model,
+            request.codex_base_url,
+            request.codex_api_key,
+            request.openclaw_model,
+            request.openclaw_base_url,
+            request.openclaw_api_key,
         )
-    ) or args.routing_profiles is not None
+    ) or request.routing_profiles is not None
 
 
-def _skill_only_config_update(args: argparse.Namespace) -> bool:
+def _skill_only_config_update(request: ConfigureRequest) -> bool:
     return (
-        _skill_distillation_args_present(args)
-        and not _provider_or_launcher_args_present(args)
+        _skill_distillation_args_present(request)
+        and not _provider_or_launcher_args_present(request)
     )
 
 
 def _apply_skill_distillation_args(
     existing: SkillDistillationConfig,
-    args: argparse.Namespace,
+    request: ConfigureRequest,
 ) -> SkillDistillationConfig:
-    if args.disable_skill_distillation:
-        if args.skill_distillation is not None:
+    if request.disable_skill_distillation:
+        if request.skill_distillation is not None:
             raise UserConfigError(
                 "--disable-skill-distillation cannot be combined with "
                 "--skill-distillation"
@@ -100,8 +100,8 @@ def _apply_skill_distillation_args(
 
     return SkillDistillationConfig(
         namespace=(
-            args.skill_distillation
-            if args.skill_distillation is not None
+            request.skill_distillation
+            if request.skill_distillation is not None
             else existing.namespace
         ),
     )
@@ -292,18 +292,18 @@ def _merge_candidate_ids(*sources: Iterable[str]) -> list[str]:
     return merged
 
 
-def _list_models(args: argparse.Namespace) -> None:
+def _list_models(request: ConfigureRequest) -> None:
     """Print a ranked list of backend models — fold of ``switchyard models``."""
     from switchyard.server.server_util import load_secrets
 
     connectivity = resolve_provider_connectivity(
-        cli_api_key=args.api_key,
-        cli_base_url=args.base_url,
+        cli_api_key=request.api_key,
+        cli_base_url=request.base_url,
         api_key_env_vars=("OPENROUTER_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY"),
         base_url_env_vars=("OPENROUTER_BASE_URL", "NVIDIA_BASE_URL", "OPENAI_BASE_URL"),
         secrets=load_secrets(),
         secrets_section_priority=DEFAULT_SECRETS_SECTION_PRIORITY,
-        default_provider=getattr(args, "provider", None),
+        default_provider=request.provider,
     )
     if not connectivity.api_key:
         raise SystemExit(
@@ -314,7 +314,7 @@ def _list_models(args: argparse.Namespace) -> None:
     # `--target provider` is meaningful for `configure` setup but not for
     # model ranking; collapse it to `all` so the renderer treats the
     # ranking target as the launcher-neutral default.
-    raw_target = getattr(args, "target", "all") or "all"
+    raw_target = request.target
     target: ModelListTarget
     if raw_target == "claude":
         target = "claude"
@@ -326,38 +326,38 @@ def _list_models(args: argparse.Namespace) -> None:
         model_ids,
         ModelListRequest(
             target=target,
-            query=getattr(args, "query", None),
-            limit=getattr(args, "limit", 50),
+            query=request.query,
+            limit=request.limit,
         ),
     ))
 
 
-def cmd_configure(args: argparse.Namespace) -> None:
+def cmd_configure(request: ConfigureRequest) -> None:
     """Set, show, or reset user-level launcher defaults."""
 
-    if getattr(args, "list_models", False):
-        _list_models(args)
+    if request.list_models:
+        _list_models(request)
         return
 
-    if args.show:
+    if request.show:
         snapshot = build_redacted_snapshot()
-        if bool(getattr(args, "json", False)):
+        if request.json:
             print(json.dumps(snapshot, indent=2, sort_keys=True))
             return
         print(format_config_snapshot(snapshot))
         print()
         print(render_status(
             StatusRequest(
-                cli_api_key=getattr(args, "api_key", None),
-                cli_base_url=getattr(args, "base_url", None),
-                provider=getattr(args, "provider", None),
-                check=bool(getattr(args, "check", False)),
+                cli_api_key=request.api_key,
+                cli_base_url=request.base_url,
+                provider=request.provider,
+                check=request.check,
                 secrets=load_secrets(),
             ),
         ))
         return
 
-    if args.reset:
+    if request.reset:
         removed = reset_user_config()
         if removed:
             print("Removed Switchyard user config:")
@@ -367,8 +367,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
             print("No Switchyard user config found.")
         return
 
-    provider = args.provider
-    target_scope = getattr(args, "target", "all")
+    provider = request.provider
+    target_scope = request.target
     configure_claude = target_scope in ("all", "claude")
     configure_codex = target_scope in ("all", "codex")
     configure_openclaw = target_scope in ("all", "openclaw")
@@ -376,9 +376,9 @@ def cmd_configure(args: argparse.Namespace) -> None:
     existing_credentials = load_user_credentials()
     skill_distillation = _apply_skill_distillation_args(
         existing_config.skill_distillation,
-        args,
+        request,
     )
-    if _skill_only_config_update(args):
+    if _skill_only_config_update(request):
         save_user_config(
             UserConfig(
                 default_provider=existing_config.default_provider,
@@ -398,15 +398,15 @@ def cmd_configure(args: argparse.Namespace) -> None:
     existing_claude_credentials = existing_credentials.launch_target("claude")
     existing_codex_credentials = existing_credentials.launch_target("codex")
     existing_openclaw_credentials = existing_credentials.launch_target("openclaw")
-    reuse_existing_provider = bool(getattr(args, "reuse_existing_provider", False))
+    reuse_existing_provider = request.reuse_existing_provider
     interactive = is_interactive_terminal()
-    wizard = build_launch_config_wizard(args) if interactive else None
+    wizard = build_launch_config_wizard(request.no_tui) if interactive else None
     if wizard:
         wizard.start(target=target_scope)
 
     base_url_default = existing_provider.base_url or _default_base_url_for_provider(provider)
-    if args.base_url:
-        base_url = args.base_url
+    if request.base_url:
+        base_url = request.base_url
     elif reuse_existing_provider and existing_provider.base_url:
         base_url = existing_provider.base_url
     elif interactive and wizard:
@@ -414,16 +414,14 @@ def cmd_configure(args: argparse.Namespace) -> None:
     else:
         base_url = base_url_default
 
-    api_key = args.api_key
+    api_key = request.api_key
     if not api_key:
         existing_api_key = existing_credentials.api_key(provider)
         prompt_default_api_key = (
             existing_api_key
-            or getattr(args, "prompt_default_api_key", None)
+            or request.prompt_default_api_key
         )
-        prompt_default_api_key_source = getattr(
-            args, "prompt_default_api_key_source", None,
-        )
+        prompt_default_api_key_source = request.prompt_default_api_key_source
         if reuse_existing_provider and existing_api_key:
             api_key = existing_api_key
         elif interactive and wizard:
@@ -446,7 +444,7 @@ def cmd_configure(args: argparse.Namespace) -> None:
             cache=model_catalog_cache,
             base_url=selection.effective_base_url,
             api_key=selection.effective_api_key,
-            disabled=args.no_model_discovery,
+            disabled=request.no_model_discovery,
         )
 
     # Resolve routing-profiles up front (CLI > existing config > interactive
@@ -455,11 +453,11 @@ def cmd_configure(args: argparse.Namespace) -> None:
     # raw `/v1/models` response and the user can't pick e.g. `opus-ds-stage_router`
     # even when their YAML declares it.
     routing_profiles = existing_config.routing_profiles
-    if args.routing_profiles is not None:
+    if request.routing_profiles is not None:
         # Empty string clears, any other value is a path whose YAML we parse.
         routing_profiles = (
-            _read_routing_profiles_file(args.routing_profiles)
-            if args.routing_profiles else None
+            _read_routing_profiles_file(request.routing_profiles)
+            if request.routing_profiles else None
         )
     elif interactive and wizard:
         prompted = wizard.prompt_routing_profiles(default=None)
@@ -489,8 +487,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
             wizard=wizard,
             interactive=interactive,
             label="Claude Code",
-            cli_base_url=args.claude_base_url,
-            cli_api_key=args.claude_api_key,
+            cli_base_url=request.claude_base_url,
+            cli_api_key=request.claude_api_key,
             existing_endpoint=existing_claude_route.endpoint(PRIMARY_TIER),
             existing_api_key=existing_claude_credentials.api_key(PRIMARY_TIER),
             default_base_url=base_url,
@@ -501,7 +499,7 @@ def cmd_configure(args: argparse.Namespace) -> None:
         )
         discovered_claude = choose_default_claude_model(claude_model_ids)
         claude_default = (
-            args.claude_model
+            request.claude_model
             or default_claude_route_model
             or existing_claude_route.model
             or discovered_claude
@@ -512,8 +510,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
                 "or run interactively."
             )
 
-        if args.claude_model:
-            claude_model = args.claude_model
+        if request.claude_model:
+            claude_model = request.claude_model
         elif interactive and wizard:
             claude_model = wizard.select_model(
                 "Claude Code",
@@ -532,8 +530,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
             wizard=wizard,
             interactive=interactive,
             label="Codex",
-            cli_base_url=args.codex_base_url,
-            cli_api_key=args.codex_api_key,
+            cli_base_url=request.codex_base_url,
+            cli_api_key=request.codex_api_key,
             existing_endpoint=existing_codex_route.endpoint(PRIMARY_TIER),
             existing_api_key=existing_codex_credentials.api_key(PRIMARY_TIER),
             default_base_url=base_url,
@@ -544,7 +542,7 @@ def cmd_configure(args: argparse.Namespace) -> None:
         )
         discovered_codex = choose_default_codex_model(codex_model_ids)
         codex_default = (
-            args.codex_model
+            request.codex_model
             or default_route_model
             or existing_codex_route.model
             or discovered_codex
@@ -555,8 +553,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
                 "or run interactively."
             )
 
-        if args.codex_model:
-            codex_model = args.codex_model
+        if request.codex_model:
+            codex_model = request.codex_model
         elif interactive and wizard:
             codex_model = wizard.select_model(
                 "Codex",
@@ -575,8 +573,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
             wizard=wizard,
             interactive=interactive,
             label="OpenClaw",
-            cli_base_url=args.openclaw_base_url,
-            cli_api_key=args.openclaw_api_key,
+            cli_base_url=request.openclaw_base_url,
+            cli_api_key=request.openclaw_api_key,
             existing_endpoint=existing_openclaw_route.endpoint(PRIMARY_TIER),
             existing_api_key=existing_openclaw_credentials.api_key(PRIMARY_TIER),
             default_base_url=base_url,
@@ -590,7 +588,7 @@ def cmd_configure(args: argparse.Namespace) -> None:
         # until OpenClaw-specific signals emerge.
         discovered_openclaw = choose_default_codex_model(openclaw_model_ids)
         openclaw_default = (
-            args.openclaw_model
+            request.openclaw_model
             or default_route_model
             or existing_openclaw_route.model
             or discovered_openclaw
@@ -601,8 +599,8 @@ def cmd_configure(args: argparse.Namespace) -> None:
                 "--openclaw-model or run interactively."
             )
 
-        if args.openclaw_model:
-            openclaw_model = args.openclaw_model
+        if request.openclaw_model:
+            openclaw_model = request.openclaw_model
         elif interactive and wizard:
             openclaw_model = wizard.select_model(
                 "OpenClaw",

--- a/switchyard/cli/configure_request.py
+++ b/switchyard/cli/configure_request.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The typed inputs for ``switchyard configure``.
+
+This is the one place that lists every field ``cmd_configure`` reads, and the
+default for each. Two callers build it: the ``configure`` CLI command (via
+``from_namespace``) and first-run launch setup (via the constructor). Because
+both build the same type, a field the command needs but a caller forgets is
+caught by mypy or at construction time — not as an ``AttributeError`` deep
+inside ``cmd_configure`` after the user has already started a launch.
+"""
+
+import argparse
+from dataclasses import dataclass, fields
+from typing import Literal
+
+from switchyard.cli.config.user_config import DEFAULT_PROVIDER
+
+# Which defaults `configure` writes. Matches the CLI's --target choices.
+ConfigureTarget = Literal["all", "provider", "claude", "codex", "openclaw"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ConfigureRequest:
+    """Everything ``cmd_configure`` reads. Each default lives here, once."""
+
+    # One of these picks a mode (matches the CLI's mutually-exclusive group).
+    show: bool = False
+    reset: bool = False
+    list_models: bool = False
+    skill_distillation: str | None = None
+    disable_skill_distillation: bool = False
+
+    # Which provider and scope to configure.
+    json: bool = False
+    target: ConfigureTarget = "all"
+    provider: str = DEFAULT_PROVIDER
+    base_url: str | None = None
+    api_key: str | None = None
+
+    # Per-launcher endpoint overrides. None means "use the provider default".
+    claude_model: str | None = None
+    claude_base_url: str | None = None
+    claude_api_key: str | None = None
+    codex_model: str | None = None
+    codex_base_url: str | None = None
+    codex_api_key: str | None = None
+    openclaw_model: str | None = None
+    openclaw_base_url: str | None = None
+    openclaw_api_key: str | None = None
+
+    # Cross-cutting behavior. routing_profiles is the global --routing-profiles
+    # flag, merged in here so configure sees it alongside the rest.
+    routing_profiles: str | None = None
+    no_model_discovery: bool = False
+    no_tui: bool = False
+
+    # Extra inputs for the read-only --show / --list-models modes.
+    query: str | None = None
+    limit: int = 50
+    check: bool = False
+
+    # Set only by first-run launch setup; the CLI has no flags for these.
+    reuse_existing_provider: bool = False
+    prompt_default_api_key: str | None = None
+    prompt_default_api_key_source: str | None = None
+
+    @classmethod
+    def from_namespace(cls, ns: argparse.Namespace) -> "ConfigureRequest":
+        """Build a request from parsed CLI args.
+
+        This is the single spot where the loosely-typed argparse namespace
+        becomes a typed request. argparse fills every configure flag plus the
+        global routing_profiles; the launch-setup-only fields fall back to the
+        defaults above. Unknown namespace attributes (argparse's own ``func``,
+        etc.) are dropped so they can't leak in.
+        """
+        known = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in vars(ns).items() if key in known})
+
+
+__all__ = ["ConfigureRequest", "ConfigureTarget"]

--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -27,6 +27,7 @@ from switchyard.cli.config.user_config import (
     resolve_provider_connectivity,
 )
 from switchyard.cli.configure_command import cmd_configure
+from switchyard.cli.configure_request import ConfigureRequest, ConfigureTarget
 from switchyard.cli.intake_cli_config import IntakeCliConfig
 from switchyard.cli.launchers.launch_intake_config import LaunchIntakeConfig
 from switchyard.cli.output import format_dry_run
@@ -260,10 +261,12 @@ def maybe_bootstrap_launch_config(
     )
     resolved_api_key = connectivity.api_key
     print(f"Switchyard is missing {target} launch defaults. Starting setup.")
-    configure_args = argparse.Namespace(
-        show=False,
-        reset=False,
-        target=target,
+    # Build the same request `switchyard configure` would. Any field we don't
+    # set here — skill distillation, routing profiles, the --show/--list modes —
+    # takes its default from ConfigureRequest, so setup can't crash on one we
+    # forgot to pass.
+    cmd_configure(ConfigureRequest(
+        target=cast(ConfigureTarget, target),
         provider=connectivity.provider,
         base_url=connectivity.base_url,
         api_key=args.api_key,
@@ -277,31 +280,9 @@ def maybe_bootstrap_launch_config(
         claude_model=args.model if target == "claude" else None,
         codex_model=args.model if target == "codex" else None,
         openclaw_model=args.model if target == "openclaw" else None,
-        claude_base_url=None,
-        claude_api_key=None,
-        claude_weak_base_url=None,
-        claude_weak_api_key=None,
-        codex_base_url=None,
-        codex_api_key=None,
-        codex_weak_base_url=None,
-        codex_weak_api_key=None,
-        openclaw_base_url=None,
-        openclaw_api_key=None,
-        openclaw_weak_base_url=None,
-        openclaw_weak_api_key=None,
-        claude_routing=None,
-        codex_routing=None,
-        openclaw_routing=None,
-        claude_weak_model=None,
-        codex_weak_model=None,
-        openclaw_weak_model=None,
-        claude_strong_probability=None,
-        codex_strong_probability=None,
-        openclaw_strong_probability=None,
         no_model_discovery=getattr(args, "no_model_discovery", False),
         no_tui=getattr(args, "no_tui", False),
-    )
-    cmd_configure(configure_args)
+    ))
     if not args.api_key:
         configured_api_key = load_user_credentials().api_key(connectivity.provider)
         if configured_api_key:

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -79,6 +79,7 @@ from switchyard.cli.config.user_config import (
 from switchyard.cli.configure_command import (
     cmd_configure,
 )
+from switchyard.cli.configure_request import ConfigureRequest
 from switchyard.cli.intake_cli_config import IntakeCliConfig
 from switchyard.cli.launch_command import (
     cmd_launch_claude,
@@ -383,7 +384,7 @@ def _add_launch_intake_args(parser: argparse.ArgumentParser) -> None:
 
 
 def _cmd_configure(args: argparse.Namespace) -> None:
-    cmd_configure(args)
+    cmd_configure(ConfigureRequest.from_namespace(args))
 
 
 def _cmd_launch_claude(args: argparse.Namespace) -> None:

--- a/tests/test_launch_claude.py
+++ b/tests/test_launch_claude.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from switchyard.cli.configure_request import ConfigureRequest
 from switchyard.cli.launchers.claude_code_launcher import (
     _EXIT_BINARY_NOT_FOUND,
     _EXIT_SIGINT,
@@ -79,10 +80,10 @@ def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path
     monkeypatch.setenv("NVIDIA_BASE_URL", "https://nvidia.test/v1")
     monkeypatch.setattr("switchyard.cli.launch_command.is_interactive_terminal", lambda: True)
     monkeypatch.setattr("switchyard.cli.launch_command.load_secrets", lambda: {})
-    captured: dict[str, argparse.Namespace] = {}
+    captured: dict[str, ConfigureRequest] = {}
     monkeypatch.setattr(
         "switchyard.cli.launch_command.cmd_configure",
-        lambda configure_args: captured.setdefault("args", configure_args),
+        lambda configure_request: captured.setdefault("request", configure_request),
     )
 
     args = argparse.Namespace(
@@ -106,11 +107,48 @@ def test_bootstrap_persists_selected_env_provider_base_url(monkeypatch, tmp_path
         ),
     )
 
-    configure_args = captured["args"]
-    assert configure_args.provider == "nvidia"
-    assert configure_args.base_url == "https://nvidia.test/v1"
-    assert configure_args.prompt_default_api_key == "nvidia-key"  # pragma: allowlist secret
-    assert configure_args.prompt_default_api_key_source == "$NVIDIA_API_KEY"
+    configure_request = captured["request"]
+    assert configure_request.provider == "nvidia"
+    assert configure_request.base_url == "https://nvidia.test/v1"
+    assert configure_request.prompt_default_api_key == "nvidia-key"  # pragma: allowlist secret
+    assert configure_request.prompt_default_api_key_source == "$NVIDIA_API_KEY"
+
+    # Setup leaves these three at their ConfigureRequest defaults. Assert them
+    # directly so a regression in any one field fails here, not mid-launch: a
+    # missing default is exactly what crashed the first run before this fix.
+    assert configure_request.routing_profiles is None
+    assert configure_request.skill_distillation is None
+    assert configure_request.disable_skill_distillation is False
+
+    # The request setup builds must work with the real configure helpers. Before
+    # the typed ConfigureRequest, setup passed a hand-built namespace missing the
+    # skill-distillation fields, and these helpers crashed with AttributeError.
+    from switchyard.cli.config.user_config import SkillDistillationConfig
+    from switchyard.cli.configure_command import (
+        _apply_skill_distillation_args,
+        _skill_only_config_update,
+    )
+
+    assert (
+        _apply_skill_distillation_args(SkillDistillationConfig(), configure_request)
+        == SkillDistillationConfig()
+    )
+    assert _skill_only_config_update(configure_request) is False
+
+
+def test_configure_parser_builds_a_complete_request() -> None:
+    # A real `switchyard configure` parse must fill every ConfigureRequest field
+    # through the one from_namespace boundary. This is the check the original bug
+    # lacked: disable_skill_distillation is the field that crashed first-run.
+    from switchyard.cli.config.user_config import DEFAULT_PROVIDER
+    from switchyard.cli.switchyard_cli import _build_parser
+
+    namespace = _build_parser().parse_args(["configure"])
+    request = ConfigureRequest.from_namespace(namespace)
+
+    assert request.provider == DEFAULT_PROVIDER
+    assert request.disable_skill_distillation is False
+    assert request.routing_profiles is None  # the global flag is merged in
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The first time you run `switchyard launch claude` (or codex/openclaw) without a saved setup, it runs a one-time setup: it asks for your provider, model, and API key and writes them to a config file so later launches don't need those flags. That setup crashed before it could write anything:

```
Switchyard is missing claude launch defaults. Starting setup.
AttributeError: 'Namespace' object has no attribute 'disable_skill_distillation'
```

## Why it happened

`cmd_configure` (the code behind `switchyard configure`) read its inputs straight off an argparse `Namespace`. Two callers built that namespace: the `configure` CLI command (argparse fills every field), and launch setup, which hand-built a namespace with ~30 fields. The two drifted — launch setup was missing three fields the command reads, so the command hit a missing attribute and stopped.

## The fix

Give `cmd_configure` a real type. A new `ConfigureRequest` dataclass lists every field the command reads and its default, in one place. Both callers build that same type:

- the `configure` command via `ConfigureRequest.from_namespace(args)` (the one spot that touches the raw argparse namespace),
- launch setup via the constructor, passing only the handful of fields it knows and letting the rest take their defaults.

Now a caller can't leave out a field the command needs — a missing or misspelled field is a mypy error or fails right where it's built, instead of crashing mid-launch. The change also lets us drop ~11 defensive `getattr(args, ...)` reads and 15 dead fields that launch setup was setting for no reason.

## What changed

- New `switchyard/cli/configure_request.py` — the `ConfigureRequest` dataclass and its `from_namespace` builder.
- `cmd_configure` and its helpers take `ConfigureRequest` instead of a bare namespace.
- Launch setup builds a `ConfigureRequest` instead of a hand-rolled namespace.
- `switchyard configure` behavior is unchanged.

## Test

The old setup test replaced `cmd_configure` with a stub, so it never noticed the missing fields — that's how the crash shipped. Now `test_configure_parser_builds_a_complete_request` runs a real `configure` parse through `from_namespace` and checks the field that crashed is present, and the bootstrap test asserts the request setup builds works with the real configure helpers.

## Live run — NVIDIA Inference Hub, real tokens

Real setup path with a fresh config dir (`--reconfigure` forces setup):

`switchyard launch claude --reconfigure --model azure/anthropic/claude-haiku-4-5 --base-url https://inference-api.nvidia.com/v1 --api-key $NVIDIA_API_KEY --no-tui --no-model-discovery`

Before (fix reverted):

```
Switchyard is missing claude launch defaults. Starting setup.
AttributeError: 'Namespace' object has no attribute 'disable_skill_distillation'
```

After:

```
Switchyard is missing claude launch defaults. Starting setup.
Saved Switchyard config to <cfg>/config.json
Saved Switchyard credentials to <cfg>/credentials.json
  switchyard  ready  →  azure/anthropic/claude-haiku-4-5
  ...
  READY
  requests : 1
  tokens   : 80,072 in  5 out
```

Setup finishes, writes the config and credentials, the proxy starts, and one `claude` turn reaches the model through the NVIDIA gateway for a real reply (80,072 in / 5 out).

Saved `config.json` (the API key goes to a separate `credentials.json`):

```json
{
  "default_provider": "nvidia",
  "launch": {
    "claude": {
      "model": "azure/anthropic/claude-haiku-4-5",
      "route": {"model": "azure/anthropic/claude-haiku-4-5", "type": "single"}
    }
  },
  "providers": {"nvidia": {"base_url": "https://inference-api.nvidia.com/v1"}}
}
```

Fixes #60.
