### PR TITLE
chore(server): guard that /v1/models reports null model capabilities

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -481,6 +481,10 @@ fn model_list_payload<'a>(models: impl IntoIterator<Item = &'a str>) -> Value {
     })
 }
 
+// One OpenAI-compatible `/v1/models` entry. `model` is a symbolic route/algorithm id
+// (e.g. "random"), not an upstream model, so the served model's context window and
+// tool-calling support are unknown here — report null rather than inferring from the id,
+// which would be wrong. `streaming` and the inbound formats are facts about this server.
 fn model_entry_json(model: &str) -> Value {
     json!({
         "id": model,

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -327,6 +327,25 @@ async fn routes_dispatch_and_discovery_endpoints_are_stable() -> TestResult {
 }
 
 #[tokio::test]
+async fn models_report_null_capabilities_for_symbolic_routes() -> TestResult {
+    // A /v1/models id is a symbolic algorithm/route name (e.g. "random"), not an upstream
+    // model, so its context window and tool-calling support are unknown and must stay null.
+    // The big-context target makes this a discriminating guard: any inference from the route
+    // id *or* the target would report a number here and fail this test.
+    let (_upstream, app) = test_app(&[("random", &["deepseek-v4-pro"])]).await?;
+
+    let models = send(&app, "GET", "/v1/models", None).await?;
+    assert_eq!(models.status, StatusCode::OK);
+    let entry = models.json()?["data"][0].clone();
+    assert_eq!(entry["id"], "random");
+    assert_eq!(entry["capabilities"]["context_window"], json!(null));
+    assert_eq!(entry["capabilities"]["tool_calling"], json!(null));
+    // Facts the server does know stay populated.
+    assert_eq!(entry["capabilities"]["streaming"], json!(true));
+    Ok(())
+}
+
+#[tokio::test]
 async fn all_inbound_formats_run_libsy_and_return_the_caller_format() -> TestResult {
     let (upstream, app) = test_app(&[(ROUTE_MODEL, &["model/a"])]).await?;
 


### PR DESCRIPTION
## What

`GET /v1/models` leaves each model's `context_window` and `tool_calling` as `null`, and this PR keeps it that way on purpose, with a test that locks it in.

## Why

The `id` in `/v1/models` is a symbolic route name (like `random` or `smart`), not the upstream model behind it — so there's nothing to read a real context window or tool-calling flag from. Inferring one from the route name (or from a target) would be a guess, and a wrong one. The operator picks the models they route to and already knows their limits, so Switchyard doesn't need to advertise them.

This replaces the earlier version of this PR, which inferred the context window from the model id and broke once the id became a route name (flagged in review).

## Change

- A comment on `model_entry_json` explaining why the two fields are `null`.
- A test that serves a route named `random` over a big-context target and asserts both fields are `null` — written so any future attempt to infer a value (from the route name or the target) fails the test.
- `streaming` and the supported inbound formats stay populated; those are facts about this server, not the upstream model.

If someone later needs these reported, the operator can declare them in the server config and we report exactly what they set — no guessing.
