### PR TITLE
fix(launch): guard zero-config default trio and report routing bundle in --dry-run

### DIFF
--- a/docs/guides/agent_launchers.md
+++ b/docs/guides/agent_launchers.md
@@ -48,6 +48,13 @@ strong tier using the validated coding-agent trio:
 when route resolution selects an explicit or saved route bundle or single
 model.
 
+The default trio uses OpenRouter model ids and therefore requires OpenRouter
+connectivity (`OPENROUTER_API_KEY`). If the resolved provider is not OpenRouter,
+the launcher fails fast. The strong tier stays `anthropic/claude-opus-4.7`, so
+`--weak-model`/`--classifier-model` don't make the trio reachable — pass
+`--model` for a single model, use `--routing-profiles` for a bundle, or set
+`OPENROUTER_API_KEY`.
+
 ## Override the default route
 
 Use `--model` for a single-model passthrough session:

--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -97,6 +97,44 @@ def resolve_launch_connectivity(
     return connectivity.api_key, connectivity.base_url
 
 
+# Marker for the OpenRouter gateway. The zero-flag deterministic default trio
+# uses OpenRouter-only model ids, so a resolved endpoint that isn't OpenRouter
+# cannot serve them.
+_OPENROUTER_URL_MARKER = "openrouter.ai"
+
+
+def _reject_openrouter_only_default_trio(
+    target: str,
+    args: argparse.Namespace,
+    api_key_env_vars: tuple[str, ...],
+    base_url: str,
+) -> None:
+    """Fail fast when the zero-config default trio can't reach the provider.
+
+    The deterministic zero-flag default uses OpenRouter-only model ids
+    (``anthropic/claude-opus-4.7`` / ``moonshotai/kimi-k2.6`` /
+    ``google/gemini-3.5-flash``). This runs only on the deterministic path, so
+    ``--model`` has already been ruled out, and ``--weak-model`` /
+    ``--classifier-model`` do not help because the strong tier stays
+    ``anthropic/claude-opus-4.7``. So when the resolved endpoint is not
+    OpenRouter, raise :class:`SystemExit` pointing the user at ``--model``,
+    ``--routing-profiles``, or ``OPENROUTER_API_KEY`` instead of launching a
+    trio that can't work.
+    """
+    if _OPENROUTER_URL_MARKER in base_url:
+        return
+    provider = _resolve_launch_connectivity(
+        args, api_key_env_vars=api_key_env_vars,
+    ).provider
+    raise SystemExit(
+        f"launch {target}: the zero-config default trio "
+        f"(anthropic/claude-opus-4.7, moonshotai/kimi-k2.6, "
+        f"google/gemini-3.5-flash) is OpenRouter-only; the resolved provider "
+        f"is {provider!r}. Pass --model, use --routing-profiles, or set "
+        f"OPENROUTER_API_KEY."
+    )
+
+
 def _is_deterministic_launch(
     target: str,
     args: argparse.Namespace,
@@ -605,6 +643,7 @@ def cmd_launch_claude(args: argparse.Namespace) -> None:
             classifier_model=dry_run_classifier_model,
             profile=dry_run_profile,
             classifier_min_confidence=dry_run_min_confidence,
+            routing_profiles=routing_profiles,
         ))
         return
 
@@ -614,6 +653,17 @@ def cmd_launch_claude(args: argparse.Namespace) -> None:
     startup_timing.mark("config + credentials resolved")
 
     if deterministic:
+        _reject_openrouter_only_default_trio(
+            target="claude",
+            args=args,
+            api_key_env_vars=(
+                "OPENROUTER_API_KEY",
+                "NVIDIA_API_KEY",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ),
+            base_url=primary_connectivity.base_url,
+        )
         primary_connectivity = require_launch_tier_key(
             target="claude",
             tier=PRIMARY_TIER,
@@ -798,6 +848,7 @@ def cmd_launch_codex(args: argparse.Namespace) -> None:
             classifier_model=dry_run_classifier_model,
             profile=dry_run_profile,
             classifier_min_confidence=dry_run_min_confidence,
+            routing_profiles=routing_profiles,
         ))
         return
 
@@ -806,6 +857,12 @@ def cmd_launch_codex(args: argparse.Namespace) -> None:
     )
 
     if deterministic:
+        _reject_openrouter_only_default_trio(
+            target="codex",
+            args=args,
+            api_key_env_vars=("OPENROUTER_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY"),
+            base_url=primary_connectivity.base_url,
+        )
         primary_connectivity = require_launch_tier_key(
             target="codex",
             tier=PRIMARY_TIER,
@@ -1006,6 +1063,7 @@ def cmd_launch_openclaw(args: argparse.Namespace) -> None:
             classifier_model=dry_run_classifier_model,
             profile=dry_run_profile,
             classifier_min_confidence=dry_run_min_confidence,
+            routing_profiles=routing_profiles,
         ))
         return
 
@@ -1014,6 +1072,17 @@ def cmd_launch_openclaw(args: argparse.Namespace) -> None:
     )
 
     if deterministic:
+        _reject_openrouter_only_default_trio(
+            target="openclaw",
+            args=args,
+            api_key_env_vars=(
+                "OPENROUTER_API_KEY",
+                "NVIDIA_API_KEY",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ),
+            base_url=primary_connectivity.base_url,
+        )
         primary_connectivity = require_launch_tier_key(
             target="openclaw",
             tier=PRIMARY_TIER,

--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -103,12 +103,7 @@ def resolve_launch_connectivity(
 _OPENROUTER_URL_MARKER = "openrouter.ai"
 
 
-def _reject_openrouter_only_default_trio(
-    target: str,
-    args: argparse.Namespace,
-    api_key_env_vars: tuple[str, ...],
-    base_url: str,
-) -> None:
+def _reject_openrouter_only_default_trio(target: str, base_url: str) -> None:
     """Fail fast when the zero-config default trio can't reach the provider.
 
     The deterministic zero-flag default uses OpenRouter-only model ids
@@ -123,15 +118,12 @@ def _reject_openrouter_only_default_trio(
     """
     if _OPENROUTER_URL_MARKER in base_url:
         return
-    provider = _resolve_launch_connectivity(
-        args, api_key_env_vars=api_key_env_vars,
-    ).provider
     raise SystemExit(
         f"launch {target}: the zero-config default trio "
         f"(anthropic/claude-opus-4.7, moonshotai/kimi-k2.6, "
-        f"google/gemini-3.5-flash) is OpenRouter-only; the resolved provider "
-        f"is {provider!r}. Pass --model, use --routing-profiles, or set "
-        f"OPENROUTER_API_KEY."
+        f"google/gemini-3.5-flash) is OpenRouter-only, but the resolved "
+        f"endpoint is {base_url!r}. Pass --model, use --routing-profiles, or "
+        f"set OPENROUTER_API_KEY."
     )
 
 
@@ -655,13 +647,6 @@ def cmd_launch_claude(args: argparse.Namespace) -> None:
     if deterministic:
         _reject_openrouter_only_default_trio(
             target="claude",
-            args=args,
-            api_key_env_vars=(
-                "OPENROUTER_API_KEY",
-                "NVIDIA_API_KEY",
-                "OPENAI_API_KEY",
-                "ANTHROPIC_API_KEY",
-            ),
             base_url=primary_connectivity.base_url,
         )
         primary_connectivity = require_launch_tier_key(
@@ -859,8 +844,6 @@ def cmd_launch_codex(args: argparse.Namespace) -> None:
     if deterministic:
         _reject_openrouter_only_default_trio(
             target="codex",
-            args=args,
-            api_key_env_vars=("OPENROUTER_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY"),
             base_url=primary_connectivity.base_url,
         )
         primary_connectivity = require_launch_tier_key(
@@ -1074,13 +1057,6 @@ def cmd_launch_openclaw(args: argparse.Namespace) -> None:
     if deterministic:
         _reject_openrouter_only_default_trio(
             target="openclaw",
-            args=args,
-            api_key_env_vars=(
-                "OPENROUTER_API_KEY",
-                "NVIDIA_API_KEY",
-                "OPENAI_API_KEY",
-                "ANTHROPIC_API_KEY",
-            ),
             base_url=primary_connectivity.base_url,
         )
         primary_connectivity = require_launch_tier_key(

--- a/switchyard/cli/output.py
+++ b/switchyard/cli/output.py
@@ -143,12 +143,19 @@ def format_dry_run(
     classifier_model: str | None = None,
     profile: str | None = None,
     classifier_min_confidence: float | None = None,
+    routing_profiles: str | None = None,
 ) -> str:
     """Render resolved launch settings without exposing secrets.
 
     The optional ``classifier_*`` / ``profile`` kwargs are populated by the
     deterministic-routing dispatch path — the routing-policy fields that
     aren't carried on :class:`LaunchRouteConfig`.
+
+    ``routing_profiles`` is the resolved routing-profiles YAML path for a
+    multi-chain bundle launch. When set, the summary reports ``route: bundle``
+    plus the bundle path and its route ids instead of the single-tier
+    :func:`format_route_config` view (``route`` is a placeholder single-tier
+    config in that case).
     """
 
     lines = [
@@ -158,15 +165,28 @@ def format_dry_run(
         f"port: {port if port is not None else 'auto'}",
         f"timeout: {timeout if timeout is not None else 'default'}",
     ]
-    for route_line in format_route_config(route):
-        lines.append(route_line)
-    if route.type == "deterministic":
-        if classifier_model:
-            lines.append(f"classifier model: {classifier_model}")
-        if profile:
-            lines.append(f"profile: {profile}")
-        if classifier_min_confidence is not None:
-            lines.append(f"min confidence: {classifier_min_confidence:.2f}")
+    if routing_profiles:
+        from switchyard.cli.route_bundle import (
+            parse_routing_profiles_file,
+            routing_profile_model_ids,
+        )
+
+        lines.append("route: bundle")
+        lines.append(f"routing profiles: {routing_profiles}")
+        for route_id in routing_profile_model_ids(
+            parse_routing_profiles_file(routing_profiles)
+        ):
+            lines.append(f"  {route_id}")
+    else:
+        for route_line in format_route_config(route):
+            lines.append(route_line)
+        if route.type == "deterministic":
+            if classifier_model:
+                lines.append(f"classifier model: {classifier_model}")
+            if profile:
+                lines.append(f"profile: {profile}")
+            if classifier_min_confidence is not None:
+                lines.append(f"min confidence: {classifier_min_confidence:.2f}")
     if forwarded_args:
         lines.append(f"forwarded args: {' '.join(forwarded_args)}")
     return "\n".join(lines)

--- a/tests/test_launch_claude_deterministic.py
+++ b/tests/test_launch_claude_deterministic.py
@@ -305,43 +305,7 @@ class TestDispatch:
         assert "anthropic/claude-opus-4.7" in message
         assert "moonshotai/kimi-k2.6" in message
         assert "google/gemini-3.5-flash" in message
-        assert "'nvidia'" in message
-
-    def test_model_flag_bypasses_non_openrouter_guard(
-        self, monkeypatch, tmp_path,
-    ) -> None:
-        """Passing --model opts out of the default trio, bypassing the guard."""
-        from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_claude
-
-        monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
-        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
-        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        monkeypatch.setattr(
-            "switchyard.cli.launch_command.resolve_launch_connectivity",
-            lambda args, **_kw: ("nvapi-test", "https://inference-api.nvidia.com/v1"),
-        )
-
-        captured: dict = {}
-
-        def fake_passthrough(**kwargs):
-            captured.update(kwargs)
-            raise SystemExit(0)
-
-        monkeypatch.setattr(
-            "switchyard.cli.launchers.claude_code_launcher.launch_claude",
-            fake_passthrough,
-        )
-
-        parser = _build_parser()
-        args = parser.parse_args([
-            "launch", "claude", "--model", "nvidia/moonshotai/kimi-k2.5",
-        ])
-
-        with pytest.raises(SystemExit) as exc_info:
-            _cmd_launch_claude(args)
-
-        assert "OpenRouter-only" not in str(exc_info.value)
-        assert captured["model"] == "nvidia/moonshotai/kimi-k2.5"
+        assert "https://inference-api.nvidia.com/v1" in message
 
 
 class TestRoutesByDefault:

--- a/tests/test_launch_claude_deterministic.py
+++ b/tests/test_launch_claude_deterministic.py
@@ -10,8 +10,6 @@ overrides (``--weak-model``, ``--classifier-model``, ``--profile``,
 ``--classifier-min-confidence``) still tune the default trio.
 """
 
-from __future__ import annotations
-
 import pytest
 
 
@@ -248,6 +246,102 @@ class TestDispatch:
 
         # Dry-run prints + returns without SystemExit.
         _cmd_launch_claude(args)
+
+    def test_dry_run_routing_profiles_reports_bundle(
+        self, monkeypatch, tmp_path, capsys,
+    ) -> None:
+        """A ``--routing-profiles`` dry run reports ``route: bundle``, not single."""
+        from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_claude
+
+        yaml_path = tmp_path / "routes.yaml"
+        yaml_path.write_text(
+            "routes:\n"
+            "  my-route:\n"
+            "    type: model\n"
+            "    model: openai/gpt-4o-mini\n",
+            encoding="utf-8",
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args([
+            "--routing-profiles", str(yaml_path),
+            "--", "launch", "claude", "--dry-run",
+        ])
+
+        monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "switchyard.cli.launch_command.resolve_launch_connectivity",
+            lambda args, **_kw: ("sk-test", "https://openrouter.ai/api/v1"),
+        )
+
+        _cmd_launch_claude(args)
+
+        out = capsys.readouterr().out
+        assert "route: bundle" in out
+        assert "route: single" not in out
+
+    def test_zero_config_non_openrouter_rejects_default_trio(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """Zero-flag launch against a non-OpenRouter provider fails fast."""
+        from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_claude
+
+        monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "switchyard.cli.launch_command.resolve_launch_connectivity",
+            lambda args, **_kw: ("nvapi-test", "https://inference-api.nvidia.com/v1"),
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args(["launch", "claude"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_launch_claude(args)
+
+        message = str(exc_info.value)
+        assert "OpenRouter-only" in message
+        assert "anthropic/claude-opus-4.7" in message
+        assert "moonshotai/kimi-k2.6" in message
+        assert "google/gemini-3.5-flash" in message
+        assert "'nvidia'" in message
+
+    def test_model_flag_bypasses_non_openrouter_guard(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """Passing --model opts out of the default trio, bypassing the guard."""
+        from switchyard.cli.switchyard_cli import _build_parser, _cmd_launch_claude
+
+        monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "switchyard.cli.launch_command.resolve_launch_connectivity",
+            lambda args, **_kw: ("nvapi-test", "https://inference-api.nvidia.com/v1"),
+        )
+
+        captured: dict = {}
+
+        def fake_passthrough(**kwargs):
+            captured.update(kwargs)
+            raise SystemExit(0)
+
+        monkeypatch.setattr(
+            "switchyard.cli.launchers.claude_code_launcher.launch_claude",
+            fake_passthrough,
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args([
+            "launch", "claude", "--model", "nvidia/moonshotai/kimi-k2.5",
+        ])
+
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_launch_claude(args)
+
+        assert "OpenRouter-only" not in str(exc_info.value)
+        assert captured["model"] == "nvidia/moonshotai/kimi-k2.5"
 
 
 class TestRoutesByDefault:

--- a/tests/test_launch_claude_deterministic.py
+++ b/tests/test_launch_claude_deterministic.py
@@ -265,7 +265,7 @@ class TestDispatch:
         parser = _build_parser()
         args = parser.parse_args([
             "--routing-profiles", str(yaml_path),
-            "--", "launch", "claude", "--dry-run",
+            "launch", "claude", "--dry-run",
         ])
 
         monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))

--- a/tests/test_launch_codex.py
+++ b/tests/test_launch_codex.py
@@ -506,9 +506,12 @@ class TestLaunchCodex:
         )
 
         monkeypatch.setenv("SWITCHYARD_CONFIG_DIR", str(tmp_path))
+        # OpenRouter endpoint: the zero-flag default trio is OpenRouter-only, so
+        # the deterministic default only dispatches when the resolved endpoint is
+        # OpenRouter (a non-OpenRouter provider is rejected).
         monkeypatch.setattr(
             "switchyard.cli.launch_command.resolve_launch_connectivity",
-            lambda args, **_kw: ("sk-test", "https://inference-api.nvidia.com/v1"),
+            lambda args, **_kw: ("sk-test", "https://openrouter.ai/api/v1"),
         )
 
         captured: dict = {}


### PR DESCRIPTION
Two launcher fixes.

**Zero-config launch on a non-OpenRouter provider now stops before it launches.**
With no `--model` and no `--routing-profiles`, `switchyard launch claude` (and `codex`/`openclaw`) uses the fixed default trio — strong `anthropic/claude-opus-4.7`, weak `moonshotai/kimi-k2.6`, classifier `google/gemini-3.5-flash` — which are all OpenRouter model ids. If your credentials resolve to a different provider (for example NVIDIA via `NVIDIA_API_KEY`), those ids don't exist on that endpoint. The old code launched anyway and only failed on the first request. Now the launcher exits first with a message that names the trio, the resolved provider, and the way out: pass `--model` for a single model or `--routing-profiles FILE` for a bundle, or set `OPENROUTER_API_KEY`.

**`launch --dry-run` now labels a routing-profiles bundle as a bundle.**
Running a dry run with `--routing-profiles FILE` printed `route: single` (the placeholder single-tier view). It now prints `route: bundle`, the bundle path, and the routable ids read from the YAML.

How to try it:
- `NVIDIA_API_KEY=... switchyard launch claude` → exits with the "OpenRouter-only" guidance instead of spawning.
- `switchyard --routing-profiles routes.yaml -- launch claude --dry-run` → prints `route: bundle`.

Regression tests for both live in `tests/test_launch_claude_deterministic.py`. The existing codex zero-flag test now points at an OpenRouter endpoint so it still exercises the deterministic dispatch path rather than tripping the new guard.
