### PR TITLE
fix(stats): record noop routes in /v1/routing/stats

### DIFF
--- a/switchyard/lib/profiles/noop.py
+++ b/switchyard/lib/profiles/noop.py
@@ -220,13 +220,9 @@ class NoopProfile:
     ) -> ChatResponse:
         """Execute no-op response generation with an existing context."""
         processed = await self.process_with_context(input, ctx)
-        # Record the call under the "noop" model. Stamping ctx.selected_model
-        # lets the stats response processor attribute the response tokens to
-        # "noop" instead of "<unknown>"; record_success counts the request so
-        # the noop route shows up in /v1/routing/stats.
+        # Stamp ctx.selected_model so the stats response processor attributes
+        # the response tokens to "noop" instead of "<unknown>".
         ctx.selected_model = _NOOP_MODEL
-        if self._stats_accumulator is not None:
-            await self._stats_accumulator.record_success(_NOOP_MODEL, None, None)
         openai_request = self._translation.request_to_any_of(
             processed.request,
             _NOOP_SUPPORTED_TYPES,
@@ -245,6 +241,12 @@ class NoopProfile:
             response = ChatResponse.openai_completion(
                 _make_completion(request_id=request_id, created=created)
             )
+        # Count the request only after the response is built, so a translation
+        # failure does not leave a spurious success in /v1/routing/stats. Record
+        # success before rprocess records tokens, which is the order the stats
+        # response processor's record_usage_after_success_attribution expects.
+        if self._stats_accumulator is not None:
+            await self._stats_accumulator.record_success(_NOOP_MODEL, None, None)
         return await self.rprocess(processed, response)
 
 

--- a/switchyard/lib/profiles/noop.py
+++ b/switchyard/lib/profiles/noop.py
@@ -118,11 +118,13 @@ class NoopProfile:
         *,
         request_processors: tuple[Any, ...] = (),
         response_processors: tuple[Any, ...] = (),
+        stats_accumulator: StatsAccumulator | None = None,
     ) -> None:
         """Create a no-op profile with a local translation helper."""
         self._translation = TranslationEngine()
         self._request_processors = request_processors
         self._response_processors = response_processors
+        self._stats_accumulator = stats_accumulator
 
     def iter_components(self) -> list[object]:
         """Return lifecycle components in startup order."""
@@ -162,6 +164,7 @@ class NoopProfile:
         return NoopProfile(
             request_processors=tuple(request_chain),
             response_processors=tuple(response_chain),
+            stats_accumulator=stats if enable_stats else None,
         )
 
     async def process(self, input: ProfileInput) -> NoopProcessedRequest:
@@ -217,6 +220,13 @@ class NoopProfile:
     ) -> ChatResponse:
         """Execute no-op response generation with an existing context."""
         processed = await self.process_with_context(input, ctx)
+        # Record the call under the "noop" model. Stamping ctx.selected_model
+        # lets the stats response processor attribute the response tokens to
+        # "noop" instead of "<unknown>"; record_success counts the request so
+        # the noop route shows up in /v1/routing/stats.
+        ctx.selected_model = _NOOP_MODEL
+        if self._stats_accumulator is not None:
+            await self._stats_accumulator.record_success(_NOOP_MODEL, None, None)
         openai_request = self._translation.request_to_any_of(
             processed.request,
             _NOOP_SUPPORTED_TYPES,

--- a/switchyard/lib/profiles/noop.py
+++ b/switchyard/lib/profiles/noop.py
@@ -35,7 +35,7 @@ _NOOP_CONTENT = "pong"
 _NOOP_MODEL = "noop"
 
 
-def _make_completion(*, request_id: str, created: int) -> ChatCompletion:
+def _make_completion(request_id: str, created: int) -> ChatCompletion:
     """Build the fixed no-op non-streaming completion."""
     return ChatCompletion(
         id=f"chatcmpl-{request_id}",
@@ -54,7 +54,6 @@ def _make_completion(*, request_id: str, created: int) -> ChatCompletion:
 
 
 async def _noop_stream(
-    *,
     request_id: str,
     created: int,
 ) -> AsyncIterator[ChatCompletionChunk]:
@@ -115,7 +114,6 @@ class NoopProfile:
 
     def __init__(
         self,
-        *,
         request_processors: tuple[Any, ...] = (),
         response_processors: tuple[Any, ...] = (),
         stats_accumulator: StatsAccumulator | None = None,

--- a/switchyard/lib/profiles/noop.py
+++ b/switchyard/lib/profiles/noop.py
@@ -244,7 +244,7 @@ class NoopProfile:
         # success before rprocess records tokens, which is the order the stats
         # response processor's record_usage_after_success_attribution expects.
         if self._stats_accumulator is not None:
-            await self._stats_accumulator.record_success(_NOOP_MODEL, None, None)
+            await self._stats_accumulator.record_success(_NOOP_MODEL)
         return await self.rprocess(processed, response)
 
 

--- a/tests/test_noop_llm_backend.py
+++ b/tests/test_noop_llm_backend.py
@@ -4,6 +4,7 @@
 """Unit tests for the no-op profile."""
 
 from switchyard.lib.profiles import NoopProfile, NoopProfileConfig, ProfileSwitchyard
+from switchyard.lib.stats_accumulator import StatsAccumulator
 from switchyard_rust.core import ChatRequest, ChatResponseType, response_type_matches
 from switchyard_rust.profiles import ProfileInput
 
@@ -106,3 +107,22 @@ class TestNoOpProfile:
 
         assert processed.request.model == "noop"
         assert processed_response is response
+
+    async def test_noop_call_reports_routing_stats(self) -> None:
+        """The no-op profile self-reports its call and model to the stats accumulator."""
+        stats = StatsAccumulator()
+        profile = NoopProfileConfig().build().with_runtime_components(
+            stats_accumulator=stats
+        )
+
+        await ProfileSwitchyard(profile).call(_openai_request(stream=False))
+
+        snap = stats.snapshot_sync()
+        assert snap["total_requests"] == 1
+        assert "noop" in snap["models"]
+        assert snap["models"]["noop"]["calls"] == 1
+        assert "<unknown>" not in snap["models"]
+        # Response tokens land on "noop", not "<unknown>".
+        assert snap["models"]["noop"]["prompt_tokens"] == 1
+        assert snap["models"]["noop"]["completion_tokens"] == 1
+        assert snap["models"]["noop"]["total_tokens"] == 2

--- a/tests/test_noop_llm_backend.py
+++ b/tests/test_noop_llm_backend.py
@@ -9,7 +9,7 @@ from switchyard_rust.core import ChatRequest, ChatResponseType, response_type_ma
 from switchyard_rust.profiles import ProfileInput
 
 
-def _openai_request(*, stream: bool = False) -> ChatRequest:
+def _openai_request(stream: bool = False) -> ChatRequest:
     return ChatRequest.openai_chat(
         {"model": "noop", "messages": [{"role": "user", "content": "ping"}], "stream": stream}
     )


### PR DESCRIPTION
Before this change, a `type: noop` route never showed up in `GET /v1/routing/stats`. The no-op profile returned its fixed "pong" response without telling the stats accumulator which model served the request, so the response-side stats processor bucketed the tokens under `<unknown>` and never counted the call. `total_requests` stayed at 0 and there was no `noop` entry.

Now `run_with_context` sets `ctx.selected_model = "noop"` and calls `record_success("noop")` before it builds the response. The call is counted once: `record_success` bumps `total_requests` and the model's `calls`, and the response processor only adds tokens. So the route shows up as the `noop` model with its request count and token totals.

This mirrors how the latency-service backend already reports itself: set `ctx.selected_model` so the Rust `StatsResponseProcessor` attributes usage to the right model, plus `record_success` so the call is counted.

This is the route-bundle / route-table serving path (the same path `switchyard launch` builds). Serving a Python-defined profile through `serve --config` uses a separate adapter that does not attach a routing-stats accumulator, so that path is unaffected here.

How to try it — serve a route bundle with a `noop` route, send one request, then read the stats:

```yaml
# noop.yaml
defaults:
  api_key: unused
  base_url: https://openrouter.ai/api/v1
  format: openai
routes:
  bench:
    type: noop
```

```
switchyard --routing-profiles noop.yaml serve --port 4000
curl -s localhost:4000/v1/chat/completions \
  -d '{"model":"bench","messages":[{"role":"user","content":"ping"}]}'
curl -s localhost:4000/v1/routing/stats
```

On this branch `/v1/routing/stats` shows `total_requests: 1` and a `noop` model with `calls: 1` and its token totals; on `main` it shows `total_requests: 0` and an `<unknown>` bucket instead.

Added `test_noop_call_reports_routing_stats`, which builds the profile through the same `with_runtime_components(...)` path the route bundle uses and asserts `total_requests == 1`, a `noop` model entry with `calls == 1` and token totals `1/1/2`, and no `<unknown>` bucket.
