### PR TITLE
docs: correct AUTO probe order, extras, saved-bundle note, and stale API references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,14 +34,16 @@ traffic that sits between client applications and LLM backends.
 - **Observability** — Prometheus `/metrics`, a JSON `/v1/stats`
   (`/v1/routing/stats` alias), and per-request cost/token/latency stats. See
   [Metrics Reference](docs/METRICS_REFERENCE.md).
-- **Python library** — `SwitchyardRecipes` (`passthrough_recipe`,
-  `random_routing_recipe`, `stage_router_recipe`, `deterministic_routing_recipe`,
-  …) and typed `ChatRequest` / `ChatResponse` containers for in-process use.
+- **Python library** — `ProfileSwitchyard` driven by typed profile configs
+  (`PassthroughProfileConfig`, `RandomRoutingProfileConfig`,
+  `StageRouterProfileConfig`, …) and typed `ChatRequest` / `ChatResponse`
+  containers for in-process use.
 - **Rust core** (PyO3) — chain execution, the latency-aware router, and the
   tool-result signal collector are implemented in Rust and re-exported to
   Python.
 - **Packaging** — `pip install nemo-switchyard` with optional extras `[server]`,
-  `[cli]`, `[gpu]`, `[all]`. See [Installation](INSTALLATION.md).
+  `[cli]`, `[tracing]`, `[intake]`, `[affinity-redis]`, `[all]`. See
+  [Installation](INSTALLATION.md).
 
 ### Deprecated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ See [Agents](AGENTS.md) for the full architecture guide. Key points:
 
 - **Typed requests/responses** — use `ChatRequest` and `ChatResponse` subtypes
 - **Composable chain** — `RequestProcessor` → `LLMBackend` → `ResponseProcessor` → `TranslationEngine`
-- **Recipes** — pre-built chains in `switchyard/lib/recipes.py`
+- **Profiles** — pre-built chains in `switchyard/lib/profiles/`
 
 When adding a new component:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ switchyard/
 │   ├── lib/                       # Core library
 │   │   ├── roles.py               # RequestProcessor, LLMBackend, ResponseProcessor ABCs
 │   │   ├── switchyard.py          # Switchyard chain executor
-│   │   ├── recipes.py             # SwitchyardRecipes (passthrough, random_routing, …)
+│   │   ├── profiles/              # Profile configs/runtimes (passthrough, random_routing, …)
 │   │   ├── proxy_context.py       # ProxyContext — per-request state
 │   │   ├── chat_request/          # Typed request hierarchy
 │   │   ├── chat_response/         # Typed response hierarchy

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -67,7 +67,7 @@ All optional dependencies for complete feature set:
 pip install nemo-switchyard[all]
 ```
 
-Equivalent to: `switchyard[server,cli]`
+Equivalent to: `nemo-switchyard[server,cli,tracing,intake,affinity-redis]`
 
 ### Common Combinations
 
@@ -114,13 +114,13 @@ pip install nemo-switchyard[all]
 Embed Switchyard with minimal overhead:
 
 ```python
-from switchyard import SwitchyardRecipes
+from switchyard import PassthroughProfileConfig, ProfileSwitchyard
 
 # Core library only — no server/CLI dependencies
-switchyard = SwitchyardRecipes.passthrough_recipe(
+switchyard = ProfileSwitchyard(PassthroughProfileConfig(
     api_key="sk-...",
     base_url="https://api.openai.com/v1",
-)
+).build())
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Optional extras:
 ```bash
 pip install "nemo-switchyard[server]"   # FastAPI / Uvicorn HTTP endpoints
 pip install "nemo-switchyard[cli]"      # Interactive CLI launchers (Claude / Codex)
-pip install "nemo-switchyard[all]"      # Server, CLI, and tracing extras
+pip install "nemo-switchyard[all]"      # Server, CLI, tracing, intake, and affinity-redis extras
 ```
 
 See [Installation](INSTALLATION.md) for a full breakdown of what each extra adds.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -455,8 +455,8 @@ switchyard [--routing-profiles PATH] configure [--show [--check] [--json] | --re
 | `--check` | With `--show`, call `GET /models` against the resolved provider and report pass/fail in the output. |
 
 > **Saved bundles keep `${VAR}` references literal.** A saved routing-profile
-> bundle stores `${OPENROUTER_API_KEY}` (and any other `${VAR}`) verbatim —
-> secrets are never baked in. The referenced environment variables must therefore
+> bundle stores `${OPENROUTER_API_KEY}` (and any other `${VAR}`) verbatim. The
+> referenced environment variables must therefore
 > be present in the environment at `serve` / `launch` time; on another machine or
 > shell, export them again or Switchyard aborts with
 > `missing environment variable(s): NAME`.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -50,9 +50,10 @@ upstream requests. Configuration files use these lowercase values:
 
 `auto` resolves formats in this order:
 
-1. Probe `/v1/messages`; use `anthropic` when supported.
-2. Probe `/v1/responses`; use `responses` when supported.
-3. Fall back to `openai` and `/v1/chat/completions`.
+1. Probe `/v1/chat/completions`; use `openai` when supported.
+2. Probe `/v1/messages`; use `anthropic` when supported.
+3. Probe `/v1/responses`; use `responses` when supported.
+4. Fall back to `openai` (`/v1/chat/completions`).
 
 Single-model Claude Code and Codex launches use `auto`. OpenClaw is pinned to
 `openai`. Prefer an explicit format when the upstream contract is known so
@@ -452,6 +453,13 @@ switchyard [--routing-profiles PATH] configure [--show [--check] [--json] | --re
 | `--no-model-discovery` | Skip `GET /models` and rely on explicit or existing model values during interactive setup. |
 | `--no-tui` | Use plain text prompts instead of the TUI selector. |
 | `--check` | With `--show`, call `GET /models` against the resolved provider and report pass/fail in the output. |
+
+> **Saved bundles keep `${VAR}` references literal.** A saved routing-profile
+> bundle stores `${OPENROUTER_API_KEY}` (and any other `${VAR}`) verbatim —
+> secrets are never baked in. The referenced environment variables must therefore
+> be present in the environment at `serve` / `launch` time; on another machine or
+> shell, export them again or Switchyard aborts with
+> `missing environment variable(s): NAME`.
 
 **Skill distillation config**
 

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # Add package to path for development (not needed when installed via pip)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from switchyard import ChatRequest, SwitchyardRecipes
+from switchyard import ChatRequest, PassthroughProfileConfig, ProfileSwitchyard
 
 
 async def main():
@@ -39,10 +39,10 @@ async def main():
         return
 
     # Create a passthrough proxy that forwards to OpenAI
-    switchyard = SwitchyardRecipes.passthrough_recipe(
+    switchyard = ProfileSwitchyard(PassthroughProfileConfig(
         api_key=api_key,
         base_url="https://api.openai.com/v1",
-    )
+    ).build())
 
     print("=" * 60)
     print("Switchyard Minimal Example")
@@ -64,8 +64,8 @@ async def main():
     response = await switchyard.call(request)
 
     print("\nResponse:")
-    print(f"  Content: {response.body['choices'][0]['message']['content']}")
-    print(f"  Tokens: {response.body['usage']['total_tokens']}")
+    print(f"  Content: {response['choices'][0]['message']['content']}")
+    print(f"  Tokens: {response['usage']['total_tokens']}")
 
     print("\n" + "=" * 60)
     print("Example completed!")

--- a/examples/route.yaml
+++ b/examples/route.yaml
@@ -24,6 +24,8 @@ routes:
   llm-classifier:                   # `type: deterministic` — LLM-as-classifier
     type: deterministic
     profile: coding_agent           # general | coding_agent | openclaw
+    fallback_target_on_evict: strong  # tier to retry on context-window evict
+
     classifier:
       model: google/gemini-3.5-flash
       api_key: ${OPENROUTER_API_KEY}


### PR DESCRIPTION
Docs and examples had several claims that no longer match the shipped package, so a new user copying from the README, INSTALLATION, or `examples/` would hit an ImportError or a config that won't load. This PR corrects them.

What changed:

- **`examples/route.yaml` now loads.** The `type: deterministic` (LLM-classifier) route was missing `fallback_target_on_evict`, which the route-bundle builder requires. Before this, building the table raised `RouteBundleConfigError: llm-classifier.fallback_target_on_evict must be a non-empty string`. Added `fallback_target_on_evict: strong`.
- **`examples/minimal.py` and the INSTALLATION library snippet use the current API.** `SwitchyardRecipes.passthrough_recipe(...)` was removed from the package, so the old example fails at import. Replaced with `ProfileSwitchyard(PassthroughProfileConfig(...).build())`. `switchyard.call()` now returns the response body directly, so the example reads `response['choices'][0]['message']['content']` instead of `response.body[...]`.
- **CHANGELOG "Python library" bullet** now names `ProfileSwitchyard` and the typed profile configs (`PassthroughProfileConfig`, `RandomRoutingProfileConfig`, `StageRouterProfileConfig`) instead of the removed `SwitchyardRecipes`.
- **DEVELOPMENT.md** points at `switchyard/lib/profiles/` instead of the deleted `recipes.py`.
- **`[all]` extra described correctly** in README and INSTALLATION: it pulls in `server, cli, tracing, intake, affinity-redis` (was "server, cli" / "tracing extras").
- **AUTO backend-format probe order** in `docs/cli_reference.md` fixed to match the resolver: probe `/v1/chat/completions` first (use `openai`), then `/v1/messages` (`anthropic`), then `/v1/responses` (`responses`), then fall back to `openai`.
- **`docs/cli_reference.md`** now notes that a saved routing-profile bundle keeps `${VAR}` references literal — the env vars must be present at `serve`/`launch` time, or Switchyard aborts with `missing environment variable(s): NAME`.

How to try it:
- `python examples/minimal.py` with `OPENAI_API_KEY` set now imports and runs; against the current package the old file raised `ImportError: cannot import name 'SwitchyardRecipes'`.
- Loading `examples/route.yaml` through the route-bundle builder no longer raises on the `llm-classifier` route.
Audit follow-up in this push: the CHANGELOG packaging line listed a `[gpu]` extra that pyproject.toml does not define and omitted `[tracing]`/`[intake]`/`[affinity-redis]`; the README `[all]` comment named `redis-affinity` (the real extra is `affinity-redis`); and CONTRIBUTING.md still pointed at the removed `switchyard/lib/recipes.py` (now `switchyard/lib/profiles/`).
