### PR TITLE
fix(translation): encode Responses tool turns correctly

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -837,23 +837,36 @@ fn encode_responses_input(
     }
     let mut encoded = Vec::new();
     for message in messages {
-        if message.content.iter().any(|block| {
+        // Anthropic-signed thinking cannot be sent as Responses input.
+        let content = message
+            .content
+            .iter()
+            .filter(|block| {
+                !matches!(
+                    block,
+                    ContentBlock::Reasoning {
+                        signature: Some(_),
+                        ..
+                    }
+                )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if content.is_empty() {
+            continue;
+        }
+        if content.iter().any(|block| {
             matches!(
                 block,
                 ContentBlock::ToolCall(_) | ContentBlock::ToolResult(_)
             )
         }) {
-            encoded.extend(
-                message
-                    .content
-                    .iter()
-                    .filter_map(encode_responses_special_input),
-            );
+            encoded.extend(content.iter().filter_map(encode_responses_special_input));
             continue;
         }
         let mut visible_content = Vec::new();
         let mut emitted_special = false;
-        for block in &message.content {
+        for block in &content {
             if let Some(item) = encode_responses_special_input(block) {
                 encoded.push(item);
                 emitted_special = true;
@@ -876,7 +889,10 @@ fn encode_responses_input(
 // Encodes IR blocks that Responses represents as top-level input items.
 fn encode_responses_special_input(block: &ContentBlock) -> Option<Value> {
     match block {
-        ContentBlock::Reasoning { text, .. } => Some(json!({
+        ContentBlock::Reasoning {
+            text,
+            signature: None,
+        } => Some(json!({
             "type": "reasoning",
             "content": [{"type": "reasoning_text", "text": text}],
             "summary": [],
@@ -885,7 +901,7 @@ fn encode_responses_special_input(block: &ContentBlock) -> Option<Value> {
             "type": "function_call",
             "call_id": call.id,
             "name": call.name,
-            "arguments": call.arguments,
+            "arguments": json_string(&call.arguments),
         })),
         ContentBlock::ToolResult(result) => Some(json!({
             "type": "function_call_output",

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1250,3 +1250,90 @@ fn responses_to_chat_preserves_tool_choice_when_tools_survive() -> TestResult {
     );
     Ok(())
 }
+
+// Responses requires function-call arguments to be a JSON-encoded string.
+#[test]
+fn anthropic_tool_use_encodes_responses_arguments_as_json_string() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet",
+        "messages": [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {"city": "SF"}
+                }]
+            }
+        ],
+        "tools": [{"name": "get_weather", "input_schema": {"type": "object"}}],
+        "max_tokens": 64
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let call = output["input"]
+        .as_array()
+        .and_then(|items| items.iter().find(|item| item["type"] == "function_call"))
+        .ok_or("expected a function_call input item")?;
+    let arguments = call["arguments"]
+        .as_str()
+        .ok_or("function_call arguments must be a JSON string")?;
+    assert_eq!(
+        serde_json::from_str::<Value>(arguments)?,
+        json!({"city": "SF"})
+    );
+    Ok(())
+}
+
+// Anthropic private thinking has no valid representation in Responses input.
+#[test]
+fn anthropic_thinking_is_dropped_from_responses_input() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet",
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": "read foo.py"},
+            {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "private chain of thought", "signature": "sig"},
+                {"type": "text", "text": "Reading it."},
+                {"type": "tool_use", "id": "tu_1", "name": "read_file", "input": {"path": "foo.py"}}
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "tu_1", "content": "print(1)"}
+            ]}
+        ]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let input = output["input"]
+        .as_array()
+        .ok_or("Responses input should be an array")?;
+    assert!(input.iter().all(|item| item["type"] != "reasoning"));
+    assert!(!json_contains_content_type(&output, "reasoning_text"));
+    assert!(!output.to_string().contains("private chain of thought"));
+    assert!(input.iter().any(|item| item["type"] == "function_call"));
+    assert!(input
+        .iter()
+        .any(|item| item["type"] == "function_call_output"));
+    Ok(())
+}


### PR DESCRIPTION
## What

Fix OpenAI Responses request encoding for normalized tool turns.

- Encode `function_call.arguments` as a JSON string, as required by the Responses API.
- Drop Anthropic-signed private thinking when targeting Responses input.
- Preserve unsigned Responses reasoning items during Responses round trips.

## Why

Anthropic tool-use input is represented as structured JSON in the neutral request type, while the
Responses API requires the same arguments to be serialized as a JSON string. Anthropic private
thinking also cannot be replayed as a Responses reasoning item.

Keeping this translation behavior in a focused MR avoids coupling provider codec correctness to the
libsy server refactor.

## How

The Responses encoder serializes normalized tool-call arguments with the existing `json_string`
helper. It filters reasoning blocks carrying an Anthropic signature and continues to encode unsigned
reasoning blocks produced by the Responses decoder.

## What to review

1. Anthropic tool-use arguments become valid Responses `function_call` input.
2. Signed Anthropic thinking does not leak into Responses input.
3. Responses reasoning still survives decode and re-encode.

## Validation

- `cargo fmt --all --check`
- `cargo test -p switchyard-translation --test request_translation` (34 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation of Anthropic requests to Responses format by excluding private signed reasoning content.
  * Preserved tool calls and their outputs when private thinking content is present.
  * Encoded tool-call arguments consistently as JSON strings.
* **Tests**
  * Added coverage for tool-call argument encoding and private thinking removal during request translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->