### PR TITLE
fix(profiles): gate DeepSeek thinking-off default on reasoning-hint compatibility

### DIFF
--- a/switchyard/lib/profiles/tier_target_builders.py
+++ b/switchyard/lib/profiles/tier_target_builders.py
@@ -20,6 +20,7 @@ from switchyard.lib.backends.multi_llm_backend import (
     build_native_backend,
     resolve_llm_target,
 )
+from switchyard.lib.processors.reasoning_hint import model_accepts_reasoning_hint
 from switchyard.lib.profiles.deterministic_routing_config import (
     DEFAULT_DETERMINISTIC_TIER_TIMEOUT_S,
 )
@@ -27,10 +28,18 @@ from switchyard.lib.roles import LLMBackend
 
 
 def apply_deepseek_overrides(target: LlmTarget) -> LlmTarget:
-    """Apply benchmark-specific DeepSeek extras without clobbering callers."""
+    """Apply benchmark-specific DeepSeek extras without clobbering callers.
+
+    The thinking-off default is a vLLM-side hint (``chat_template_kwargs``);
+    serving stacks on the :func:`model_accepts_reasoning_hint` deny list
+    reject the field outright (HTTP 400 ``Extra inputs are not permitted``),
+    so the default is gated on the same model-id check the LLM classifier
+    already uses for its own calls. The batch-priority header default is
+    provider-neutral and stays unconditional.
+    """
     default_body = (
         {"chat_template_kwargs": {"enable_thinking": False}}
-        if "deepseek-v4" in target.model
+        if "deepseek-v4" in target.model and model_accepts_reasoning_hint(target.model)
         else None
     )
     default_headers = (

--- a/tests/test_deterministic_routing_profile.py
+++ b/tests/test_deterministic_routing_profile.py
@@ -391,6 +391,21 @@ class TestDeepSeekOverrides:
         out = apply_deepseek_overrides(target)
         assert out.extra_body == {}
 
+    def test_hint_incompatible_model_id_skips_thinking_off(self) -> None:
+        """Deny-listed serving stacks reject the vLLM hint with HTTP 400,
+        so the thinking-off default must not be injected for their ids.
+        The provider-neutral batch-priority header still applies."""
+        target = LlmTarget(
+            id="weak",
+            model="bedrock/deepseek-ai/deepseek-v4-flash",
+            format=BackendFormat.OPENAI,
+            api_key="k",
+            base_url="https://e/v1",
+        )
+        out = apply_deepseek_overrides(target)
+        assert not out.extra_body
+        assert out.extra_headers == {"X-Inference-Priority": "batch"}
+
 
 class TestTierTimeoutDefaults:
     """Deterministic tiers get a bounded timeout unless callers set one."""


### PR DESCRIPTION
Fixes the tier-call half of #121.

## What

`apply_deepseek_overrides()` unconditionally injects the vLLM-only `chat_template_kwargs.enable_thinking=false` hint for any target whose model id contains `deepseek-v4`. Providers with strict request validation (observed: Fireworks AI serverless) reject the unknown field with HTTP 400 `Extra inputs are not permitted`, breaking every routed call for such tiers.

This PR gates the body default on `model_accepts_reasoning_hint()` — the same model-id compatibility check `LLMClassifierConfig.disable_reasoning` auto-detect already applies before sending the identical hint on classifier calls. The provider-neutral `X-Inference-Priority` header default is unchanged, and explicitly provided `extra_body` still wins as before.

Pairs with #123 (adds `fireworks` to the deny list); together they stop the 400 for Fireworks-served deepseek-v4 targets.

## Validation

- New unit test: deny-listed model id keeps `extra_body` untouched while still receiving the batch-priority header; existing `TestDeepSeekOverrides` cases unchanged and passing.
- `tests/test_deterministic_routing_profile.py` + `tests/test_reasoning_hint.py`: 47 passed. Two failures (`TestProfileStructure::test_shared_stats_accumulator`, `test_overflow_reroutes_to_custom_strong_id_through_full_profile`) are pre-existing on unmodified `main` in my environment (same class of stale-build failure noted in #118's validation notes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for DeepSeek models that do not support reasoning hints.
  * Prevented unsupported “thinking off” request parameters that could cause HTTP 400 errors.
  * Preserved batch inference prioritization for affected requests.

* **Tests**
  * Added coverage to verify incompatible DeepSeek models receive valid request settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->