### PR TITLE
fix(processors): treat Fireworks model ids as reasoning-hint incompatible

### DIFF
--- a/switchyard/lib/processors/reasoning_hint.py
+++ b/switchyard/lib/processors/reasoning_hint.py
@@ -5,16 +5,21 @@
 
 from __future__ import annotations
 
-# Anthropic-served (Claude) ids reject the vLLM ``chat_template_kwargs`` field;
-# vLLM-served reasoning models that need the hint never carry these tokens.
-_NO_REASONING_HINT_TAGS = ("anthropic", "bedrock", "claude")
+# Anthropic-served (Claude) ids reject the vLLM ``chat_template_kwargs``
+# field, and Fireworks AI's OpenAI-compatible API validates request bodies
+# strictly and 400s on it as well ("Extra inputs are not permitted");
+# Fireworks ids always carry the provider namespace
+# (``accounts/fireworks/models/...``). vLLM-served reasoning models that
+# need the hint never carry these tokens.
+_NO_REASONING_HINT_TAGS = ("anthropic", "bedrock", "claude", "fireworks")
 
 
 def model_accepts_reasoning_hint(model: str) -> bool:
     """Whether ``model`` tolerates the vLLM ``enable_thinking=False`` hint.
 
-    ``False`` for Anthropic/Bedrock/Claude ids (they 400 on it), else ``True``
-    — usable directly as a classifier ``disable_reasoning`` default.
+    ``False`` for Anthropic/Bedrock/Claude and Fireworks-served ids (they
+    400 on it), else ``True`` — usable directly as a classifier
+    ``disable_reasoning`` default.
     """
     lowered = model.lower()
     return not any(tag in lowered for tag in _NO_REASONING_HINT_TAGS)

--- a/tests/test_reasoning_hint.py
+++ b/tests/test_reasoning_hint.py
@@ -18,6 +18,9 @@ from switchyard.lib.processors.reasoning_hint import model_accepts_reasoning_hin
         "azure/anthropic/claude-opus-4-6",
         "anthropic/claude-3-5-sonnet",
         "Bedrock-Claude-Whatever",  # case-insensitive
+        "accounts/fireworks/models/deepseek-v4-flash",
+        "accounts/fireworks/models/deepseek-v4-pro",
+        "accounts/fireworks/models/glm-5p2",
     ],
 )
 def test_claude_family_rejects_hint(model: str) -> None:


### PR DESCRIPTION
Fixes the classifier half of #121.

## What

Fireworks AI's OpenAI-compatible API validates request bodies strictly and rejects the vLLM `chat_template_kwargs` hint with HTTP 400 (`Extra inputs are not permitted, field: 'chat_template_kwargs'`). Fireworks model ids always carry the provider namespace (`accounts/fireworks/models/...`), so this PR adds `fireworks` to `_NO_REASONING_HINT_TAGS`.

With this, the LLM classifier's `disable_reasoning` auto-detect stops injecting the hint for Fireworks-served classifier models, and — combined with #122 — deterministic tier calls stop injecting it as well.

## Validation

- Parametrized deny-list cases extended with three Fireworks ids (`deepseek-v4-flash`, `deepseek-v4-pro`, `glm-5p2`); `tests/test_reasoning_hint.py` 13 passed.
- Real-world check: with the deny list patched this way, a deterministic profile with a Fireworks-hosted classifier (`accounts/fireworks/models/deepseek-v4-flash`) classifies successfully end to end (main @ `060ad758`, Fireworks serverless).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Fireworks-served models by preventing unsupported reasoning hints that could cause request failures.
  * Added coverage for additional DeepSeek and GLM model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->