### PR TITLE
ci: skip full CI for documentation-only PRs

### DIFF
--- a/.agents/skills/switchyard-docs/SKILL.md
+++ b/.agents/skills/switchyard-docs/SKILL.md
@@ -73,6 +73,9 @@ Run `ls docs/` and `grep -A20 "^nav:" mkdocs.yml` to see the current set in one 
 
 - **Path-filtered triggers** on `docs/**`, `mkdocs_hooks.py`, `mkdocs.yml`, `pyproject.toml`,
   `uv.lock`, and the workflow file. Keeps unrelated PRs out of the docs job graph.
+- **Docs-only PRs skip full CI.** The lightweight change detector and required `CI Success` job
+  still run, while published-site validation remains owned by this workflow and the focused README
+  or getting-started workflows run when their source pages change.
 - **Read-only default permissions** at the workflow level. Each job re-declares write scopes only when it needs them (`contents: write` for the Pages deploy, `pull-requests: write` for the preview comment).
 - **`concurrency` group `${{ github.workflow }}-${{ github.ref }}`** with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. Superseded PR runs are cancelled; main runs queue so the `gh-pages` writes don't race.
 - **Workflow-level `MKDOCS_SOURCE_REF`** resolves from

--- a/.agents/skills/switchyard-testing-ci/SKILL.md
+++ b/.agents/skills/switchyard-testing-ci/SKILL.md
@@ -24,7 +24,7 @@ use `cargo test --workspace` before calling a broad Rust MR ready.
 
 | Situation | Command |
 |---|---|
-| Pick gates from the current diff | `python .agents/skills/switchyard-testing-ci/scripts/select_validation.py --changed` |
+| Inspect the current diff | `git status -sb && git diff --stat && git diff --name-only` |
 | Pre-PR hermetic gate (default) | `uv run ruff check . && uv run mypy switchyard && env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` |
 | Mirror CI pytest with no live creds | `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` |
 | Rust component crate change | `cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p switchyard-components` |
@@ -34,31 +34,33 @@ use `cargo test --workspace` before calling a broad Rust MR ready.
 | Live e2e (only on explicit user request) | `NVIDIA_API_KEY=… uv run pytest tests/e2e/ -v -m integration -o addopts= --maxfail=10` |
 | Skill/docs change only | YAML frontmatter check + `git diff --check` (see [Skill/docs-only gate](#skilldocs-only-gate)) |
 
-## Dynamic Selection First
+## Diff Selection First
 
-From the repo root, inspect the diff and let the selector propose focused gates:
+From the repo root, inspect the diff before choosing focused gates:
 
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 git status -sb
 git diff --stat
-python .agents/skills/switchyard-testing-ci/scripts/select_validation.py --changed
+git diff --name-only
 ```
 
-For a not-yet-edited area, pass likely owners explicitly:
+For a not-yet-edited area, search likely owners and their tests explicitly:
 
 ```bash
-python .agents/skills/switchyard-testing-ci/scripts/select_validation.py \
-  --path switchyard/lib/translation/request_engine.py \
-  --path tests/test_request_translation_engine.py
+rg -n "request_engine|RequestTranslationEngine" switchyard tests
 ```
 
-Use the output as the starting plan, then add any tests revealed by code search or by the failure.
+Use the changed paths and search results to choose the smallest trustworthy gate, then add any tests
+revealed by code search or by a failure.
 
 ## CI Gates and Local Equivalence
 
 The hard GitHub Actions gates live in `.github/workflows/ci.yml`:
 
+- A lightweight change-detection job keeps the required `CI Success` check present on every pull
+  request. Clearly documentation-only pull requests skip the full lint, test, Rust, typecheck, and
+  install-smoke suite; pushes to `main` always run the complete suite.
 - `uv run ruff check .`
 - SPDX header check for every Python file found by CI, including `.agents/skills/**/scripts/*.py`
 - `uv run pytest tests/ -v -m "not integration"` on Python 3.12 through 3.14
@@ -72,6 +74,10 @@ The hard GitHub Actions gates live in `.github/workflows/ci.yml`:
 The local pre-commit config also runs the Rust fmt/clippy gate when Rust files,
 `Cargo.toml`, or `Cargo.lock` change. Treat those hooks as hard failures; do not
 bypass them with `--no-verify`.
+
+Documentation-only classification is intentionally narrow: `docs/**`, repository-root Markdown,
+README files, GitHub issue/PR templates, benchmark Markdown, and skill Markdown. Markdown used as
+runtime prompt content is not excluded and still runs full CI.
 
 A CI-equivalent `ruff` claim means a clean checkout or generated artifacts removed. Do not treat
 `uv run ruff check . --exclude docs/.venv-docs --exclude docs/_build` as canonical PR validation;

--- a/.agents/skills/switchyard-testing-ci/SKILL.md
+++ b/.agents/skills/switchyard-testing-ci/SKILL.md
@@ -24,7 +24,7 @@ use `cargo test --workspace` before calling a broad Rust MR ready.
 
 | Situation | Command |
 |---|---|
-| Inspect the current diff | `git status -sb && git diff --stat && git diff --name-only` |
+| Inspect all local changes | `git status -sb && git diff HEAD --stat && git diff HEAD --name-only && git ls-files --others --exclude-standard` |
 | Pre-PR hermetic gate (default) | `uv run ruff check . && uv run mypy switchyard && env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` |
 | Mirror CI pytest with no live creds | `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` |
 | Rust component crate change | `cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p switchyard-components` |
@@ -41,8 +41,9 @@ From the repo root, inspect the diff before choosing focused gates:
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 git status -sb
-git diff --stat
-git diff --name-only
+git diff HEAD --stat
+git diff HEAD --name-only
+git ls-files --others --exclude-standard
 ```
 
 For a not-yet-edited area, search likely owners and their tests explicitly:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,36 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      full_ci: ${{ github.event_name != 'pull_request' || steps.filter.outputs.full_ci == 'true' }}
+    steps:
+      - name: Detect non-documentation changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v4
+        with:
+          predicate-quantifier: every
+          filters: |
+            full_ci:
+              - "**"
+              - "!docs/**"
+              - "!*.md"
+              - "!**/README.md"
+              - "!benchmark/*.md"
+              - "!.github/ISSUE_TEMPLATE/**"
+              - "!.github/PULL_REQUEST_TEMPLATE.md"
+              - "!.agents/skills/**/*.md"
+
   # ruff is a hard gate — the codebase passes today, keep it that way.
   lint:
     name: Lint (ruff)
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +63,8 @@ jobs:
   # within the first four lines.
   spdx-headers:
     name: SPDX License Headers
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,6 +101,8 @@ jobs:
 
   rust:
     name: Rust
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +117,8 @@ jobs:
 
   typecheck:
     name: Typecheck (mypy)
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -104,6 +137,8 @@ jobs:
   # credentials, or network egress.
   test:
     name: Tests (Python ${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -128,6 +163,8 @@ jobs:
   # This is the actual hard gate on the workflow.
   slim-install-smoke:
     name: Slim install smoke test
+    needs: changes
+    if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
     env:
       SWITCHYARD_DEFAULT_PACKAGE: "nemo-switchyard @ file://${{ github.workspace }}"
@@ -197,7 +234,7 @@ jobs:
   ci-success:
     name: CI Success
     if: always()
-    needs: [lint, spdx-headers, rust, typecheck, test, slim-install-smoke]
+    needs: [changes, lint, spdx-headers, rust, typecheck, test, slim-install-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded


### PR DESCRIPTION
## What

Add a lightweight change-detection job to the main CI workflow and skip the expensive lint, SPDX,
Rust, mypy, Python test matrix, and slim-install jobs when a pull request changes documentation
only.

## Why

Documentation-only pull requests currently run the complete CI suite even though focused
documentation workflows already validate the published docs, README, and getting-started guide.
The required `CI Success` check must still appear so branch protection is not left waiting on a
skipped workflow.

## How

- Classify clearly non-runtime documentation paths with `dorny/paths-filter`.
- Gate the full CI jobs on the resulting `full_ci` output.
- Keep the lightweight detector and `CI Success` jobs running for every pull request.
- Always run the complete suite for pushes to `main`.
- Treat runtime Markdown prompts and mixed docs/code diffs as code-impacting changes.
- Update the repository CI skills and remove their stale reference to a missing validation helper.

## Validation

- `actionlint .github/workflows/ci.yml`
- Parsed the workflow structure and all skill frontmatter with PyYAML.
- Exercised docs-only, runtime-prompt, workflow, source, and mixed-diff classifier cases with
  picomatch.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI guidance for documentation-only pull requests.
  * Documented that lightweight change detection and the required CI success check still run, while broader validation is skipped.
  * Clarified that published-site checks remain part of the documentation workflow, with focused README and getting-started checks triggered by relevant changes.
  * Added guidance for manual change inspection and identifying targeted validation coverage.
* **Chores**
  * Improved CI change detection to run full validation only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->