### PR TITLE
fix(container): make server image non-root compatible

### DIFF
--- a/benchmark/switchyard-server.Dockerfile
+++ b/benchmark/switchyard-server.Dockerfile
@@ -7,16 +7,19 @@ FROM rust:${RUST_VERSION}-bookworm
 COPY --from=ghcr.io/astral-sh/uv:0.9.17 /uv /uvx /usr/local/bin/
 
 WORKDIR /opt/switchyard
+# Hosted runtimes can override the container UID, so keep Python and package imports
+# independent of root's home and the copied source tree.
 ENV PATH="/opt/switchyard/.venv/bin:${PATH}" \
     PYTHONUNBUFFERED=1 \
     UV_LINK_MODE=copy \
-    UV_PROJECT_ENVIRONMENT=/opt/switchyard/.venv
+    UV_PROJECT_ENVIRONMENT=/opt/switchyard/.venv \
+    UV_PYTHON_INSTALL_DIR=/opt/uv-python
 
 COPY pyproject.toml uv.lock README.md Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY switchyard ./switchyard
 COPY switchyard_rust ./switchyard_rust
 
-RUN uv sync --frozen --no-dev --extra server --extra cli
+RUN uv sync --frozen --no-dev --extra server --extra cli --no-editable
 
 ENTRYPOINT ["switchyard"]


### PR DESCRIPTION
## What

Make the Switchyard server image runnable under a non-root UID:

- Install uv-managed Python under `/opt/uv-python` instead of `/root/.local/share/uv/python`.
- Install Switchyard non-editably into the virtual environment with `--no-editable`.

## Why

scaled-evals runs the image as UID 1000. Previously, `.venv/bin/python` resolved to uv’s interpreter under `/root`, which the runtime UID could not traverse. Python failed before Switchyard started with `No module named encodings`.

The editable install also coupled runtime imports to the copied source tree and its file permissions. Installing non-editably puts the package and Rust extension in `.venv/site-packages`.

Closes #

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/ -v -m "not integration"` green (`1997 passed`, `12 skipped`)
- [x] Built and ran the image as UID/GID `1000:1000`; `/health` returned 200 and Python resolved under `/opt/uv-python`
- [x] Ran `benchmark/run-baseline.sh` with a no-op Harbor; image build, route loading, host health check, Docker-network preflight, finalization, and cleanup all passed

## Checklist

- [x] N/A — no classes added.
- [x] N/A — no public symbols added.
- [x] N/A — Dockerfile-only fix covered by runtime image and baseline smokes.
- [x] N/A — no customer-facing CLI or documentation surface changed.
- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The image does not set a default `USER`. scaled-evals continues to supply the runtime UID, while existing `run-baseline.sh` behavior remains unchanged.

The current commit still needs a DCO sign-off before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container setup for Python runtime configuration.
  * Updated dependency installation during image builds to use non-editable package installation.
  * Documented that hosted runtimes may override the container user ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->