### PR TITLE
ci: publish switchyard-server container from main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ benchmark/datasets
 benchmark/tb_runs
 dist
 site
+target

--- a/.github/workflows/server-container.yml
+++ b/.github/workflows/server-container.yml
@@ -1,0 +1,88 @@
+name: Publish switchyard-server container
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
+env:
+  PACKAGE_NAME: switchyard-server
+
+jobs:
+  publish:
+    name: Publish container
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set image coordinates
+        id: image
+        shell: bash
+        run: |
+          echo "name=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish commit image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/switchyard-server/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.name }}:${{ steps.image.outputs.short_sha }}
+          build-args: |
+            IMAGE_VERSION=${{ steps.image.outputs.short_sha }}
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha,scope=switchyard-server
+          cache-to: type=gha,mode=max,scope=switchyard-server
+      - name: Publish main image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/switchyard-server/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.name }}:main
+          build-args: |
+            IMAGE_VERSION=main
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha,scope=switchyard-server
+
+  cleanup:
+    name: Delete expired commit images
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete commit images older than 23 hours
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_path="/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}/versions"
+          versions_file="${RUNNER_TEMP}/switchyard-server-versions.tsv"
+          cutoff="$(date -u -d '23 hours ago' +%s)"
+
+          gh api --paginate "${package_path}?per_page=100" \
+            --jq '.[] | [.id, .created_at, (.metadata.container.tags | join(","))] | @tsv' \
+            > "${versions_file}"
+
+          while IFS=$'\t' read -r version_id created_at tags; do
+            if [[ "${tags}" =~ ^[0-9a-f]{7}$ ]] \
+              && (( $(date -u -d "${created_at}" +%s) < cutoff )); then
+              echo "Deleting expired container tag ${tags}"
+              gh api --method DELETE "${package_path}/${version_id}"
+            fi
+          done < "${versions_file}"

--- a/crates/switchyard-server/Dockerfile
+++ b/crates/switchyard-server/Dockerfile
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG RUST_VERSION=1.96.1
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+WORKDIR /src
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+RUN cargo build --locked --release -p switchyard-server
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/release/switchyard-server /usr/local/bin/switchyard-server
+
+ARG IMAGE_VERSION=local
+ARG VCS_REF=unknown
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA-NeMo/Switchyard" \
+      org.opencontainers.image.description="Switchyard's libsy-based HTTP server" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}"
+
+USER 65532:65532
+EXPOSE 4000
+ENTRYPOINT ["/usr/local/bin/switchyard-server"]

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -40,6 +40,16 @@ export API_KEY="..."
 cargo run -p switchyard-server -- --config routes.toml
 ```
 
+The same server can run from the repository's Docker image:
+
+```bash
+docker run --rm -p 4000:4000 \
+  --env API_KEY \
+  --mount type=bind,src="$PWD/routes.toml",dst=/etc/switchyard/routes.toml,readonly \
+  ghcr.io/nvidia-nemo/switchyard-server:main \
+  --config /etc/switchyard/routes.toml
+```
+
 Target and route table names are local references. A target's `id` is the exact model ID sent
 upstream, and a route's `id` is the model clients send to select that algorithm.
 


### PR DESCRIPTION
## What

- add a multi-stage Docker image for the Rust `switchyard-server` binary
- publish `ghcr.io/nvidia-nemo/switchyard-server:main` and a seven-character commit tag on pushes to `main`
- delete SHA-only package versions after 23 hours with an hourly cleanup job
- document running the published image with a mounted TOML configuration

## Why

`switchyard-server` can currently be built and run from Cargo, but it has no distributable server container. This adds a GitHub-only container path without introducing registry credentials or publishing from pull requests.

The `main` and commit tags are built as separate OCI manifests with shared filesystem layers. This lets retention delete the short-SHA version without deleting the moving `main` tag.

## Review

- the runtime image contains only the release binary and CA certificates and runs as a non-root user
- publishing is triggered only by pushes to `main`
- cleanup only selects versions whose sole tag is a seven-character hexadecimal SHA
- the OCI source label links the GHCR package to this repository

## Validation

- built `crates/switchyard-server/Dockerfile` locally
- ran the image and loaded a TOML config with `--dry-run`
- verified the `main` and short-SHA builds have distinct image IDs
- `cargo test -p switchyard-server`
- `cargo fmt --all --check`
- `uv run ruff check .`
- workflow YAML parse and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Docker image for running the `switchyard-server` service.
  - Added automated publishing of server images to GitHub Container Registry.
  - Added scheduled cleanup of older commit-tagged images.

- **Documentation**
  - Added instructions for running the server with Docker, including configuration, API key, and port setup.

- **Chores**
  - Excluded build artifacts from Docker build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->