### PR TITLE
test: add reusable end-to-end LLM mock server

### DIFF
--- a/.agents/skills/switchyard-testing-ci/SKILL.md
+++ b/.agents/skills/switchyard-testing-ci/SKILL.md
@@ -29,6 +29,7 @@ use `cargo test --workspace` before calling a broad Rust MR ready.
 | Mirror CI pytest with no live creds | `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` |
 | Rust component crate change | `cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p switchyard-components` |
 | Rust server crate change | `cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p switchyard-server` |
+| Rust HTTP end-to-end test | Use the private `switchyard-test-server` crate; do not add an ad hoc provider server |
 | Broad Rust crate change | `cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` |
 | Slim-install regression guard | see [Slim-install smoke gate](#slim-install-smoke-gate) |
 | Live e2e (only on explicit user request) | `NVIDIA_API_KEY=… uv run pytest tests/e2e/ -v -m integration -o addopts= --maxfail=10` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
  "serde_json",
  "switchyard-libsy",
  "switchyard-llm-client",
+ "switchyard-test-server",
  "switchyard-translation",
  "tempfile",
  "tokio",
@@ -1876,6 +1877,21 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "switchyard-test-server"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "futures-util",
+ "rand 0.9.5",
+ "reqwest",
+ "serde_json",
+ "switchyard-protocol",
+ "switchyard-translation",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/protocol",
     "crates/switchyard-server",
     "crates/switchyard-skill-distillation",
+    "crates/switchyard-test-server",
     "crates/switchyard-translation",
 ]
 

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -30,6 +30,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 [dev-dependencies]
 async-trait = "0.1"
 http-body-util = "0.1"
+switchyard-test-server = { path = "../switchyard-test-server" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "net"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -4,18 +4,13 @@
 //! Integration tests for the libsy Rust server.
 
 use std::collections::{BTreeMap, HashSet};
-use std::convert::Infallible;
 use std::error::Error;
 use std::io::Write;
 use std::sync::Arc;
 
 use axum::body::{Body, Bytes};
-use axum::extract::State;
 use axum::http::{Request as HttpRequest, StatusCode};
-use axum::response::sse::{Event, Sse};
-use axum::response::{IntoResponse, Response as HttpResponse};
-use axum::routing::post;
-use axum::{Json, Router};
+use axum::Router;
 use http_body_util::BodyExt;
 use libsy::algorithms::Random;
 use libsy::{Algorithm, LlmTarget, LlmTargetSet, RoutedLlmClient};
@@ -23,101 +18,13 @@ use serde_json::{json, Value};
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
 use switchyard_server::config::load_server_state;
 use switchyard_server::{build_switchyard_router, ServerState};
-use tokio::net::TcpListener;
-use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
+use switchyard_test_server::MockLlmServer;
 use tower::ServiceExt;
 
 type TestError = Box<dyn Error + Send + Sync>;
 type TestResult<T = ()> = Result<T, TestError>;
 
 const ROUTE_MODEL: &str = "switchyard/random";
-
-struct MockUpstream {
-    base_url: String,
-    calls: Arc<Mutex<Vec<Value>>>,
-    task: JoinHandle<()>,
-}
-
-impl MockUpstream {
-    async fn start() -> TestResult<Self> {
-        let calls = Arc::new(Mutex::new(Vec::new()));
-        let app = Router::new()
-            .route("/v1/chat/completions", post(upstream_chat))
-            .with_state(Arc::clone(&calls));
-        let listener = TcpListener::bind("127.0.0.1:0").await?;
-        let addr = listener.local_addr()?;
-        let task = tokio::spawn(async move {
-            if let Err(error) = axum::serve(listener, app).await {
-                tracing::error!(error = %error, "mock upstream stopped");
-            }
-        });
-        Ok(Self {
-            base_url: format!("http://{addr}/v1"),
-            calls,
-            task,
-        })
-    }
-}
-
-impl Drop for MockUpstream {
-    fn drop(&mut self) {
-        self.task.abort();
-    }
-}
-
-async fn upstream_chat(
-    State(calls): State<Arc<Mutex<Vec<Value>>>>,
-    Json(body): Json<Value>,
-) -> HttpResponse {
-    calls.lock().await.push(body.clone());
-    if body["messages"][0]["content"] == "fail" {
-        return (
-            StatusCode::IM_A_TEAPOT,
-            Json(json!({"error": {"message": "upstream rejected request"}})),
-        )
-            .into_response();
-    }
-
-    let model = body["model"].as_str().unwrap_or("unknown").to_string();
-    if body["stream"].as_bool() == Some(true) {
-        let events = [
-            json!({"id": "chatcmpl-stream", "model": model, "choices": [{"index": 0, "delta": {"role": "assistant"}}]}).to_string(),
-            json!({"id": "chatcmpl-stream", "model": model, "choices": [{"index": 0, "delta": {"content": "hello"}}]}).to_string(),
-            json!({"id": "chatcmpl-stream", "model": model, "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}).to_string(),
-            "[DONE]".to_string(),
-        ];
-        let stream = futures_util::stream::iter(
-            events
-                .into_iter()
-                .map(|data| Ok::<Event, Infallible>(Event::default().data(data))),
-        );
-        return Sse::new(stream).into_response();
-    }
-
-    let content = if model == "model/classifier" {
-        "0.9"
-    } else {
-        "ok"
-    };
-    Json(json!({
-        "id": "chatcmpl-test",
-        "object": "chat.completion",
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "message": {"role": "assistant", "content": content},
-            "finish_reason": "stop"
-        }],
-        "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 2,
-            "total_tokens": 12,
-            "prompt_tokens_details": {"cached_tokens": 7}
-        }
-    }))
-    .into_response()
-}
 
 fn random_state(base_url: &str, routes: &[(&str, &[&str])]) -> TestResult<ServerState> {
     let backend = Backend::OpenAiChat(HttpBackendConfig {
@@ -150,9 +57,13 @@ fn random_state(base_url: &str, routes: &[(&str, &[&str])]) -> TestResult<Server
     Ok(ServerState::new(entries)?)
 }
 
-async fn test_app(routes: &[(&str, &[&str])]) -> TestResult<(MockUpstream, Router)> {
-    let upstream = MockUpstream::start().await?;
-    let app = build_switchyard_router(random_state(&upstream.base_url, routes)?);
+async fn test_app(routes: &[(&str, &[&str])]) -> TestResult<(MockLlmServer, Router)> {
+    let upstream = MockLlmServer::builder()
+        .default_response("ok")
+        .model_response("model/classifier", "0.9")
+        .start()
+        .await?;
+    let app = build_switchyard_router(random_state(&upstream.base_url(), routes)?);
     Ok((upstream, app))
 }
 
@@ -203,7 +114,11 @@ impl Response {
 
 #[tokio::test]
 async fn toml_config_constructs_and_serves_multiple_algorithms() -> TestResult {
-    let upstream = MockUpstream::start().await?;
+    let upstream = MockLlmServer::builder()
+        .default_response("ok")
+        .model_response("model/classifier", "0.9")
+        .start()
+        .await?;
     let state = load_test_config(&format!(
         r#"
 schema_version = 1
@@ -237,7 +152,7 @@ strong_target = "strong"
 weak_target = "weak"
 threshold = 0.5
 "#,
-        base_url = upstream.base_url
+        base_url = upstream.base_url()
     ))?;
     let app = build_switchyard_router(state);
 
@@ -265,11 +180,11 @@ threshold = 0.5
         );
     }
 
-    let calls = upstream.calls.lock().await;
+    let calls = upstream.requests().await;
     assert_eq!(calls.len(), 3);
-    assert_eq!(calls[0]["model"], "model/weak");
-    assert_eq!(calls[1]["model"], "model/classifier");
-    assert_eq!(calls[2]["model"], "model/strong");
+    assert_eq!(calls[0].body["model"], "model/weak");
+    assert_eq!(calls[1].body["model"], "model/classifier");
+    assert_eq!(calls[2].body["model"], "model/strong");
     Ok(())
 }
 
@@ -320,9 +235,9 @@ async fn routes_dispatch_and_discovery_endpoints_are_stable() -> TestResult {
         );
     }
 
-    let calls = upstream.calls.lock().await;
-    assert_eq!(calls[0]["model"], "model/general");
-    assert_eq!(calls[1]["model"], "model/code");
+    let calls = upstream.requests().await;
+    assert_eq!(calls[0].body["model"], "model/general");
+    assert_eq!(calls[1].body["model"], "model/code");
     Ok(())
 }
 
@@ -391,9 +306,9 @@ async fn all_inbound_formats_run_libsy_and_return_the_caller_format() -> TestRes
         );
     }
 
-    let calls = upstream.calls.lock().await;
+    let calls = upstream.requests().await;
     assert_eq!(calls.len(), 3);
-    assert!(calls.iter().all(|call| call["model"] == "model/a"));
+    assert!(calls.iter().all(|call| call.body["model"] == "model/a"));
     Ok(())
 }
 
@@ -414,14 +329,21 @@ async fn streaming_response_is_framed_for_the_inbound_api() -> TestResult {
     .await?;
 
     assert_eq!(response.status, StatusCode::OK);
-    assert!(response.text()?.contains("hello"));
+    assert!(response.text()?.contains("ok"));
     assert!(response.text()?.contains("data: [DONE]"));
     Ok(())
 }
 
 #[tokio::test]
 async fn request_and_upstream_errors_use_the_canonical_envelope() -> TestResult {
-    let (_upstream, app) = test_app(&[(ROUTE_MODEL, &["model/a"])]).await?;
+    let upstream = MockLlmServer::builder()
+        .model_error("model/a", StatusCode::IM_A_TEAPOT)
+        .start()
+        .await?;
+    let app = build_switchyard_router(random_state(
+        &upstream.base_url(),
+        &[(ROUTE_MODEL, &["model/a"])],
+    )?);
 
     let unknown = send(
         &app,
@@ -455,7 +377,7 @@ async fn request_and_upstream_errors_use_the_canonical_envelope() -> TestResult 
         "/v1/chat/completions",
         Some(json!({
             "model": ROUTE_MODEL,
-            "messages": [{"role": "user", "content": "fail"}]
+            "messages": [{"role": "user", "content": "hi"}]
         })),
     )
     .await?;

--- a/crates/switchyard-test-server/Cargo.toml
+++ b/crates/switchyard-test-server/Cargo.toml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "switchyard-test-server"
+version = "0.0.0"
+description = "Private mock LLM server for Switchyard integration tests"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+axum = "0.8"
+futures-util = "0.3"
+rand = "0.9"
+serde_json = "1"
+switchyard-protocol = { path = "../protocol" }
+switchyard-translation = { path = "../switchyard-translation" }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["json"] }

--- a/crates/switchyard-test-server/src/lib.rs
+++ b/crates/switchyard-test-server/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -27,17 +27,16 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-/// Representative assistant text used when a test does not configure a response.
-pub const DEFAULT_RESPONSE_BANK: &[&str] = &[
-    "Done.",
-    "The request completed successfully.",
-    "Short answer: 42.",
-    "Here is the result:\n\n- first item\n- second item",
-    "```json\n{\"status\":\"ok\",\"items\":[]}\n```",
-    "```python\nprint(\"hello from the mock server\")\n```",
-    "I checked the available context and found no additional action is required.",
-    "The operation succeeded. Review the returned metadata for details.",
-];
+const RESPONSE_CORPUS: &str = include_str!("../../../README.md");
+
+/// Representative Markdown responses sourced from the repository README.
+pub static DEFAULT_RESPONSE_BANK: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    RESPONSE_CORPUS
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|response| (40..=1_200).contains(&response.len()))
+        .collect()
+});
 
 /// A request received by the mock server.
 #[derive(Clone, Debug, PartialEq)]
@@ -65,7 +64,7 @@ impl Default for MockLlmServerBuilder {
             bind_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             response_bank: DEFAULT_RESPONSE_BANK
                 .iter()
-                .map(|response| (*response).to_string())
+                .map(|response| response.to_string())
                 .collect(),
             model_responses: BTreeMap::new(),
             model_errors: BTreeMap::new(),

--- a/crates/switchyard-test-server/src/lib.rs
+++ b/crates/switchyard-test-server/src/lib.rs
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deterministic OpenAI and Anthropic HTTP endpoints for integration tests.
+
+use std::collections::BTreeMap;
+use std::convert::Infallible;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::extract::{OriginalUri, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use futures_util::stream::{self, StreamExt};
+use rand::seq::IndexedRandom;
+use serde_json::{json, Value};
+use switchyard_protocol::{
+    AggLlmResponse, ContentBlock, LlmResponseChunk, LlmResponseStream, ResponseOutput, Role,
+    StopReason, Usage,
+};
+use switchyard_translation::{encode_aggregated_response, encode_stream, WireFormat};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Representative assistant text used when a test does not configure a response.
+pub const DEFAULT_RESPONSE_BANK: &[&str] = &[
+    "Done.",
+    "The request completed successfully.",
+    "Short answer: 42.",
+    "Here is the result:\n\n- first item\n- second item",
+    "```json\n{\"status\":\"ok\",\"items\":[]}\n```",
+    "```python\nprint(\"hello from the mock server\")\n```",
+    "I checked the available context and found no additional action is required.",
+    "The operation succeeded. Review the returned metadata for details.",
+];
+
+/// A request received by the mock server.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CapturedRequest {
+    /// Provider endpoint path.
+    pub path: String,
+    /// UTF-8 request headers keyed by lowercase name.
+    pub headers: BTreeMap<String, String>,
+    /// Parsed JSON request body.
+    pub body: Value,
+}
+
+/// Configures deterministic responses before starting a mock server.
+#[derive(Clone, Debug)]
+pub struct MockLlmServerBuilder {
+    bind_addr: SocketAddr,
+    response_bank: Vec<String>,
+    model_responses: BTreeMap<String, String>,
+    model_errors: BTreeMap<String, StatusCode>,
+}
+
+impl Default for MockLlmServerBuilder {
+    fn default() -> Self {
+        Self {
+            bind_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            response_bank: DEFAULT_RESPONSE_BANK
+                .iter()
+                .map(|response| (*response).to_string())
+                .collect(),
+            model_responses: BTreeMap::new(),
+            model_errors: BTreeMap::new(),
+        }
+    }
+}
+
+impl MockLlmServerBuilder {
+    /// Binds the server to `addr`; the default uses an ephemeral localhost port.
+    pub fn bind_addr(mut self, addr: SocketAddr) -> Self {
+        self.bind_addr = addr;
+        self
+    }
+
+    /// Sets the response text used when a model has no specific response.
+    pub fn default_response(mut self, text: impl Into<String>) -> Self {
+        self.response_bank = vec![text.into()];
+        self
+    }
+
+    /// Sets the response text returned for `model`.
+    pub fn model_response(mut self, model: impl Into<String>, text: impl Into<String>) -> Self {
+        self.model_responses.insert(model.into(), text.into());
+        self
+    }
+
+    /// Makes requests for `model` return `status` and a standard error body.
+    pub fn model_error(mut self, model: impl Into<String>, status: StatusCode) -> Self {
+        self.model_errors.insert(model.into(), status);
+        self
+    }
+
+    /// Starts the configured server.
+    pub async fn start(self) -> io::Result<MockLlmServer> {
+        let listener = TcpListener::bind(self.bind_addr).await?;
+        let addr = listener.local_addr()?;
+        let state = Arc::new(ServerState {
+            response_bank: self.response_bank,
+            model_responses: self.model_responses,
+            model_errors: self.model_errors,
+            requests: Mutex::new(Vec::new()),
+        });
+        let server_state = Arc::clone(&state);
+        let task = tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, router(server_state)).await {
+                tracing::error!(error = %error, "test LLM server stopped");
+            }
+        });
+        Ok(MockLlmServer { addr, state, task })
+    }
+}
+
+/// A running mock LLM server that stops when dropped.
+pub struct MockLlmServer {
+    addr: SocketAddr,
+    state: Arc<ServerState>,
+    task: JoinHandle<()>,
+}
+
+impl MockLlmServer {
+    /// Returns a builder for custom behavior.
+    pub fn builder() -> MockLlmServerBuilder {
+        MockLlmServerBuilder::default()
+    }
+
+    /// Starts a server with the default response behavior.
+    pub async fn start() -> io::Result<Self> {
+        Self::builder().start().await
+    }
+
+    /// Returns the server root URL.
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// Returns the `/v1` URL expected by Switchyard LLM client configuration.
+    pub fn base_url(&self) -> String {
+        format!("{}/v1", self.url())
+    }
+
+    /// Returns all requests captured so far.
+    pub async fn requests(&self) -> Vec<CapturedRequest> {
+        self.state.requests.lock().await.clone()
+    }
+}
+
+impl Drop for MockLlmServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+struct ServerState {
+    response_bank: Vec<String>,
+    model_responses: BTreeMap<String, String>,
+    model_errors: BTreeMap<String, StatusCode>,
+    requests: Mutex<Vec<CapturedRequest>>,
+}
+
+fn router(state: Arc<ServerState>) -> Router {
+    Router::new()
+        .route("/v1/chat/completions", post(openai_chat))
+        .route("/v1/responses", post(openai_responses))
+        .route("/v1/messages", post(anthropic_messages))
+        .with_state(state)
+}
+
+async fn openai_chat(
+    state: State<Arc<ServerState>>,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    handle_request(
+        state.0,
+        uri.0.path().to_string(),
+        headers,
+        body,
+        WireFormat::OpenAiChat,
+    )
+    .await
+}
+
+async fn openai_responses(
+    state: State<Arc<ServerState>>,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    handle_request(
+        state.0,
+        uri.0.path().to_string(),
+        headers,
+        body,
+        WireFormat::OpenAiResponses,
+    )
+    .await
+}
+
+async fn anthropic_messages(
+    state: State<Arc<ServerState>>,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    handle_request(
+        state.0,
+        uri.0.path().to_string(),
+        headers,
+        body,
+        WireFormat::AnthropicMessages,
+    )
+    .await
+}
+
+async fn handle_request(
+    state: Arc<ServerState>,
+    path: String,
+    headers: HeaderMap,
+    body: Value,
+    format: WireFormat,
+) -> Response {
+    state.requests.lock().await.push(CapturedRequest {
+        path,
+        headers: capture_headers(&headers),
+        body: body.clone(),
+    });
+
+    let model = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("mock-model");
+    if let Some(status) = state.model_errors.get(model).copied() {
+        return mock_error(status);
+    }
+    if let Some(status) = requested_error_status(&headers) {
+        return mock_error(status);
+    }
+
+    let text = state
+        .model_responses
+        .get(model)
+        .map(String::as_str)
+        .or_else(|| {
+            state
+                .response_bank
+                .choose(&mut rand::rng())
+                .map(String::as_str)
+        })
+        .unwrap_or("ok");
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        stream_response(format, model.to_string(), text.to_string())
+    } else {
+        aggregate_response(format, model, text)
+    }
+}
+
+fn capture_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+fn requested_error_status(headers: &HeaderMap) -> Option<StatusCode> {
+    headers
+        .get("x-switchyard-test-status")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u16>().ok())
+        .and_then(|value| StatusCode::from_u16(value).ok())
+}
+
+fn mock_error(status: StatusCode) -> Response {
+    (
+        status,
+        Json(json!({
+            "error": {
+                "message": format!("mock upstream returned {}", status.as_u16()),
+                "type": "mock_error"
+            }
+        })),
+    )
+        .into_response()
+}
+
+fn aggregate_response(format: WireFormat, model: &str, text: &str) -> Response {
+    let response = mock_response(model, text);
+    match encode_aggregated_response(&response, format, Some(model)) {
+        Ok(body) => Json(body).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": {"message": error.to_string()}})),
+        )
+            .into_response(),
+    }
+}
+
+fn mock_response(model: &str, text: &str) -> AggLlmResponse {
+    AggLlmResponse {
+        id: Some("mock-response".to_string()),
+        model: Some(model.to_string()),
+        outputs: vec![ResponseOutput {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+            stop_reason: Some(StopReason::EndTurn),
+        }],
+        usage: mock_usage(),
+        ..AggLlmResponse::default()
+    }
+}
+
+fn mock_usage() -> Usage {
+    Usage {
+        input_tokens: Some(3),
+        cache: Usage::cache_details(Some(7), None),
+        output_tokens: Some(2),
+        total_tokens: Some(12),
+        reasoning_tokens: None,
+    }
+}
+
+fn stream_response(format: WireFormat, model: String, text: String) -> Response {
+    let chunks: LlmResponseStream = Box::pin(stream::iter(vec![
+        Ok(LlmResponseChunk::MessageStart {
+            id: Some("mock-response".to_string()),
+            model: Some(model.clone()),
+        }),
+        Ok(LlmResponseChunk::TextDelta { index: 0, text }),
+        Ok(LlmResponseChunk::Usage(mock_usage())),
+        Ok(LlmResponseChunk::MessageStop {
+            reason: Some("stop".to_string()),
+        }),
+    ]));
+    let events = match encode_stream(chunks, format, Some(model)) {
+        Ok(events) => events,
+        Err(error) => return mock_stream_error(error.to_string()),
+    };
+    let framed = events.map(move |item| {
+        Ok::<Event, Infallible>(match item {
+            Ok(value) => frame_event(format, value),
+            Err(error) => Event::default().event("error").data(error.to_string()),
+        })
+    });
+    let terminal = match format {
+        WireFormat::OpenAiChat | WireFormat::OpenAiResponses => {
+            Some(Ok::<Event, Infallible>(Event::default().data("[DONE]")))
+        }
+        WireFormat::AnthropicMessages => None,
+    };
+    Sse::new(framed.chain(stream::iter(terminal))).into_response()
+}
+
+fn frame_event(format: WireFormat, value: Value) -> Event {
+    match format {
+        WireFormat::OpenAiChat => Event::default().data(value.to_string()),
+        WireFormat::OpenAiResponses | WireFormat::AnthropicMessages => {
+            let event_type = value
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("message");
+            Event::default().event(event_type).data(value.to_string())
+        }
+    }
+}
+
+fn mock_stream_error(message: String) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({"error": {"message": message}})),
+    )
+        .into_response()
+}

--- a/crates/switchyard-test-server/src/main.rs
+++ b/crates/switchyard-test-server/src/main.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runs the mock LLM server as a standalone process.
+
+use std::error::Error;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use switchyard_test_server::MockLlmServer;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let default_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    let addr = match std::env::args().nth(1) {
+        Some(value) => value.parse()?,
+        None => default_addr,
+    };
+    let server = MockLlmServer::builder().bind_addr(addr).start().await?;
+    println!("{}", server.base_url());
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/crates/switchyard-test-server/tests/server.rs
+++ b/crates/switchyard-test-server/tests/server.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the reusable mock LLM server.
+
+use std::error::Error;
+
+use reqwest::Client;
+use serde_json::{json, Value};
+use switchyard_protocol::completion_text;
+use switchyard_test_server::{MockLlmServer, DEFAULT_RESPONSE_BANK};
+use switchyard_translation::{decode_aggregated_response, WireFormat};
+
+type TestResult = Result<(), Box<dyn Error + Send + Sync>>;
+
+#[tokio::test]
+async fn serves_all_buffered_provider_formats_and_captures_requests() -> TestResult {
+    let server = MockLlmServer::builder()
+        .default_response("ok")
+        .model_response("model/special", "special")
+        .start()
+        .await?;
+    let client = Client::new();
+    let cases = [
+        (
+            "/v1/chat/completions",
+            WireFormat::OpenAiChat,
+            json!({"model": "model/default", "messages": []}),
+            "ok",
+        ),
+        (
+            "/v1/responses",
+            WireFormat::OpenAiResponses,
+            json!({"model": "model/special", "input": "hi"}),
+            "special",
+        ),
+        (
+            "/v1/messages",
+            WireFormat::AnthropicMessages,
+            json!({"model": "model/default", "max_tokens": 16, "messages": []}),
+            "ok",
+        ),
+    ];
+
+    for (path, format, request, expected) in cases {
+        let body: Value = client
+            .post(format!("{}{path}", server.url()))
+            .bearer_auth("test-key")
+            .json(&request)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        let response = decode_aggregated_response(&body, format)?;
+        assert_eq!(completion_text(&response), expected);
+        assert_eq!(response.usage.cached_input_tokens(), Some(7));
+    }
+
+    let requests = server.requests().await;
+    assert_eq!(requests.len(), 3);
+    assert_eq!(requests[0].path, "/v1/chat/completions");
+    assert_eq!(
+        requests[0].headers.get("authorization").map(String::as_str),
+        Some("Bearer test-key")
+    );
+    assert_eq!(requests[1].body["model"], "model/special");
+    assert_eq!(requests[2].path, "/v1/messages");
+    Ok(())
+}
+
+#[tokio::test]
+async fn serves_streams_for_all_provider_formats() -> TestResult {
+    let server = MockLlmServer::builder()
+        .default_response("ok")
+        .start()
+        .await?;
+    let client = Client::new();
+    for (path, request, expected_event, has_done) in [
+        (
+            "/v1/chat/completions",
+            json!({"model": "model/a", "messages": [], "stream": true}),
+            None,
+            true,
+        ),
+        (
+            "/v1/responses",
+            json!({"model": "model/a", "input": "hi", "stream": true}),
+            Some("event: response."),
+            true,
+        ),
+        (
+            "/v1/messages",
+            json!({"model": "model/a", "max_tokens": 16, "messages": [], "stream": true}),
+            Some("event: message_"),
+            false,
+        ),
+    ] {
+        let body = client
+            .post(format!("{}{path}", server.url()))
+            .json(&request)
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        assert!(body.contains("ok"));
+        assert_eq!(body.contains("data: [DONE]"), has_done);
+        if let Some(expected_event) = expected_event {
+            assert!(body.contains(expected_event));
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_response_is_selected_from_the_built_in_bank() -> TestResult {
+    let server = MockLlmServer::start().await?;
+    let body: Value = Client::new()
+        .post(format!("{}/v1/chat/completions", server.url()))
+        .json(&json!({"model": "model/a", "messages": []}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let response = decode_aggregated_response(&body, WireFormat::OpenAiChat)?;
+    assert!(DEFAULT_RESPONSE_BANK.contains(&completion_text(&response).as_str()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn injects_errors_by_model_or_header() -> TestResult {
+    let server = MockLlmServer::builder()
+        .model_error("model/fail", reqwest::StatusCode::IM_A_TEAPOT)
+        .start()
+        .await?;
+    let client = Client::new();
+
+    let by_model = client
+        .post(format!("{}/v1/chat/completions", server.url()))
+        .json(&json!({"model": "model/fail", "messages": []}))
+        .send()
+        .await?;
+    assert_eq!(by_model.status(), reqwest::StatusCode::IM_A_TEAPOT);
+
+    let by_header = client
+        .post(format!("{}/v1/messages", server.url()))
+        .header("x-switchyard-test-status", "429")
+        .json(&json!({"model": "model/a", "messages": []}))
+        .send()
+        .await?;
+    assert_eq!(by_header.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+    Ok(())
+}

--- a/crates/switchyard-test-server/tests/server.rs
+++ b/crates/switchyard-test-server/tests/server.rs
@@ -115,6 +115,7 @@ async fn serves_streams_for_all_provider_formats() -> TestResult {
 
 #[tokio::test]
 async fn default_response_is_selected_from_the_built_in_bank() -> TestResult {
+    assert!(DEFAULT_RESPONSE_BANK.len() >= 40);
     let server = MockLlmServer::start().await?;
     let body: Value = Client::new()
         .post(format!("{}/v1/chat/completions", server.url()))


### PR DESCRIPTION
## What

- add a private, non-publishable `switchyard-test-server` workspace crate
- serve OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages
- support buffered and SSE streaming responses through the existing translation codecs
- provide a curated random response bank plus deterministic per-test overrides
- support model/header-based HTTP error injection and request capture
- expose both an in-process fixture and a standalone binary
- replace the inline mock implementation in `switchyard-server` integration tests

## Why

Switchyard integration tests need one reusable provider mock rather than independent,
partially compatible servers embedded in each test suite. Generating responses through
`switchyard-translation` keeps the mock aligned with the same wire formats the product
supports.

## Review

- confirm the fixture API is intentionally small and sufficient for server/client tests
- confirm the built-in response bank covers useful text shapes without making exact tests flaky
- confirm `publish = false` and dev-only consumption keep this out of production artifacts

## Validation

- `cargo test -p switchyard-test-server`
- `cargo test -p switchyard-server`
- `cargo test --workspace`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- standalone binary HTTP smoke against `/v1/chat/completions`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable mock LLM server for integration testing across OpenAI and Anthropic-compatible endpoints.
  * Supports configurable responses, streaming output, request capture, and simulated errors.
  * Added a standalone mode for running the mock server locally.

* **Tests**
  * Updated server integration tests to use the shared mock server.
  * Added coverage for buffered and streaming responses, request recording, default responses, and error handling.

* **Documentation**
  * Added guidance recommending the shared mock server for Rust HTTP end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->