### PR TITLE
fix(anthropic): accept done stream terminator

### DIFF
--- a/crates/switchyard-components/src/backends/anthropic.rs
+++ b/crates/switchyard-components/src/backends/anthropic.rs
@@ -524,9 +524,10 @@ fn anthropic_sse_stream(response: reqwest::Response) -> BoxResponseStream {
             // Anthropic SSE has named events, but the payload we care about is
             // still the JSON `data:` line.
             while let Some(frame) = drain_next_sse_frame(&mut buffer, "Anthropic")? {
-                match parse_json_sse_frame(&frame, "Anthropic", None)? {
+                match parse_json_sse_frame(&frame, "Anthropic", Some("[DONE]"))? {
                     ParsedSseFrame::Json(value) => yield StreamEvent::Json(value),
-                    ParsedSseFrame::Done | ParsedSseFrame::Empty => {}
+                    ParsedSseFrame::Done => return,
+                    ParsedSseFrame::Empty => {}
                 }
             }
         }
@@ -535,7 +536,7 @@ fn anthropic_sse_stream(response: reqwest::Response) -> BoxResponseStream {
         // separator.
         if has_non_whitespace_bytes(&buffer) {
             let frame = decode_sse_frame(&buffer, "Anthropic")?;
-            match parse_json_sse_frame(&frame, "Anthropic", None)? {
+            match parse_json_sse_frame(&frame, "Anthropic", Some("[DONE]"))? {
                 ParsedSseFrame::Json(value) => yield StreamEvent::Json(value),
                 ParsedSseFrame::Done | ParsedSseFrame::Empty => {}
             }

--- a/crates/switchyard-components/tests/adversarial_native_backends.rs
+++ b/crates/switchyard-components/tests/adversarial_native_backends.rs
@@ -1040,6 +1040,42 @@ async fn anthropic_streaming_returns_stream_events() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn anthropic_streaming_stops_at_done_marker() -> Result<()> {
+    let server = OneShotServer::sse(
+        "event: message_start\n\
+         data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg-stream\"}}\n\n\
+         data: [DONE]\n\n\
+         event: message_stop\n\
+         data: {\"type\":\"message_stop\"}\n\n",
+    )?;
+    let backend = AnthropicNativeBackend::new(anthropic_target(server.base_url().to_string())?)?;
+    let mut ctx = ProxyContext::new();
+
+    let response = backend
+        .call(
+            &mut ctx,
+            &ChatRequest::anthropic(json!({
+                "model": "client-claude",
+                "max_tokens": 128,
+                "messages": [{"role": "user", "content": "stream"}],
+                "stream": true
+            })),
+        )
+        .await?;
+    let events = collect_json_events(response).await?;
+    server.captured()?;
+
+    assert_eq!(
+        events,
+        vec![json!({
+            "type": "message_start",
+            "message": {"id": "msg-stream"}
+        })]
+    );
+    Ok(())
+}
+
 // Anthropic native must reject targets configured for OpenAI format.
 #[test]
 fn anthropic_backend_rejects_openai_targets() -> Result<()> {


### PR DESCRIPTION
## What

Teach the native Anthropic streaming backend to recognize the OpenAI-style
`[DONE]` SSE sentinel and stop the stream when it appears.

Add a regression test that verifies events after the sentinel are not emitted.
Existing coverage still verifies normal Anthropic streams that end without
`[DONE]`.

## Why

OpenRouter's Anthropic-compatible endpoint can append `data: [DONE]` after
otherwise valid Anthropic SSE events. Switchyard previously tried to parse that
sentinel as JSON, turning a successful response into a mid-stream parse error.

## Reproduction

With Switchyard running on port 4001 and `openrouter-opus` configured as an
Anthropic-format route to `anthropic/claude-opus-4.8` on OpenRouter:

```bash
curl --no-buffer http://127.0.0.1:4001/v1/messages \
  -H 'content-type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  --data '{
    "model": "openrouter-opus",
    "max_tokens": 16,
    "stream": true,
    "messages": [
      {"role": "user", "content": "Reply with exactly: OK"}
    ]
  }'
```

Before this fix, the response contains the normal Anthropic events through
`message_stop`, then ends with:

```text
event: error
data: {"type": "error", "error": {"message": "SwitchyardProcessorError('processor failed: SwitchyardUpstreamError: upstream failed: Anthropic stream emitted invalid JSON frame: expected value at line 1 column 2')", "type": "internal_error"}}
```

OpenRouter has appended `data: [DONE]`; Switchyard tries to decode it as JSON
and emits the error above. After this fix, `[DONE]` terminates the stream
cleanly and no error event is emitted.

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/ -v -m 'not integration'` — 1949 passed, 12 skipped
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] User-confirmed OpenRouter streaming smoke against `/api/v1/messages`

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A: no classes added.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: no public symbols added.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (N/A: compatibility fix only.)
- [x] Commits signed off (`Signed-off-by: Bhuvan Agrawal <11240550+bhuvan002@users.noreply.github.com>`) per the DCO.

## Notes for reviewers

The full live E2E suite reached 17 passing tests, then hit its five-error limit
because the shared fixture on current `main` still invokes the removed
`switchyard passthrough` command. That harness issue is unrelated to this
two-file parser change; 19 live tests were therefore not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Anthropic streaming responses to stop processing immediately at the `[DONE]` marker.
  * Prevented events sent after stream completion from appearing in responses.
  * Improved handling when a connection closes without a final separator.

* **Tests**
  * Added coverage verifying that events after `[DONE]` are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->