### PR TITLE
feat(llm-client): support OpenRouter Anthropic Messages

### DIFF
--- a/crates/libsy-llm-client/README.md
+++ b/crates/libsy-llm-client/README.md
@@ -20,10 +20,10 @@ provider SDK.
   default [`Backend`] and can have additional backends for other wire formats.
   [`TranslatingLlmClient::call_rewrite_model`] uses the request's metadata wire format
   when set, otherwise the model's default backend.
-- **Backends.** A [`Backend`] is one of `OpenAiChat`, `OpenAiResponses`, or
-  `Anthropic`, each wrapping an [`HttpBackendConfig`] (`base_url`, `api_key`,
-  static `extra_headers`). The variant fixes the URL path and auth scheme
-  (Bearer vs `x-api-key` + `anthropic-version`).
+- **Backends.** A [`Backend`] is one of `OpenAiChat`, `OpenAiResponses`,
+  `Anthropic`, or `OpenRouterAnthropic`, each wrapping an
+  [`HttpBackendConfig`] (`base_url`, `api_key`, static `extra_headers`). The
+  variant fixes the URL path and auth scheme.
 - **Model rewrite.** The resolved model name is both the map key and the model id
   sent upstream — it overwrites whatever `model` the request arrived with.
 - **Streaming is chosen by the request.** If the encoded body has `stream: true`
@@ -164,11 +164,24 @@ fn build_multi_format_client(
 
 - The `Backend` variant sets auth: OpenAI formats send `Authorization: Bearer <key>`;
   Anthropic sends `x-api-key: <key>` plus `anthropic-version`.
+- `OpenRouterAnthropic` sends bearer auth to `/api/v1/messages`. For Claude
+  models it enables automatic prompt caching with a five-minute
+  `cache_control` and forwards `Metadata::session_id` as `x-session-id` for
+  sticky routing.
 - `request.metadata.http_headers` are forwarded upstream, **except** reserved ones:
   `host`, `content-length`, `connection`, and the backend-owned
   `authorization` / `x-api-key` / `anthropic-version` / `content-type`. So a
   caller's placeholder credential never overrides the backend's real key.
 - Per-backend static headers go in `HttpBackendConfig::extra_headers`.
+
+To request Anthropic's one-hour prompt cache, override the automatic default:
+
+```rust
+request.llm_request.extensions.fields.insert(
+    "cache_control".to_string(),
+    serde_json::json!({"type": "ephemeral", "ttl": "1h"}),
+);
+```
 
 ## Errors
 

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -51,7 +51,7 @@ impl fmt::Debug for HttpBackendConfig {
     }
 }
 
-/// A configured upstream backend, one variant per built-in wire format.
+/// A configured upstream backend, including provider-specific protocol variants.
 ///
 /// The variant fixes the wire format, URL path, and auth scheme together so no
 /// invalid combination can be constructed.
@@ -63,6 +63,8 @@ pub enum Backend {
     OpenAiResponses(HttpBackendConfig),
     /// Anthropic Messages API.
     Anthropic(HttpBackendConfig),
+    /// OpenRouter's Anthropic Messages-compatible API.
+    OpenRouterAnthropic(HttpBackendConfig),
 }
 
 impl Backend {
@@ -71,7 +73,9 @@ impl Backend {
         match self {
             Backend::OpenAiChat(_) => WireFormat::OpenAiChat,
             Backend::OpenAiResponses(_) => WireFormat::OpenAiResponses,
-            Backend::Anthropic(_) => WireFormat::AnthropicMessages,
+            Backend::Anthropic(_) | Backend::OpenRouterAnthropic(_) => {
+                WireFormat::AnthropicMessages
+            }
         }
     }
 
@@ -80,7 +84,8 @@ impl Backend {
         match self {
             Backend::OpenAiChat(config)
             | Backend::OpenAiResponses(config)
-            | Backend::Anthropic(config) => config,
+            | Backend::Anthropic(config)
+            | Backend::OpenRouterAnthropic(config) => config,
         }
     }
 
@@ -93,18 +98,20 @@ impl Backend {
         match self {
             Backend::OpenAiChat(_) => openai_url(base_url, "/chat/completions"),
             Backend::OpenAiResponses(_) => openai_url(base_url, "/responses"),
-            Backend::Anthropic(_) => anthropic_url(base_url),
+            Backend::Anthropic(_) | Backend::OpenRouterAnthropic(_) => anthropic_url(base_url),
         }
     }
 
     /// Applies this backend's auth and version headers to a request builder.
     ///
-    /// OpenAI variants use `Authorization: Bearer <key>`; Anthropic uses
-    /// `x-api-key: <key>` plus the required `anthropic-version` header.
+    /// OpenAI and OpenRouter variants use `Authorization: Bearer <key>`;
+    /// Anthropic uses `x-api-key: <key>` plus the required version header.
     pub fn apply_auth(&self, mut builder: RequestBuilder) -> RequestBuilder {
         let api_key = self.config().api_key.as_deref();
         match self {
-            Backend::OpenAiChat(_) | Backend::OpenAiResponses(_) => {
+            Backend::OpenAiChat(_)
+            | Backend::OpenAiResponses(_)
+            | Backend::OpenRouterAnthropic(_) => {
                 if let Some(api_key) = api_key {
                     builder = builder.bearer_auth(api_key);
                 }
@@ -117,6 +124,29 @@ impl Backend {
             }
         }
         builder
+    }
+
+    /// Applies provider-specific session affinity used to improve cache hits.
+    pub(crate) fn apply_session_id(
+        &self,
+        mut builder: RequestBuilder,
+        session_id: Option<&str>,
+    ) -> RequestBuilder {
+        if let (Backend::OpenRouterAnthropic(_), Some(session_id)) = (self, session_id) {
+            builder = builder.header("x-session-id", session_id);
+        }
+        builder
+    }
+
+    /// Whether this backend supports top-level automatic prompt caching for `model`.
+    pub(crate) fn supports_automatic_prompt_caching(&self, model: &str) -> bool {
+        match self {
+            Backend::Anthropic(_) => true,
+            Backend::OpenRouterAnthropic(_) => model
+                .trim_start_matches('~')
+                .starts_with("anthropic/claude-"),
+            Backend::OpenAiChat(_) | Backend::OpenAiResponses(_) => false,
+        }
     }
 
     /// Static per-backend headers to forward on every call.
@@ -139,7 +169,9 @@ impl Backend {
                 },
                 OPENAI_OVERFLOW_PHRASES,
             ),
-            Backend::Anthropic(_) => is_overflow_body(body, |_| false, ANTHROPIC_OVERFLOW_PHRASES),
+            Backend::Anthropic(_) | Backend::OpenRouterAnthropic(_) => {
+                is_overflow_body(body, |_| false, ANTHROPIC_OVERFLOW_PHRASES)
+            }
         }
     }
 }
@@ -219,6 +251,23 @@ mod tests {
     }
 
     #[test]
+    fn openrouter_messages_uses_anthropic_path_and_format() {
+        let backend = Backend::OpenRouterAnthropic(config("https://openrouter.ai/api/v1"));
+        assert_eq!(backend.url(), "https://openrouter.ai/api/v1/messages");
+        assert_eq!(backend.wire_format(), WireFormat::AnthropicMessages);
+    }
+
+    #[test]
+    fn automatic_prompt_caching_is_model_aware() {
+        assert!(
+            Backend::Anthropic(config("x")).supports_automatic_prompt_caching("claude-sonnet-4-6")
+        );
+        let openrouter = Backend::OpenRouterAnthropic(config("x"));
+        assert!(openrouter.supports_automatic_prompt_caching("anthropic/claude-sonnet-4.6"));
+        assert!(!openrouter.supports_automatic_prompt_caching("openrouter/free"));
+    }
+
+    #[test]
     fn wire_format_matches_variant() {
         assert_eq!(
             Backend::OpenAiChat(config("x")).wire_format(),
@@ -230,6 +279,10 @@ mod tests {
         );
         assert_eq!(
             Backend::Anthropic(config("x")).wire_format(),
+            WireFormat::AnthropicMessages
+        );
+        assert_eq!(
+            Backend::OpenRouterAnthropic(config("x")).wire_format(),
             WireFormat::AnthropicMessages
         );
     }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -166,6 +166,17 @@ impl TranslatingLlmClient {
 
         let mut body = encode_request(&llm_request, wire_format)
             .map_err(|error| LlmClientError::RequestEncoding(error.to_string()))?;
+        if backend.supports_automatic_prompt_caching(&model) {
+            let cache_control = llm_request
+                .extensions
+                .fields
+                .get("cache_control")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({"type": "ephemeral"}));
+            if let Value::Object(object) = &mut body {
+                object.entry("cache_control").or_insert(cache_control);
+            }
+        }
         // `encode_request` round-trips a preserved same-format body verbatim,
         // which keeps the caller's original `model`; force the resolved model so
         // the upstream always sees the target id.
@@ -175,6 +186,12 @@ impl TranslatingLlmClient {
         let builder = self.client.post(backend.url()).json(&body);
         let builder = forward_metadata_headers(builder, metadata.as_ref());
         let builder = apply_extra_headers(builder, backend);
+        let builder = backend.apply_session_id(
+            builder,
+            metadata
+                .as_ref()
+                .and_then(|metadata| metadata.session_id.as_deref()),
+        );
         let builder = backend.apply_auth(builder);
 
         let http_response = builder.send().await.map_err(convert_reqwest_error)?;
@@ -379,7 +396,7 @@ mod tests {
 
     use serde_json::json;
     use switchyard_protocol::{completion_text, text_request, LlmRequest};
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_partial_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -398,6 +415,14 @@ mod tests {
         vec![ModelConfig::new(
             "gpt",
             Backend::OpenAiChat(config(base_url)),
+            None,
+        )]
+    }
+
+    fn openrouter_map(base_url: &str) -> Vec<ModelConfig> {
+        vec![ModelConfig::new(
+            "anthropic/claude-sonnet-4.6",
+            Backend::OpenRouterAnthropic(config(base_url)),
             None,
         )]
     }
@@ -569,6 +594,82 @@ mod tests {
         let agg = response.llm_response.into_agg().await?;
         assert_eq!(completion_text(&agg), "Hi there");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn openrouter_claude_enables_prompt_caching_and_session_affinity(
+    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/messages"))
+            .and(header("authorization", "Bearer secret"))
+            .and(header("x-session-id", "session-1"))
+            .and(body_partial_json(
+                json!({"cache_control": {"type": "ephemeral"}}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "anthropic/claude-sonnet-4.6",
+                "content": [{"type": "text", "text": "cached"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let client =
+            TranslatingLlmClient::new(&openrouter_map(&format!("{}/api/v1", server.uri())))?;
+        let mut request = request_for(Some("anthropic/claude-sonnet-4.6"), false);
+        request.metadata = Some(Metadata {
+            session_id: Some("session-1".to_string()),
+            ..Metadata::default()
+        });
+        let response = client
+            .call_rewrite_model(Context::default(), request, None)
+            .await?;
+        assert_eq!(
+            completion_text(&response.llm_response.into_agg().await?),
+            "cached"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_prompt_cache_ttl_overrides_default(
+    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/messages"))
+            .and(body_partial_json(json!({
+                "cache_control": {"type": "ephemeral", "ttl": "1h"}
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "anthropic/claude-sonnet-4.6",
+                "content": [{"type": "text", "text": "cached"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": null,
+                "usage": {"input_tokens": 1, "output_tokens": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let client =
+            TranslatingLlmClient::new(&openrouter_map(&format!("{}/api/v1", server.uri())))?;
+        let mut request = request_for(Some("anthropic/claude-sonnet-4.6"), false);
+        request.llm_request.extensions.fields.insert(
+            "cache_control".to_string(),
+            json!({"type": "ephemeral", "ttl": "1h"}),
+        );
+        client
+            .call_rewrite_model(Context::default(), request, None)
+            .await?;
         Ok(())
     }
 

--- a/crates/switchyard-translation/src/sse.rs
+++ b/crates/switchyard-translation/src/sse.rs
@@ -14,13 +14,14 @@ use crate::WireFormat;
 /// Boxed, thread-safe error carried by a streamed item.
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-/// The terminal SSE marker for `format`, if any. OpenAI Chat and Responses use
-/// `[DONE]`; Anthropic ends on its `message_stop` event with no marker.
+/// The terminal SSE marker accepted for each format. Anthropic itself ends on
+/// `message_stop`, but compatible providers may append `[DONE]`.
 #[inline]
 pub(crate) fn done_marker(format: WireFormat) -> Option<&'static str> {
     match format {
-        WireFormat::OpenAiChat | WireFormat::OpenAiResponses => Some("[DONE]"),
-        WireFormat::AnthropicMessages => None,
+        WireFormat::OpenAiChat | WireFormat::OpenAiResponses | WireFormat::AnthropicMessages => {
+            Some("[DONE]")
+        }
     }
 }
 
@@ -106,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_has_no_done_marker() {
-        assert_eq!(done_marker(WireFormat::AnthropicMessages), None);
+    fn anthropic_compatible_streams_may_terminate_on_done() {
+        assert_eq!(done_marker(WireFormat::AnthropicMessages), Some("[DONE]"));
     }
 }


### PR DESCRIPTION
## What

- add `Backend::OpenRouterAnthropic` to the existing `TranslatingLlmClient`
- use Anthropic Messages encoding with OpenRouter bearer authentication
- enable five-minute automatic prompt caching for native Anthropic and explicit OpenRouter Claude models
- use `Metadata::session_id` for OpenRouter provider stickiness
- preserve explicit `cache_control` values, including the one-hour TTL
- accept OpenRouter's trailing `[DONE]` marker on Anthropic-compatible streams

## Why

OpenRouter's Messages API only differs from the existing Anthropic backend in provider transport behavior and request defaults. Keeping that behavior in the shared translating client avoids introducing another `RoutedLlmClient` wrapper while retaining the shared HTTP pool, translation, streaming, and error handling.

## Review

Please focus on:

- whether model-aware automatic caching belongs at the backend boundary
- the OpenRouter bearer-auth and `x-session-id` behavior
- compatibility of accepting `[DONE]` after Anthropic `message_stop`

## Validation

- `cargo test -p switchyard-llm-client` (34 passed)
- `cargo test -p switchyard-translation sse` (11 passed)
- `cargo clippy -p switchyard-llm-client -p switchyard-translation --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- live `openrouter/free` buffered and streaming calls through `TranslatingLlmClient`
