### PR TITLE
fix(translation): decode OpenRouter cache write usage

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -1072,7 +1072,11 @@ pub(crate) fn decode_openai_usage(value: Option<&Value>) -> Usage {
         .and_then(Value::as_u64);
     let cache_creation_input_tokens = value
         .get("prompt_tokens_details")
-        .and_then(|details| details.get("cache_creation_tokens"))
+        .and_then(|details| {
+            details
+                .get("cache_write_tokens")
+                .or_else(|| details.get("cache_creation_tokens"))
+        })
         .and_then(Value::as_u64);
     Usage {
         input_tokens: value

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -244,7 +244,11 @@ fn openai_usage(usage: &Map<String, Value>) -> Usage {
         .and_then(Value::as_u64);
     let cache_creation_input_tokens = usage
         .get("prompt_tokens_details")
-        .and_then(|details| details.get("cache_creation_tokens"))
+        .and_then(|details| {
+            details
+                .get("cache_write_tokens")
+                .or_else(|| details.get("cache_creation_tokens"))
+        })
         .and_then(Value::as_u64);
     Usage {
         input_tokens: usage

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -159,38 +159,42 @@ fn openai_chat_cache_usage_translates_to_responses_usage_details() -> TestResult
     Ok(())
 }
 
-// Verifies OpenAI cache usage is expressed in Anthropic's standard sibling fields.
+// Verifies OpenRouter's cache-write field and the legacy alias normalize identically.
 #[test]
-fn openai_chat_cache_usage_translates_to_anthropic_usage_fields() -> TestResult {
+fn openai_chat_cache_write_aliases_translate_to_anthropic_usage_fields() -> TestResult {
     let engine = TranslationEngine::default();
-    let body = json!({
-        "id": "chatcmpl-test",
-        "model": "gpt-cached",
-        "choices": [{
-            "index": 0,
-            "message": {"role": "assistant", "content": "Cached answer"},
-            "finish_reason": "stop"
-        }],
-        "usage": {
-            "prompt_tokens": 100,
-            "completion_tokens": 5,
-            "total_tokens": 105,
-            "prompt_tokens_details": {"cached_tokens": 80}
-        }
-    });
+    for cache_write_field in ["cache_write_tokens", "cache_creation_tokens"] {
+        let mut body = json!({
+            "id": "chatcmpl-test",
+            "model": "gpt-cached",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Cached answer"},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 5,
+                "total_tokens": 105,
+                "prompt_tokens_details": {"cached_tokens": 70}
+            }
+        });
+        body["usage"]["prompt_tokens_details"][cache_write_field] = json!(10);
 
-    let output = engine
-        .translate_response(
-            WireFormat::OpenAiChat,
-            WireFormat::AnthropicMessages,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
+        let output = engine
+            .translate_response(
+                WireFormat::OpenAiChat,
+                WireFormat::AnthropicMessages,
+                &body,
+                &TranslationPolicy::default(),
+            )?
+            .body;
 
-    assert_eq!(output["usage"]["input_tokens"], 20);
-    assert_eq!(output["usage"]["cache_read_input_tokens"], 80);
-    assert_eq!(output["usage"]["output_tokens"], 5);
+        assert_eq!(output["usage"]["input_tokens"], 20);
+        assert_eq!(output["usage"]["cache_read_input_tokens"], 70);
+        assert_eq!(output["usage"]["cache_creation_input_tokens"], 10);
+        assert_eq!(output["usage"]["output_tokens"], 5);
+    }
     Ok(())
 }
 

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -310,6 +310,41 @@ fn openai_chat_stream_cache_usage_translates_to_responses_usage_details() -> Tes
     Ok(())
 }
 
+// Verifies OpenRouter's cache-write field and the legacy alias normalize identically.
+#[test]
+fn openai_chat_stream_cache_write_usage_is_normalized() -> TestResult {
+    for cache_write_field in ["cache_write_tokens", "cache_creation_tokens"] {
+        let mut state = StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::OpenAiChat);
+        let mut event = json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "model": "gpt-cached",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 5,
+                "total_tokens": 105,
+                "prompt_tokens_details": {"cached_tokens": 70}
+            }
+        });
+        event["usage"]["prompt_tokens_details"][cache_write_field] = json!(10);
+
+        let chunks = decode_stream_event(&mut state, WireFormat::OpenAiChat, &event);
+        let Some(usage) = chunks.iter().find_map(|chunk| match chunk {
+            LlmResponseChunk::Usage(usage) => Some(usage),
+            _ => None,
+        }) else {
+            return Err(format!("expected usage chunk for {cache_write_field}").into());
+        };
+
+        assert_eq!(usage.input_tokens, Some(20));
+        assert_eq!(usage.cached_input_tokens(), Some(70));
+        assert_eq!(usage.cache_creation_input_tokens(), Some(10));
+        assert_eq!(usage.output_tokens, Some(5));
+    }
+    Ok(())
+}
+
 // Verifies the streamed total-token fallback keeps cached tokens when upstream omits total_tokens.
 #[test]
 fn responses_stream_usage_without_total_keeps_cached_tokens_in_total() -> TestResult {


### PR DESCRIPTION
## Summary

- decode OpenRouter's current `prompt_tokens_details.cache_write_tokens` field in buffered OpenAI Chat responses
- decode the same field from streaming usage chunks
- retain `cache_creation_tokens` as a compatibility alias

## Root cause

OpenRouter reports cache writes as `cache_write_tokens`, while the OpenAI Chat codecs only recognized `cache_creation_tokens`. Cache-write tokens were therefore left in the uncached input count and omitted from normalized cache-creation usage.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p switchyard-translation`
- `cargo clippy -p switchyard-translation --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage reporting for OpenAI-compatible responses and streaming events.
  * Cache-write token counts are now recognized consistently, including support for legacy cache-creation fields.
  * Corrected input, cached, cache-creation, and output token totals in translated usage data.

* **Tests**
  * Added coverage confirming equivalent handling of both cache-write field formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->