### PR TITLE
build: widen openai floor to >=2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ classifiers = [
 #   pip install nemo-switchyard[all]            # Everything
 dependencies = [
     # openai: request/response schema types, plus the async client in lib/llm_client.py.
-    # Keep this floor low so downstream consumers that pin an older openai can depend on
-    # Switchyard; the suite passes unchanged from 2.0.0 through 2.48.0.
-    "openai>=2.0.0,<3.0",
+    # Keep this floor low enough for downstream consumers to co-install us; NeMo Gym pins
+    # openai<=2.7.2. The suite passes unchanged from 2.7.0 through 2.48.0.
+    "openai>=2.7,<3.0",
     "anthropic>=0.99.0,<1.0",
     "httpx>=0.28.1,<1.0",
     "pydantic>=2.13.3,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ classifiers = [
 #   pip install nemo-switchyard[cli]            # Add prompt-toolkit for CLI
 #   pip install nemo-switchyard[all]            # Everything
 dependencies = [
-    "openai>=2.34.0,<3.0",
+    # openai: request/response schema types, plus the async client in lib/llm_client.py.
+    # Keep this floor low so downstream consumers that pin an older openai can depend on
+    # Switchyard; the suite passes unchanged from 2.0.0 through 2.48.0.
+    "openai>=2.0.0,<3.0",
     "anthropic>=0.99.0,<1.0",
     "httpx>=0.28.1,<1.0",
     "pydantic>=2.13.3,<3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2255,7 +2255,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1.0" },
     { name = "nemo-platform", marker = "extra == 'intake'", specifier = ">=0.1.0,<1.0" },
     { name = "nemo-switchyard", extras = ["server", "cli", "tracing", "intake", "affinity-redis"], marker = "extra == 'all'" },
-    { name = "openai", specifier = ">=2.0.0,<3.0" },
+    { name = "openai", specifier = ">=2.7,<3.0" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3.0.52,<4.0" },
     { name = "pydantic", specifier = ">=2.13.3,<3.0" },
     { name = "redis", marker = "extra == 'affinity-redis'", specifier = ">=5.0.1,<6" },

--- a/uv.lock
+++ b/uv.lock
@@ -2255,7 +2255,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1.0" },
     { name = "nemo-platform", marker = "extra == 'intake'", specifier = ">=0.1.0,<1.0" },
     { name = "nemo-switchyard", extras = ["server", "cli", "tracing", "intake", "affinity-redis"], marker = "extra == 'all'" },
-    { name = "openai", specifier = ">=2.34.0,<3.0" },
+    { name = "openai", specifier = ">=2.0.0,<3.0" },
     { name = "prompt-toolkit", marker = "extra == 'cli'", specifier = ">=3.0.52,<4.0" },
     { name = "pydantic", specifier = ">=2.13.3,<3.0" },
     { name = "redis", marker = "extra == 'affinity-redis'", specifier = ">=5.0.1,<6" },


### PR DESCRIPTION
In order to integrate into Gym, we need to widen the openai floor

## What

Lowers the `openai` dependency floor from `>=2.34.0` to `>=2.7`. The upper bound at the major version is unchanged, and the resolved version stays 2.34.0 — this only widens what consumers are allowed to bring.

## Why

The floor was set to whatever version was current when the package metadata was written, not to a version the code needs. The same pattern shows in its neighbours: every floor equals its locked version (`openai` 2.34.0/2.34.0, `pydantic` 2.13.3/2.13.3, `httpx` 0.28.1/0.28.1).

It has a concrete downstream cost. NeMo Gym pins `openai<=2.7.2`, so adding `nemo-switchyard` to Gym is unsatisfiable today:

```
Because nemo-switchyard==0.1.0 depends on openai>=2.34.0,<3.0 and your
project depends on openai<=2.7.2, we can conclude that your project's
requirements are unsatisfiable.
```

That blocks the Gym <> Switchyard integration — Gym needs to launch the proxy for router evals and, later, to import Switchyard for schema mapping. Fixing it from Gym's side instead would mean migrating Gym's openai SDK across ~27 minor versions, touching ~10 core modules that import internal type paths (`openai.types.responses.response_create_params`, `response_output_text_param`, `shared.chat_model`, …). Relaxing an over-tight floor here is the cheaper and more accurate fix.

`>=2.7` rather than lower is deliberate: it is the narrowest floor that overlaps Gym's ceiling, so the supported range grows no more than it has to.

## Verification

Switchyard uses openai for request/response schema types plus the async client in `lib/llm_client.py`. Two checks:

1. **Import surface** — every openai symbol imported anywhere in `switchyard/` resolves on 2.7.0, including `openai.types.chat.chat_completion_message_function_tool_call`, which was the one I expected to be version-gated. Zero missing modules or symbols.
2. **Test suite** — the Python suite at tag `v0.1.0`, run against the published `nemo-switchyard[server]==0.1.0` wheel, is identical across every version tested:

| openai | result |
|---|---|
| 2.7.0 | 69 passed, 1 failed |
| 2.7.1 | 69 passed, 1 failed |
| 2.7.2 | 69 passed, 1 failed |
| 2.34.0 | 69 passed, 1 failed |
| 2.48.0 | 69 passed, 1 failed |

The single failure is `test_build_and_serve_registers_extra_endpoints`, identical in all runs — an artifact of running the tests against the installed wheel rather than the source tree, not an openai regression. `e2e`, `contract`, `getting_started` and `readme` were excluded (network / docs deps).

For what it's worth the suite also passes on 2.0.0, 2.2.0 and 2.5.0, so 2.7 is a policy choice rather than a limit of the code. Happy to drop it further if reviewers prefer.

`uv lock --check` passes.

## Follow-up

Once this ships in a release, adding `nemo-switchyard` to NeMo Gym becomes a one-line change scoped to the Switchyard model server package, rather than a change to Gym's core dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility to support a broader range of OpenAI library versions.
  * Added documentation clarifying the supported version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->