### PR TITLE
fix(translation): always emit Responses usage detail objects

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -1210,21 +1210,18 @@ fn encode_responses_usage(usage: &Usage) -> Value {
     let input_tokens = usage.input_tokens.unwrap_or(0)
         + usage.cached_input_tokens().unwrap_or(0)
         + usage.cache_creation_input_tokens().unwrap_or(0);
-    let mut value = json!({
+    // The detail objects are required by the Responses schema, so both are always present. An
+    // upstream that reports no cache or reasoning breakdown means zero, not "unknown"; omitting
+    // them instead yields a payload that fails to deserialize into the OpenAI SDK's
+    // ResponseUsage, which types both as non-optional.
+    json!({
         "input_tokens": input_tokens,
         "output_tokens": usage.output_tokens.unwrap_or(0),
         "total_tokens": usage
             .total_tokens
             .or_else(|| Some(input_tokens + usage.output_tokens.unwrap_or(0)))
             .unwrap_or(0),
-    });
-    if let Some(cached_tokens) = usage.cached_input_tokens() {
-        value["input_tokens_details"] = json!({"cached_tokens": cached_tokens});
-    }
-    if let Some(reasoning_tokens) = usage.reasoning_tokens {
-        value["output_tokens_details"] = json!({
-            "reasoning_tokens": reasoning_tokens,
-        });
-    }
-    value
+        "input_tokens_details": {"cached_tokens": usage.cached_input_tokens().unwrap_or(0)},
+        "output_tokens_details": {"reasoning_tokens": usage.reasoning_tokens.unwrap_or(0)},
+    })
 }

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -555,22 +555,17 @@ fn responses_usage_value(usage: &Usage) -> Value {
     let input_tokens = usage.input_tokens.unwrap_or(0)
         + usage.cached_input_tokens().unwrap_or(0)
         + usage.cache_creation_input_tokens().unwrap_or(0);
-    let mut value = json!({
+    // Both detail objects are always present, for the same reason as the buffered encoder: the
+    // Responses schema types them as required, so a missing breakdown serializes as zero.
+    json!({
         "input_tokens": input_tokens,
         "output_tokens": usage.output_tokens.unwrap_or(0),
         "total_tokens": usage.total_tokens.unwrap_or_else(|| {
             input_tokens + usage.output_tokens.unwrap_or(0)
         }),
-    });
-    if let Some(cached_tokens) = usage.cached_input_tokens() {
-        value["input_tokens_details"] = json!({"cached_tokens": cached_tokens});
-    }
-    if let Some(reasoning_tokens) = usage.reasoning_tokens {
-        value["output_tokens_details"] = json!({
-            "reasoning_tokens": reasoning_tokens,
-        });
-    }
-    value
+        "input_tokens_details": {"cached_tokens": usage.cached_input_tokens().unwrap_or(0)},
+        "output_tokens_details": {"reasoning_tokens": usage.reasoning_tokens.unwrap_or(0)},
+    })
 }
 
 // Converts any upstream message ID into a Responses-looking response ID.

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -353,7 +353,13 @@ fn openai_chat_response_with_tool_call_translates_to_responses_output_item() -> 
     assert_eq!(output["output"][0]["arguments"], "{\"q\": \"rust\"}");
     assert_eq!(
         output["usage"],
-        json!({"input_tokens": 4, "output_tokens": 3, "total_tokens": 7})
+        json!({
+            "input_tokens": 4,
+            "output_tokens": 3,
+            "total_tokens": 7,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0}
+        })
     );
     Ok(())
 }
@@ -394,5 +400,85 @@ fn openai_chat_response_with_text_and_tool_call_translates_both_to_responses() -
     assert_eq!(output["output"][0]["content"][0]["text"], "Let me check.");
     assert_eq!(output["output"][1]["type"], "function_call");
     assert_eq!(output["output"][1]["call_id"], "call_1");
+    Ok(())
+}
+
+// Verifies both Responses usage detail objects are emitted even when the upstream reports no
+// cache or reasoning breakdown. The Responses schema types them as required, so omitting them
+// makes the payload unparseable by OpenAI-SDK clients.
+#[test]
+fn openai_chat_usage_without_breakdowns_still_emits_responses_usage_details() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "chatcmpl-test",
+        "model": "plain-model",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hi"},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 41, "completion_tokens": 3, "total_tokens": 44}
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["usage"],
+        json!({
+            "input_tokens": 41,
+            "output_tokens": 3,
+            "total_tokens": 44,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0}
+        })
+    );
+    Ok(())
+}
+
+// Verifies a partial breakdown does not suppress the other detail object: an upstream that
+// reports cached tokens but no reasoning tokens must still carry both.
+#[test]
+fn openai_chat_cache_only_usage_still_emits_reasoning_details() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "chatcmpl-test",
+        "model": "cache-only-model",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hi"},
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 41,
+            "completion_tokens": 3,
+            "total_tokens": 44,
+            "prompt_tokens_details": {"cached_tokens": 32}
+        }
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["usage"]["input_tokens_details"],
+        json!({"cached_tokens": 32})
+    );
+    assert_eq!(
+        output["usage"]["output_tokens_details"],
+        json!({"reasoning_tokens": 0})
+    );
     Ok(())
 }

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -597,3 +597,47 @@ fn openai_chat_error_frame_decodes_to_stream_error() -> TestResult {
     }
     Ok(())
 }
+
+// Verifies the streaming encoder matches the buffered one: both Responses usage detail objects
+// are present even when the upstream reports no cache or reasoning breakdown.
+#[test]
+fn openai_chat_stream_usage_without_breakdowns_still_emits_responses_usage_details() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::OpenAiResponses);
+    let usage = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "plain-model",
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 41, "completion_tokens": 3, "total_tokens": 44}
+    });
+
+    let mut events = engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::OpenAiResponses,
+        &usage,
+    )?;
+    events.extend(engine.finish_stream(&mut state, WireFormat::OpenAiResponses)?);
+
+    let Some(completed) = events
+        .iter()
+        .find(|event| event["type"] == "response.completed")
+    else {
+        return Err("expected final Responses completion event".into());
+    };
+    assert_eq!(
+        completed["response"]["usage"]["input_tokens_details"],
+        json!({"cached_tokens": 0})
+    );
+    assert_eq!(
+        completed["response"]["usage"]["output_tokens_details"],
+        json!({"reasoning_tokens": 0})
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

`encode_responses_usage` (buffered) and `responses_usage_value` (streaming) emitted
`input_tokens_details` and `output_tokens_details` only when the upstream happened to report a
cache or reasoning breakdown. Both are now always emitted, defaulting to zero.

## Why

Both fields are **required** by the Responses `usage` schema. The OpenAI SDK types them as
non-optional, with non-optional ints inside:

```python
class ResponseUsage(BaseModel):
    input_tokens_details: InputTokensDetails    # cached_tokens: int
    output_tokens_details: OutputTokensDetails  # reasoning_tokens: int
```

So when an upstream omits the breakdown, Switchyard returns a Responses payload that any
OpenAI-SDK client fails to deserialize:

```
ValidationError: 2 validation errors for Response
usage.input_tokens_details   Field required
usage.output_tokens_details  Field required
```

This is not a hypothetical. Routing `/v1/responses` to an OpenAI-format upstream on
`integrate.api.nvidia.com` fails for every request, because those models report no
`completion_tokens_details`:

| Upstream model | `prompt_tokens_details` | `completion_tokens_details` | Missing fields |
|---|---|---|---|
| `meta/llama-3.3-70b-instruct` | `{cached_tokens: 32}` | absent | 1 |
| `nvidia/nemotron-3-ultra-550b-a55b` | absent | absent | 2 |
| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | absent | absent | 2 |

Absent means the upstream reported no cached or reasoning tokens — that is zero, not unknown — so
defaulting to zero is the accurate encoding rather than a placeholder.

Found while routing NeMo Gym evals through Switchyard: `/v1/chat/completions` worked end-to-end
while `/v1/responses` returned 500 on every rollout.

## How tested

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean (160 files)
- [x] `uv run pytest tests/ -m "not integration"` green (1944 passed, 12 skipped)
- [x] Manual: replayed the live `integrate.api.nvidia.com` usage payloads above through the
      bindings; both now deserialize into `openai.types.responses.ResponseUsage`.

Three regression tests added: no-breakdown (buffered), cache-only-still-emits-reasoning
(buffered, guards the partial case), and no-breakdown (streaming).

## Notes for reviewers

- The streaming encoder had the identical bug; fixing only `buffered.rs` would have left SSE
  clients broken, so both are changed together.
- One existing assertion in `response_translation.rs` compared the whole `usage` object for a
  chat→responses translation and was updated to include the two now-always-present objects. No
  other expectation changed; the decode paths are untouched.
- Scope is deliberately narrow: the Anthropic and Chat encoders are untouched, since their schemas
  do not mark these objects required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses usage data now consistently includes input and output token detail objects.
  * Missing cached-token and reasoning-token breakdowns are represented as `0`, improving compatibility with clients expecting the standard schema.

* **Tests**
  * Added coverage for buffered and streaming responses, including missing and partially available usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->