### PR TITLE
refactor: Replace std::sync::Mutex with parking_lot::Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "futures",
  "opentelemetry",
  "opentelemetry_sdk",
+ "parking_lot",
  "rand 0.8.7",
  "serde_json",
  "switchyard-llm-client",
@@ -1829,6 +1830,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
+ "parking_lot",
  "pyo3",
  "pyo3-async-runtimes",
  "pythonize",

--- a/crates/libsy/Cargo.toml
+++ b/crates/libsy/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3"
 # Metrics-only OTel API: instruments record through the host-installed global
 # meter provider. Pinned to the 0.32 line used across the workspace.
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
+parking_lot = "0.12"
 rand = "0.8"
 switchyard-protocol = { path = "../protocol" }
 thiserror = "2"

--- a/crates/libsy/examples/ensemble.rs
+++ b/crates/libsy/examples/ensemble.rs
@@ -13,15 +13,16 @@
 //!   NVIDIA_API_KEY=... cargo run -p switchyard-libsy --example ensemble
 //!
 //! Unlike the reference routers, this algorithm is **stateful**: the win tally,
-//! turn counter, and committed choice live behind a [`std::sync::Mutex`] so one
+//! turn counter, and committed choice live behind a [`parking_lot::Mutex`] so one
 //! shared `&self` can serve a session's requests concurrently (see the
 //! `Algorithm` docs). In a proxy setup one `EnsembleOrchAlgo` is created per session,
 //! so this state is per-session.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use parking_lot::Mutex;
 
 use switchyard_libsy::{
     Algorithm, Context, Decision, Driver, LibsyError, LlmTarget, LlmTargetSet, Request, Response,
@@ -144,10 +145,7 @@ impl EnsembleOrchAlgo {
     /// concurrency two requests may both commit; they pick the same model from
     /// the same tally (with a stable tie-break), so the result is identical.
     fn resolve_committed(&self) -> Result<Option<String>> {
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| ensemble_error("state lock poisoned"))?;
+        let mut state = self.state.lock();
         if let Some(model) = &state.committed {
             return Ok(Some(model.clone()));
         }
@@ -307,10 +305,7 @@ impl EnsembleOrchAlgo {
         // Record the win and advance the turn counter under the lock (not held
         // across any await).
         {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|_| ensemble_error("state lock poisoned"))?;
+            let mut state = self.state.lock();
             *state.wins.entry(winner_model.clone()).or_insert(0) += 1;
             state.turns += 1;
         }
@@ -470,7 +465,6 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex as StdMutex;
     use switchyard_libsy::{LlmResponse, LlmTarget, Response, RoutedLlmClient, Signals};
     use switchyard_protocol::text_response;
 
@@ -481,7 +475,7 @@ mod tests {
     struct JudgingClient {
         judge_model: String,
         prefer: String,
-        calls: Arc<StdMutex<Vec<String>>>,
+        calls: Arc<Mutex<Vec<String>>>,
     }
 
     #[async_trait]
@@ -493,10 +487,7 @@ mod tests {
             decision: Arc<dyn Decision>,
         ) -> std::result::Result<Response, switchyard_protocol::LlmClientError> {
             let name = decision.selected_model().to_string();
-            self.calls
-                .lock()
-                .map_err(|_| switchyard_protocol::LlmClientError::Other("lock poisoned".into()))?
-                .push(name.clone());
+            self.calls.lock().push(name.clone());
             let completion = if name == self.judge_model {
                 judge_pick(&prompt_text(&request.llm_request), &self.prefer)
             } else {
@@ -534,8 +525,8 @@ mod tests {
         judge: &str,
         prefer: &str,
         exploration_turns: u64,
-    ) -> (EnsembleOrchAlgo, Arc<StdMutex<Vec<String>>>) {
-        let calls = Arc::new(StdMutex::new(Vec::new()));
+    ) -> (EnsembleOrchAlgo, Arc<Mutex<Vec<String>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
         let client = Arc::new(JudgingClient {
             judge_model: judge.to_string(),
             prefer: prefer.to_string(),
@@ -620,9 +611,7 @@ mod tests {
         );
 
         // Both candidates and the judge were called.
-        let calls = calls
-            .lock()
-            .map_err(|_| ensemble_error("test call-log lock poisoned"))?;
+        let calls = calls.lock();
         assert!(calls.contains(&"a/model".to_string()));
         assert!(calls.contains(&"b/model".to_string()));
         assert!(calls.contains(&"judge/haiku".to_string()));
@@ -647,12 +636,8 @@ mod tests {
         // Two exploration turns.
         orch.clone().run(Context::default(), request("t1")).await?;
         orch.clone().run(Context::default(), request("t2")).await?;
-        let judge_calls_after_exploration = calls
-            .lock()
-            .map_err(|_| ensemble_error("test call-log lock poisoned"))?
-            .iter()
-            .filter(|c| *c == "judge/haiku")
-            .count();
+        let judge_calls_after_exploration =
+            calls.lock().iter().filter(|c| *c == "judge/haiku").count();
         assert_eq!(judge_calls_after_exploration, 2);
 
         // Third request: committed fast path — routes straight to b/model with no
@@ -671,9 +656,7 @@ mod tests {
         assert_eq!(decision.phase, EnsemblePhase::Committed);
         assert_eq!(decision.selected_model, "b/model");
 
-        let calls = calls
-            .lock()
-            .map_err(|_| ensemble_error("test call-log lock poisoned"))?;
+        let calls = calls.lock();
         // Judge was not called again on the committed turn.
         assert_eq!(calls.iter().filter(|c| *c == "judge/haiku").count(), 2);
         // a/model was called only on the two exploration turns, not the third.
@@ -694,10 +677,7 @@ mod tests {
             "answer from only/model"
         );
         // No judge call for a lone candidate.
-        assert!(!calls
-            .lock()
-            .map_err(|_| ensemble_error("test call-log lock poisoned"))?
-            .contains(&"judge/haiku".to_string()));
+        assert!(!calls.lock().contains(&"judge/haiku".to_string()));
         // Trace: [candidate, winner] — no judge entry.
         assert_eq!(trace.len(), 2);
         assert_eq!(as_ensemble(&trace[1])?.phase, EnsemblePhase::Winner);
@@ -719,12 +699,7 @@ mod tests {
         }
         // Judge ran on every turn.
         assert_eq!(
-            calls
-                .lock()
-                .map_err(|_| ensemble_error("test call-log lock poisoned"))?
-                .iter()
-                .filter(|c| *c == "judge/haiku")
-                .count(),
+            calls.lock().iter().filter(|c| *c == "judge/haiku").count(),
             3
         );
         Ok(())

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -348,7 +348,7 @@ mod tests {
 
     #[tokio::test]
     async fn processor_observes_request_and_decision() -> Result<()> {
-        use std::sync::Mutex;
+        use parking_lot::Mutex;
 
         // Records which event kinds it saw, proving the request-then-decision replay.
         struct RecordingProcessor(Arc<Mutex<Vec<&'static str>>>);
@@ -361,10 +361,7 @@ mod tests {
                     Event::Decision(_) => "decision",
                     _ => "other",
                 };
-                self.0
-                    .lock()
-                    .map_err(|_| test_error("lock poisoned"))?
-                    .push(kind);
+                self.0.lock().push(kind);
                 Ok(())
             }
         }
@@ -375,10 +372,7 @@ mod tests {
             .with_classifier(fixed(vec![score("strong", 1.0)]));
         run(router).await?;
 
-        assert_eq!(
-            *seen.lock().map_err(|_| test_error("lock poisoned"))?,
-            vec!["request", "decision"]
-        );
+        assert_eq!(*seen.lock(), vec!["request", "decision"]);
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -219,7 +219,7 @@ impl Algorithm for LlmClassifier {
 mod tests {
     use super::*;
     use crate::{LlmResponse, LlmTarget, Response, RoutedLlmClient};
-    use std::sync::Mutex;
+    use parking_lot::Mutex;
     use switchyard_protocol::text_response;
 
     /// Returns `score` for the classifier target, an answer tagged with the model
@@ -245,12 +245,7 @@ mod tests {
             } else {
                 format!("answer from {name}")
             };
-            self.seen
-                .lock()
-                .map_err(|_| {
-                    switchyard_protocol::LlmClientError::General("lock poisoned".to_string())
-                })?
-                .push(request);
+            self.seen.lock().push(request);
             Ok(Response {
                 llm_response: LlmResponse::Agg(text_response(None, completion)),
                 metadata: None,

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -21,9 +21,9 @@
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 
 use async_trait::async_trait;
+use parking_lot::Mutex;
 use switchyard_protocol::Request;
 
 use crate::{Classification, Classifier, Event, Processor, Score, State};
@@ -129,12 +129,8 @@ impl AffinityRouter {
 #[async_trait]
 impl Processor for AffinityRouter {
     async fn process(&self, _state: &mut State, event: Event<'_>) -> crate::Result<()> {
-        // No `.await` is held across this guard, so a std Mutex is sufficient; recover from
-        // poisoning rather than panicking, since a stale assignment map is harmless.
-        let mut fact = self
-            .assignments
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // No `.await` is held across this guard.
+        let mut fact = self.assignments.lock();
         match event {
             // Capture the identity now; the model it maps to is only known at the decision.
             Event::Request(request) => {
@@ -169,13 +165,7 @@ impl Classifier for AffinityRouter {
         let Some(key) = self.affinity_key(request) else {
             return Ok(Classification::Scores(Vec::new()));
         };
-        let assigned = self
-            .assignments
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .assignments
-            .get(&key)
-            .cloned();
+        let assigned = self.assignments.lock().assignments.get(&key).cloned();
         Ok(Classification::Scores(match assigned {
             Some(target) => vec![Score {
                 confidence: 1.0,
@@ -533,12 +523,7 @@ mod tests {
             .await?;
         }
 
-        let len = router
-            .assignments
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .assignments
-            .len();
+        let len = router.assignments.lock().assignments.len();
         assert_eq!(len, MAX_ASSIGNMENTS);
         Ok(())
     }

--- a/crates/libsy/src/core/driver.rs
+++ b/crates/libsy/src/core/driver.rs
@@ -47,12 +47,10 @@
 //! producer runs on a task the driver does not own, hard cancellation (e.g. mid-compute
 //! that never touches the driver) is the caller's concern — abort the producer task.
 
-use std::{
-    any::Any,
-    sync::{Arc, Mutex},
-};
+use std::{any::Any, sync::Arc};
 
 use crate::{Context, DriverError, LibsyError, Result};
+use parking_lot::Mutex;
 
 use futures::{Stream, StreamExt};
 use tokio::sync::{mpsc, oneshot};
@@ -145,11 +143,7 @@ impl TypeErasedDriver {
     }
 
     fn ensure_started(&self) -> Result<()> {
-        let guard = self
-            .inner
-            .step_rx
-            .lock()
-            .map_err(|_| DriverError::LockPoisoned)?;
+        let guard = self.inner.step_rx.lock();
         if guard.is_none() {
             Ok(())
         } else {
@@ -244,12 +238,12 @@ impl TypeErasedDriver {
     /// Take the single consumer stream of [`DriverStep`]s. Callable once: a second
     /// call yields a one-item stream carrying an `Err`, since the receiver is gone.
     pub fn stream(&self) -> impl Stream<Item = Result<DriverStep>> {
-        let receiver = match self.inner.step_rx.lock() {
-            Ok(mut guard) => guard
-                .take()
-                .ok_or_else(|| LibsyError::from(DriverError::StreamAlreadyTaken)),
-            Err(_) => Err(DriverError::LockPoisoned.into()),
-        };
+        let receiver = self
+            .inner
+            .step_rx
+            .lock()
+            .take()
+            .ok_or_else(|| LibsyError::from(DriverError::StreamAlreadyTaken));
         match receiver {
             Ok(rx) => ReceiverStream::new(rx).left_stream(),
             Err(error) => futures::stream::once(async move { Err(error) }).right_stream(),

--- a/crates/libsy/src/error.rs
+++ b/crates/libsy/src/error.rs
@@ -129,10 +129,6 @@ pub enum DriverError {
         /// Human-readable expected payload type or role.
         expected: &'static str,
     },
-
-    /// The driver's receiver lock was poisoned by a panic.
-    #[error("driver receiver lock was poisoned")]
-    LockPoisoned,
 }
 
 #[cfg(test)]

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -12,12 +12,13 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use futures::StreamExt;
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+use parking_lot::Mutex;
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id, Record};
 use tracing::{Event, Subscriber};
@@ -37,14 +38,6 @@ struct TestError(&'static str);
 
 fn test_error(message: &'static str) -> LibsyError {
     LibsyError::external("test", TestError(message))
-}
-
-/// Locks a mutex, recovering the inner value if a panicking test poisoned it.
-fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    match mutex.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
 }
 
 /// One captured span: its name, contextual parent span name, and fields
@@ -72,11 +65,11 @@ struct CaptureStore {
 
 impl CaptureStore {
     fn spans(&self) -> Vec<SpanRecord> {
-        lock(&self.spans).values().cloned().collect()
+        self.spans.lock().values().cloned().collect()
     }
 
     fn events(&self) -> Vec<EventRecord> {
-        lock(&self.events).clone()
+        self.events.lock().clone()
     }
 }
 
@@ -120,7 +113,7 @@ where
         } else {
             None
         };
-        lock(&self.store.spans).insert(
+        self.store.spans.lock().insert(
             id.into_u64(),
             SpanRecord {
                 name: attrs.metadata().name().to_string(),
@@ -131,7 +124,7 @@ where
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, _ctx: LayerContext<'_, S>) {
-        if let Some(record) = lock(&self.store.spans).get_mut(&id.into_u64()) {
+        if let Some(record) = self.store.spans.lock().get_mut(&id.into_u64()) {
             values.record(&mut FieldVisitor(&mut record.fields));
         }
     }
@@ -139,7 +132,7 @@ where
     fn on_event(&self, event: &Event<'_>, _ctx: LayerContext<'_, S>) {
         let mut fields = BTreeMap::new();
         event.record(&mut FieldVisitor(&mut fields));
-        lock(&self.store.events).push(EventRecord {
+        self.store.events.lock().push(EventRecord {
             target: event.metadata().target().to_string(),
             fields,
         });

--- a/crates/switchyard-components/src/backends/anthropic.rs
+++ b/crates/switchyard-components/src/backends/anthropic.rs
@@ -546,8 +546,7 @@ fn anthropic_sse_stream(response: reqwest::Response) -> BoxResponseStream {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
+    use parking_lot::Mutex;
     use serde_json::json;
     use switchyard_core::{EndpointConfig, LlmTargetId, ModelId};
 
@@ -570,21 +569,10 @@ mod tests {
     #[async_trait]
     impl AnthropicTransport for FakeAnthropicTransport {
         async fn send(&self, request: AnthropicHttpRequest) -> Result<AnthropicHttpResponse> {
-            self.requests
-                .lock()
-                .map_err(|_| {
-                    SwitchyardError::Other("fake transport request mutex poisoned".to_string())
-                })?
-                .push(request);
-            self.response
-                .lock()
-                .map_err(|_| {
-                    SwitchyardError::Other("fake transport response mutex poisoned".to_string())
-                })?
-                .take()
-                .ok_or_else(|| {
-                    SwitchyardError::Other("fake transport response already consumed".to_string())
-                })?
+            self.requests.lock().push(request);
+            self.response.lock().take().ok_or_else(|| {
+                SwitchyardError::Other("fake transport response already consumed".to_string())
+            })?
         }
     }
 

--- a/crates/switchyard-components/src/backends/openai.rs
+++ b/crates/switchyard-components/src/backends/openai.rs
@@ -580,8 +580,7 @@ fn openai_sse_stream(response: reqwest::Response) -> BoxResponseStream {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
+    use parking_lot::Mutex;
     use serde_json::json;
     use switchyard_core::{EndpointConfig, LlmTargetId, ModelId};
 
@@ -604,21 +603,10 @@ mod tests {
     #[async_trait]
     impl OpenAiTransport for FakeOpenAiTransport {
         async fn send(&self, request: OpenAiHttpRequest) -> Result<OpenAiHttpResponse> {
-            self.requests
-                .lock()
-                .map_err(|_| {
-                    SwitchyardError::Other("fake transport request mutex poisoned".to_string())
-                })?
-                .push(request);
-            self.response
-                .lock()
-                .map_err(|_| {
-                    SwitchyardError::Other("fake transport response mutex poisoned".to_string())
-                })?
-                .take()
-                .ok_or_else(|| {
-                    SwitchyardError::Other("fake transport response already consumed".to_string())
-                })?
+            self.requests.lock().push(request);
+            self.response.lock().take().ok_or_else(|| {
+                SwitchyardError::Other("fake transport response already consumed".to_string())
+            })?
         }
     }
 

--- a/crates/switchyard-components/src/request_processors/random_routing.rs
+++ b/crates/switchyard-components/src/request_processors/random_routing.rs
@@ -4,8 +4,8 @@
 //! Runtime support for random routing.
 
 use std::fmt;
-use std::sync::Mutex;
 
+use parking_lot::Mutex;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
@@ -130,7 +130,7 @@ impl RandomRoutingEngine {
 
     /// Selects a target without mutating a request.
     pub fn select(&self, original_model: Option<String>) -> Result<RandomRoutingDecision> {
-        let draw = self.next_draw()?;
+        let draw = self.next_draw();
         let tier = if draw < self.config.strong_probability {
             RandomRoutingTier::Strong
         } else {
@@ -155,13 +155,9 @@ impl RandomRoutingEngine {
         }
     }
 
-    // Draws the next probability sample while surfacing poisoned-lock failures.
-    fn next_draw(&self) -> Result<f64> {
-        let mut rng = self
-            .rng
-            .lock()
-            .map_err(|_| SwitchyardError::Other("random routing rng mutex poisoned".to_string()))?;
-        Ok(rng.gen())
+    // Draws the next probability sample.
+    fn next_draw(&self) -> f64 {
+        self.rng.lock().gen()
     }
 }
 

--- a/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
+++ b/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
@@ -3,9 +3,10 @@
 
 //! Adversarial tests for the Rust multi-target LLM backend.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_trait::async_trait;
+use parking_lot::Mutex;
 use serde_json::{json, Value};
 use switchyard_components::{
     BackendSelection, BackendSelectionReason, LlmTargetBackend, MultiLlmBackend,
@@ -43,27 +44,15 @@ impl<T> Default for Shared<T> {
 }
 
 impl<T: Clone> Shared<T> {
-    /// Appends one observation with a typed test error on poisoned mutexes.
+    /// Appends one observation.
     fn push(&self, value: T) -> Result<()> {
-        match self.0.lock() {
-            Ok(mut values) => {
-                values.push(value);
-                Ok(())
-            }
-            Err(_) => Err(SwitchyardError::Other(
-                "shared test log mutex poisoned".to_string(),
-            )),
-        }
+        self.0.lock().push(value);
+        Ok(())
     }
 
     /// Returns a cloned copy of all observations.
     fn values(&self) -> Result<Vec<T>> {
-        match self.0.lock() {
-            Ok(values) => Ok(values.clone()),
-            Err(_) => Err(SwitchyardError::Other(
-                "shared test log mutex poisoned".to_string(),
-            )),
-        }
+        Ok(self.0.lock().clone())
     }
 }
 

--- a/crates/switchyard-components/tests/stats_processors.rs
+++ b/crates/switchyard-components/tests/stats_processors.rs
@@ -4,11 +4,12 @@
 //! Stats processor tests covering request stamps, backend wrappers, and stream usage.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use parking_lot::Mutex;
 use serde_json::json;
 use switchyard_components::{
     BackendSelection, BackendSelectionReason, RandomRoutingDecision, RandomRoutingTier,
@@ -80,11 +81,7 @@ impl FakeBackend {
 
     // Returns every request model observed by the fake backend.
     fn calls(&self) -> Result<Vec<Option<String>>> {
-        Ok(self
-            .calls
-            .lock()
-            .map_err(|_| SwitchyardError::Other("fake calls mutex poisoned".to_string()))?
-            .clone())
+        Ok(self.calls.lock().clone())
     }
 }
 
@@ -95,10 +92,7 @@ impl LlmBackend for FakeBackend {
     }
 
     async fn call(&self, ctx: &mut ProxyContext, request: &ChatRequest) -> Result<ChatResponse> {
-        self.calls
-            .lock()
-            .map_err(|_| SwitchyardError::Other("fake calls mutex poisoned".to_string()))?
-            .push(request.model().map(str::to_string));
+        self.calls.lock().push(request.model().map(str::to_string));
         if let Some(model) = &self.selected_model {
             record_backend_selection(ctx, model.clone());
         }
@@ -107,7 +101,6 @@ impl LlmBackend for FakeBackend {
         }
         self.response
             .lock()
-            .map_err(|_| SwitchyardError::Other("fake response mutex poisoned".to_string()))?
             .take()
             .ok_or_else(|| SwitchyardError::Other("fake response already consumed".to_string()))?
     }

--- a/crates/switchyard-components/tests/support/intake.rs
+++ b/crates/switchyard-components/tests/support/intake.rs
@@ -5,10 +5,9 @@
 
 //! Shared intake fixtures used by payload and processor tests.
 
-use std::sync::Mutex;
-
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use parking_lot::Mutex;
 use serde_json::{json, Value};
 use switchyard_components::{
     BackendSelection, BackendSelectionReason, IntakeRequestMetadata, IntakeRequestState,
@@ -42,44 +41,27 @@ impl RecordingSink {
 
     /// Returns the payloads captured so far.
     pub fn payloads(&self) -> Result<Vec<Value>> {
-        self.payloads
-            .lock()
-            .map_err(|_| SwitchyardError::Other("payload mutex poisoned".to_string()))
-            .map(|payloads| payloads.clone())
+        Ok(self.payloads.lock().clone())
     }
 
     /// Returns the shutdown count captured so far.
     pub fn shutdowns(&self) -> Result<u64> {
-        self.shutdowns
-            .lock()
-            .map_err(|_| SwitchyardError::Other("shutdown mutex poisoned".to_string()))
-            .map(|shutdowns| *shutdowns)
+        Ok(*self.shutdowns.lock())
     }
 }
 
 #[async_trait]
 impl IntakeSink for RecordingSink {
     async fn enqueue(&self, payload: Value) -> Result<()> {
-        if let Some(error) = self
-            .error
-            .lock()
-            .map_err(|_| SwitchyardError::Other("error mutex poisoned".to_string()))?
-            .take()
-        {
+        if let Some(error) = self.error.lock().take() {
             return Err(error);
         }
-        self.payloads
-            .lock()
-            .map_err(|_| SwitchyardError::Other("payload mutex poisoned".to_string()))?
-            .push(payload);
+        self.payloads.lock().push(payload);
         Ok(())
     }
 
     async fn shutdown(&self) -> Result<()> {
-        let mut shutdowns = self
-            .shutdowns
-            .lock()
-            .map_err(|_| SwitchyardError::Other("shutdown mutex poisoned".to_string()))?;
+        let mut shutdowns = self.shutdowns.lock();
         *shutdowns = shutdowns.saturating_add(1);
         Ok(())
     }

--- a/crates/switchyard-py/Cargo.toml
+++ b/crates/switchyard-py/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
+parking_lot = "0.12"
 switchyard-libsy = { path = "../libsy" }
 pyo3 = { version = "0.28.3", features = ["abi3-py312", "extension-module"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }

--- a/crates/switchyard-py/src/core_bindings/context.rs
+++ b/crates/switchyard-py/src/core_bindings/context.rs
@@ -5,8 +5,9 @@
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 
+use parking_lot::{Mutex, MutexGuard};
 use pyo3::class::basic::CompareOp;
 use pyo3::exceptions::{PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -67,17 +68,15 @@ impl PyProxyMetadata {
         Ok(store)
     }
 
-    /// Locks the metadata store with a Python-facing poisoned-lock error.
-    fn lock(&self) -> PyResult<MutexGuard<'_, MetadataStore>> {
-        self.inner
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("ProxyMetadata lock is poisoned"))
+    /// Locks the metadata store.
+    fn lock(&self) -> MutexGuard<'_, MetadataStore> {
+        self.inner.lock()
     }
 
     /// Merges entries from a Python mapping into the metadata store.
     fn update_from_mapping(&self, py: Python<'_>, metadata: &Bound<'_, PyAny>) -> PyResult<()> {
         let entries = metadata_entries(py, metadata)?;
-        let mut store = self.lock()?;
+        let mut store = self.lock();
         store.values.extend(entries);
         Ok(())
     }
@@ -85,7 +84,7 @@ impl PyProxyMetadata {
     /// Materializes the metadata store as a Python dict.
     fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
         let entries = {
-            let store = self.lock()?;
+            let store = self.lock();
             store
                 .values
                 .iter()
@@ -131,11 +130,7 @@ impl PyProxyMetadata {
         key: &str,
         default: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Py<PyAny>> {
-        let value = self
-            .lock()?
-            .values
-            .get(key)
-            .map(|value| value.clone_ref(py));
+        let value = self.lock().values.get(key).map(|value| value.clone_ref(py));
         match value {
             Some(value) => Ok(value),
             None => Ok(default
@@ -155,7 +150,7 @@ impl PyProxyMetadata {
         let default = default
             .map(|value| value.clone().unbind())
             .unwrap_or_else(|| py.None());
-        let mut store = self.lock()?;
+        let mut store = self.lock();
         if let Some(value) = store.values.get(&key) {
             return Ok(value.clone_ref(py));
         }
@@ -199,7 +194,7 @@ impl PyProxyMetadata {
 
     /// Implements metadata indexing.
     fn __getitem__(&self, py: Python<'_>, key: &str) -> PyResult<Py<PyAny>> {
-        self.lock()?
+        self.lock()
             .values
             .get(key)
             .map(|value| value.clone_ref(py))
@@ -208,13 +203,13 @@ impl PyProxyMetadata {
 
     /// Implements metadata assignment.
     fn __setitem__(&self, key: String, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        self.lock()?.values.insert(key, value.clone().unbind());
+        self.lock().values.insert(key, value.clone().unbind());
         Ok(())
     }
 
     /// Implements metadata deletion.
     fn __delitem__(&self, key: &str) -> PyResult<()> {
-        self.lock()?
+        self.lock()
             .values
             .remove(key)
             .map(|_| ())
@@ -223,12 +218,12 @@ impl PyProxyMetadata {
 
     /// Implements `key in metadata`.
     fn __contains__(&self, key: &str) -> PyResult<bool> {
-        Ok(self.lock()?.values.contains_key(key))
+        Ok(self.lock().values.contains_key(key))
     }
 
     /// Implements `len(metadata)`.
     fn __len__(&self) -> PyResult<usize> {
-        Ok(self.lock()?.values.len())
+        Ok(self.lock().values.len())
     }
 
     /// Iterates over metadata keys like a Python dict.
@@ -301,9 +296,7 @@ impl PyProxyContext {
                 "ProxyContext is already borrowed by an async Rust component",
             ));
         }
-        self.inner
-            .lock()
-            .map_err(|_| PyValueError::new_err("ProxyContext lock is poisoned"))
+        Ok(self.inner.lock())
     }
 
     /// Temporarily moves the Rust context out for async Rust component execution.
@@ -314,10 +307,7 @@ impl PyProxyContext {
             ));
         }
         let context = {
-            let mut guard = self
-                .inner
-                .lock()
-                .map_err(|_| PyValueError::new_err("ProxyContext lock is poisoned"))?;
+            let mut guard = self.inner.lock();
             std::mem::take(&mut *guard)
         };
         Ok(PyProxyContextLease {
@@ -369,10 +359,7 @@ impl PyProxyContextLease {
     /// Restores the leased context into the Python wrapper.
     pub(crate) fn restore(mut self) -> PyResult<()> {
         if let Some(context) = self.context.take() {
-            let mut guard = self
-                .inner
-                .lock()
-                .map_err(|_| PyValueError::new_err("ProxyContext lock is poisoned"))?;
+            let mut guard = self.inner.lock();
             *guard = context;
         }
         self.in_use.store(false, Ordering::Release);
@@ -384,9 +371,7 @@ impl Drop for PyProxyContextLease {
     /// Restores the context during unwinding and always clears the borrow flag.
     fn drop(&mut self) {
         if let Some(context) = self.context.take() {
-            if let Ok(mut guard) = self.inner.lock() {
-                *guard = context;
-            }
+            *self.inner.lock() = context;
         }
         self.in_use.store(false, Ordering::Release);
     }

--- a/crates/switchyard-py/src/core_bindings/response.rs
+++ b/crates/switchyard-py/src/core_bindings/response.rs
@@ -5,10 +5,11 @@
 
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures_util::{stream, Stream, StreamExt};
+use parking_lot::Mutex;
 use pyo3::exceptions::{PyAttributeError, PyRuntimeError, PyStopAsyncIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
@@ -519,10 +520,7 @@ fn push_callback(
     callbacks: &Arc<Mutex<Vec<Py<PyAny>>>>,
     callback: &Bound<'_, PyAny>,
 ) -> PyResult<()> {
-    callbacks
-        .lock()
-        .map_err(|_| PyRuntimeError::new_err("ChatResponseStream callback lock is poisoned"))?
-        .push(callback.clone().unbind());
+    callbacks.lock().push(callback.clone().unbind());
     Ok(())
 }
 
@@ -748,11 +746,10 @@ async fn run_taps(callbacks: Arc<Mutex<Vec<Py<PyAny>>>>, event: &Py<PyAny>) {
     if failed.is_empty() {
         return;
     }
-    if let Ok(mut callbacks) = callbacks.lock() {
-        for index in failed.into_iter().rev() {
-            if index < callbacks.len() {
-                callbacks.remove(index);
-            }
+    let mut callbacks = callbacks.lock();
+    for index in failed.into_iter().rev() {
+        if index < callbacks.len() {
+            callbacks.remove(index);
         }
     }
 }
@@ -789,9 +786,7 @@ async fn run_completion_once(callbacks: Arc<Mutex<Vec<Py<PyAny>>>>, completed: A
 
 fn clone_callbacks(callbacks: &Arc<Mutex<Vec<Py<PyAny>>>>) -> PyResult<Vec<(usize, Py<PyAny>)>> {
     Python::attach(|py| {
-        let callbacks = callbacks
-            .lock()
-            .map_err(|_| PyRuntimeError::new_err("ChatResponseStream callback lock is poisoned"))?;
+        let callbacks = callbacks.lock();
         Ok(callbacks
             .iter()
             .enumerate()


### PR DESCRIPTION
- Faster
- Uses less memory
- No `unwrap()` after `lock()`
- Deadlock detection possible

Full list of differences:
https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html#differences-from-the-standard-library-mutex

Dynamo did this [here](https://github.com/ai-dynamo/dynamo/pull/3740)
for the same reasons.

All of the changes in this PR come from not having to handle poisoning.

Assisted-by: Codex:GPT 5.6 Sol medium
Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reliability across routing, orchestration, telemetry, backend integrations, and Python bindings.
  * Removed failures caused by poisoned locks, allowing affected operations to continue normally.
  * Preserved existing error handling for unavailable or already-consumed responses.

* **Refactor**
  * Simplified internal locking behavior for more consistent runtime and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->