### PR TITLE
chore: Share dependency versions in workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,22 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,10 +715,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1025,12 +1009,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -1451,7 +1429,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1468,6 +1445,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1510,25 +1488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -1566,42 +1531,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "serde"
@@ -2360,6 +2293,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,22 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA-NeMo/Switchyard"
 rust-version = "1.96.1"
+
+[workspace.dependencies]
+async-stream = "0.3"
+async-trait = "0.1"
+futures = "0.3"
+futures-util = "0.3"
+parking_lot = "0.12"
+rand = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+switchyard-core = { path = "crates/switchyard-core", version = "0.1.0" }
+switchyard-libsy = { path = "crates/libsy", version = "0.1.0" }
+switchyard-llm-client = { path = "crates/libsy-llm-client", version = "0.1.0" }
+switchyard-protocol = { path = "crates/protocol", version = "0.1.0" }
+switchyard-translation = { path = "crates/switchyard-translation", version = "0.1.0" }
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tracing = { version = "0.1", default-features = false, features = ["attributes", "std"] }

--- a/crates/libsy-llm-client/Cargo.toml
+++ b/crates/libsy-llm-client/Cargo.toml
@@ -12,14 +12,14 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-switchyard-protocol = { path = "../protocol", version = "0.1.0" }
-switchyard-translation = { path = "../switchyard-translation", version = "0.1.0" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream"] }
-async-trait = "0.1"
-futures-util = "0.3"
-serde_json = "1"
+switchyard-protocol.workspace = true
+switchyard-translation.workspace = true
+reqwest.workspace = true
+async-trait.workspace = true
+futures-util.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
-futures = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+futures.workspace = true
+tokio.workspace = true
 wiremock = "0.6"

--- a/crates/libsy/Cargo.toml
+++ b/crates/libsy/Cargo.toml
@@ -12,23 +12,23 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1"
-serde_json = "1"
-futures = "0.3"
+async-trait.workspace = true
+serde_json.workspace = true
+futures.workspace = true
 # Metrics-only OTel API: instruments record through the host-installed global
 # meter provider. Pinned to the 0.32 line used across the workspace.
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
-parking_lot = "0.12"
-rand = "0.8"
-switchyard-protocol = { path = "../protocol" }
-thiserror = "2"
-tokio = { version = "1", features = ["full"] }
+parking_lot.workspace = true
+rand.workspace = true
+switchyard-protocol.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 tokio-stream = "0.1"
-tracing = { version = "0.1", default-features = false, features = ["std", "attributes"] }
+tracing.workspace = true
 
 [dev-dependencies]
 # SDK + in-memory exporter to assert what the observability layer records.
 opentelemetry_sdk = { version = "0.32", features = ["metrics", "testing"] }
-switchyard-llm-client = { path = "../libsy-llm-client" }
-tokio = { version = "1", features = ["macros", "rt"] }
+switchyard-llm-client.workspace = true
+tokio.workspace = true
 tracing-subscriber = "0.3"

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["llm", "protocol", "openai", "anthropic"]
 publish = ["crates-io"]
 
 [dependencies]
-async-trait = "0.1"
-futures = "0.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+async-trait.workspace = true
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/crates/switchyard-components/Cargo.toml
+++ b/crates/switchyard-components/Cargo.toml
@@ -12,20 +12,20 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-stream = "0.3"
-async-trait = "0.1"
-futures-util = "0.3"
-parking_lot = "0.12"
-rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-switchyard-core = { path = "../switchyard-core" }
-switchyard-libsy = { path = "../libsy" }
-switchyard-protocol = { path = "../protocol" }
-switchyard-translation = { path = "../switchyard-translation" }
-tokio = { version = "1", features = ["rt", "sync"] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+async-stream.workspace = true
+async-trait.workspace = true
+futures-util.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+switchyard-core.workspace = true
+switchyard-libsy.workspace = true
+switchyard-protocol.workspace = true
+switchyard-translation.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tokio.workspace = true

--- a/crates/switchyard-core/Cargo.toml
+++ b/crates/switchyard-core/Cargo.toml
@@ -12,14 +12,14 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 futures-core = "0.3"
 lru = "0.12"
-rand = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tokio.workspace = true

--- a/crates/switchyard-py/Cargo.toml
+++ b/crates/switchyard-py/Cargo.toml
@@ -16,18 +16,18 @@ name = "_switchyard_rust"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-async-trait = "0.1"
-futures-util = "0.3"
-parking_lot = "0.12"
-switchyard-libsy = { path = "../libsy" }
+async-trait.workspace = true
+futures-util.workspace = true
+parking_lot.workspace = true
+switchyard-libsy.workspace = true
 pyo3 = { version = "0.28.3", features = ["abi3-py312", "extension-module"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 pythonize = "0.28.0"
-serde = "1"
-serde_json = "1"
-switchyard-core = { path = "../switchyard-core" }
-switchyard-protocol = { path = "../protocol" }
+serde.workspace = true
+serde_json.workspace = true
+switchyard-core.workspace = true
+switchyard-protocol.workspace = true
 switchyard-components = { path = "../switchyard-components" }
-switchyard-translation = { path = "../switchyard-translation" }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+switchyard-translation.workspace = true
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -12,24 +12,24 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-stream = "0.3"
+async-stream.workspace = true
 axum = "0.8"
-axum-server = { version = "0.8", features = ["tls-rustls"] }
-rustls = { version = "0.23" }
+axum-server = { version = "0.8", default-features = false, features = ["tls-rustls"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std", "tls12"] }
 clap = { version = "4", features = ["derive", "env"] }
-futures-util = "0.3"
+futures-util.workspace = true
 libsy = { package = "switchyard-libsy", path = "../libsy" }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 toml = "1.1"
-switchyard-llm-client = { path = "../libsy-llm-client" }
-serde_json = "1"
-switchyard-translation = { path = "../switchyard-translation" }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+switchyard-llm-client.workspace = true
+serde_json.workspace = true
+switchyard-translation.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 http-body-util = "0.1"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "net"] }
+tokio.workspace = true
 tower = { version = "0.5", features = ["util"] }

--- a/crates/switchyard-skill-distillation/Cargo.toml
+++ b/crates/switchyard-skill-distillation/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tokio.workspace = true

--- a/crates/switchyard-translation/Cargo.toml
+++ b/crates/switchyard-translation/Cargo.toml
@@ -17,12 +17,12 @@ keywords = ["llm", "translation", "openai", "anthropic"]
 publish = ["crates-io"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-switchyard-protocol = { path = "../protocol", version = "0.1.0" }
-thiserror = "2"
-futures = "0.3"
-async-stream = "0.3"
+serde.workspace = true
+serde_json.workspace = true
+switchyard-protocol.workspace = true
+thiserror.workspace = true
+futures.workspace = true
+async-stream.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
Move the shared dependencies to the workspace root `Cargo.toml` so that
all `crates/` share the same version and features.

This makes the binary smaller, compile times faster, and makes the project
easier to understand.

This is a defensive / forward looking change. Our crates were using
the same versions. This makes it easier to keep it that way.

Also ensure we don't accidentally link `openssl` by using Rust native
TLS implementation and web PKI roots.

Assisted-by: Codex:GPT 5.6 Sol medium
Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized shared dependency versions and feature configurations across the workspace.
  * Standardized dependency management for internal crates and common libraries.
  * Consolidated async runtime, networking, serialization, tracing, and error-handling configurations.
  * Updated TLS-related settings for improved consistency across server components.
  * Added shared development tooling configuration, including tracing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->