### PR TITLE
fix(skills): use standard YAML frontmatter in stage-router-scorer SKILL.md

### DIFF
--- a/.agents/skills/switchyard-stage-router-scorer/SKILL.md
+++ b/.agents/skills/switchyard-stage-router-scorer/SKILL.md
@@ -1,6 +1,9 @@
-# Skill: switchyard-stage-router-scorer
+---
+name: switchyard-stage-router-scorer
+description: Score benchmark run trajectories through the stage-router Rust scorer and picker, then visualise score distributions. Use when you want to replay trajectories through the picker, analyse routing splits, or compare score distributions across configs.
+---
 
-**description**: Score benchmark run trajectories through the stage-router Rust scorer and picker, then visualise score distributions. Use when you want to replay trajectories through the picker, analyse routing splits, or compare score distributions across configs.
+# Skill: switchyard-stage-router-scorer
 
 ## Scripts
 


### PR DESCRIPTION
Codex warns on startup that `.agents/skills/switchyard-stage-router-scorer/SKILL.md` is `missing YAML frontmatter delimited by ---`. It used a non-standard `**description**:` line instead of a `---`-delimited YAML header.

Converts it to standard frontmatter (`name` + `description`), matching every other skill in `.agents/skills/`. Still loads in Claude.

Audited the sibling SKILL.md files — this was the only one affected.

Linear: SWITCH-1080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized name and description metadata to the skill documentation.
  * Improved the document’s structure by replacing the inline description with front matter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->