### PR TITLE
feat(libsy): make LlmClassifier recent_turn_window configurable

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -62,6 +62,9 @@ impl Decision for ClassifierDecision {
     }
 }
 
+/// Default trailing conversation turns included in the classifier prompt.
+pub const DEFAULT_RECENT_TURN_WINDOW: usize = 5;
+
 /// LLM-classifier router: classify with one target, then route to strong/weak.
 pub struct LlmClassifier {
     classifier_model: String,
@@ -69,6 +72,7 @@ pub struct LlmClassifier {
     weak_model: String,
     threshold: f64,
     target_set: LlmTargetSet,
+    recent_turn_window: usize,
 }
 
 impl LlmClassifier {
@@ -89,7 +93,17 @@ impl LlmClassifier {
             weak_model: weak_model.into(),
             threshold,
             target_set,
+            recent_turn_window: DEFAULT_RECENT_TURN_WINDOW,
         }
+    }
+
+    /// Set the number of trailing conversation turns included in the classifier
+    /// prompt (default [`DEFAULT_RECENT_TURN_WINDOW`]). `0` sends only the first
+    /// user message.
+    #[must_use]
+    pub fn with_recent_turn_window(mut self, recent_turn_window: usize) -> Self {
+        self.recent_turn_window = recent_turn_window;
+        self
     }
 }
 
@@ -152,7 +166,8 @@ impl Algorithm for LlmClassifier {
         // model each sub-call actually hits is carried by its decision instead.
         let inbound = request.llm_request.model.clone();
 
-        let mut just_the_key_messages = trim_messages(&request.llm_request.messages, 5);
+        let mut just_the_key_messages =
+            trim_messages(&request.llm_request.messages, self.recent_turn_window);
         just_the_key_messages.insert(0, Message::text(Role::System, CLASSIFIER_SYSTEM_PROMPT));
 
         // 1. Classify: call the classifier target with the score-eliciting prompt.
@@ -276,8 +291,17 @@ mod tests {
             weak_model: "cheap/model".to_string(),
             threshold,
             target_set,
+            recent_turn_window: DEFAULT_RECENT_TURN_WINDOW,
         };
         (algo, seen)
+    }
+
+    #[test]
+    fn recent_turn_window_defaults_and_is_configurable() {
+        let classifier = LlmClassifier::new("c", "s", "w", 0.5, LlmTargetSet::new(vec![]));
+        assert_eq!(classifier.recent_turn_window, DEFAULT_RECENT_TURN_WINDOW);
+        let classifier = classifier.with_recent_turn_window(2);
+        assert_eq!(classifier.recent_turn_window, 2);
     }
 
     fn request(prompt: &str) -> Request {

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -175,6 +175,8 @@ enum RouteConfig {
         strong_target: String,
         weak_target: String,
         threshold: f64,
+        #[serde(default)]
+        recent_turn_window: Option<usize>,
     },
 }
 
@@ -257,6 +259,7 @@ fn build_algorithm(
             strong_target,
             weak_target,
             threshold,
+            recent_turn_window,
             ..
         } => {
             if !threshold.is_finite() || !(0.0..=1.0).contains(threshold) {
@@ -269,13 +272,17 @@ fn build_algorithm(
             let weak = resolve_target(route_name, weak_target, targets)?;
             let target_set =
                 LlmTargetSet::new(vec![classifier.clone(), strong.clone(), weak.clone()]);
-            Ok(Arc::new(LlmClassifier::new(
+            let mut classifier_algo = LlmClassifier::new(
                 classifier.semantic_name,
                 strong.semantic_name,
                 weak.semantic_name,
                 *threshold,
                 target_set,
-            )))
+            );
+            if let Some(window) = recent_turn_window {
+                classifier_algo = classifier_algo.with_recent_turn_window(*window);
+            }
+            Ok(Arc::new(classifier_algo))
         }
     }
 }


### PR DESCRIPTION
`LlmClassifier`'s classifier-prompt window (`recent_turn_window` — first user message + last N turns) was **hardcoded to `5`** (`trim_messages(..., 5)`). This makes it user-configurable, closing a parity gap with the v2 `ClassifierConfig.recent_turn_window`.

- `LlmClassifier`: new `recent_turn_window` field + `DEFAULT_RECENT_TURN_WINDOW = 5` + `with_recent_turn_window(n)` builder (non-breaking; `new()` signature unchanged); call site uses `self.recent_turn_window`.
- Server config: `recent_turn_window: Option<usize>` on the `llm_classifier` route type, threaded to the classifier when set (unset → default 5).
- Test: builder default + override.

libsy + server build clean; cargo fmt + clippy clean; libsy + server tests pass.

Linear: SWITCH-1110 (parity work item)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable trailing conversation context for LLM classification prompts.
  * Added support for setting the recent-turn window through server TOML routing configuration.
  * Existing configurations continue using the default context window when no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->