### PR TITLE
feat(libsy): Add passthrough algorithm

### DIFF
--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -9,12 +9,14 @@
 pub mod fall_through;
 pub mod llm_class;
 pub mod noop;
+pub mod passthrough;
 pub mod rand;
 pub mod subagent_override;
 
 pub use fall_through::{FallThrough, FallThroughDecision};
 pub use llm_class::{ClassifierDecision, ClassifierTier, LlmClassifier};
 pub use noop::{Noop, NoopDecision};
+pub use passthrough::{Passthrough, PassthroughDecision};
 pub use rand::{Random, RandomDecision};
 pub use subagent_override::{SubagentDecision, SubagentOverride};
 

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router that only routes to a single backend, always.
+//! - For testing if issues come from backend or from Switchyard
+//! - For logging request / responses for RL
+
+use std::sync::Arc;
+
+use switchyard_protocol::{Request, Response};
+
+use crate::{Algorithm, Context, Decision, Driver, LlmTarget, Result};
+
+/// See module comment
+pub struct Passthrough {
+    target: LlmTarget,
+}
+
+impl Passthrough {
+    pub fn new(target: LlmTarget) -> Self {
+        Passthrough { target }
+    }
+}
+
+pub struct PassthroughDecision {
+    model_id: String,
+}
+
+impl Decision for PassthroughDecision {
+    fn selected_model(&self) -> &str {
+        &self.model_id
+    }
+    fn reasoning(&self) -> Option<&str> {
+        // There is no decision to take, so no reasoning
+        None
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl Algorithm for Passthrough {
+    fn name(&self) -> &str {
+        "passthrough"
+    }
+
+    async fn create_run_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Response> {
+        let decision: Arc<dyn Decision> = Arc::new(PassthroughDecision {
+            model_id: self.target.semantic_name.clone(),
+        });
+        driver.info(ctx.clone(), decision.clone()).await?;
+        driver
+            .call_llm_target(ctx, &self.target, request, decision)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        Algorithm, Context, Decision, LlmResponse, LlmTarget, Request, Response, RoutedLlmClient,
+    };
+    use switchyard_protocol::{completion_text, text_request, text_response};
+
+    /// Echoes the selected target so tests can inspect which target was called.
+    /// TODO: Duplicated from rand.rs
+    struct EchoClient;
+
+    #[async_trait::async_trait]
+    impl RoutedLlmClient for EchoClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> std::result::Result<Response, switchyard_protocol::LlmClientError> {
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(None, decision.selected_model())),
+                metadata: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_passthrough() -> crate::error::Result<()> {
+        const MODEL_ID: &str = "testing/passthrough";
+        let request = Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: None,
+        };
+        let algorithm = Arc::new(super::Passthrough::new(LlmTarget {
+            semantic_name: MODEL_ID.to_string(),
+            llm_client: Some(Arc::new(EchoClient)),
+        }));
+        let (trace, response) = algorithm.run(Context::default(), request).await?;
+
+        assert_eq!(
+            response
+                .llm_response
+                .as_agg()
+                .map(completion_text)
+                .unwrap_or_default(),
+            MODEL_ID
+        );
+        assert_eq!(trace.len(), 1);
+        assert_eq!(trace[0].selected_model(), MODEL_ID);
+        Ok(())
+    }
+}

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -33,6 +33,11 @@ classifier_target = "model_a"
 strong_target = "model_a"
 weak_target = "model_b"
 threshold = 0.5
+
+[routes.passthrough]
+id = "switchyard/passthrough"
+type = "passthrough"
+target = "model_a"
 ```
 
 ```bash
@@ -45,8 +50,8 @@ upstream, and a route's `id` is the model clients send to select that algorithm.
 
 Each target references an entry under `llm_clients`. All configured clients use
 `TranslatingLlmClient`; supported formats are `openai_chat`, `openai_responses`, and
-`anthropic_messages`. Supported algorithms are `noop`, `random`, and `llm_classifier`. An
-`api_key_env` value names an environment variable; the TOML never contains the secret itself. If
-omitted, the client sends no authentication.
+`anthropic_messages`. Supported algorithms are `noop`, `random`, `passthrough`, and
+`llm_classifier`. An `api_key_env` value names an environment variable; the TOML
+never contains the secret itself. If omitted, the client sends no authentication.
 
 See [CONFIGURATION.md](CONFIGURATION.md) to add an LLM client, target, or algorithm.

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use libsy::algorithms::{LlmClassifier, Noop, Random};
+use libsy::algorithms::{LlmClassifier, Noop, Passthrough, Random};
 use libsy::{Algorithm, LlmTarget, LlmTargetSet, RoutedLlmClient};
 use serde::Deserialize;
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
@@ -169,6 +169,10 @@ enum RouteConfig {
         id: String,
         targets: Vec<String>,
     },
+    Passthrough {
+        id: String,
+        target: String,
+    },
     LlmClassifier {
         id: String,
         classifier_target: String,
@@ -180,8 +184,11 @@ enum RouteConfig {
 
 impl RouteConfig {
     fn id(&self) -> &str {
+        use RouteConfig::*;
         match self {
-            Self::Noop { id } | Self::Random { id, .. } | Self::LlmClassifier { id, .. } => id,
+            Noop { id } | Random { id, .. } | LlmClassifier { id, .. } | Passthrough { id, .. } => {
+                id
+            }
         }
     }
 }
@@ -251,6 +258,10 @@ fn build_algorithm(
                 names.iter().map(String::as_str),
                 targets,
             )?)))
+        }
+        RouteConfig::Passthrough { target, .. } => {
+            let target = resolve_target(route_name, target, targets)?;
+            Ok(Arc::new(Passthrough::new(target)))
         }
         RouteConfig::LlmClassifier {
             classifier_target,
@@ -360,6 +371,11 @@ classifier_target = "classifier"
 strong_target = "strong"
 weak_target = "weak"
 threshold = 0.5
+
+[routes.passthrough]
+id = "switchyard/passthrough"
+type = "passthrough"
+target = "weak"
 "#;
 
     fn error_message(toml: &str) -> String {
@@ -372,12 +388,14 @@ threshold = 0.5
     #[test]
     fn builds_all_supported_algorithm_types() -> ServerResult<()> {
         let state = server_state_from_toml(VALID_CONFIG)?;
+        // The model id array is sorted alphabetically
         assert_eq!(
             state.models().collect::<Vec<_>>(),
             [
                 "switchyard/classifier",
                 "switchyard/noop",
-                "switchyard/random"
+                "switchyard/passthrough",
+                "switchyard/random",
             ]
         );
         Ok(())

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -236,6 +236,11 @@ classifier_target = "classifier"
 strong_target = "strong"
 weak_target = "weak"
 threshold = 0.5
+
+[routes.passthrough]
+id = "switchyard/passthrough"
+type = "passthrough"
+target = "weak"
 "#,
         base_url = upstream.base_url
     ))?;
@@ -244,6 +249,7 @@ threshold = 0.5
     for (route, selected) in [
         ("switchyard/random", "model/weak"),
         ("switchyard/classifier", "model/strong"),
+        ("switchyard/passthrough", "model/weak"),
     ] {
         let response = send(
             &app,
@@ -266,10 +272,11 @@ threshold = 0.5
     }
 
     let calls = upstream.calls.lock().await;
-    assert_eq!(calls.len(), 3);
+    assert_eq!(calls.len(), 4);
     assert_eq!(calls[0]["model"], "model/weak");
     assert_eq!(calls[1]["model"], "model/classifier");
     assert_eq!(calls[2]["model"], "model/strong");
+    assert_eq!(calls[3]["model"], "model/weak");
     Ok(())
 }
 


### PR DESCRIPTION
It does no routing, forwards directly to a target. The null algorithm.

Applications:
- Testing if issues come from backend or from Switchyard, by skipping
  most of Switchyard.
- For logging request / responses for RL
- Gives operator flexibility in routing decision. Most of the time the
  model "coding" might go to a sophisticated algo, but at times it could
  be switched to "passthrough" and pined to a single model.

Example config.toml:
```
schema_version = 1

[llm_clients.openrouter]
format = "openai_chat"
base_url = "https://openrouter.ai/api/v1"
api_key_env = "OPENROUTER_API_KEY"

[targets.qwen27]
id = "qwen/qwen3.6-27b"
llm_client = "openrouter"

[routes.passthrough]
id = "passthrough"
type = "passthrough"
target = "qwen27"
```

Then `curl -d {"model":"passthrough", ...} ...`.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a passthrough routing option that consistently sends requests to a configured model target.
  * Exposed passthrough routing for server configuration and route selection.
  * Added support for configuring passthrough routes in TOML files.

* **Documentation**
  * Updated configuration examples and supported routing algorithm documentation.

* **Tests**
  * Added coverage verifying passthrough routing and model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->