### PR TITLE
feat(server): add structured request logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1809,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2127,10 +2137,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -107,7 +107,7 @@ pub(crate) fn run_span(algorithm: &str, metadata: Option<&Metadata>) -> Span {
 }
 
 /// Runs one algorithm task to completion, recording the run counter, duration
-/// histogram, span outcome, and failure log when it resolves. Executes inside
+/// histogram, span outcome, and debug event when it resolves. Executes inside
 /// the `libsy.run` span its caller instruments the task with.
 pub(crate) async fn observe_run<S>(
     ctx: Context<S>,
@@ -136,14 +136,14 @@ pub(crate) fn record_client_call(result: &Result<Response>) {
 }
 
 /// Records the end of one algorithm run: the run counter and duration
-/// histogram, the `outcome`/`error` fields on `span`, and a warn log when the
+/// histogram, the `outcome`/`error` fields on `span`, and debug detail when the
 /// run failed.
 fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, span: &Span) {
     let outcome = outcome_value(result);
     span.record("outcome", outcome);
     if let Err(error) = result {
         span.record("error", tracing::field::display(error));
-        tracing::warn!(target: SCOPE, algorithm, error = %error, "algorithm run failed");
+        tracing::debug!(target: SCOPE, algorithm, error = %error, "algorithm run failed");
     }
 
     let attributes = [
@@ -161,7 +161,7 @@ fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, sp
 /// Records the resolution of one offloaded model call: the call counter and
 /// latency histogram, token counters from the response usage (absent fields are
 /// skipped, not recorded as zero), the `outcome`/`error`/token fields on
-/// `span`, and a warn log when the call failed.
+/// `span`, and debug detail when the call failed.
 pub(crate) fn record_llm_call(
     algorithm: &str,
     selected_model: &str,
@@ -219,7 +219,7 @@ pub(crate) fn record_llm_call(
         }
         Err(error) => {
             span.record("error", tracing::field::display(error));
-            tracing::warn!(
+            tracing::debug!(
                 target: SCOPE,
                 algorithm,
                 selected_model,
@@ -231,11 +231,11 @@ pub(crate) fn record_llm_call(
 }
 
 /// Records one published routing decision: the decision counter plus a
-/// structured info log carrying the decision's reasoning.
+/// structured debug event carrying the decision's reasoning.
 pub(crate) fn record_decision(ctx: &Context, decision: &dyn Decision) {
     let algorithm = algorithm_label(ctx);
     let selected_model = decision.selected_model();
-    tracing::info!(
+    tracing::debug!(
         target: SCOPE,
         algorithm,
         selected_model,

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -107,7 +107,7 @@ pub(crate) fn run_span(algorithm: &str, metadata: Option<&Metadata>) -> Span {
 }
 
 /// Runs one algorithm task to completion, recording the run counter, duration
-/// histogram, span outcome, and debug event when it resolves. Executes inside
+/// histogram, span outcome, and failure log when it resolves. Executes inside
 /// the `libsy.run` span its caller instruments the task with.
 pub(crate) async fn observe_run<S>(
     ctx: Context<S>,
@@ -136,14 +136,14 @@ pub(crate) fn record_client_call(result: &Result<Response>) {
 }
 
 /// Records the end of one algorithm run: the run counter and duration
-/// histogram, the `outcome`/`error` fields on `span`, and debug detail when the
+/// histogram, the `outcome`/`error` fields on `span`, and a warn log when the
 /// run failed.
 fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, span: &Span) {
     let outcome = outcome_value(result);
     span.record("outcome", outcome);
     if let Err(error) = result {
         span.record("error", tracing::field::display(error));
-        tracing::debug!(target: SCOPE, algorithm, error = %error, "algorithm run failed");
+        tracing::warn!(target: SCOPE, algorithm, error = %error, "algorithm run failed");
     }
 
     let attributes = [
@@ -161,7 +161,7 @@ fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, sp
 /// Records the resolution of one offloaded model call: the call counter and
 /// latency histogram, token counters from the response usage (absent fields are
 /// skipped, not recorded as zero), the `outcome`/`error`/token fields on
-/// `span`, and debug detail when the call failed.
+/// `span`, and a warn log when the call failed.
 pub(crate) fn record_llm_call(
     algorithm: &str,
     selected_model: &str,
@@ -219,7 +219,7 @@ pub(crate) fn record_llm_call(
         }
         Err(error) => {
             span.record("error", tracing::field::display(error));
-            tracing::debug!(
+            tracing::warn!(
                 target: SCOPE,
                 algorithm,
                 selected_model,

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -516,7 +516,7 @@ async fn successful_run_records_metrics_spans_and_decision_log() -> switchyard_l
 }
 
 #[tokio::test]
-async fn failed_call_records_error_outcome_and_debug_events() -> switchyard_libsy::Result<()> {
+async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::Result<()> {
     let (store, exporter, provider) = telemetry();
     const ALGO: &str = "obs-failure-algo";
     const MODEL: &str = "obs-failure-model";
@@ -589,12 +589,12 @@ async fn failed_call_records_error_outcome_and_debug_events() -> switchyard_libs
         Some("error")
     );
 
-    // Debug events retain the propagated failures without polluting normal logs.
+    // Structured logs warn once for the failed call and failed run.
     let events = store.events();
     assert!(
         events.iter().any(|event| {
             event.target == "libsy"
-                && event.level == "DEBUG"
+                && event.level == "WARN"
                 && event.fields.get("selected_model").map(String::as_str) == Some(MODEL)
                 && event
                     .fields
@@ -606,7 +606,7 @@ async fn failed_call_records_error_outcome_and_debug_events() -> switchyard_libs
     assert!(
         events.iter().any(|event| {
             event.target == "libsy"
-                && event.level == "DEBUG"
+                && event.level == "WARN"
                 && event.fields.get("algorithm").map(String::as_str) == Some(ALGO)
                 && event
                     .fields

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -53,6 +53,7 @@ struct SpanRecord {
 #[derive(Clone, Debug, Default)]
 struct EventRecord {
     target: String,
+    level: String,
     fields: BTreeMap<String, String>,
 }
 
@@ -134,6 +135,7 @@ where
         event.record(&mut FieldVisitor(&mut fields));
         self.store.events.lock().push(EventRecord {
             target: event.metadata().target().to_string(),
+            level: event.metadata().level().to_string(),
             fields,
         });
     }
@@ -492,11 +494,12 @@ async fn successful_run_records_metrics_spans_and_decision_log() -> switchyard_l
         Some("2")
     );
 
-    // Structured log: the published decision with its reasoning.
+    // Structured debug event: the published decision with its reasoning.
     let events = store.events();
     assert!(
         events.iter().any(|event| {
             event.target == "libsy"
+                && event.level == "DEBUG"
                 && event.fields.get("selected_model").map(String::as_str) == Some(MODEL)
                 && event
                     .fields
@@ -513,7 +516,7 @@ async fn successful_run_records_metrics_spans_and_decision_log() -> switchyard_l
 }
 
 #[tokio::test]
-async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::Result<()> {
+async fn failed_call_records_error_outcome_and_debug_events() -> switchyard_libsy::Result<()> {
     let (store, exporter, provider) = telemetry();
     const ALGO: &str = "obs-failure-algo";
     const MODEL: &str = "obs-failure-model";
@@ -586,11 +589,12 @@ async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::
         Some("error")
     );
 
-    // Structured logs: a warn per failed call and per failed run.
+    // Debug events retain the propagated failures without polluting normal logs.
     let events = store.events();
     assert!(
         events.iter().any(|event| {
             event.target == "libsy"
+                && event.level == "DEBUG"
                 && event.fields.get("selected_model").map(String::as_str) == Some(MODEL)
                 && event
                     .fields
@@ -602,6 +606,7 @@ async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::
     assert!(
         events.iter().any(|event| {
             event.target == "libsy"
+                && event.level == "DEBUG"
                 && event.fields.get("algorithm").map(String::as_str) == Some(ALGO)
                 && event
                     .fields

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -26,6 +26,7 @@ serde_json.workspace = true
 switchyard-translation.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -47,8 +47,8 @@ export API_KEY="..."
 cargo run -p switchyard-server -- --config routes.toml
 ```
 
-The server logs one structured line per LLM request at `INFO`. Set `RUST_LOG=debug` to include
-individual routing decisions and model-call failures.
+The server logs one structured line per LLM request at `INFO` and actual failures at `WARN`. Set
+`RUST_LOG=debug` to include individual routing decisions and other diagnostic details.
 
 Target and route table names are local references. A target's `id` is the exact model ID sent
 upstream, and a route's `id` is the model clients send to select that algorithm.

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -47,8 +47,10 @@ export API_KEY="..."
 cargo run -p switchyard-server -- --config routes.toml
 ```
 
-The server logs one structured line per LLM request at `INFO` and actual failures at `WARN`. Set
-`RUST_LOG=debug` to include individual routing decisions and other diagnostic details.
+The server logs exactly one structured terminal event per LLM request: handled requests at `INFO`
+and algorithm or upstream failures at `WARN`. Set
+`RUST_LOG=switchyard_server=debug,libsy=debug` to include routing decisions and nested failure
+details. A streaming failure is logged separately because it can occur after the response starts.
 
 Target and route table names are local references. A target's `id` is the exact model ID sent
 upstream, and a route's `id` is the model clients send to select that algorithm.

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -47,6 +47,9 @@ export API_KEY="..."
 cargo run -p switchyard-server -- --config routes.toml
 ```
 
+The server logs one structured line per LLM request at `INFO`. Set `RUST_LOG=debug` to include
+individual routing decisions and model-call failures.
+
 Target and route table names are local references. A target's `id` is the exact model ID sent
 upstream, and a route's `id` is the model clients send to select that algorithm.
 

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -47,8 +47,8 @@ export API_KEY="..."
 cargo run -p switchyard-server -- --config routes.toml
 ```
 
-The server logs exactly one structured terminal event per LLM request: handled requests at `INFO`
-and algorithm or upstream failures at `WARN`. Set
+The server logs exactly one structured terminal event per LLM request: successful responses at
+`INFO`, 4xx responses at `WARN`, and 5xx responses at `ERROR`. Set
 `RUST_LOG=switchyard_server=debug,libsy=debug` to include routing decisions and nested failure
 details. A streaming failure is logged separately because it can occur after the response starts.
 

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -252,36 +252,31 @@ async fn handle_endpoint(
     body: std::result::Result<Json<Value>, JsonRejection>,
     wire_format: WireFormat,
 ) -> Response {
-    let started = Instant::now();
     let metadata = metadata_from_headers(&headers);
-    let session_id = metadata.session_id.clone();
-    let correlation_id = metadata.correlation_id.clone();
-    let requested_model = body
-        .as_ref()
-        .ok()
-        .and_then(|body| body.0.get("model"))
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let streaming = body
-        .as_ref()
-        .ok()
-        .and_then(|body| body.0.get("stream"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-
-    let response = match llm_json_body(body) {
-        Ok(body) => handle_llm_request(state, metadata, body, wire_format).await,
-        Err(message) => invalid_body_error(message),
-    };
-    log_llm_request(
-        &response,
+    let request_log = RequestLogContext {
+        started: Instant::now(),
         wire_format,
-        requested_model.as_deref(),
-        session_id.as_deref(),
-        correlation_id.as_deref(),
-        streaming,
-        started.elapsed(),
-    );
+        requested_model: body
+            .as_ref()
+            .ok()
+            .and_then(|body| body.0.get("model"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        streaming: body
+            .as_ref()
+            .ok()
+            .and_then(|body| body.0.get("stream"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        session_id: metadata.session_id.clone(),
+        correlation_id: metadata.correlation_id.clone(),
+    };
+
+    let (response, error) = match llm_json_body(body) {
+        Ok(body) => handle_llm_request(state, metadata, body, wire_format).await,
+        Err(message) => (invalid_body_error(message), None),
+    };
+    request_log.emit(&response, error.as_deref());
     response
 }
 
@@ -300,29 +295,35 @@ async fn handle_llm_request(
     metadata: Metadata,
     body: Value,
     wire_format: WireFormat,
-) -> Response {
+) -> (Response, Option<String>) {
     let llm_request = match decode_request(wire_format, &body) {
         Ok(request) => request,
-        Err(error) => return invalid_body_error(error.to_string()),
+        Err(error) => return (invalid_body_error(error.to_string()), None),
     };
     let Some(requested_model) = llm_request
         .model
         .clone()
         .filter(|model| !model.trim().is_empty())
     else {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "request body must include a non-empty string `model`",
-            "invalid_request_error",
-            "invalid_request_error",
+        return (
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "request body must include a non-empty string `model`",
+                "invalid_request_error",
+                "invalid_request_error",
+            ),
+            None,
         );
     };
     let Some(algorithm) = state.algorithm_for_model(&requested_model) else {
-        return error_response(
-            StatusCode::NOT_FOUND,
-            format!("No route registered for model {requested_model}"),
-            "model_not_found",
-            "model_not_found",
+        return (
+            error_response(
+                StatusCode::NOT_FOUND,
+                format!("No route registered for model {requested_model}"),
+                "model_not_found",
+                "model_not_found",
+            ),
+            None,
         );
     };
 
@@ -333,45 +334,71 @@ async fn handle_llm_request(
     };
     let (trace, response) = match algorithm.run(Context::default(), request).await {
         Ok(result) => result,
-        Err(error) => return algorithm_error(error),
+        Err(error) => {
+            let message = error.to_string();
+            return (algorithm_error(error), Some(message));
+        }
     };
 
     let mut response = match into_http_response(response, wire_format, Some(requested_model)) {
         Ok(response) => response,
-        Err(error) => return server_error(error.to_string()),
+        Err(error) => {
+            let message = error.to_string();
+            return (server_error(&message), Some(message));
+        }
     };
     if let Some(decision) = trace.last() {
         attach_routing_headers(&mut response, decision.as_ref());
     }
-    response
+    (response, None)
 }
 
-fn log_llm_request(
-    response: &Response,
+// Request metadata held until the terminal response determines the event level.
+struct RequestLogContext {
+    started: Instant,
     wire_format: WireFormat,
-    requested_model: Option<&str>,
-    session_id: Option<&str>,
-    correlation_id: Option<&str>,
+    requested_model: Option<String>,
     streaming: bool,
-    duration: Duration,
-) {
-    let selected_model = response
-        .headers()
-        .get(HEADER_SELECTED_MODEL)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or("");
-    tracing::info!(
-        target: "switchyard_server::request",
-        wire_format = %wire_format,
-        status = response.status().as_u16(),
-        requested_model = requested_model.unwrap_or(""),
-        selected_model,
-        streaming,
-        session_id = session_id.unwrap_or(""),
-        correlation_id = correlation_id.unwrap_or(""),
-        handling_duration_ms = duration.as_secs_f64() * 1_000.0,
-        "LLM request handled"
-    );
+    session_id: Option<String>,
+    correlation_id: Option<String>,
+}
+
+impl RequestLogContext {
+    fn emit(self, response: &Response, error: Option<&str>) {
+        let selected_model = response
+            .headers()
+            .get(HEADER_SELECTED_MODEL)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        let duration_ms = self.started.elapsed().as_secs_f64() * 1_000.0;
+        match error {
+            Some(error) => tracing::warn!(
+                target: "switchyard_server::request",
+                wire_format = %self.wire_format,
+                status = response.status().as_u16(),
+                requested_model = self.requested_model.as_deref().unwrap_or(""),
+                selected_model,
+                streaming = self.streaming,
+                session_id = self.session_id.as_deref().unwrap_or(""),
+                correlation_id = self.correlation_id.as_deref().unwrap_or(""),
+                handling_duration_ms = duration_ms,
+                error,
+                "LLM request failed"
+            ),
+            None => tracing::info!(
+                target: "switchyard_server::request",
+                wire_format = %self.wire_format,
+                status = response.status().as_u16(),
+                requested_model = self.requested_model.as_deref().unwrap_or(""),
+                selected_model,
+                streaming = self.streaming,
+                session_id = self.session_id.as_deref().unwrap_or(""),
+                correlation_id = self.correlation_id.as_deref().unwrap_or(""),
+                handling_duration_ms = duration_ms,
+                "LLM request handled"
+            ),
+        }
+    }
 }
 
 fn metadata_from_headers(headers: &HeaderMap) -> Metadata {

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -13,7 +13,7 @@ use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::extract::{rejection::JsonRejection, State};
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
@@ -252,11 +252,37 @@ async fn handle_endpoint(
     body: std::result::Result<Json<Value>, JsonRejection>,
     wire_format: WireFormat,
 ) -> Response {
-    let body = match llm_json_body(body) {
-        Ok(body) => body,
-        Err(message) => return invalid_body_error(message),
+    let started = Instant::now();
+    let metadata = metadata_from_headers(&headers);
+    let session_id = metadata.session_id.clone();
+    let correlation_id = metadata.correlation_id.clone();
+    let requested_model = body
+        .as_ref()
+        .ok()
+        .and_then(|body| body.0.get("model"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let streaming = body
+        .as_ref()
+        .ok()
+        .and_then(|body| body.0.get("stream"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let response = match llm_json_body(body) {
+        Ok(body) => handle_llm_request(state, metadata, body, wire_format).await,
+        Err(message) => invalid_body_error(message),
     };
-    handle_llm_request(state, headers, body, wire_format).await
+    log_llm_request(
+        &response,
+        wire_format,
+        requested_model.as_deref(),
+        session_id.as_deref(),
+        correlation_id.as_deref(),
+        streaming,
+        started.elapsed(),
+    );
+    response
 }
 
 fn llm_json_body(
@@ -271,7 +297,7 @@ fn llm_json_body(
 
 async fn handle_llm_request(
     state: ServerState,
-    headers: HeaderMap,
+    metadata: Metadata,
     body: Value,
     wire_format: WireFormat,
 ) -> Response {
@@ -303,7 +329,7 @@ async fn handle_llm_request(
     let request = Request {
         llm_request,
         raw_request: Some(body),
-        metadata: Some(metadata_from_headers(&headers)),
+        metadata: Some(metadata),
     };
     let (trace, response) = match algorithm.run(Context::default(), request).await {
         Ok(result) => result,
@@ -318,6 +344,34 @@ async fn handle_llm_request(
         attach_routing_headers(&mut response, decision.as_ref());
     }
     response
+}
+
+fn log_llm_request(
+    response: &Response,
+    wire_format: WireFormat,
+    requested_model: Option<&str>,
+    session_id: Option<&str>,
+    correlation_id: Option<&str>,
+    streaming: bool,
+    duration: Duration,
+) {
+    let selected_model = response
+        .headers()
+        .get(HEADER_SELECTED_MODEL)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+    tracing::info!(
+        target: "switchyard_server::request",
+        wire_format = %wire_format,
+        status = response.status().as_u16(),
+        requested_model = requested_model.unwrap_or(""),
+        selected_model,
+        streaming,
+        session_id = session_id.unwrap_or(""),
+        correlation_id = correlation_id.unwrap_or(""),
+        handling_duration_ms = duration.as_secs_f64() * 1_000.0,
+        "LLM request handled"
+    );
 }
 
 fn metadata_from_headers(headers: &HeaderMap) -> Metadata {

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -24,6 +24,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use libsy::{Algorithm, Context, Decision, LibsyError, LlmClientError, Metadata, Request};
 use serde_json::{json, Value};
 use tokio::net::{TcpListener, TcpSocket};
+use tracing::Level;
 
 use switchyard_translation::{decode_request, WireFormat};
 
@@ -272,11 +273,11 @@ async fn handle_endpoint(
         correlation_id: metadata.correlation_id.clone(),
     };
 
-    let (response, error) = match llm_json_body(body) {
+    let response = match llm_json_body(body) {
         Ok(body) => handle_llm_request(state, metadata, body, wire_format).await,
-        Err(message) => (invalid_body_error(message), None),
+        Err(message) => invalid_body_error(message),
     };
-    request_log.emit(&response, error.as_deref());
+    request_log.emit(&response);
     response
 }
 
@@ -295,35 +296,29 @@ async fn handle_llm_request(
     metadata: Metadata,
     body: Value,
     wire_format: WireFormat,
-) -> (Response, Option<String>) {
+) -> Response {
     let llm_request = match decode_request(wire_format, &body) {
         Ok(request) => request,
-        Err(error) => return (invalid_body_error(error.to_string()), None),
+        Err(error) => return invalid_body_error(error.to_string()),
     };
     let Some(requested_model) = llm_request
         .model
         .clone()
         .filter(|model| !model.trim().is_empty())
     else {
-        return (
-            error_response(
-                StatusCode::BAD_REQUEST,
-                "request body must include a non-empty string `model`",
-                "invalid_request_error",
-                "invalid_request_error",
-            ),
-            None,
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "request body must include a non-empty string `model`",
+            "invalid_request_error",
+            "invalid_request_error",
         );
     };
     let Some(algorithm) = state.algorithm_for_model(&requested_model) else {
-        return (
-            error_response(
-                StatusCode::NOT_FOUND,
-                format!("No route registered for model {requested_model}"),
-                "model_not_found",
-                "model_not_found",
-            ),
-            None,
+        return error_response(
+            StatusCode::NOT_FOUND,
+            format!("No route registered for model {requested_model}"),
+            "model_not_found",
+            "model_not_found",
         );
     };
 
@@ -334,23 +329,17 @@ async fn handle_llm_request(
     };
     let (trace, response) = match algorithm.run(Context::default(), request).await {
         Ok(result) => result,
-        Err(error) => {
-            let message = error.to_string();
-            return (algorithm_error(error), Some(message));
-        }
+        Err(error) => return algorithm_error(error),
     };
 
     let mut response = match into_http_response(response, wire_format, Some(requested_model)) {
         Ok(response) => response,
-        Err(error) => {
-            let message = error.to_string();
-            return (server_error(&message), Some(message));
-        }
+        Err(error) => return server_error(error.to_string()),
     };
     if let Some(decision) = trace.last() {
         attach_routing_headers(&mut response, decision.as_ref());
     }
-    (response, None)
+    response
 }
 
 // Request metadata held until the terminal response determines the event level.
@@ -363,41 +352,58 @@ struct RequestLogContext {
     correlation_id: Option<String>,
 }
 
+// Error text carried separately so terminal logging never consumes an HTTP body.
+#[derive(Clone)]
+struct RequestLogError(String);
+
 impl RequestLogContext {
-    fn emit(self, response: &Response, error: Option<&str>) {
+    fn emit(self, response: &Response) {
         let selected_model = response
             .headers()
             .get(HEADER_SELECTED_MODEL)
             .and_then(|value| value.to_str().ok())
             .unwrap_or("");
         let duration_ms = self.started.elapsed().as_secs_f64() * 1_000.0;
-        match error {
-            Some(error) => tracing::warn!(
-                target: "switchyard_server::request",
-                wire_format = %self.wire_format,
-                status = response.status().as_u16(),
-                requested_model = self.requested_model.as_deref().unwrap_or(""),
-                selected_model,
-                streaming = self.streaming,
-                session_id = self.session_id.as_deref().unwrap_or(""),
-                correlation_id = self.correlation_id.as_deref().unwrap_or(""),
-                handling_duration_ms = duration_ms,
-                error,
-                "LLM request failed"
-            ),
-            None => tracing::info!(
-                target: "switchyard_server::request",
-                wire_format = %self.wire_format,
-                status = response.status().as_u16(),
-                requested_model = self.requested_model.as_deref().unwrap_or(""),
-                selected_model,
-                streaming = self.streaming,
-                session_id = self.session_id.as_deref().unwrap_or(""),
-                correlation_id = self.correlation_id.as_deref().unwrap_or(""),
-                handling_duration_ms = duration_ms,
-                "LLM request handled"
-            ),
+        let error = response
+            .extensions()
+            .get::<RequestLogError>()
+            .map(|error| error.0.as_str())
+            .unwrap_or("");
+
+        macro_rules! emit {
+            ($level:expr, $message:literal) => {
+                tracing::event!(
+                    target: "switchyard_server::request",
+                    $level,
+                    wire_format = %self.wire_format,
+                    status = response.status().as_u16(),
+                    requested_model = self.requested_model.as_deref().unwrap_or(""),
+                    selected_model,
+                    streaming = self.streaming,
+                    session_id = self.session_id.as_deref().unwrap_or(""),
+                    correlation_id = self.correlation_id.as_deref().unwrap_or(""),
+                    handling_duration_ms = duration_ms,
+                    error,
+                    $message
+                )
+            };
         }
+
+        match request_log_level(response.status()) {
+            Level::ERROR => emit!(Level::ERROR, "LLM request failed"),
+            Level::WARN => emit!(Level::WARN, "LLM request failed"),
+            _ => emit!(Level::INFO, "LLM request handled"),
+        }
+    }
+}
+
+fn request_log_level(status: StatusCode) -> Level {
+    if status.is_server_error() {
+        Level::ERROR
+    } else if status.is_success() {
+        Level::INFO
+    } else {
+        Level::WARN
     }
 }
 
@@ -523,17 +529,20 @@ fn error_response(
     error_type: &'static str,
     code: &'static str,
 ) -> Response {
-    (
+    let message = message.into();
+    let mut response = (
         status,
         Json(json!({
             "error": {
-                "message": message.into(),
+                "message": message.clone(),
                 "type": error_type,
                 "code": code,
             }
         })),
     )
-        .into_response()
+        .into_response();
+    response.extensions_mut().insert(RequestLogError(message));
+    response
 }
 
 async fn models(State(state): State<ServerState>) -> Json<Value> {
@@ -613,5 +622,40 @@ fn host_for_url(ip: std::net::IpAddr) -> String {
     match ip {
         std::net::IpAddr::V4(ip) => ip.to_string(),
         std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Terminal request severity follows HTTP status instead of error-path bookkeeping.
+    #[test]
+    fn request_log_level_follows_http_status() {
+        assert_eq!(request_log_level(StatusCode::OK), Level::INFO);
+        assert_eq!(request_log_level(StatusCode::BAD_REQUEST), Level::WARN);
+        assert_eq!(
+            request_log_level(StatusCode::INTERNAL_SERVER_ERROR),
+            Level::ERROR
+        );
+    }
+
+    // Canonical error text remains available without consuming the response body.
+    #[test]
+    fn error_response_carries_request_log_error() {
+        let response = error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid request",
+            "invalid_request_error",
+            "invalid_request_error",
+        );
+
+        assert_eq!(
+            response
+                .extensions()
+                .get::<RequestLogError>()
+                .map(|error| error.0.as_str()),
+            Some("invalid request")
+        );
     }
 }

--- a/crates/switchyard-server/src/main.rs
+++ b/crates/switchyard-server/src/main.rs
@@ -5,10 +5,18 @@
 
 use std::process::ExitCode;
 
+use tracing_subscriber::EnvFilter;
+
 mod cli;
+
+const DEFAULT_LOG_FILTER: &str = "switchyard_server=info";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> ExitCode {
+    if let Err(error) = init_logging() {
+        eprintln!("failed to initialize logging: {error}");
+        return ExitCode::FAILURE;
+    }
     match cli::run(cli::ServerArgs::parse_args()).await {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
@@ -16,4 +24,15 @@ async fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn init_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .with_writer(std::io::stderr)
+        .try_init()?;
+    Ok(())
 }

--- a/crates/switchyard-server/src/main.rs
+++ b/crates/switchyard-server/src/main.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::EnvFilter;
 
 mod cli;
 
-const DEFAULT_LOG_FILTER: &str = "switchyard_server=info";
+const DEFAULT_LOG_FILTER: &str = "switchyard_server=info,libsy=warn";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> ExitCode {

--- a/crates/switchyard-server/src/main.rs
+++ b/crates/switchyard-server/src/main.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::EnvFilter;
 
 mod cli;
 
-const DEFAULT_LOG_FILTER: &str = "switchyard_server=info,libsy=warn";
+const DEFAULT_LOG_FILTER: &str = "switchyard_server=info";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> ExitCode {

--- a/crates/switchyard-server/src/sse.rs
+++ b/crates/switchyard-server/src/sse.rs
@@ -32,7 +32,7 @@ pub(crate) fn frame_stream(
                     }
                 },
                 Err(error) => {
-                    tracing::debug!(error = %error, "stream iteration failed");
+                    tracing::warn!(error = %error, "stream iteration failed");
                     failed = true;
                     error_event(target_format, error.to_string())
                 }

--- a/crates/switchyard-server/src/sse.rs
+++ b/crates/switchyard-server/src/sse.rs
@@ -32,7 +32,7 @@ pub(crate) fn frame_stream(
                     }
                 },
                 Err(error) => {
-                    tracing::warn!(error = %error, "stream iteration failed");
+                    tracing::debug!(error = %error, "stream iteration failed");
                     failed = true;
                     error_event(target_format, error.to_string())
                 }


### PR DESCRIPTION
## What

- Initialize structured `tracing` output in `switchyard-server`.
- Emit exactly one terminal request event for each non-stream failure/success path.
- Log handled requests and client errors at `INFO`.
- Log algorithm, translation, and upstream failures at `WARN` with the propagated error.
- Keep libsy routing decisions and nested call details available through opt-in debug logging.

Streaming failures remain a separate `WARN` because they can occur after the HTTP response has started.

## Why

The Rust server records spans and OpenTelemetry metrics but did not install a tracing subscriber, so operators received no request logs. The server needs a concise default signal: one event that says what route was requested, what model was selected, how the request ended, and how long handling took. Internal routing detail should remain available without making routine logs noisy.

## How

- Install `tracing-subscriber` in the server binary with the default filter `switchyard_server=info`.
- Capture request metadata before dispatch and retain propagated terminal error context alongside the HTTP response.
- Emit the terminal event centrally after response construction:
  - `INFO ... LLM request handled` for successful and client-error responses.
  - `WARN ... LLM request failed` for algorithm/upstream failures.
- Include wire format, HTTP status, requested model, selected model, streaming flag, session ID, correlation ID, handling duration, and the propagated error on failures.
- Keep libsy warning semantics unchanged while excluding nested libsy events from the default server filter, preventing duplicate failure lines.
- Write logs to stderr without ANSI formatting for container and service log collectors.
- Leave OpenTelemetry counters, histograms, and span recording unchanged; log filtering does not gate metric recording.

This MR intentionally does not add disk persistence, RL records, session aggregation, or new endpoints.

## Operator know-how

Default operation needs no environment variable and emits one terminal server event per request:

```text
INFO switchyard_server::request: LLM request handled ... status=200
WARN switchyard_server::request: LLM request failed ... status=502 error="..."
```

Enable Switchyard-specific routing and nested call diagnostics without enabling debug logs from every dependency:

```bash
RUST_LOG=switchyard_server=debug,libsy=debug switchyard-server --config routes.toml
```

## What to review

- Confirm the terminal event carries useful routing metadata without prompt, response, API-key, or raw-header content.
- Confirm propagated failures produce one default `WARN`, not duplicate model-call and algorithm-run warnings.
- Confirm handled requests and client errors produce one `INFO` event.
- Confirm the streaming-error exception is appropriate because stream consumption outlives response construction.
- Confirm libsy OpenTelemetry metrics and standalone warning semantics remain unchanged.

## Validation

- `cargo test -p switchyard-server`
- `cargo test -p switchyard-libsy --test observability`
- `cargo fmt --all --check`
- `cargo clippy -p switchyard-server --all-targets -- -D warnings`
- Live real-binary smoke test:
  - no-op route returned HTTP 200 and emitted one `INFO`
  - unreachable passthrough returned HTTP 502 and emitted one `WARN` with the propagated transport error
  - zero nested `libsy` lines appeared under the default filter