### PR TITLE
docs(libsy): fix rustdoc intra-doc links, name Context fields

### DIFF
--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -325,5 +325,5 @@ agents live in [`examples`](examples/) folder.
 ## Not yet built
 
 - **`Signals` events** — `process_signals` / `Signals` exist but carry nothing yet.
-- **`Context` fields** — carries the algorithm telemetry label today; correlation ids, budgets, and deadlines still to come.
+- **`Context` fields** — `values: HashMap<String, String>` carries the algorithm telemetry label and `state: S` the caller's per-session state; correlation ids, budgets, and deadlines still to come.
 - **Config-driven construction**.

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -4,13 +4,13 @@
 //! Fall-through classifier routing: a stateful [`Algorithm`] that routes each turn
 //! through a processor chain and a classifier cascade.
 //!
-//! Each turn: request-side [`Processor`]s fold facts into the session [`State`]; the
+//! Each turn: request-side [`Processor`]s fold facts into the session [`State`](crate::State); the
 //! [`Classifier`] cascade is consulted in order and the first to score decides the target
 //! (its `argmax`); the [`Decision`] is published and then replayed to the processors so
 //! stateful ones (latch, affinity) can bind it.
 //!
 //! [`FallThrough`] itself is stateless — one shared instance serves every session. The
-//! per-session [`State`] rides in the threaded [`Context<SharedState>`] the caller passes into
+//! per-session [`State`](crate::State) rides in the threaded [`Context<SharedState>`] the caller passes into
 //! each turn, so routing can depend on accumulated history rather than the current request
 //! alone. The state is held under a lock, so concurrent turns of the same session serialize
 //! on it.
@@ -46,7 +46,7 @@ impl Decision for FallThroughDecision {
 
 /// Processor chain → classifier cascade → routed model call. See the [module docs](self).
 ///
-/// Stateless: the per-session [`State`] lives in the threaded [`Context<SharedState>`], so one
+/// Stateless: the per-session [`State`](crate::State) lives in the threaded [`Context<SharedState>`], so one
 /// shared instance serves every session (see the module docs).
 pub struct FallThrough {
     processors: Vec<Arc<dyn Processor>>,

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -185,14 +185,14 @@ static NUMERIC_FAILURE_KEYWORDS: &[&str] = &["failed", "failure", "failures", "e
 ///
 /// A short horizon captures "what is the agent doing right now" while keeping
 /// signals sticky — an error or stall persists a few recovery turns instead of
-/// flickering off the moment one clean result lands. Override per-extractor by
-/// calling [`extract_tool_signals_with_window`] directly.
+/// flickering off the moment one clean result lands. Override per request by
+/// passing a window to [`ToolSignals::from_request`].
 pub const DEFAULT_RECENT_WINDOW: usize = 3;
 
 // ─── output type ─────────────────────────────────────────────────────────────
 
 /// Tool-execution signals stamped on `ProxyContext`. Read by stage_router pickers
-/// via [`crate::get_tool_result_signal`].
+/// via the `get_tool_result_signal` binding.
 #[derive(Clone, Debug, Default)]
 pub struct ToolSignals {
     /// Max severity across the recent window (last `recent_window` tool results):
@@ -209,13 +209,13 @@ pub struct ToolSignals {
     /// TodoWrite / planning tool calls. Investigative (non-producing) activity —
     /// recent todowrites distinguish `exploring` from `spinning` in the scorer.
     pub todowrite_count: u32,
-    /// Edit-type calls within the last [`RECENT_WINDOW`] tool calls.
+    /// Edit-type calls within the configured recent window (default: [`DEFAULT_RECENT_WINDOW`]).
     pub recent_edit_count: u32,
-    /// Write-type calls within the last [`RECENT_WINDOW`] tool calls.
+    /// Write-type calls within the configured recent window (default: [`DEFAULT_RECENT_WINDOW`]).
     pub recent_write_count: u32,
-    /// Read-type calls within the last [`RECENT_WINDOW`] tool calls.
+    /// Read-type calls within the configured recent window (default: [`DEFAULT_RECENT_WINDOW`]).
     pub recent_read_count: u32,
-    /// TodoWrite calls within the last [`RECENT_WINDOW`] tool calls.
+    /// TodoWrite calls within the configured recent window (default: [`DEFAULT_RECENT_WINDOW`]).
     pub recent_todowrite_count: u32,
     /// Consecutive trailing tool calls in the `Other` category (no Write/Edit/Read/
     /// Plan match). Surfaced in the classifier state summary; not scored directly.

--- a/crates/libsy/src/core/state.rs
+++ b/crates/libsy/src/core/state.rs
@@ -17,7 +17,7 @@ pub enum StateValue {
     Scalar(f32),
 }
 
-/// State maitaineed by [`Algorithm`]s
+/// State maintained by [`Algorithm`](crate::Algorithm)s
 #[derive(Debug, Clone, Default)]
 pub struct State {
     pub turn_count: u32,


### PR DESCRIPTION
Strict rustdoc fails on `switchyard-libsy` on `main`:

    RUSTDOCFLAGS="-D warnings" cargo doc -p switchyard-libsy --no-deps

reports 10 broken intra-doc links and ends with `could not document switchyard-libsy`. This fixes the doc comments so the strict build passes. Doc comments and the README only — no code change.

What changed:

- `core/state.rs` and `algorithms/fall_through.rs`: `[Algorithm]` and `[State]` were unresolved because those types aren't in scope in those modules. Link them to their crate-root paths (`crate::Algorithm`, `crate::State`).
- `signal/tool_signals.rs`:
  - The public `DEFAULT_RECENT_WINDOW` linked to the private `extract_tool_signals_with_window`. Point the override note at the public entry point instead, `ToolSignals::from_request`.
  - Dropped the `crate::get_tool_result_signal` link — that function is a PyO3 binding in the `switchyard-py` crate, not a libsy item — so it is now a plain code span.
  - Four `[RECENT_WINDOW]` links pointed at a name that does not exist; the real constant is `DEFAULT_RECENT_WINDOW`.
- `README.md`: the "Context fields" bullet now names the two real public fields, `values: HashMap<String, String>` and `state: S`. It previously described only the telemetry label and left out `state`.

Evidence — strict rustdoc now passes:

    $ RUSTDOCFLAGS="-D warnings" cargo doc -p switchyard-libsy --no-deps
    ...
     Documenting switchyard-libsy v0.1.0 (crates/libsy)
        Finished `dev` profile [unoptimized + debuginfo] target(s)
       Generated target/doc/switchyard_libsy/index.html
    $ echo $?
    0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `Context` stores telemetry labels and per-session state.
  * Documented pending support for correlation IDs, budgets, and deadlines.
  * Improved explanations of fall-through routing and state handling.
  * Corrected cross-references for algorithm documentation.
  * Clarified configurable tool-signal time windows and result bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->