### PR TITLE
chore(libsy): make reqeust mut in clasifer and processor

### DIFF
--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -106,10 +106,14 @@ impl Algorithm<SharedState> for FallThrough {
         // turns of the same session serialize on it.
         let mut state = ctx.state.lock().await;
 
+        // The request is threaded mutably through the whole fold: any component may rewrite
+        // it, later components see the rewrite, and the final value is what reaches the model.
+        let mut request = request;
+
         // 1. Processor chain accumulates request-side facts into the session State.
         for processor in &self.processors {
             processor
-                .process(&mut state, Event::Request(&request))
+                .process(&mut state, Event::Request(&mut request))
                 .await?;
         }
 
@@ -118,7 +122,7 @@ impl Algorithm<SharedState> for FallThrough {
         let mut winner: Option<Score> = None;
         for classifier in &self.classifiers {
             let scores = classifier
-                .score(&mut state, &request, Some(&driver))
+                .score(&mut state, &mut request, Some(&driver))
                 .await?;
             if let Some(score) = scores.argmax(false)? {
                 winner = Some(score);
@@ -198,6 +202,29 @@ mod tests {
         }
     }
 
+    /// A client that captures the request it was handed, so a test can assert on what
+    /// actually reached the model.
+    struct CapturingClient(Arc<parking_lot::Mutex<Option<Request>>>);
+
+    #[async_trait]
+    impl RoutedLlmClient for CapturingClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> std::result::Result<Response, switchyard_protocol::LlmClientError> {
+            *self.0.lock() = Some(request);
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(
+                    None,
+                    decision.selected_model().to_string(),
+                )),
+                metadata: None,
+            })
+        }
+    }
+
     /// A target set whose targets all serve via [`EchoClient`].
     fn target_set(names: &[&str]) -> LlmTargetSet {
         LlmTargetSet::new(
@@ -219,7 +246,7 @@ mod tests {
         async fn score(
             &self,
             _state: &mut State,
-            _request: &Request,
+            _request: &mut Request,
             _driver: Option<&Driver>,
         ) -> Result<Classification> {
             Ok(Classification::Scores(
@@ -342,7 +369,7 @@ mod tests {
             async fn score(
                 &self,
                 _state: &mut State,
-                _request: &Request,
+                _request: &mut Request,
                 driver: Option<&Driver>,
             ) -> Result<Classification> {
                 match driver {
@@ -390,6 +417,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_rewrite_propagates_down_the_chain_and_into_the_model_call() -> Result<()> {
+        use parking_lot::Mutex;
+
+        /// Appends a marker message to the request it observes.
+        struct Appender(&'static str);
+
+        #[async_trait]
+        impl Processor for Appender {
+            async fn process(&self, _state: &mut State, event: Event<'_>) -> Result<()> {
+                if let Event::Request(request) = event {
+                    request
+                        .llm_request
+                        .messages
+                        .push(Message::text(Role::User, self.0));
+                }
+                Ok(())
+            }
+        }
+
+        /// Records the marker trail it was handed, then appends its own — proving the
+        /// classifier scored the processors' rewrite rather than the original request.
+        struct TrailClassifier(Arc<Mutex<Vec<String>>>);
+
+        #[async_trait]
+        impl Classifier for TrailClassifier {
+            async fn score(
+                &self,
+                _state: &mut State,
+                request: &mut Request,
+                _driver: Option<&Driver>,
+            ) -> Result<Classification> {
+                *self.0.lock() = request
+                    .llm_request
+                    .messages
+                    .iter()
+                    .filter_map(|message| message.text_content(""))
+                    .collect();
+                request
+                    .llm_request
+                    .messages
+                    .push(Message::text(Role::User, "classifier"));
+                Ok(Classification::Scores(vec![score("strong", 1.0)]))
+            }
+        }
+
+        let seen_by_classifier = Arc::new(Mutex::new(Vec::new()));
+        let seen_by_model = Arc::new(Mutex::new(None));
+        let targets = LlmTargetSet::new(vec![LlmTarget {
+            semantic_name: "strong".to_string(),
+            llm_client: Some(Arc::new(CapturingClient(seen_by_model.clone()))),
+        }]);
+        let router = FallThrough::new(targets)
+            .with_processor(Arc::new(Appender("first")))
+            .with_processor(Arc::new(Appender("second")))
+            .with_classifier(Arc::new(TrailClassifier(seen_by_classifier.clone())));
+
+        run_turn(&Arc::new(router), Context::default()).await?;
+
+        // The classifier saw both processors' edits, in chain order, on top of the original.
+        assert_eq!(*seen_by_classifier.lock(), vec!["hi", "first", "second"]);
+
+        // ...and the request that reached the model carries the classifier's edit too.
+        let routed = seen_by_model
+            .lock()
+            .take()
+            .ok_or_else(|| test_error("the model was never called"))?;
+        let trail: Vec<String> = routed
+            .llm_request
+            .messages
+            .iter()
+            .filter_map(|message| message.text_content(""))
+            .collect();
+        assert_eq!(trail, vec!["hi", "first", "second", "classifier"]);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn state_persists_across_turns() -> Result<()> {
         // Increments the session turn count on every request.
         struct CountingProcessor;
@@ -413,7 +517,7 @@ mod tests {
             async fn score(
                 &self,
                 state: &mut State,
-                _request: &Request,
+                _request: &mut Request,
                 _driver: Option<&Driver>,
             ) -> Result<Classification> {
                 let target = if state.turn_count >= 2 {

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -157,7 +157,7 @@ impl Classifier for AffinityRouter {
     async fn score(
         &self,
         _state: &mut State,
-        request: &Request,
+        request: &mut Request,
         _driver: Option<&crate::Driver>,
     ) -> crate::Result<Classification> {
         let Some(key) = self.affinity_key(request) else {
@@ -242,7 +242,7 @@ mod tests {
     async fn retain(
         router: &AffinityRouter,
         state: &mut State,
-        request: &Request,
+        request: &mut Request,
         model: &'static str,
     ) -> Result<(), BoxErr> {
         router.process(state, Event::Request(request)).await?;
@@ -256,7 +256,7 @@ mod tests {
     async fn scores(
         classifier: &dyn Classifier,
         state: &mut State,
-        request: &Request,
+        request: &mut Request,
     ) -> Result<Vec<Score>, BoxErr> {
         match classifier.score(state, request, None).await? {
             Classification::Scores(scores) => Ok(scores),
@@ -269,12 +269,12 @@ mod tests {
         let router = AffinityRouter::new();
         let mut state = State::default();
 
-        let first = request(session("session-1", "agent-a"));
-        retain(&router, &mut state, &first, "model-a").await?;
+        let mut first = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &mut first, "model-a").await?;
 
         // A different agent in the same session is scored onto the retained model.
-        let second = request(session("session-1", "agent-b"));
-        let scores = scores(&router, &mut state, &second).await?;
+        let mut second = request(session("session-1", "agent-b"));
+        let scores = scores(&router, &mut state, &mut second).await?;
         assert_eq!(scores.len(), 1);
         assert_eq!(scores[0].confidence, 1.0);
         assert_eq!(scores[0].target, "model-a");
@@ -286,14 +286,14 @@ mod tests {
         let router = AffinityRouter::for_subagents();
         let mut state = State::default();
 
-        let root = request(session("session-1", "root-agent"));
-        retain(&router, &mut state, &root, "model-a").await?;
-        assert!(scores(&router, &mut state, &root).await?.is_empty());
+        let mut root = request(session("session-1", "root-agent"));
+        retain(&router, &mut state, &mut root, "model-a").await?;
+        assert!(scores(&router, &mut state, &mut root).await?.is_empty());
 
-        let first_child_turn = request(subagent("child-1", "task-1"));
-        retain(&router, &mut state, &first_child_turn, "model-b").await?;
-        let later_child_turn = request(subagent("child-1", "task-2"));
-        let scores = scores(&router, &mut state, &later_child_turn).await?;
+        let mut first_child_turn = request(subagent("child-1", "task-1"));
+        retain(&router, &mut state, &mut first_child_turn, "model-b").await?;
+        let mut later_child_turn = request(subagent("child-1", "task-2"));
+        let scores = scores(&router, &mut state, &mut later_child_turn).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-b")
@@ -306,12 +306,12 @@ mod tests {
         let router = AffinityRouter::new();
         let mut state = State::default();
 
-        let req = request(session("session-1", "agent-a"));
-        retain(&router, &mut state, &req, "model-a").await?;
+        let mut req = request(session("session-1", "agent-a"));
+        retain(&router, &mut state, &mut req, "model-a").await?;
         // A later decision for the same identity must not overwrite the first.
-        retain(&router, &mut state, &req, "model-b").await?;
+        retain(&router, &mut state, &mut req, "model-b").await?;
 
-        let scores = scores(&router, &mut state, &req).await?;
+        let scores = scores(&router, &mut state, &mut req).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -324,12 +324,12 @@ mod tests {
         let router = AffinityRouter::new();
         let mut state = State::default();
 
-        let first = request(subagent("child-1", "task-1"));
-        retain(&router, &mut state, &first, "model-a").await?;
+        let mut first = request(subagent("child-1", "task-1"));
+        retain(&router, &mut state, &mut first, "model-a").await?;
 
         // Same child, different task: still scored onto the retained model.
-        let second = request(subagent("child-1", "task-2"));
-        let scores = scores(&router, &mut state, &second).await?;
+        let mut second = request(subagent("child-1", "task-2"));
+        let scores = scores(&router, &mut state, &mut second).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -346,14 +346,14 @@ mod tests {
         retain(
             &router,
             &mut state,
-            &request(subagent("child-1", "task-1")),
+            &mut request(subagent("child-1", "task-1")),
             "model-a",
         )
         .await?;
 
         // ...a sibling child in the same session has no assignment of its own yet.
-        let sibling = request(subagent("child-2", "task-1"));
-        assert!(scores(&router, &mut state, &sibling).await?.is_empty());
+        let mut sibling = request(subagent("child-2", "task-1"));
+        assert!(scores(&router, &mut state, &mut sibling).await?.is_empty());
         Ok(())
     }
 
@@ -366,14 +366,14 @@ mod tests {
         retain(
             &router,
             &mut state,
-            &request(session("session-1", "root-1")),
+            &mut request(session("session-1", "root-1")),
             "model-a",
         )
         .await?;
 
         // ...so the sub-agent abstains until it is assigned in its own right.
-        let child = request(subagent("child-1", "task-1"));
-        assert!(scores(&router, &mut state, &child).await?.is_empty());
+        let mut child = request(subagent("child-1", "task-1"));
+        assert!(scores(&router, &mut state, &mut child).await?.is_empty());
         Ok(())
     }
 
@@ -383,8 +383,8 @@ mod tests {
         let mut state = State::default();
 
         // No session id at all: nothing to key on.
-        let req = request(Metadata::default());
-        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        let mut req = request(Metadata::default());
+        assert!(scores(&router, &mut state, &mut req).await?.is_empty());
         Ok(())
     }
 
@@ -397,16 +397,16 @@ mod tests {
         let classifier: Arc<dyn Classifier> = router;
         let mut state = State::default();
 
-        let first = request(session("session-1", "agent-a"));
+        let mut first = request(session("session-1", "agent-a"));
         processor
-            .process(&mut state, Event::Request(&first))
+            .process(&mut state, Event::Request(&mut first))
             .await?;
         processor
             .process(&mut state, Event::Decision(&FixedDecision("model-a")))
             .await?;
 
-        let second = request(session("session-1", "agent-b"));
-        let scores = scores(classifier.as_ref(), &mut state, &second).await?;
+        let mut second = request(session("session-1", "agent-b"));
+        let scores = scores(classifier.as_ref(), &mut state, &mut second).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -424,8 +424,8 @@ mod tests {
             .process(&mut state, Event::Decision(&FixedDecision("model-a")))
             .await?;
 
-        let req = request(session("session-1", "agent-a"));
-        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        let mut req = request(session("session-1", "agent-a"));
+        assert!(scores(&router, &mut state, &mut req).await?.is_empty());
         Ok(())
     }
 
@@ -434,8 +434,8 @@ mod tests {
         let router = AffinityRouter::new();
         let mut state = State::default();
 
-        let req = request(session("session-1", "agent-a"));
-        router.process(&mut state, Event::Request(&req)).await?;
+        let mut req = request(session("session-1", "agent-a"));
+        router.process(&mut state, Event::Request(&mut req)).await?;
         // A stray signal between the request and its decision must not drop the captured
         // identity, nor create an assignment of its own.
         router
@@ -445,7 +445,7 @@ mod tests {
             .process(&mut state, Event::Decision(&FixedDecision("model-a")))
             .await?;
 
-        let scores = scores(&router, &mut state, &req).await?;
+        let scores = scores(&router, &mut state, &mut req).await?;
         assert_eq!(
             scores.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -461,20 +461,30 @@ mod tests {
         retain(
             &router,
             &mut state,
-            &request(session("session-1", "agent-a")),
+            &mut request(session("session-1", "agent-a")),
             "model-a",
         )
         .await?;
         retain(
             &router,
             &mut state,
-            &request(session("session-2", "agent-a")),
+            &mut request(session("session-2", "agent-a")),
             "model-b",
         )
         .await?;
 
-        let first = scores(&router, &mut state, &request(session("session-1", "other"))).await?;
-        let second = scores(&router, &mut state, &request(session("session-2", "other"))).await?;
+        let first = scores(
+            &router,
+            &mut state,
+            &mut request(session("session-1", "other")),
+        )
+        .await?;
+        let second = scores(
+            &router,
+            &mut state,
+            &mut request(session("session-2", "other")),
+        )
+        .await?;
         assert_eq!(
             first.first().map(|score| score.target.as_str()),
             Some("model-a")
@@ -498,9 +508,9 @@ mod tests {
             is_subagent: true,
             ..Metadata::default()
         };
-        let req = request(metadata);
-        retain(&router, &mut state, &req, "model-a").await?;
-        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        let mut req = request(metadata);
+        retain(&router, &mut state, &mut req, "model-a").await?;
+        assert!(scores(&router, &mut state, &mut req).await?.is_empty());
         Ok(())
     }
 
@@ -515,7 +525,7 @@ mod tests {
             retain(
                 &router,
                 &mut state,
-                &request(session(&session_id, "agent-a")),
+                &mut request(session(&session_id, "agent-a")),
                 "model-a",
             )
             .await?;
@@ -530,16 +540,16 @@ mod tests {
     async fn latch_only_retains_matching_models() -> Result<(), BoxErr> {
         let router = AffinityRouter::new().with_latch_only(["strong"]);
         let mut state = State::default();
-        let req = request(session("session-1", "agent-a"));
+        let mut req = request(session("session-1", "agent-a"));
 
         // A "weak" decision is not retained — a later turn is not latched.
-        retain(&router, &mut state, &req, "weak").await?;
-        assert!(scores(&router, &mut state, &req).await?.is_empty());
+        retain(&router, &mut state, &mut req, "weak").await?;
+        assert!(scores(&router, &mut state, &mut req).await?.is_empty());
 
         // A "strong" decision is retained — later turns latch onto it.
-        retain(&router, &mut state, &req, "strong").await?;
+        retain(&router, &mut state, &mut req, "strong").await?;
         assert_eq!(
-            scores(&router, &mut state, &req)
+            scores(&router, &mut state, &mut req)
                 .await?
                 .first()
                 .map(|s| s.target.as_str()),

--- a/crates/libsy/src/algorithms/util/stage_router.rs
+++ b/crates/libsy/src/algorithms/util/stage_router.rs
@@ -309,7 +309,7 @@ impl Classifier for StageClassifier {
     async fn score(
         &self,
         state: &mut State,
-        _request: &Request,
+        _request: &mut Request,
         _driver: Option<&Driver>,
     ) -> Result<Classification> {
         let tool_signals = &state.tool_signals;
@@ -471,7 +471,7 @@ mod tests {
         // (efficient_first → weak), recorded in `extra` for the caller.
         let mut state = State::default();
         let classification = StageClassifier::new(PickerMode::EfficientFirst, 0.5)
-            .score(&mut state, &Request::default(), None)
+            .score(&mut state, &mut Request::default(), None)
             .await?;
         match classification {
             Classification::Ambiguous(scores) => {
@@ -500,7 +500,7 @@ mod tests {
         };
         let mut state = state_with(signal);
         let classification = StageClassifier::new(PickerMode::EfficientFirst, 0.5)
-            .score(&mut state, &Request::default(), None)
+            .score(&mut state, &mut Request::default(), None)
             .await?;
         match classification {
             Classification::Scores(scores) => {
@@ -529,7 +529,7 @@ mod tests {
         };
         let mut state = state_with(signal);
         let classification = StageClassifier::new(PickerMode::EfficientFirst, 0.5)
-            .score(&mut state, &Request::default(), None)
+            .score(&mut state, &mut Request::default(), None)
             .await?;
         match classification {
             Classification::Scores(scores) => {
@@ -547,7 +547,7 @@ mod tests {
         // efficient (weak) tier, which is also stashed in `extra` for the caller.
         let mut state = state_with(ToolSignals::default());
         let classification = StageClassifier::new(PickerMode::EfficientFirst, 0.5)
-            .score(&mut state, &Request::default(), None)
+            .score(&mut state, &mut Request::default(), None)
             .await?;
         match classification {
             Classification::Ambiguous(scores) => {
@@ -573,7 +573,7 @@ mod tests {
         // proving the configured picker mode is used, not a hardcoded default.
         let mut state = state_with(ToolSignals::default());
         let classification = StageClassifier::new(PickerMode::CapableFirst, 0.5)
-            .score(&mut state, &Request::default(), None)
+            .score(&mut state, &mut Request::default(), None)
             .await?;
         match classification {
             Classification::Ambiguous(scores) => {

--- a/crates/libsy/src/algorithms/util/subagent.rs
+++ b/crates/libsy/src/algorithms/util/subagent.rs
@@ -42,7 +42,7 @@ impl Classifier for SubagentOverride {
     async fn score(
         &self,
         _state: &mut State,
-        request: &Request,
+        request: &mut Request,
         _driver: Option<&Driver>,
     ) -> Result<Classification> {
         // Delegated *work* only. A harness maintenance turn (e.g. Codex `compact`) carries
@@ -89,7 +89,7 @@ mod tests {
     async fn selected(headers: &[(&str, &str)]) -> Result<Option<String>> {
         let mut state = State::default();
         let classification = SubagentOverride::new("worker")
-            .score(&mut state, &request(headers), None)
+            .score(&mut state, &mut request(headers), None)
             .await?;
         Ok(classification.argmax(false)?.map(|score| score.target))
     }
@@ -139,7 +139,7 @@ mod tests {
         let classification = SubagentOverride::new("worker")
             .score(
                 &mut state,
-                &request(&[("x-openai-subagent", "review")]),
+                &mut request(&[("x-openai-subagent", "review")]),
                 None,
             )
             .await?;

--- a/crates/libsy/src/core/classifier.rs
+++ b/crates/libsy/src/core/classifier.rs
@@ -72,10 +72,16 @@ fn argmax(scores: &[Score]) -> Result<Option<Score>> {
 pub trait Classifier: Send + Sync {
     /// Score the classifier's targets given the current state and request.
     /// driver is optional. It is used to offload model calls
+    ///
+    /// `request` is borrowed mutably so a classifier may rewrite it in place — inject a
+    /// system prompt, drop tools, compact history. The edit is not scoped to this call:
+    /// later classifiers in the cascade score the rewritten request, and it is the
+    /// rewritten request that is finally sent to the selected model. Most classifiers
+    /// only read it.
     async fn score(
         &self,
         state: &mut State,
-        request: &Request,
+        request: &mut Request,
         driver: Option<&Driver>,
     ) -> Result<Classification>;
 }
@@ -171,7 +177,7 @@ mod tests {
         async fn score(
             &self,
             state: &mut State,
-            request: &Request,
+            request: &mut Request,
             _driver: Option<&Driver>,
         ) -> Result<Classification> {
             // Stash a marker in `extra` to prove state is threaded mutably.
@@ -187,20 +193,58 @@ mod tests {
     #[tokio::test]
     async fn classifier_reads_request_and_mutates_state() -> Result<()> {
         let mut state = State::default();
-        let request = Request {
+        let mut request = Request {
             llm_request: text_request(Some("strong".to_string()), "hi"),
             raw_request: None,
             metadata: None,
         };
         // A `None` driver is valid: the classifier scored without offloading a model call.
         let classification = RecordingClassifier
-            .score(&mut state, &request, None)
+            .score(&mut state, &mut request, None)
             .await?;
         assert_eq!(
             classification.argmax(false)?.map(|s| s.target),
             Some("strong".to_string())
         );
         assert!(matches!(state.extra.get("ran"), Some(StateValue::Count(1))));
+        Ok(())
+    }
+
+    /// Rewrites the request's model, then scores the rewritten value.
+    struct RewritingClassifier;
+
+    #[async_trait]
+    impl Classifier for RewritingClassifier {
+        async fn score(
+            &self,
+            _state: &mut State,
+            request: &mut Request,
+            _driver: Option<&Driver>,
+        ) -> Result<Classification> {
+            request.llm_request.model = Some("rewritten".to_string());
+            Ok(Classification::Scores(vec![Score {
+                target: "rewritten".to_string(),
+                confidence: 1.0,
+            }]))
+        }
+    }
+
+    #[tokio::test]
+    async fn classifier_rewrites_the_request_in_place() -> Result<()> {
+        let mut state = State::default();
+        let mut request = Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: None,
+        };
+
+        RewritingClassifier
+            .score(&mut state, &mut request, None)
+            .await?;
+
+        // The rewrite outlives the call: later classifiers in the cascade score this value,
+        // and it is what reaches the model.
+        assert_eq!(request.requested_model(), Some("rewritten"));
         Ok(())
     }
 }

--- a/crates/libsy/src/core/processor.rs
+++ b/crates/libsy/src/core/processor.rs
@@ -6,15 +6,19 @@ use async_trait::async_trait;
 use switchyard_protocol::{AggLlmResponse, Decision, Request, Signals};
 
 /// An event observed by the algorithm. Events are consumed by [`Processor`] to mutate [`State`]
+///
+/// The two request-bearing variants borrow the request mutably, so a processor may rewrite
+/// it in place and pass the rewritten request down the chain (see [`Processor::process`]).
+/// The observation-only variants stay immutable.
 pub enum Event<'a> {
     /// The inbound request that begins a turn.
-    Request(&'a Request),
+    Request(&'a mut Request),
     /// An out-of-band agentic-stack signal (tool results, budget updates, …).
     Signal(&'a Signals),
     /// A routing decision the algorithm just made.
     Decision(&'a dyn Decision),
     /// A request about to be sent to a model.
-    ModelRequest(&'a Request),
+    ModelRequest(&'a mut Request),
     /// A buffered response received back from a model.
     ModelResponse(&'a AggLlmResponse),
 }
@@ -23,6 +27,10 @@ pub enum Event<'a> {
 #[async_trait]
 pub trait Processor: Send + Sync {
     /// Process an event, accumulating facts into `state`.
+    ///
+    /// A request-bearing event ([`Event::Request`], [`Event::ModelRequest`]) may also be
+    /// rewritten in place; the edit propagates to the rest of the chain and to the model
+    /// call. Most processors only read it.
     async fn process(&self, state: &mut State, event: Event<'_>) -> Result<()>;
 }
 
@@ -95,15 +103,17 @@ mod tests {
     async fn processor_tallies_each_event_variant_into_state() -> Result<()> {
         let processor = CountingProcessor;
         let mut state = State::default();
-        let req = request();
+        let mut req = request();
         let response = text_response(None, "ok");
         let decision = TestDecision;
         let signals = Signals {};
 
         // Feed one of every event variant through the processor.
-        processor.process(&mut state, Event::Request(&req)).await?;
         processor
-            .process(&mut state, Event::ModelRequest(&req))
+            .process(&mut state, Event::Request(&mut req))
+            .await?;
+        processor
+            .process(&mut state, Event::ModelRequest(&mut req))
             .await?;
         processor
             .process(&mut state, Event::ModelResponse(&response))
@@ -127,13 +137,43 @@ mod tests {
     async fn process_accumulates_state_across_repeated_events() -> Result<()> {
         let processor = CountingProcessor;
         let mut state = State::default();
-        let req = request();
+        let mut req = request();
 
         for _ in 0..3 {
-            processor.process(&mut state, Event::Request(&req)).await?;
+            processor
+                .process(&mut state, Event::Request(&mut req))
+                .await?;
         }
 
         assert_eq!(count(&state, "requests"), 3);
+        Ok(())
+    }
+
+    /// Rewrites the requested model on every request-bearing event.
+    struct RewritingProcessor;
+
+    #[async_trait]
+    impl Processor for RewritingProcessor {
+        async fn process(&self, _state: &mut State, event: Event<'_>) -> Result<()> {
+            if let Event::Request(request) | Event::ModelRequest(request) = event {
+                request.llm_request.model = Some("rewritten".to_string());
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn processor_rewrites_the_request_in_place() -> Result<()> {
+        let mut state = State::default();
+        let mut req = request();
+        assert_eq!(req.requested_model(), Some("auto"));
+
+        RewritingProcessor
+            .process(&mut state, Event::Request(&mut req))
+            .await?;
+
+        // The edit outlives the call, so the next component sees the rewritten request.
+        assert_eq!(req.requested_model(), Some("rewritten"));
         Ok(())
     }
 }

--- a/crates/libsy/tests/subagent_affinity.rs
+++ b/crates/libsy/tests/subagent_affinity.rs
@@ -46,7 +46,7 @@ impl Classifier for AlwaysOrchestrator {
     async fn score(
         &self,
         _state: &mut State,
-        _request: &Request,
+        _request: &mut Request,
         _driver: Option<&Driver>,
     ) -> Result<Classification> {
         Ok(Classification::Scores(vec![Score {


### PR DESCRIPTION
## What

Makes `request` `mut` in `Classifier.score` and in `Event`

This is so that processors and Classifiers can mutate requests and the mutated request passes to the next clas / proc in the chain

Closes #

## How tested

- [ ] `uv run ruff check .` clean
- [ ] `uv run mypy switchyard` clean
- [ ] `uv run pytest tests/` green
- [ ] Manual smoke (describe what was run)

## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class.
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use.
- [ ] Unit tests added for new components / bug fixes.
- [ ] README / `--help` updated if customer-facing surface changed.
- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

Anything reviewers should pay extra attention to — risky paths, follow-up tickets, intentional trade-offs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request updates made during processing and classification now carry through to the final model call.
  * Routing classifiers can observe and rewrite requests before model selection.

* **Bug Fixes**
  * Ensured request changes remain consistent across the processing and classification chain.

* **Tests**
  * Added coverage confirming rewritten requests reach the selected model and remain visible throughout routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->