### PR TITLE
feat: task affinity based llm classifier with message hash fallback

### DIFF
--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -12,7 +12,7 @@ Build the targets, pick an algorithm, run a request:
 
 ```rust
 use switchyard_libsy::{Algorithm, Context, RoutedLlmClient, LlmTarget, Request};
-use switchyard_libsy::algorithms::LlmTaskClassifier;
+use switchyard_libsy::algorithms::{LlmTaskClassifier, TaskClassifierConfig};
 use switchyard_protocol::{completion_text, text_request};
 use std::sync::Arc;
 
@@ -21,7 +21,11 @@ let client = Arc::new(MyClient { /* .. */ }) as Arc<dyn RoutedLlmClient>;
 let target = |name: &str| LlmTarget { semantic_name: name.into(), llm_client: Some(client.clone()) };
 
 let algo: Arc<dyn Algorithm> = Arc::new(LlmTaskClassifier::new(
-    target("classifier"), target("weak"), target("strong"), 0.5,
+    target("classifier"),   // the judge
+    target("weak"),         // efficient tier
+    target("strong"),       // capable tier
+    // Every field but `base_threshold` has a default; see "Tuning the classifier" below.
+    TaskClassifierConfig { base_threshold: 0.5, ..Default::default() },
 )?);
 
 let req = Request {
@@ -220,8 +224,34 @@ pub trait Decision: Send + Sync {
 then invokes the selected target:
 
 ```rust
-let router = LlmTaskClassifier::new(judge_target, weak_target, strong_target, 0.5)?;
+let router = LlmTaskClassifier::new(
+    judge_target,
+    weak_target,
+    strong_target,
+    TaskClassifierConfig { base_threshold: 0.5, ..Default::default() },
+)?;
 ```
+
+### Tuning the classifier
+
+The judge returns a `p_solve` — its estimate that the efficient tier completes the task
+correctly — plus a confidence and a capability boundary. `TaskClassifierConfig` decides what
+to do with that verdict. Anything invalid, abstained, or below a threshold routes to the
+capable target, so every knob below trades cost against quality in the same direction.
+
+| Field | Default | Meaning |
+|---|---|---|
+| `base_threshold` | *required* | Lowest `p_solve` that routes a supported task to the efficient target. Raise it to send less traffic to the cheap model. |
+| `min_confidence` | `0.0` | Lowest judge confidence that permits efficient routing. `0.0` disables the gate. |
+| `capability_elevated_floor` | `None` | A higher `p_solve` floor applied only when the judge marks the task `uncertain`, `unsupported`, or `unmatched`. `None` reuses `base_threshold`. |
+| `session_affinity` | `false` | Retains the first decision per session and reuses it on later turns, so the judge is called once per session instead of once per turn. |
+| `message_hash_fallback` | `false` | Extends affinity to clients that send no session header, keying on a hash of the first user message. Requires `session_affinity`. |
+
+Two things to understand before enabling affinity. The retained decision is **sticky for the
+process lifetime** — including a fail-closed `capable` verdict produced when the judge was
+unreachable — so a transient judge failure pins that identity until restart. And
+`message_hash_fallback` keys on request *content*, not a correlation id, so unrelated callers
+sending identical text share one assignment.
 
 ## Errors
 

--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -8,11 +8,11 @@ so it drops into a proxy, gateway, or agent runtime.
 
 ## Example
 
-Build a target set, pick an algorithm, run a request:
+Build the targets, pick an algorithm, run a request:
 
 ```rust
-use switchyard_libsy::{Algorithm, Context, RoutedLlmClient, LlmTarget, LlmTargetSet, Request, State};
-use switchyard_libsy::algorithms::{FallThrough, LlmTaskClassifier};
+use switchyard_libsy::{Algorithm, Context, RoutedLlmClient, LlmTarget, Request};
+use switchyard_libsy::algorithms::LlmTaskClassifier;
 use switchyard_protocol::{completion_text, text_request};
 use std::sync::Arc;
 
@@ -20,15 +20,9 @@ use std::sync::Arc;
 let client = Arc::new(MyClient { /* .. */ }) as Arc<dyn RoutedLlmClient>;
 let target = |name: &str| LlmTarget { semantic_name: name.into(), llm_client: Some(client.clone()) };
 
-let classifier = target("classifier");
-let strong = target("strong");
-let weak = target("weak");
-let targets = LlmTargetSet::new(vec![strong.clone(), weak.clone()]);
-let algo: Arc<dyn Algorithm> = Arc::new(
-    FallThrough::<State>::new_with_state(targets).with_classifier(Arc::new(LlmTaskClassifier::new(
-        classifier, weak, strong, 0.5,
-    )?)),
-);
+let algo: Arc<dyn Algorithm> = Arc::new(LlmTaskClassifier::new(
+    target("classifier"), target("weak"), target("strong"), 0.5,
+)?);
 
 let req = Request {
     // `text_request` is the single-turn shortcut; build an `LlmRequest` directly for
@@ -222,13 +216,11 @@ pub trait Decision: Send + Sync {
 }
 ```
 
-Compose a classifier into `FallThrough`; the fall-through algorithm calls the judge,
-applies its policy, and then invokes the selected target:
+`LlmTaskClassifier` owns its fall-through cascade: it calls the judge, applies its policy, and
+then invokes the selected target:
 
 ```rust
-let classifier = LlmTaskClassifier::new(judge_target, weak_target, strong_target, 0.5)?;
-let router =
-    FallThrough::<State>::new_with_state(targets).with_classifier(Arc::new(classifier));
+let router = LlmTaskClassifier::new(judge_target, weak_target, strong_target, 0.5)?;
 ```
 
 ## Errors
@@ -301,8 +293,8 @@ agents live in [`examples`](examples/) folder.
 
 - [`Random`](src/algorithms/rand.rs) — uniform or weighted random over the set
   (one call).
-- [`LlmTaskClassifier`](src/algorithms/llm_class.rs) — capability judge for a
-  [`FallThrough`](src/algorithms/fall_through.rs) classifier cascade.
+- [`LlmTaskClassifier`](src/algorithms/llm_class.rs) — task-level capability routing with an
+  internal [`FallThrough`](src/algorithms/fall_through.rs) cascade.
 - [`EnsembleOrchAlgo`](examples/ensemble.rs) — stateful: fan out to
   candidates, judge the best, commit to the winner after N exploration turns.
 

--- a/crates/libsy/examples/research_agent.rs
+++ b/crates/libsy/examples/research_agent.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use switchyard_libsy::algorithms::LlmTaskClassifier;
+use switchyard_libsy::algorithms::{LlmTaskClassifier, TaskClassifierConfig};
 use switchyard_libsy::{
     Algorithm, Context, Decision, LibsyError, LlmResponse, LlmTarget, LlmTargetSet, Request,
     Response, Result, RoutedLlmClient,
@@ -25,7 +25,7 @@ const CLASSIFIER: &str = "classifier/model";
 const STRONG: &str = "strong/model";
 const WEAK: &str = "weak/model";
 /// Lowest judge-estimated solve probability that still routes to the weak model.
-const THRESHOLD: f64 = 0.5;
+const BASE_THRESHOLD: f64 = 0.5;
 
 /// Stub transport. Real integrators implement `RoutedLlmClient` over their own HTTP.
 struct StubClient;
@@ -102,8 +102,18 @@ async fn main() -> Result<()> {
     let classifier = target_set.get_target(CLASSIFIER)?;
     let weak = target_set.get_target(WEAK)?;
     let strong = target_set.get_target(STRONG)?;
-    let algo: Arc<dyn Algorithm> =
-        Arc::new(LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?);
+    let algo: Arc<dyn Algorithm> = Arc::new(LlmTaskClassifier::new(
+        classifier,
+        weak,
+        strong,
+        TaskClassifierConfig {
+            base_threshold: BASE_THRESHOLD,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+        },
+    )?);
 
     let agent = ResearchAgent { algo };
     println!("{}", agent.run("what is switchyard?").await?);

--- a/crates/libsy/examples/research_agent.rs
+++ b/crates/libsy/examples/research_agent.rs
@@ -6,7 +6,7 @@
 //! Every target owns an `RoutedLlmClient`, so the agent runs each request to completion with
 //! [`Algorithm::run`]: it serves each offloaded call with the routed
 //! target's `default_client` and returns the final response — no stream to drive. The
-//! classifier cascade runs inside `FallThrough`; the agent never sees it. To drive the step
+//! classifier cascade runs inside `LlmTaskClassifier`; the agent never sees it. To drive the step
 //! stream yourself instead, use
 //! `Algorithm::run_stream`. Run with:
 //!   cargo run -p libsy --example research_agent
@@ -14,10 +14,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use switchyard_libsy::algorithms::{FallThrough, LlmTaskClassifier};
+use switchyard_libsy::algorithms::LlmTaskClassifier;
 use switchyard_libsy::{
     Algorithm, Context, Decision, LibsyError, LlmResponse, LlmTarget, LlmTargetSet, Request,
-    Response, Result, RoutedLlmClient, State,
+    Response, Result, RoutedLlmClient,
 };
 use switchyard_protocol::{completion_text, text_request, text_response};
 
@@ -102,11 +102,8 @@ async fn main() -> Result<()> {
     let classifier = target_set.get_target(CLASSIFIER)?;
     let weak = target_set.get_target(WEAK)?;
     let strong = target_set.get_target(STRONG)?;
-    let algo: Arc<dyn Algorithm> = Arc::new(
-        FallThrough::<State>::new_with_state(target_set).with_classifier(Arc::new(
-            LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?,
-        )),
-    );
+    let algo: Arc<dyn Algorithm> =
+        Arc::new(LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?);
 
     let agent = ResearchAgent { algo };
     println!("{}", agent.run("what is switchyard?").await?);

--- a/crates/libsy/examples/research_agent_core.rs
+++ b/crates/libsy/examples/research_agent_core.rs
@@ -11,10 +11,10 @@
 
 use std::sync::Arc;
 
-use switchyard_libsy::algorithms::{FallThrough, LlmTaskClassifier};
+use switchyard_libsy::algorithms::LlmTaskClassifier;
 use switchyard_libsy::{
     Algorithm, Context, Decision, LibsyError, LlmResponse, LlmTarget, LlmTargetSet, Request,
-    Response, Result, State, Step,
+    Response, Result, Step,
 };
 use switchyard_protocol::{completion_text, text_request, text_response};
 use tokio_stream::StreamExt;
@@ -110,11 +110,8 @@ async fn main() -> Result<()> {
     let classifier = target_set.get_target(CLASSIFIER)?;
     let weak = target_set.get_target(WEAK)?;
     let strong = target_set.get_target(STRONG)?;
-    let algo: Arc<dyn Algorithm> = Arc::new(
-        FallThrough::<State>::new_with_state(target_set).with_classifier(Arc::new(
-            LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?,
-        )),
-    );
+    let algo: Arc<dyn Algorithm> =
+        Arc::new(LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?);
 
     let mut agent = ResearchAgent { algo };
     println!("{}", agent.run("what is switchyard?").await?);

--- a/crates/libsy/examples/research_agent_core.rs
+++ b/crates/libsy/examples/research_agent_core.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use switchyard_libsy::algorithms::LlmTaskClassifier;
+use switchyard_libsy::algorithms::{LlmTaskClassifier, TaskClassifierConfig};
 use switchyard_libsy::{
     Algorithm, Context, Decision, LibsyError, LlmResponse, LlmTarget, LlmTargetSet, Request,
     Response, Result, Step,
@@ -23,7 +23,7 @@ const CLASSIFIER: &str = "classifier/model";
 const STRONG: &str = "strong/model";
 const WEAK: &str = "weak/model";
 /// Lowest judge-estimated solve probability that still routes to the weak model.
-const THRESHOLD: f64 = 0.5;
+const BASE_THRESHOLD: f64 = 0.5;
 
 /// The "real" model call the agent makes to fulfill a promise. The core never
 /// makes the call itself — it hands back a request and waits for the response.
@@ -110,8 +110,18 @@ async fn main() -> Result<()> {
     let classifier = target_set.get_target(CLASSIFIER)?;
     let weak = target_set.get_target(WEAK)?;
     let strong = target_set.get_target(STRONG)?;
-    let algo: Arc<dyn Algorithm> =
-        Arc::new(LlmTaskClassifier::new(classifier, weak, strong, THRESHOLD)?);
+    let algo: Arc<dyn Algorithm> = Arc::new(LlmTaskClassifier::new(
+        classifier,
+        weak,
+        strong,
+        TaskClassifierConfig {
+            base_threshold: BASE_THRESHOLD,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+        },
+    )?);
 
     let mut agent = ResearchAgent { algo };
     println!("{}", agent.run("what is switchyard?").await?);

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -13,7 +13,7 @@ pub mod passthrough;
 pub mod rand;
 
 pub use fall_through::{FallThrough, FallThroughDecision};
-pub use llm_class::LlmTaskClassifier;
+pub use llm_class::{LlmTaskClassifier, TaskClassifierConfig};
 pub use noop::{Noop, NoopDecision};
 pub use passthrough::{Passthrough, PassthroughDecision};
 pub use rand::{Random, RandomClassifier, RandomDecision};

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -263,7 +263,6 @@ where
         self.execute(ctx, driver, request).await
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -24,19 +24,21 @@ use crate::{
 // TODO: As a first implementation, keeping the prompt and schema paths hardcoded. Add a way to dynamically load and parse user passed prompt and schema.
 const PROMPT_TEMPLATE: &str = include_str!("../prompts/capability-classifier/prompt.md");
 const SCHEMA_TEMPLATE: &str = include_str!("../prompts/capability-classifier/schema.json");
-// TODO: There can be more knobs to tune the classifier after its verdict is parsed. Add more later.
+/// Telemetry label for this algorithm's spans, metrics, and logs.
+const ALGORITHM_NAME: &str = "llm_task_classifier";
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 /// Parsed judge output. Only confidence, abstention, and solve probability affect v0 routing.
+/// These fields are parsed from the judge output and used to route the request.
+/// For supporting a new schema, we need to add a new Verdict struct and parse the new
 struct TaskClassifierVerdict {
     #[serde(rename = "recommended_route")]
     _recommended_route: String,
     p_solve: f64,
     confidence: f64,
     abstain: bool,
-    #[serde(rename = "capability_boundary")]
-    _capability_boundary: String,
+    capability_boundary: String,
     #[serde(rename = "primary_rule")]
     _primary_rule: String,
     #[serde(rename = "crux")]
@@ -47,10 +49,28 @@ impl TaskClassifierVerdict {
     /// Reject out-of-range probabilities before the policy can route efficiently. Range
     /// containment also rejects NaN and the infinities, which compare false against both bounds.
     fn is_valid(&self) -> bool {
-        (0.0..=1.0).contains(&self.p_solve) && (0.0..=1.0).contains(&self.confidence)
+        (0.0..=1.0).contains(&self.p_solve)
+            && (0.0..=1.0).contains(&self.confidence)
+            && matches!(
+                self.capability_boundary.as_str(),
+                "supported" | "uncertain" | "unsupported" | "unmatched"
+            )
+    }
+
+    /// Whether this verdict needs the elevated capability threshold.
+    /// When capability boundary is "uncertain", "unsupported", or "unmatched", we need to use the elevated capability threshold to route the request to weak model
+    /// This is to ensure that we are not routing too many requests to the weak model.
+    fn is_capability_elevated(&self) -> bool {
+        matches!(
+            self.capability_boundary.as_str(),
+            "uncertain" | "unsupported" | "unmatched"
+        )
     }
 }
 
+/// The judge is responsible for any kind of llm judge based calls
+/// Example: A judge can be a capability classifier, a escalation classifier etc
+/// Builds capability-specific judge requests from shared classifier configuration.
 struct CapabilityJudge {
     config: JudgeConfig,
 }
@@ -58,8 +78,11 @@ struct CapabilityJudge {
 impl Judge for CapabilityJudge {
     type Verdict = TaskClassifierVerdict;
 
+    /// For different judges, the request building logic can be different
+    /// To have a single interface for all judges, we may make a common request building logic here.
     fn build_request(&self, _state: &State, request: &Request) -> Request {
         // For task-based routing, classify only the newest user message with the judge prompt.
+        // For any turn window size setting, use TaskClassifierConfig to define the window size.
         let mut messages = request
             .llm_request
             .messages
@@ -92,20 +115,30 @@ impl Judge for CapabilityJudge {
 struct TaskClassifierPolicy {
     efficient_target: String,
     capable_target: String,
-    /// Lowest `p_solve` that still routes to the efficient target.
-    threshold: f64,
+    config: TaskClassifierConfig,
 }
 
 impl TaskClassifierPolicy {
     fn new(
         efficient_target: impl Into<String>,
         capable_target: impl Into<String>,
-        threshold: f64,
+        config: TaskClassifierConfig,
     ) -> Self {
         Self {
             efficient_target: efficient_target.into(),
             capable_target: capable_target.into(),
-            threshold,
+            config,
+        }
+    }
+
+    /// Returns the required solve probability for one validated verdict.
+    fn threshold(&self, verdict: &TaskClassifierVerdict) -> f64 {
+        if verdict.is_capability_elevated() {
+            self.config
+                .capability_elevated_floor
+                .unwrap_or(self.config.base_threshold)
+        } else {
+            self.config.base_threshold
         }
     }
 }
@@ -114,11 +147,14 @@ impl JudgePolicy for TaskClassifierPolicy {
     type Verdict = TaskClassifierVerdict;
 
     fn to_classification(&self, verdict: Option<&Self::Verdict>) -> Classification {
-        // Judge output is untrusted. Anything incomplete, invalid, abstained, or below the
-        // threshold routes to the capable target rather than risking an underpowered route.
+        // Judge output is untrusted. Anything incomplete, invalid, abstained, or below its
+        // configured confidence or capability threshold routes to the capable target.
         let target = match verdict {
             Some(verdict)
-                if verdict.is_valid() && !verdict.abstain && verdict.p_solve >= self.threshold =>
+                if verdict.is_valid()
+                    && !verdict.abstain
+                    && verdict.confidence >= self.config.min_confidence
+                    && verdict.p_solve >= self.threshold(verdict) =>
             {
                 &self.efficient_target
             }
@@ -131,6 +167,69 @@ impl JudgePolicy for TaskClassifierPolicy {
     }
 }
 
+#[derive(Clone, Debug, Default, Deserialize)]
+/// Thresholds that control capability classifier routing.
+pub struct TaskClassifierConfig {
+    /// Lowest solve probability that routes a supported task to the efficient target.
+    pub base_threshold: f64,
+    /// Lowest judge confidence that permits efficient routing.
+    #[serde(default)]
+    pub min_confidence: f64,
+    /// Higher solve-probability floor for uncertain, unmatched, and unsupported tasks.
+    #[serde(default)]
+    pub capability_elevated_floor: Option<f64>,
+    /// Enables session affinity before the judge-backed classifier.
+    #[serde(default)]
+    pub session_affinity: bool,
+    /// Uses the first user message as the SessionKey for sticky routing when session metadata is unavailable.
+    #[serde(default)]
+    pub message_hash_fallback: bool,
+}
+
+impl TaskClassifierConfig {
+    /// Validates routing thresholds before the classifier is constructed.
+    fn validate(&self) -> Result<()> {
+        if !(0.0..=1.0).contains(&self.base_threshold) {
+            return Err(LibsyError::AlgorithmError {
+                message: format!(
+                    "base_threshold must be between 0 and 1, got {}",
+                    self.base_threshold
+                ),
+            });
+        }
+        if !(0.0..=1.0).contains(&self.min_confidence) {
+            return Err(LibsyError::AlgorithmError {
+                message: format!(
+                    "min_confidence must be between 0 and 1, got {}",
+                    self.min_confidence
+                ),
+            });
+        }
+        if let Some(floor) = self.capability_elevated_floor {
+            if !(0.0..=1.0).contains(&floor) {
+                return Err(LibsyError::AlgorithmError {
+                    message: format!(
+                        "capability_elevated_floor must be between 0 and 1, got {floor}"
+                    ),
+                });
+            }
+            if floor <= self.base_threshold {
+                return Err(LibsyError::AlgorithmError {
+                    message: format!(
+                        "capability_elevated_floor must be greater than base_threshold, got {floor}"
+                    ),
+                });
+            }
+        }
+        if self.message_hash_fallback && !self.session_affinity {
+            return Err(LibsyError::AlgorithmError {
+                message: "message_hash_fallback requires session_affinity".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
 struct TaskClassifier {
     classifier: JudgeClassifier<CapabilityJudge, TaskClassifierPolicy>,
     efficient_target: String,
@@ -140,71 +239,57 @@ struct TaskClassifier {
 /// A task-level capability routing algorithm with an internal fall-through cascade.
 pub struct LlmTaskClassifier {
     route: FallThrough<State>,
-    targets: LlmTargetSet,
     classifier: Arc<TaskClassifier>,
 }
 
 impl LlmTaskClassifier {
-    /// Routes to `efficient_target` when the judge's `p_solve` reaches `threshold`; otherwise
-    /// routes to `capable_target`. Errors if `threshold` is outside `[0.0, 1.0]`.
+    /// Routes according to `config` and returns errors for invalid thresholds.
     pub fn new(
         judge_target: LlmTarget,
         efficient_target: LlmTarget,
         capable_target: LlmTarget,
-        threshold: f64,
+        config: TaskClassifierConfig,
     ) -> Result<Self> {
-        if !(0.0..=1.0).contains(&threshold) {
-            return Err(LibsyError::AlgorithmError {
-                message: format!("threshold must be between 0 and 1, got {threshold}"),
-            });
-        }
-        let judge = CapabilityJudge {
-            config: Self::load_judge_config()?,
-        };
+        config.validate()?;
+        let judge_config = Self::load_judge_config()?;
         let targets = LlmTargetSet::new(vec![efficient_target.clone(), capable_target.clone()]);
-        let efficient_target = efficient_target.semantic_name;
-        let capable_target = capable_target.semantic_name;
+        let session_affinity = config.session_affinity;
+        let message_hash_fallback = config.message_hash_fallback;
         let classifier = Arc::new(TaskClassifier {
             classifier: JudgeClassifier::new(
-                judge,
+                CapabilityJudge {
+                    config: judge_config,
+                },
                 judge_target,
                 TaskClassifierPolicy::new(
-                    efficient_target.clone(),
-                    capable_target.clone(),
-                    threshold,
+                    efficient_target.semantic_name.clone(),
+                    capable_target.semantic_name.clone(),
+                    config,
                 ),
             ),
-            efficient_target,
-            capable_target,
+            efficient_target: efficient_target.semantic_name,
+            capable_target: capable_target.semantic_name,
         });
-        // Added Fallthrough to the classifier so that it remains the internal implementation detail only
-        // Users just have to export the algorithm as a whole.
+
+        // The cascade is an internal detail: callers drive the algorithm, not its parts.
+        // Affinity comes first so a retained assignment short-circuits the judge call.
+        let mut route = FallThrough::<State>::new_with_state(targets).with_name(ALGORITHM_NAME);
+        if session_affinity {
+            let affinity = if message_hash_fallback {
+                AffinityRouter::new().with_message_hash_fallback()
+            } else {
+                AffinityRouter::new()
+            };
+            // Both roles must share one `Arc` so the classifier reads what the processor wrote.
+            let affinity = Arc::new(affinity);
+            route = route
+                .with_processor(affinity.clone())
+                .with_classifier(affinity);
+        }
         Ok(Self {
-            route: FallThrough::<State>::new_with_state(targets.clone())
-                .with_name("llm_task_classifier")
-                .with_classifier(classifier.clone()),
-            targets,
+            route: route.with_classifier(classifier.clone()),
             classifier,
         })
-    }
-
-    /// Adds session affinity before the judge-backed classifier.
-    ///
-    /// When `message_hash_fallback` is enabled, requests without a session header are keyed by
-    /// their latest user message.
-    pub fn with_affinity(self, message_hash_fallback: bool) -> Self {
-        let affinity = if message_hash_fallback {
-            AffinityRouter::new().with_message_hash_fallback()
-        } else {
-            AffinityRouter::new()
-        };
-        let affinity = Arc::new(affinity);
-        let route = FallThrough::<State>::new_with_state(self.targets.clone())
-            .with_name("llm_task_classifier")
-            .with_processor(affinity.clone())
-            .with_classifier(affinity)
-            .with_classifier(self.classifier.clone());
-        Self { route, ..self }
     }
 
     /// Loads the judge configuration from the packaged prompt and schema.
@@ -306,8 +391,18 @@ mod tests {
 
     const TEST_THRESHOLD: f64 = 0.5;
 
+    fn test_config(base_threshold: f64) -> TaskClassifierConfig {
+        TaskClassifierConfig {
+            base_threshold,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+        }
+    }
+
     fn policy() -> TaskClassifierPolicy {
-        TaskClassifierPolicy::new("efficient", "capable", TEST_THRESHOLD)
+        TaskClassifierPolicy::new("efficient", "capable", test_config(TEST_THRESHOLD))
     }
 
     /// A verdict whose non-routing fields are fixed — only the three the policy reads vary.
@@ -317,7 +412,7 @@ mod tests {
             p_solve,
             confidence,
             abstain,
-            _capability_boundary: "supported".to_string(),
+            capability_boundary: "supported".to_string(),
             _primary_rule: "SUP-1".to_string(),
             _crux: "test crux".to_string(),
         }
@@ -401,7 +496,7 @@ mod tests {
             target("judge"),
             target("efficient"),
             target("capable"),
-            TEST_THRESHOLD,
+            test_config(TEST_THRESHOLD),
         )?))
     }
 
@@ -424,6 +519,19 @@ mod tests {
             }),
             ..classify_request()
         }
+    }
+
+    fn classify_follow_up_request() -> Request {
+        let mut request = classify_request();
+        request
+            .llm_request
+            .messages
+            .push(Message::text(Role::Assistant, "I will add the test."));
+        request.llm_request.messages.push(Message::text(
+            Role::User,
+            "Now run the test suite and report the result.",
+        ));
+        request
     }
 
     #[tokio::test]
@@ -457,22 +565,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn affinity_reuses_the_first_session_decision_without_a_second_judge_call() -> Result<()>
-    {
+    async fn classifier_config_enables_session_affinity() -> Result<()> {
         let client = Arc::new(PerRequestClient::default());
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
         };
-        let router = Arc::new(
-            LlmTaskClassifier::new(
-                target("judge"),
-                target("efficient"),
-                target("capable"),
-                TEST_THRESHOLD,
-            )?
-            .with_affinity(false),
-        );
+        let router = Arc::new(LlmTaskClassifier::new(
+            target("judge"),
+            target("efficient"),
+            target("capable"),
+            TaskClassifierConfig {
+                session_affinity: true,
+                ..test_config(TEST_THRESHOLD)
+            },
+        )?);
 
         router
             .clone()
@@ -488,21 +595,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn message_hash_fallback_reuses_a_task_without_session_metadata() -> Result<()> {
+    async fn classifier_config_reuses_message_hash_affinity_for_a_follow_up() -> Result<()> {
         let client = Arc::new(PerRequestClient::default());
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
         };
-        let router = Arc::new(
-            LlmTaskClassifier::new(
-                target("judge"),
-                target("efficient"),
-                target("capable"),
-                TEST_THRESHOLD,
-            )?
-            .with_affinity(true),
-        );
+        let router = Arc::new(LlmTaskClassifier::new(
+            target("judge"),
+            target("efficient"),
+            target("capable"),
+            TaskClassifierConfig {
+                session_affinity: true,
+                message_hash_fallback: true,
+                ..test_config(TEST_THRESHOLD)
+            },
+        )?);
 
         router
             .clone()
@@ -510,7 +618,7 @@ mod tests {
             .await?;
         router
             .clone()
-            .run(Context::default(), classify_request())
+            .run(Context::default(), classify_follow_up_request())
             .await?;
 
         assert_eq!(client.calls(), vec!["judge", "efficient", "efficient"]);
@@ -530,27 +638,60 @@ mod tests {
     #[test]
     fn the_threshold_moves_the_routing_boundary() -> Result<()> {
         let borderline = verdict(0.5, 1.0, false);
-        let strict = TaskClassifierPolicy::new("efficient", "capable", 0.9);
-        let lenient = TaskClassifierPolicy::new("efficient", "capable", 0.1);
+        let strict = TaskClassifierPolicy::new("efficient", "capable", test_config(0.9));
+        let lenient = TaskClassifierPolicy::new("efficient", "capable", test_config(0.1));
         assert_eq!(selected(&strict, Some(&borderline))?, "capable");
         assert_eq!(selected(&lenient, Some(&borderline))?, "efficient");
         Ok(())
     }
 
     #[test]
-    fn an_out_of_range_threshold_is_rejected() -> Result<()> {
+    fn invalid_classifier_config_is_rejected() -> Result<()> {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: None,
         };
         for bad in [1.5, -0.1, f64::NAN, f64::INFINITY] {
             assert!(
-                LlmTaskClassifier::new(target("judge"), target("e"), target("c"), bad).is_err(),
-                "threshold {bad} should be rejected"
+                LlmTaskClassifier::new(
+                    target("judge"),
+                    target("e"),
+                    target("c"),
+                    test_config(bad),
+                )
+                .is_err(),
+                "base threshold {bad} should be rejected"
             );
         }
-        LlmTaskClassifier::new(target("judge"), target("e"), target("c"), 0.0)?;
-        LlmTaskClassifier::new(target("judge"), target("e"), target("c"), 1.0)?;
+        for config in [
+            TaskClassifierConfig {
+                base_threshold: 0.5,
+                min_confidence: 1.1,
+                capability_elevated_floor: None,
+                session_affinity: false,
+                message_hash_fallback: false,
+            },
+            TaskClassifierConfig {
+                base_threshold: 0.5,
+                min_confidence: 0.0,
+                capability_elevated_floor: Some(0.5),
+                session_affinity: false,
+                message_hash_fallback: false,
+            },
+            TaskClassifierConfig {
+                base_threshold: 0.5,
+                min_confidence: 0.0,
+                capability_elevated_floor: None,
+                session_affinity: false,
+                message_hash_fallback: true,
+            },
+        ] {
+            assert!(
+                LlmTaskClassifier::new(target("judge"), target("e"), target("c"), config).is_err()
+            );
+        }
+        LlmTaskClassifier::new(target("judge"), target("e"), target("c"), test_config(0.0))?;
+        LlmTaskClassifier::new(target("judge"), target("e"), target("c"), test_config(1.0))?;
         Ok(())
     }
 
@@ -559,9 +700,40 @@ mod tests {
         let policy = policy();
         let invalid_probability = verdict(1.1, 1.0, false);
         let abstained = verdict(1.0, 1.0, true);
+        let invalid_boundary = TaskClassifierVerdict {
+            capability_boundary: "unknown".to_string(),
+            ..verdict(1.0, 1.0, false)
+        };
         assert_eq!(selected(&policy, Some(&invalid_probability))?, "capable");
         assert_eq!(selected(&policy, Some(&abstained))?, "capable");
+        assert_eq!(selected(&policy, Some(&invalid_boundary))?, "capable");
         assert_eq!(selected(&policy, None)?, "capable");
+        Ok(())
+    }
+
+    #[test]
+    fn elevated_capability_floor_is_a_targeted_safety_brake() -> Result<()> {
+        let policy = TaskClassifierPolicy::new(
+            "efficient",
+            "capable",
+            TaskClassifierConfig {
+                capability_elevated_floor: Some(0.45),
+                ..test_config(0.25)
+            },
+        );
+        let supported = verdict(0.30, 1.0, false);
+        let elevated = TaskClassifierVerdict {
+            capability_boundary: "uncertain".to_string(),
+            ..verdict(0.30, 1.0, false)
+        };
+        let strong_elevated = TaskClassifierVerdict {
+            capability_boundary: "unsupported".to_string(),
+            ..verdict(0.50, 1.0, false)
+        };
+
+        assert_eq!(selected(&policy, Some(&supported))?, "efficient");
+        assert_eq!(selected(&policy, Some(&elevated))?, "capable");
+        assert_eq!(selected(&policy, Some(&strong_elevated))?, "efficient");
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -1,20 +1,24 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Capability routing with a judge-backed classifier.
+//! Task-level capability routing with a judge-backed classifier.
 //!
-//! The classifier judges the full inbound request and emits one decisive target for a
-//! [`FallThrough`](super::FallThrough) cascade. Invalid, abstained, or unavailable judge output
-//! always selects the capable target.
+//! The algorithm owns a [`FallThrough`](super::FallThrough) cascade. Its classifier judges the
+//! full inbound request and selects one decisive target. Invalid, abstained, or unavailable judge
+//! output always selects the capable target.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
 use switchyard_protocol::{LlmRequest, Message, OutputParams, Role};
 
-use super::util::{Judge, JudgeClassifier, JudgeConfig, JudgePolicy};
+use super::util::{AffinityRouter, Judge, JudgeClassifier, JudgeConfig, JudgePolicy};
+use super::FallThrough;
 use crate::{
-    Classification, Classifier, Driver, LibsyError, LlmTarget, Request, Result, Score, State,
+    Algorithm, Classification, Classifier, Context, Driver, LibsyError, LlmTarget, LlmTargetSet,
+    Request, Response, Result, RoutedLlmClient, Score, State,
 };
 
 // TODO: As a first implementation, keeping the prompt and schema paths hardcoded. Add a way to dynamically load and parse user passed prompt and schema.
@@ -162,16 +166,22 @@ impl JudgePolicy for TaskClassifierPolicy {
     }
 }
 
-/// A full-request capability classifier configured with the packaged prompt and schema.
-pub struct LlmTaskClassifier {
+struct TaskClassifier {
     classifier: JudgeClassifier<CapabilityJudge, TaskClassifierPolicy>,
     efficient_target: String,
     capable_target: String,
 }
 
+/// A task-level capability routing algorithm with an internal fall-through cascade.
+pub struct LlmTaskClassifier {
+    route: FallThrough<State>,
+    targets: LlmTargetSet,
+    classifier: Arc<TaskClassifier>,
+}
+
 impl LlmTaskClassifier {
-    /// Selects `efficient_target` when the judge's `p_solve` reaches `threshold`, and
-    /// `capable_target` otherwise. Errors if `threshold` is outside `[0.0, 1.0]`.
+    /// Routes to `efficient_target` when the judge's `p_solve` reaches `threshold`; otherwise
+    /// routes to `capable_target`. Errors if `threshold` is outside `[0.0, 1.0]`.
     pub fn new(
         judge_target: LlmTarget,
         efficient_target: LlmTarget,
@@ -186,9 +196,10 @@ impl LlmTaskClassifier {
         let judge = CapabilityJudge {
             config: Self::load_judge_config()?,
         };
+        let targets = LlmTargetSet::new(vec![efficient_target.clone(), capable_target.clone()]);
         let efficient_target = efficient_target.semantic_name;
         let capable_target = capable_target.semantic_name;
-        Ok(Self {
+        let classifier = Arc::new(TaskClassifier {
             classifier: JudgeClassifier::new(
                 judge,
                 judge_target,
@@ -200,7 +211,35 @@ impl LlmTaskClassifier {
             ),
             efficient_target,
             capable_target,
+        });
+        // Added Fallthrough to the classifier so that it remains the internal implementation detail only
+        // Users just have to export the algorithm as a whole.
+        Ok(Self {
+            route: FallThrough::<State>::new_with_state(targets.clone())
+                .with_name("llm_task_classifier")
+                .with_classifier(classifier.clone()),
+            targets,
+            classifier,
         })
+    }
+
+    /// Adds session affinity before the judge-backed classifier.
+    ///
+    /// When `message_hash_fallback` is enabled, requests without a session header are keyed by
+    /// their stable system/developer and first-user-message prefix.
+    pub fn with_affinity(self, message_hash_fallback: bool) -> Self {
+        let affinity = if message_hash_fallback {
+            AffinityRouter::new().with_message_hash_fallback()
+        } else {
+            AffinityRouter::new()
+        };
+        let affinity = Arc::new(affinity);
+        let route = FallThrough::<State>::new_with_state(self.targets.clone())
+            .with_name("llm_task_classifier")
+            .with_processor(affinity.clone())
+            .with_classifier(affinity)
+            .with_classifier(self.classifier.clone());
+        Self { route, ..self }
     }
 
     /// Loads the judge configuration from the packaged prompt and schema.
@@ -230,7 +269,7 @@ impl LlmTaskClassifier {
 }
 
 #[async_trait]
-impl Classifier<State> for LlmTaskClassifier {
+impl Classifier<State> for TaskClassifier {
     fn routing_tier(&self, selected_model: &str) -> Option<&'static str> {
         if self.efficient_target == self.capable_target {
             None
@@ -253,6 +292,42 @@ impl Classifier<State> for LlmTaskClassifier {
     }
 }
 
+#[async_trait]
+impl Classifier<State> for LlmTaskClassifier {
+    fn routing_tier(&self, selected_model: &str) -> Option<&'static str> {
+        self.classifier.routing_tier(selected_model)
+    }
+
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &mut Request,
+        driver: Option<&Driver>,
+    ) -> Result<Classification> {
+        self.classifier.score(state, request, driver).await
+    }
+}
+
+#[async_trait]
+impl Algorithm for LlmTaskClassifier {
+    fn name(&self) -> &str {
+        "llm_task_classifier"
+    }
+
+    fn count_tokens_client(&self) -> Option<Arc<dyn RoutedLlmClient>> {
+        self.route.count_tokens_client()
+    }
+
+    async fn create_run_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Response> {
+        self.route.execute(ctx, driver, request).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -260,9 +335,9 @@ mod tests {
     use parking_lot::Mutex;
 
     use super::*;
-    use switchyard_protocol::{completion_text, text_response, LlmClientError};
+    use switchyard_protocol::{completion_text, text_response, LlmClientError, Metadata};
 
-    use crate::{Algorithm, Context, LlmResponse, LlmTargetSet, Response, RoutedLlmClient};
+    use crate::{Algorithm, Context, LlmResponse, Response, RoutedLlmClient};
 
     const TEST_THRESHOLD: f64 = 0.5;
 
@@ -352,19 +427,17 @@ mod tests {
         }
     }
 
-    fn router(client: Arc<dyn RoutedLlmClient>) -> Result<Arc<super::super::FallThrough<State>>> {
+    fn router(client: Arc<dyn RoutedLlmClient>) -> Result<Arc<LlmTaskClassifier>> {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
         };
-        let targets = LlmTargetSet::new(vec![target("efficient"), target("capable")]);
-        let efficient = targets.get_target("efficient")?;
-        let capable = targets.get_target("capable")?;
-        Ok(Arc::new(
-            super::super::FallThrough::<State>::new_with_state(targets).with_classifier(Arc::new(
-                LlmTaskClassifier::new(target("judge"), efficient, capable, TEST_THRESHOLD)?,
-            )),
-        ))
+        Ok(Arc::new(LlmTaskClassifier::new(
+            target("judge"),
+            target("efficient"),
+            target("capable"),
+            TEST_THRESHOLD,
+        )?))
     }
 
     fn classify_request() -> Request {
@@ -375,6 +448,16 @@ mod tests {
             ),
             raw_request: None,
             metadata: None,
+        }
+    }
+
+    fn classify_session_request() -> Request {
+        Request {
+            metadata: Some(Metadata {
+                session_id: Some("session-1".to_string()),
+                ..Metadata::default()
+            }),
+            ..classify_request()
         }
     }
 
@@ -405,6 +488,67 @@ mod tests {
             client.calls(),
             vec!["judge", "efficient", "judge", "efficient"]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn affinity_reuses_the_first_session_decision_without_a_second_judge_call() -> Result<()>
+    {
+        let client = Arc::new(PerRequestClient::default());
+        let target = |name: &str| LlmTarget {
+            semantic_name: name.to_string(),
+            llm_client: Some(client.clone()),
+        };
+        let router = Arc::new(
+            LlmTaskClassifier::new(
+                target("judge"),
+                target("efficient"),
+                target("capable"),
+                TEST_THRESHOLD,
+            )?
+            .with_affinity(false),
+        );
+
+        router
+            .clone()
+            .run(Context::default(), classify_session_request())
+            .await?;
+        router
+            .clone()
+            .run(Context::default(), classify_session_request())
+            .await?;
+
+        assert_eq!(client.calls(), vec!["judge", "efficient", "efficient"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn message_hash_fallback_reuses_a_task_without_session_metadata() -> Result<()> {
+        let client = Arc::new(PerRequestClient::default());
+        let target = |name: &str| LlmTarget {
+            semantic_name: name.to_string(),
+            llm_client: Some(client.clone()),
+        };
+        let router = Arc::new(
+            LlmTaskClassifier::new(
+                target("judge"),
+                target("efficient"),
+                target("capable"),
+                TEST_THRESHOLD,
+            )?
+            .with_affinity(true),
+        );
+
+        router
+            .clone()
+            .run(Context::default(), classify_request())
+            .await?;
+        router
+            .clone()
+            .run(Context::default(), classify_request())
+            .await?;
+
+        assert_eq!(client.calls(), vec!["judge", "efficient", "efficient"]);
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -25,7 +25,6 @@ use crate::{
 const PROMPT_TEMPLATE: &str = include_str!("../prompts/capability-classifier/prompt.md");
 const SCHEMA_TEMPLATE: &str = include_str!("../prompts/capability-classifier/schema.json");
 // TODO: There can be more knobs to tune the classifier after its verdict is parsed. Add more later.
-const RECENT_MESSAGE_WINDOW: usize = 5;
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -52,48 +51,6 @@ impl TaskClassifierVerdict {
     }
 }
 
-/// Keeps client instructions, the initial task, and bounded recent dialogue for the judge.
-fn trim_messages(messages: &[Message], recent_turn_window: usize) -> Vec<Message> {
-    let mut system = Vec::new();
-    let mut first_user = None;
-    let mut first_user_idx = None;
-    for (idx, message) in messages.iter().enumerate() {
-        match message.role {
-            Role::System | Role::Developer => system.push(message.clone()),
-            Role::User if first_user.is_none() => {
-                first_user = Some(message.clone());
-                first_user_idx = Some(idx);
-            }
-            _ => {}
-        }
-    }
-    let Some(first_user) = first_user else {
-        return system;
-    };
-    let tail = messages
-        .iter()
-        .enumerate()
-        .filter(|(idx, message)| {
-            *idx > first_user_idx.unwrap_or(0)
-                && !matches!(message.role, Role::System | Role::Developer)
-        })
-        .map(|(_, message)| message.clone())
-        .collect::<Vec<_>>();
-    if recent_turn_window == 0 {
-        let mut out = system;
-        out.push(first_user);
-        if let Some(last_user) = tail.iter().rev().find(|message| message.role == Role::User) {
-            out.push(last_user.clone());
-        }
-        return out;
-    }
-    let mut out = system;
-    out.push(first_user);
-    let start = tail.len().saturating_sub(recent_turn_window);
-    out.extend_from_slice(&tail[start..]);
-    out
-}
-
 struct CapabilityJudge {
     config: JudgeConfig,
 }
@@ -102,8 +59,16 @@ impl Judge for CapabilityJudge {
     type Verdict = TaskClassifierVerdict;
 
     fn build_request(&self, _state: &State, request: &Request) -> Request {
-        // The judge owns the leading system prompt; client instructions and task context follow.
-        let mut messages = trim_messages(&request.llm_request.messages, RECENT_MESSAGE_WINDOW);
+        // For task-based routing, classify only the newest user message with the judge prompt.
+        let mut messages = request
+            .llm_request
+            .messages
+            .iter()
+            .rev()
+            .find(|message| message.role == Role::User)
+            .cloned()
+            .into_iter()
+            .collect::<Vec<_>>();
         messages.insert(
             0,
             Message::text(Role::System, self.config.system_prompt.clone()),
@@ -226,7 +191,7 @@ impl LlmTaskClassifier {
     /// Adds session affinity before the judge-backed classifier.
     ///
     /// When `message_hash_fallback` is enabled, requests without a session header are keyed by
-    /// their stable system/developer and first-user-message prefix.
+    /// their latest user message.
     pub fn with_affinity(self, message_hash_fallback: bool) -> Self {
         let affinity = if message_hash_fallback {
             AffinityRouter::new().with_message_hash_fallback()
@@ -628,23 +593,17 @@ mod tests {
         let judge_request = judge.build_request(&State::default(), &request);
 
         assert_eq!(judge_request.llm_request.model, request.llm_request.model);
-        assert_eq!(
-            judge_request.llm_request.messages.len(),
-            RECENT_MESSAGE_WINDOW + 4
-        );
+        assert_eq!(judge_request.llm_request.messages.len(), 2);
         let contents = judge_request
             .llm_request
             .messages
             .iter()
             .filter_map(|message| message.text_content("\n"))
             .collect::<Vec<_>>();
-        assert!(contents.contains(&"initial task".to_string()));
-        assert!(contents.contains(&"recent 1".to_string()));
-        assert!(contents.contains(&"recent 5".to_string()));
-        assert!(contents.contains(&"client instructions".to_string()));
-        assert!(contents.contains(&"client developer instructions".to_string()));
-        assert!(!contents.contains(&"old response".to_string()));
-        assert!(!contents.contains(&"old follow-up".to_string()));
+        assert!(contents.contains(&"recent 4".to_string()));
+        assert!(!contents.contains(&"initial task".to_string()));
+        assert!(!contents.contains(&"recent 5".to_string()));
+        assert!(!contents.contains(&"client instructions".to_string()));
         assert_eq!(
             judge_request.llm_request.output.response_format,
             judge.config.response_schema

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -83,7 +83,7 @@ impl AffinityRouter {
         }
     }
 
-    /// Uses a stable system/developer and first-user-message hash when metadata has no session.
+    /// Uses the latest user-message text as a fallback key when metadata has no session.
     pub fn with_message_hash_fallback(mut self) -> Self {
         self.message_hash_fallback = true;
         self
@@ -127,7 +127,7 @@ impl AffinityRouter {
             .is_some_and(|metadata| metadata.is_subagent);
         (!self.subagents_only && !is_subagent && self.message_hash_fallback)
             .then(|| {
-                message_hash(request).map(|hash| {
+                last_user_message_hash(request).map(|hash| {
                     tracing::debug!(affinity_key = %hash, "affinity using message hash fallback");
                     AffinityKey::Session(hash)
                 })
@@ -156,30 +156,19 @@ where
     }
 }
 
-/// Hashes the stable prefix shared by every turn of one task.
-fn message_hash(request: &Request) -> Option<String> {
-    let mut hasher = DefaultHasher::new();
-    for instruction in request
+/// Hashes the newest user message for task-based fallback affinity.
+/// For benchmarking purpose with harnesses, task instructions are added as a user prompt to the request so we need to hash the latest user message.
+/// TODO: Have not considered multi-modal payloads yet. That needs to be handled separately.
+fn last_user_message_hash(request: &Request) -> Option<String> {
+    let message = request
         .llm_request
-        .instructions
+        .messages
         .iter()
-        .filter(|instruction| matches!(instruction.role, Role::System | Role::Developer))
-    {
-        serde_json::to_string(instruction).ok()?.hash(&mut hasher);
-    }
-    for message in &request.llm_request.messages {
-        match message.role {
-            Role::System | Role::Developer => {
-                serde_json::to_string(message).ok()?.hash(&mut hasher);
-            }
-            Role::User => {
-                serde_json::to_string(message).ok()?.hash(&mut hasher);
-                return Some(format!("{:016x}", hasher.finish()));
-            }
-            _ => {}
-        }
-    }
-    None
+        .rev()
+        .find(|message| message.role == Role::User)?;
+    let mut hasher = DefaultHasher::new();
+    message.text_content("")?.hash(&mut hasher);
+    Some(format!("{:016x}", hasher.finish()))
 }
 
 #[async_trait]
@@ -222,7 +211,9 @@ mod tests {
 
     use std::sync::Arc;
 
-    use switchyard_protocol::{text_request, Decision, LlmRequest, Message, Metadata};
+    use switchyard_protocol::{
+        text_request, ContentBlock, Decision, LlmRequest, Message, Metadata,
+    };
 
     /// Boxed, thread-safe error type keeping the test helpers ergonomic.
     type BoxErr = Box<dyn std::error::Error + Send + Sync>;
@@ -450,26 +441,69 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn message_hash_fallback_retains_a_task_across_turns() -> Result<(), BoxErr> {
+    async fn message_hash_fallback_uses_the_latest_user_message() -> Result<(), BoxErr> {
         let router = AffinityRouter::new().with_message_hash_fallback();
         let mut state = ();
 
-        let mut first = task_request(None, "Add a unit test for this function.", None);
+        let mut first = task_request(
+            None,
+            "Add a unit test for this function.",
+            Some("Now run the test suite."),
+        );
         retain(&router, &mut state, &mut first, "weak").await?;
 
-        let mut follow_up = task_request(
+        let mut same_turn = task_request(
             None,
             "Add a unit test for this function.",
             Some("Now run the test suite."),
         );
         assert_eq!(
-            scores(&router, &mut state, &mut follow_up)
+            scores(&router, &mut state, &mut same_turn)
                 .await?
                 .first()
                 .map(|score| score.target.as_str()),
             Some("weak")
         );
+
+        let mut next_turn = task_request(
+            None,
+            "Add a unit test for this function.",
+            Some("Now file a pull request."),
+        );
+        assert!(scores(&router, &mut state, &mut next_turn)
+            .await?
+            .is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn user_message_hash_ignores_non_text_provider_payloads() {
+        let request = |user_message| Request {
+            llm_request: LlmRequest {
+                messages: vec![user_message],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        };
+        let text_only = request(Message::text(Role::User, "Implement the parser."));
+        let text_with_reasoning = request(Message {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "Implement the parser.".to_string(),
+                },
+                ContentBlock::Reasoning {
+                    text: "Internal provider reasoning.".to_string(),
+                    signature: Some("provider-signature".to_string()),
+                },
+            ],
+        });
+
+        assert_eq!(
+            last_user_message_hash(&text_only),
+            last_user_message_hash(&text_with_reasoning)
+        );
     }
 
     #[tokio::test]

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -17,11 +17,12 @@
 //! session. [`AffinityRouter::for_subagents`] narrows affinity to explicitly identified
 //! child agents, leaving root traffic to later classifiers on every turn.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use switchyard_protocol::Request;
+use switchyard_protocol::{Request, Role};
 
 use crate::{Classification, Classifier, Event, Processor, Score};
 
@@ -57,6 +58,8 @@ pub struct AffinityRouter {
     latch_only: Option<HashSet<String>>,
     /// Whether root-session requests should abstain instead of being retained.
     subagents_only: bool,
+    /// In absence of headers, use the message hash based fallback key to do task based routing
+    message_hash_fallback: bool,
     /// Retained assignments, shared across this router's processor and classifier roles.
     ///
     /// Held on the instance so the two roles share one process-local map through a
@@ -80,6 +83,12 @@ impl AffinityRouter {
         }
     }
 
+    /// Uses a stable system/developer and first-user-message hash when metadata has no session.
+    pub fn with_message_hash_fallback(mut self) -> Self {
+        self.message_hash_fallback = true;
+        self
+    }
+
     /// Restricts latching to `models`; a decision for any other model routes but is not
     /// retained.
     pub fn with_latch_only(mut self, models: impl IntoIterator<Item = impl Into<String>>) -> Self {
@@ -96,18 +105,32 @@ impl AffinityRouter {
 
     /// Derives the stable identity this router should retain for `request`.
     fn affinity_key(&self, request: &Request) -> Option<AffinityKey> {
-        let metadata = request.metadata.as_ref()?;
-        let session = metadata.session_id.clone()?;
-        if metadata.is_subagent {
-            Some(AffinityKey::Subagent {
-                session,
-                agent: metadata.agent_id.clone()?,
-            })
-        } else if self.subagents_only {
-            None
-        } else {
-            Some(AffinityKey::Session(session))
+        if let Some(metadata) = request.metadata.as_ref() {
+            if let Some(session) = metadata.session_id.clone() {
+                return if metadata.is_subagent {
+                    metadata
+                        .agent_id
+                        .clone()
+                        .map(|agent| AffinityKey::Subagent { session, agent })
+                } else if self.subagents_only {
+                    None
+                } else {
+                    Some(AffinityKey::Session(session))
+                };
+            }
         }
+        let is_subagent = request
+            .metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.is_subagent);
+        (!self.subagents_only && !is_subagent && self.message_hash_fallback)
+            .then(|| {
+                message_hash(request).map(|hash| {
+                    tracing::debug!(affinity_key = %hash, "affinity using message hash fallback");
+                    AffinityKey::Session(hash)
+                })
+            })
+            .flatten()
     }
 }
 
@@ -129,6 +152,32 @@ where
         }
         Ok(())
     }
+}
+
+/// Hashes the stable prefix shared by every turn of one task.
+fn message_hash(request: &Request) -> Option<String> {
+    let mut hasher = DefaultHasher::new();
+    for instruction in request
+        .llm_request
+        .instructions
+        .iter()
+        .filter(|instruction| matches!(instruction.role, Role::System | Role::Developer))
+    {
+        serde_json::to_string(instruction).ok()?.hash(&mut hasher);
+    }
+    for message in &request.llm_request.messages {
+        match message.role {
+            Role::System | Role::Developer => {
+                serde_json::to_string(message).ok()?.hash(&mut hasher);
+            }
+            Role::User => {
+                serde_json::to_string(message).ok()?.hash(&mut hasher);
+                return Some(format!("{:016x}", hasher.finish()));
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 #[async_trait]
@@ -171,7 +220,7 @@ mod tests {
 
     use std::sync::Arc;
 
-    use switchyard_protocol::{text_request, Decision, Metadata};
+    use switchyard_protocol::{text_request, Decision, LlmRequest, Message, Metadata};
 
     /// Boxed, thread-safe error type keeping the test helpers ergonomic.
     type BoxErr = Box<dyn std::error::Error + Send + Sync>;
@@ -201,6 +250,30 @@ mod tests {
         }
     }
 
+    fn task_request(
+        metadata: Option<Metadata>,
+        first_user: &str,
+        follow_up: Option<&str>,
+    ) -> Request {
+        let mut messages = vec![
+            Message::text(Role::System, "follow repository instructions"),
+            Message::text(Role::User, first_user),
+        ];
+        if let Some(follow_up) = follow_up {
+            messages.push(Message::text(Role::Assistant, "I will inspect the code."));
+            messages.push(Message::text(Role::User, follow_up));
+        }
+        Request {
+            llm_request: LlmRequest {
+                model: Some("auto".to_string()),
+                messages,
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata,
+        }
+    }
+
     fn session(session_id: &str, agent_id: &str) -> Metadata {
         Metadata {
             session_id: Some(session_id.to_string()),
@@ -223,7 +296,7 @@ mod tests {
     async fn retain(
         router: &AffinityRouter,
         state: &mut (),
-        request: &mut Request,
+        request: &Request,
         model: &'static str,
     ) -> Result<(), BoxErr> {
         router
@@ -371,6 +444,69 @@ mod tests {
         // No session id at all: nothing to key on.
         let mut req = request(Metadata::default());
         assert!(scores(&router, &mut state, &mut req).await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn message_hash_fallback_retains_a_task_across_turns() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new().with_message_hash_fallback();
+        let mut state = ();
+
+        let first = task_request(None, "Add a unit test for this function.", None);
+        retain(&router, &mut state, &first, "weak").await?;
+
+        let mut follow_up = task_request(
+            None,
+            "Add a unit test for this function.",
+            Some("Now run the test suite."),
+        );
+        assert_eq!(
+            scores(&router, &mut state, &mut follow_up)
+                .await?
+                .first()
+                .map(|score| score.target.as_str()),
+            Some("weak")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn metadata_session_takes_precedence_over_message_hash() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new().with_message_hash_fallback();
+        let mut state = ();
+
+        let first = task_request(
+            Some(session("session-1", "agent-a")),
+            "Implement the parser.",
+            None,
+        );
+        retain(&router, &mut state, &first, "strong").await?;
+
+        let mut other_session = task_request(
+            Some(session("session-2", "agent-a")),
+            "Implement the parser.",
+            None,
+        );
+        assert!(scores(&router, &mut state, &mut other_session)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn message_hash_fallback_abstains_for_subagents() -> Result<(), BoxErr> {
+        let router = AffinityRouter::new().with_message_hash_fallback();
+        let mut state = ();
+        let mut subagent = task_request(
+            Some(Metadata {
+                is_subagent: true,
+                ..Metadata::default()
+            }),
+            "Implement the parser.",
+            None,
+        );
+
+        assert!(scores(&router, &mut state, &mut subagent).await?.is_empty());
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -83,7 +83,7 @@ impl AffinityRouter {
         }
     }
 
-    /// Uses the latest user-message text as a fallback key when metadata has no session.
+    /// Uses the first user-message text as a fallback key when metadata has no session.
     pub fn with_message_hash_fallback(mut self) -> Self {
         self.message_hash_fallback = true;
         self
@@ -127,7 +127,7 @@ impl AffinityRouter {
             .is_some_and(|metadata| metadata.is_subagent);
         (!self.subagents_only && !is_subagent && self.message_hash_fallback)
             .then(|| {
-                last_user_message_hash(request).map(|hash| {
+                first_user_message_hash(request).map(|hash| {
                     tracing::debug!(affinity_key = %hash, "affinity using message hash fallback");
                     AffinityKey::Session(hash)
                 })
@@ -156,15 +156,14 @@ where
     }
 }
 
-/// Hashes the newest user message for task-based fallback affinity.
-/// For benchmarking purpose with harnesses, task instructions are added as a user prompt to the request so we need to hash the latest user message.
+/// Hashes the first user message so later turns retain the initial task's affinity.
+/// For benchmarking purpose with harnesses, task instructions are added as a user prompt to the request so we hash the initial user message.
 /// TODO: Have not considered multi-modal payloads yet. That needs to be handled separately.
-fn last_user_message_hash(request: &Request) -> Option<String> {
+fn first_user_message_hash(request: &Request) -> Option<String> {
     let message = request
         .llm_request
         .messages
         .iter()
-        .rev()
         .find(|message| message.role == Role::User)?;
     let mut hasher = DefaultHasher::new();
     message.text_content("")?.hash(&mut hasher);
@@ -441,7 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn message_hash_fallback_uses_the_latest_user_message() -> Result<(), BoxErr> {
+    async fn message_hash_fallback_uses_the_first_user_message() -> Result<(), BoxErr> {
         let router = AffinityRouter::new().with_message_hash_fallback();
         let mut state = ();
 
@@ -452,25 +451,25 @@ mod tests {
         );
         retain(&router, &mut state, &mut first, "weak").await?;
 
-        let mut same_turn = task_request(
+        let mut follow_up = task_request(
             None,
             "Add a unit test for this function.",
-            Some("Now run the test suite."),
+            Some("Now file a pull request."),
         );
         assert_eq!(
-            scores(&router, &mut state, &mut same_turn)
+            scores(&router, &mut state, &mut follow_up)
                 .await?
                 .first()
                 .map(|score| score.target.as_str()),
             Some("weak")
         );
 
-        let mut next_turn = task_request(
+        let mut other_task = task_request(
             None,
-            "Add a unit test for this function.",
-            Some("Now file a pull request."),
+            "Reimplement this binary from two input/output pairs.",
+            Some("Now run the test suite."),
         );
-        assert!(scores(&router, &mut state, &mut next_turn)
+        assert!(scores(&router, &mut state, &mut other_task)
             .await?
             .is_empty());
         Ok(())
@@ -501,8 +500,8 @@ mod tests {
         });
 
         assert_eq!(
-            last_user_message_hash(&text_only),
-            last_user_message_hash(&text_with_reasoning)
+            first_user_message_hash(&text_only),
+            first_user_message_hash(&text_with_reasoning)
         );
     }
 

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -298,7 +298,7 @@ mod tests {
     async fn retain(
         router: &AffinityRouter,
         state: &mut (),
-        request: &Request,
+        request: &mut Request,
         model: &'static str,
     ) -> Result<(), BoxErr> {
         router

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -119,6 +119,8 @@ impl AffinityRouter {
                 };
             }
         }
+
+        // If headers are not present and we are not a subagent, use the message hash based fallback key to do task based routing
         let is_subagent = request
             .metadata
             .as_ref()
@@ -452,8 +454,8 @@ mod tests {
         let router = AffinityRouter::new().with_message_hash_fallback();
         let mut state = ();
 
-        let first = task_request(None, "Add a unit test for this function.", None);
-        retain(&router, &mut state, &first, "weak").await?;
+        let mut first = task_request(None, "Add a unit test for this function.", None);
+        retain(&router, &mut state, &mut first, "weak").await?;
 
         let mut follow_up = task_request(
             None,
@@ -475,12 +477,12 @@ mod tests {
         let router = AffinityRouter::new().with_message_hash_fallback();
         let mut state = ();
 
-        let first = task_request(
+        let mut first = task_request(
             Some(session("session-1", "agent-a")),
             "Implement the parser.",
             None,
         );
-        retain(&router, &mut state, &first, "strong").await?;
+        retain(&router, &mut state, &mut first, "strong").await?;
 
         let mut other_session = task_request(
             Some(session("session-2", "agent-a")),

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -74,8 +74,7 @@
 //!
 //! [`algorithms::Random`] provides uniform or weighted random routing.
 //!
-//! [`algorithms::LlmTaskClassifier`] classifies with one model; compose it with
-//! [`algorithms::FallThrough`] to route to the selected target.
+//! [`algorithms::LlmTaskClassifier`] uses one model to classify and route to its selected target.
 
 mod core;
 pub use core::*;

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -26,10 +26,10 @@ use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
-use switchyard_libsy::algorithms::{FallThrough, LlmTaskClassifier};
+use switchyard_libsy::algorithms::LlmTaskClassifier;
 use switchyard_libsy::{
     AggLlmResponse, Algorithm, Context, Decision, Driver, LibsyError, LlmResponse, LlmTarget,
-    LlmTargetSet, Metadata, Request, Response, RoutedLlmClient, State, Step, Usage,
+    LlmTargetSet, Metadata, Request, Response, RoutedLlmClient, Step, Usage,
 };
 use switchyard_protocol::{text_request, text_response, LlmClientError};
 
@@ -725,11 +725,12 @@ async fn classifier_metrics_count_only_the_final_routed_call() -> switchyard_lib
     let targets = LlmTargetSet::new(vec![target("weak"), target("strong")]);
     let weak = targets.get_target("weak")?;
     let strong = targets.get_target("strong")?;
-    let router = Arc::new(
-        FallThrough::<State>::new_with_state(targets).with_classifier(Arc::new(
-            LlmTaskClassifier::new(target("classifier"), weak, strong, 0.5)?,
-        )),
-    );
+    let router = Arc::new(LlmTaskClassifier::new(
+        target("classifier"),
+        weak,
+        strong,
+        0.5,
+    )?);
 
     let (trace, _response) = router
         .run(

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -26,7 +26,7 @@ use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
-use switchyard_libsy::algorithms::LlmTaskClassifier;
+use switchyard_libsy::algorithms::{LlmTaskClassifier, TaskClassifierConfig};
 use switchyard_libsy::{
     AggLlmResponse, Algorithm, Context, Decision, Driver, LibsyError, LlmResponse, LlmTarget,
     LlmTargetSet, Metadata, Request, Response, RoutedLlmClient, Step, Usage,
@@ -729,7 +729,13 @@ async fn classifier_metrics_count_only_the_final_routed_call() -> switchyard_lib
         target("classifier"),
         weak,
         strong,
-        0.5,
+        TaskClassifierConfig {
+            base_threshold: 0.5,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+        },
     )?);
 
     let (trace, _response) = router

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -34,7 +34,7 @@ type = "llm_classifier"
 classifier_target = "model_a"
 strong_target = "model_a"
 weak_target = "model_b"
-threshold = 0.5
+base_threshold = 0.5
 
 [routes.passthrough]
 id = "switchyard/passthrough"
@@ -63,6 +63,23 @@ never contains the secret itself. If omitted, the client sends no authentication
 
 Random-route `weights` are relative, follow target order, and do not need to sum to one. Omit them
 for equal weighting. The optional `seed` reproduces the selection sequence for the same call order.
+
+An `llm_classifier` route sends each task to `classifier_target` for a capability verdict, then
+routes to `weak_target` or `strong_target`. Beyond the three targets it accepts these keys; only
+`base_threshold` is required, and anything the judge cannot decide routes to `strong_target`:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `base_threshold` | *required* | Lowest solve probability that routes a task to `weak_target`. Raise it to send less traffic to the weak model. |
+| `min_confidence` | `0.0` | Lowest judge confidence that permits weak routing. `0.0` disables the gate. |
+| `capability_elevated_floor` | unset | Higher solve-probability floor applied only to tasks the judge marks uncertain, unsupported, or unmatched. Unset reuses `base_threshold`. |
+| `session_affinity` | `false` | Reuses a session's first routing decision on later turns, so the judge is called once per session rather than once per turn. |
+| `message_hash_fallback` | `false` | Extends affinity to clients that send no session header, keying on the first user message. Requires `session_affinity = true`. |
+
+Session affinity retains a decision for the process lifetime, including a `strong_target`
+fallback produced while the judge was unreachable. `message_hash_fallback` keys on request
+content rather than a session id, so unrelated callers sending identical text share one
+assignment.
 
 ## Metrics
 

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use libsy::algorithms::{FallThrough, LlmTaskClassifier, Noop, Passthrough, Random};
-use libsy::{Algorithm, LlmTarget, LlmTargetSet, RoutedLlmClient, State};
+use libsy::algorithms::{LlmTaskClassifier, Noop, Passthrough, Random};
+use libsy::{Algorithm, LlmTarget, LlmTargetSet, RoutedLlmClient};
 use serde::Deserialize;
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
 
@@ -181,6 +181,10 @@ enum RouteConfig {
         strong_target: String,
         weak_target: String,
         threshold: f64,
+        #[serde(default)]
+        session_affinity: bool,
+        #[serde(default)]
+        message_hash_fallback: bool,
     },
 }
 
@@ -264,21 +268,29 @@ fn build_algorithm(
             strong_target,
             weak_target,
             threshold,
+            session_affinity,
+            message_hash_fallback,
             ..
         } => {
+            if *message_hash_fallback && !*session_affinity {
+                return Err(ServerError::new(format!(
+                    "llm_classifier route {route_name}: message_hash_fallback requires session_affinity"
+                )));
+            }
             let classifier = resolve_target(route_name, classifier_target, targets)?;
             let strong = resolve_target(route_name, strong_target, targets)?;
             let weak = resolve_target(route_name, weak_target, targets)?;
-            // The judge is called through its own target, so it is not a routing destination.
-            let target_set = LlmTargetSet::new(vec![strong.clone(), weak.clone()]);
             // The weak model is the efficient tier; the strong model is the capable one.
-            let judge =
+            let algorithm =
                 LlmTaskClassifier::new(classifier, weak, strong, *threshold).map_err(|error| {
                     ServerError::new(format!("llm_classifier route {route_name}: {error}"))
                 })?;
-            let router =
-                FallThrough::<State>::new_with_state(target_set).with_classifier(Arc::new(judge));
-            Ok(Arc::new(router))
+            let algorithm = if *session_affinity {
+                algorithm.with_affinity(*message_hash_fallback)
+            } else {
+                algorithm
+            };
+            Ok(Arc::new(algorithm))
         }
     }
 }
@@ -443,6 +455,13 @@ target = "weak"
                 "threshold must be between 0 and 1",
             ),
             (
+                VALID_CONFIG.replace(
+                    "threshold = 0.5",
+                    "threshold = 0.5\nmessage_hash_fallback = true",
+                ),
+                "message_hash_fallback requires session_affinity",
+            ),
+            (
                 VALID_CONFIG.replace("schema_version = 1", "schema_version = 2"),
                 "unsupported schema_version 2",
             ),
@@ -467,6 +486,16 @@ target = "weak"
             "targets = [\"strong\", \"weak\"]\nweights = [1, 3]\nseed = 42",
         );
         server_state_from_toml(&weighted)?;
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_session_affinity_with_message_hash_fallback() -> ServerResult<()> {
+        let configured = VALID_CONFIG.replace(
+            "threshold = 0.5",
+            "threshold = 0.5\nsession_affinity = true\nmessage_hash_fallback = true",
+        );
+        server_state_from_toml(&configured)?;
         Ok(())
     }
 

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use libsy::algorithms::{LlmTaskClassifier, Noop, Passthrough, Random};
+use libsy::algorithms::{LlmTaskClassifier, Noop, Passthrough, Random, TaskClassifierConfig};
 use libsy::{Algorithm, LlmTarget, LlmTargetSet, RoutedLlmClient};
 use serde::Deserialize;
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
@@ -180,11 +180,8 @@ enum RouteConfig {
         classifier_target: String,
         strong_target: String,
         weak_target: String,
-        threshold: f64,
-        #[serde(default)]
-        session_affinity: bool,
-        #[serde(default)]
-        message_hash_fallback: bool,
+        #[serde(flatten)]
+        classifier_config: TaskClassifierConfig,
     },
 }
 
@@ -267,29 +264,18 @@ fn build_algorithm(
             classifier_target,
             strong_target,
             weak_target,
-            threshold,
-            session_affinity,
-            message_hash_fallback,
+            classifier_config,
             ..
         } => {
-            if *message_hash_fallback && !*session_affinity {
-                return Err(ServerError::new(format!(
-                    "llm_classifier route {route_name}: message_hash_fallback requires session_affinity"
-                )));
-            }
             let classifier = resolve_target(route_name, classifier_target, targets)?;
             let strong = resolve_target(route_name, strong_target, targets)?;
             let weak = resolve_target(route_name, weak_target, targets)?;
             // The weak model is the efficient tier; the strong model is the capable one.
             let algorithm =
-                LlmTaskClassifier::new(classifier, weak, strong, *threshold).map_err(|error| {
-                    ServerError::new(format!("llm_classifier route {route_name}: {error}"))
-                })?;
-            let algorithm = if *session_affinity {
-                algorithm.with_affinity(*message_hash_fallback)
-            } else {
-                algorithm
-            };
+                LlmTaskClassifier::new(classifier, weak, strong, classifier_config.clone())
+                    .map_err(|error| {
+                        ServerError::new(format!("llm_classifier route {route_name}: {error}"))
+                    })?;
             Ok(Arc::new(algorithm))
         }
     }
@@ -374,7 +360,7 @@ type = "llm_classifier"
 classifier_target = "classifier"
 strong_target = "strong"
 weak_target = "weak"
-threshold = 0.5
+base_threshold = 0.5
 
 [routes.passthrough]
 id = "switchyard/passthrough"
@@ -451,13 +437,13 @@ target = "weak"
                 "at least one weight must be positive",
             ),
             (
-                VALID_CONFIG.replace("threshold = 0.5", "threshold = 1.5"),
-                "threshold must be between 0 and 1",
+                VALID_CONFIG.replace("base_threshold = 0.5", "base_threshold = 1.5"),
+                "base_threshold must be between 0 and 1",
             ),
             (
                 VALID_CONFIG.replace(
-                    "threshold = 0.5",
-                    "threshold = 0.5\nmessage_hash_fallback = true",
+                    "base_threshold = 0.5",
+                    "base_threshold = 0.5\nmessage_hash_fallback = true",
                 ),
                 "message_hash_fallback requires session_affinity",
             ),
@@ -492,8 +478,8 @@ target = "weak"
     #[test]
     fn accepts_session_affinity_with_message_hash_fallback() -> ServerResult<()> {
         let configured = VALID_CONFIG.replace(
-            "threshold = 0.5",
-            "threshold = 0.5\nsession_affinity = true\nmessage_hash_fallback = true",
+            "base_threshold = 0.5",
+            "base_threshold = 0.25\nmin_confidence = 0.0\ncapability_elevated_floor = 0.45\nsession_affinity = true\nmessage_hash_fallback = true",
         );
         server_state_from_toml(&configured)?;
         Ok(())

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -299,7 +299,7 @@ type = "llm_classifier"
 classifier_target = "classifier"
 strong_target = "strong"
 weak_target = "weak"
-threshold = 0.5
+base_threshold = 0.5
 
 [routes.passthrough]
 id = "switchyard/passthrough"


### PR DESCRIPTION
## What

- Extend the base llm classifier implementation to work with AffinityRouter for doing task based routing
- Added message_hash_fallback to treat first message hash as the AffinityKey in case of absence of headers
- Make FallThrough as the internal implementation detail , so that users just export the algorithm directly
- Earlier in the affinity Router, if concurrent sessions hit the same server their session keys were getting stashed because they were not stored in state, so fixed that

## Why

The motivation — Completes Sticky Task Based LLM Classifier implementation 

Closes #

## Where to Start Review

1. `crates/libsy/src/algorithms/llm_class.rs` — public algorithm shape and internal routing composition.
2. `crates/libsy/src/algorithms/util/affinity.rs` — affinity-key selection and message-hash fallback behavior.
3. `crates/switchyard-server/src/config.rs` — TOML wiring and validation.
4. `crates/libsy/src/algorithms/fall_through.rs` — internal execution delegation.

## How Tested

- `cargo test -p switchyard-libsy`
- `cargo test -p switchyard-server`
- `cargo clippy --workspace --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional session affinity for classifier-routed requests.
  * Added message-based affinity fallback when no session identifier is available.
  * Improved request consistency by reusing prior routing decisions across related requests.

* **Bug Fixes**
  * Explicit session metadata now takes precedence over message-based affinity.
  * Subagent requests correctly avoid message-hash fallback routing.

* **Documentation**
  * Updated examples and guidance to reflect the simplified classifier configuration and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->