### PR TITLE
feat(libsy-llm-client): Metrics on HTTP traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-util",
+ "opentelemetry",
  "reqwest",
  "serde_json",
  "switchyard-protocol",

--- a/crates/libsy-llm-client/Cargo.toml
+++ b/crates/libsy-llm-client/Cargo.toml
@@ -17,6 +17,7 @@ switchyard-translation.workspace = true
 reqwest.workspace = true
 async-trait.workspace = true
 futures-util.workspace = true
+opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -20,6 +20,7 @@ use switchyard_translation::{
 
 use crate::backend::Backend;
 use crate::error::{LlmClientError, Result};
+use crate::metrics::record_upstream_attempt;
 use crate::raw::RawResponse;
 
 // TODO: Why is this here? What does it do?
@@ -168,7 +169,16 @@ impl TranslatingLlmClient {
         let builder = apply_extra_headers(builder, backend);
         let builder = backend.apply_auth(builder);
 
-        let http_response = builder.send().await.map_err(convert_reqwest_error)?;
+        let http_response = match builder.send().await {
+            Ok(response) => {
+                record_upstream_attempt(Some(response.status().as_u16()));
+                response
+            }
+            Err(error) => {
+                record_upstream_attempt(None);
+                return Err(convert_reqwest_error(error));
+            }
+        };
         let status = http_response.status();
         if !status.is_success() {
             let body = match http_response.text().await {

--- a/crates/libsy-llm-client/src/lib.rs
+++ b/crates/libsy-llm-client/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod backend;
 pub mod client;
 pub mod error;
+pub mod metrics;
 pub mod raw;
 
 pub use backend::{Backend, HttpBackendConfig};

--- a/crates/libsy-llm-client/src/metrics.rs
+++ b/crates/libsy-llm-client/src/metrics.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metric labelling inherited from Python
+
+use opentelemetry::{global, KeyValue};
+
+pub const fn http_outcome_label(status: Option<u16>) -> &'static str {
+    match status {
+        Some(200..=299) => "success",
+        Some(429 | 500 | 504) | None => "retryable_error",
+        Some(_) => "other_error",
+    }
+}
+
+/// Limit the cardinality of the HTTP status code.
+/// This matches Python, but likely we should log the status code directly. Most of these never
+/// appear.
+pub const fn http_status_code_label(status: Option<u16>) -> &'static str {
+    match status {
+        None => "none",
+        Some(200) => "200",
+        Some(400) => "400",
+        Some(401) => "401",
+        Some(403) => "403",
+        Some(404) => "404",
+        Some(408) => "408",
+        Some(409) => "409",
+        Some(422) => "422",
+        Some(429) => "429",
+        Some(500) => "500",
+        Some(502) => "502",
+        Some(503) => "503",
+        Some(504) => "504",
+        Some(100..=199) => "1xx",
+        Some(200..=299) => "2xx",
+        Some(300..=399) => "3xx",
+        Some(400..=499) => "4xx",
+        Some(500..=599) => "5xx",
+        Some(_) => "other",
+    }
+}
+
+pub(crate) fn record_upstream_attempt(status: Option<u16>) {
+    global::meter("switchyard")
+        .u64_counter("switchyard.upstream_attempts")
+        .build()
+        .add(
+            1,
+            &[
+                KeyValue::new("outcome", http_outcome_label(status)),
+                KeyValue::new("code", http_status_code_label(status)),
+            ],
+        );
+}

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -77,6 +77,9 @@ Routed-call compatibility metrics are:
 | `switchyard_requests_total` | counter | `model`, optional `tier` | Successful final routed calls |
 | `switchyard_errors_total` | counter | `model`, optional `tier` | Failed final routed calls |
 | `switchyard_model_call_latency_ms` | histogram | `model`, optional `tier` | Successful final routed-call latency |
+| `switchyard_client_responses_total` | counter | `outcome` | Final LLM-route responses |
+| `switchyard_upstream_attempts_total` | counter | `outcome`, `code` | Actual upstream HTTP attempts |
+| `switchyard_router_retry_recovered_total` | counter | none | Retry recoveries (currently always zero) |
 
 The `tier` label is `strong` or `weak` for a distinguishable built-in LLM-classifier decision and
 is omitted for untiered algorithms. Classifier calls are excluded from these families.

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -194,8 +194,8 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
     Router::new()
         .route("/v1/chat/completions", post(openai_chat_completions))
         .route("/v1/messages", post(anthropic_messages))
-        .route("/v1/messages/count_tokens", post(anthropic_count_tokens))
         .route("/v1/responses", post(openai_responses))
+        .route("/v1/messages/count_tokens", post(anthropic_count_tokens))
         .route("/v1/models", get(models))
         .route("/metrics", get(prometheus_metrics))
         .route("/health", get(health))
@@ -330,6 +330,7 @@ async fn handle_endpoint(
         Ok(body) => handle_llm_request(state, metadata, body, wire_format).await,
         Err(message) => invalid_body_error(message),
     };
+    metrics::record_client_response(response.status().as_u16());
     request_log.emit(&response);
     response
 }

--- a/crates/switchyard-server/src/metrics.rs
+++ b/crates/switchyard-server/src/metrics.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
+use switchyard_llm_client::metrics::{http_outcome_label, http_status_code_label};
 
 pub(crate) const CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
 
@@ -39,10 +40,47 @@ fn initialize() -> Result<Metrics, String> {
         .u64_gauge("switchyard.build_info")
         .build()
         .record(1, &[KeyValue::new("version", env!("CARGO_PKG_VERSION"))]);
+    seed_outcome_metrics();
     Ok(Metrics {
         registry,
         _provider: provider,
     })
+}
+
+/// Make the metrics exist before they get a hit. Nicer for dashboards but not really necessary.
+/// The HTTP status codes we seed are somewhat arbitrary.
+fn seed_outcome_metrics() {
+    let meter = global::meter("switchyard");
+    let upstream_attempts = meter.u64_counter("switchyard.upstream_attempts").build();
+    for status in [Some(200), Some(404), Some(429), Some(500), Some(504), None] {
+        upstream_attempts.add(
+            0,
+            &[
+                KeyValue::new("outcome", http_outcome_label(status)),
+                KeyValue::new("code", http_status_code_label(status)),
+            ],
+        );
+    }
+
+    let client_responses = meter.u64_counter("switchyard.client_responses").build();
+    for outcome in ["success", "retryable_error", "other_error"] {
+        client_responses.add(0, &[KeyValue::new("outcome", outcome)]);
+    }
+    meter
+        .u64_counter("switchyard.router_retry_recovered")
+        .build()
+        .add(0, &[]);
+}
+
+/// Records the final status returned by an LLM-serving route.
+pub(crate) fn record_client_response(status: u16) {
+    global::meter("switchyard")
+        .u64_counter("switchyard.client_responses")
+        .build()
+        .add(
+            1,
+            &[KeyValue::new("outcome", http_outcome_label(Some(status)))],
+        );
 }
 
 /// Encodes the current cumulative metric values in Prometheus text format.

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -183,6 +183,26 @@ async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
             .and_then(|value| value.to_str().ok()),
         Some("text/plain; version=0.0.4; charset=utf-8")
     );
+    let seeded = before.text()?;
+    for expected in [
+        "# TYPE switchyard_client_responses_total counter",
+        "switchyard_client_responses_total{outcome=\"success\",",
+        "switchyard_client_responses_total{outcome=\"retryable_error\",",
+        "switchyard_client_responses_total{outcome=\"other_error\",",
+        "# TYPE switchyard_upstream_attempts_total counter",
+        "switchyard_upstream_attempts_total{code=\"200\",outcome=\"success\",",
+        "switchyard_upstream_attempts_total{code=\"429\",outcome=\"retryable_error\",",
+        "switchyard_upstream_attempts_total{code=\"500\",outcome=\"retryable_error\",",
+        "switchyard_upstream_attempts_total{code=\"504\",outcome=\"retryable_error\",",
+        "switchyard_upstream_attempts_total{code=\"none\",outcome=\"retryable_error\",",
+        "# TYPE switchyard_router_retry_recovered_total counter",
+        "switchyard_router_retry_recovered_total{otel_scope_name=\"switchyard\"} 0",
+    ] {
+        assert!(
+            seeded.contains(expected),
+            "missing seeded {expected:?} in metrics:\n{seeded}"
+        );
+    }
 
     let response = send(
         &app,
@@ -205,6 +225,8 @@ async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
         "# TYPE switchyard_total_errors gauge",
         "# TYPE switchyard_requests_total counter",
         "# TYPE switchyard_model_call_latency_ms histogram",
+        "switchyard_client_responses_total{outcome=\"success\",",
+        "switchyard_upstream_attempts_total{code=\"200\",outcome=\"success\",",
         "# TYPE switchyard_runs_total counter",
         "# TYPE switchyard_llm_calls_total counter",
         "# TYPE switchyard_run_duration_ms histogram",


### PR DESCRIPTION
More matching Python server. New metrics:

- `switchyard_client_responses_total`: Final result classified as either
  "success", "retryable_error", or "other_error". Matches Python.
- `switchyard_upstream_attempts_total`: Upstream HTTP attempts by HTTP
  status code.
- `switchyard_router_retry_recovered_total`: Rust server doesn't
  implement retries yet so always 0. This is what we'll use when we add
  retries, and it matches Python.

Assisted-by: Codex:GPT 5.6 Sol medium
Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics for upstream request attempts and client response outcomes.
  * Metrics now include categorized HTTP status and outcome labels.
  * Prometheus metrics are initialized with common zero-valued series for immediate dashboard visibility.

* **Documentation**
  * Documented the new client response, upstream attempt, and retry recovery metrics.

* **Tests**
  * Expanded metrics coverage to verify declarations, labels, and recorded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->