### PR TITLE
fix(server): warn on duplicate target model ids

### DIFF
--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -3,7 +3,7 @@
 
 //! Typed TOML configuration and explicit construction for the Rust server.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -64,6 +64,26 @@ impl ServerConfig {
             )));
         }
 
+        // An llm client keys its models by id, so two targets that share an id on one
+        // client end up as one entry: the client keeps one target and drops the other. Warn
+        // so the drop is visible at startup instead of silent, and still build both routes.
+        // The set only tells us the pair was already seen, not whether the two targets
+        // differ, so it warns for a harmless duplicate and for one whose extra_body would be
+        // dropped alike. The same id on two different clients never collides: each client
+        // keeps its own model.
+        let mut seen_client_model_ids = HashSet::new();
+        for (target_name, target) in &self.targets {
+            validate_value("target name", target_name)?;
+            validate_value(&format!("target {target_name} id"), &target.id)?;
+            if !seen_client_model_ids.insert((target.llm_client.as_str(), target.id.as_str())) {
+                tracing::warn!(
+                    "target {target_name} reuses model id {} on llm client {}; only one target per id is kept and the other is dropped. Give each target a unique model id, or point both routes at one target.",
+                    target.id,
+                    target.llm_client
+                );
+            }
+        }
+
         let clients = self.build_clients()?;
         let targets = self.build_targets(&clients)?;
         let mut routes = Vec::with_capacity(self.routes.len());
@@ -89,8 +109,6 @@ impl ServerConfig {
             validate_value("llm client name", name)?;
         }
         for (target_name, target) in &self.targets {
-            validate_value("target name", target_name)?;
-            validate_value(&format!("target {target_name} id"), &target.id)?;
             let client_config = self.llm_clients.get(&target.llm_client).ok_or_else(|| {
                 ServerError::new(format!(
                     "target {target_name} references unknown llm client {}",
@@ -777,6 +795,83 @@ classifier_magic = true
                 "expected error containing {expected}"
             );
         }
+    }
+
+    #[test]
+    fn accepts_duplicate_target_model_ids_on_one_client() -> ServerResult<()> {
+        // Two targets share one model id on one client. The client keeps one and drops the
+        // other, so the build warns and still succeeds, and both routes resolve. Serving one
+        // model under two route names this way is allowed; pointing both routes at one target
+        // is the tidier form.
+        const SAME_MODEL_TWO_ROUTES: &str = r#"
+schema_version = 1
+
+[llm_clients.primary]
+format = "openai_chat"
+base_url = "https://example.test/v1"
+
+[targets.fast]
+id = "gpt-4o"
+llm_client = "primary"
+
+[targets.smart]
+id = "gpt-4o"
+llm_client = "primary"
+
+[routes.fast]
+id = "switchyard/fast"
+type = "passthrough"
+target = "fast"
+
+[routes.smart]
+id = "switchyard/smart"
+type = "passthrough"
+target = "smart"
+"#;
+        let state = server_state_from_toml(SAME_MODEL_TWO_ROUTES)?;
+        assert_eq!(
+            state.models().collect::<Vec<_>>(),
+            ["switchyard/fast", "switchyard/smart"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_same_model_id_on_different_llm_clients() -> ServerResult<()> {
+        // The same model id served by two llm clients never collides (each client keys its own
+        // models), so cross-provider A/B builds with no warning; only a repeat within one client
+        // warns.
+        const CROSS_PROVIDER: &str = r#"
+schema_version = 1
+
+[llm_clients.openai]
+format = "openai_chat"
+base_url = "https://example.test/v1"
+
+[llm_clients.azure]
+format = "openai_chat"
+base_url = "https://azure.test/v1"
+
+[targets.openai]
+id = "gpt-4o"
+llm_client = "openai"
+
+[targets.azure]
+id = "gpt-4o"
+llm_client = "azure"
+
+[routes.openai]
+id = "switchyard/openai-gpt4o"
+type = "passthrough"
+target = "openai"
+
+[routes.azure]
+id = "switchyard/azure-gpt4o"
+type = "passthrough"
+target = "azure"
+"#;
+        server_state_from_toml(CROSS_PROVIDER)?;
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Two targets accidentally share one model id on one llm client:

```toml
[llm_clients.primary]
format = "openai_chat"
base_url = "https://api.openai.com/v1"

[targets.priority]
id = "gpt-4o"
llm_client = "primary"

[targets.flex]
id = "gpt-4o"
llm_client = "primary"

[routes.priority]
id = "switchyard/priority"
type = "passthrough"
target = "priority"

[routes.flex]
id = "switchyard/flex"
type = "passthrough"
target = "flex"
```

An llm client keeps its models in a map keyed by id, so two targets with the same id on one client end up as one entry: the client keeps one target and drops the other. Both routes still start, and nothing reports the dropped target:

```
$ switchyard-server --config deploy.toml --dry-run
server OK: switchyard/flex, switchyard/priority     # one target was dropped, no message
```

## The fix

`switchyard-server` now checks each `(llm client, model id)` pair while it reads the config. When two targets on one client reuse an id, it logs a warning that names the target, the id, and the client, then keeps starting:

```
$ switchyard-server --config deploy.toml --dry-run
WARN switchyard_server::config: target priority reuses model id gpt-4o on llm client primary; only one target per id is kept and the other is dropped. Give each target a unique model id, or point both routes at one target.
server OK: switchyard/flex, switchyard/priority
```

The same id on two different llm clients is fine and stays quiet — each client keeps its own model, so nothing is dropped. That is how you serve one model through two providers or two API keys.

## What it does and does not do

The warning makes the dropped target visible at startup instead of silent. It does **not** stop the server: both routes still start, and the surviving target is what both serve.

One case to know: if the two targets differ only by `extra_body` (say two `service_tier` values), the client still keeps one and drops the other's `extra_body`. The check works from a set of `(llm client, model id)` pairs, so it can't compare the two targets — it warns the same for a harmless duplicate and for one that drops real config. Read the warning as "a target was dropped; make sure that is what you meant." To serve two tiers of one model, give each its own llm client (same `base_url`, different client name).

## Evidence

```
$ switchyard-server --config deploy.toml --dry-run          # two targets, same id on one client
WARN ...: target priority reuses model id gpt-4o on llm client primary; only one target per id is kept and the other is dropped. ...
server OK: switchyard/flex, switchyard/priority             # exit 0, both routes start

$ switchyard-server --config deploy-fixed.toml --dry-run     # flex.id = gpt-4o-mini
server OK: switchyard/flex, switchyard/priority              # exit 0, no warning
```

No perf table — this change adds a startup warning, it does not change speed.

## Compatibility

No breaking change: every config that started before still starts. A config with two same-id targets on one client now prints a warning where it used to say nothing.

## How tested

`cargo test -p switchyard-server` passes (23 config tests, 17 server tests). Two config tests cover the behavior:

- `accepts_duplicate_target_model_ids_on_one_client` — two targets, same id and client; the build warns and still succeeds, and both routes resolve.
- `accepts_same_model_id_on_different_llm_clients` — same id on two clients; the build succeeds with no warning.

`cargo clippy -p switchyard-server --all-targets -- -D warnings` and `cargo fmt --all --check` are clean.

Reproducer:

```
cargo build -p switchyard-server
./target/debug/switchyard-server --config deploy.toml --dry-run     # then deploy-fixed.toml
```
