### PR TITLE
feat: switchyard rust server image

### DIFF
--- a/benchmark/switchyard-rust-server.Dockerfile
+++ b/benchmark/switchyard-rust-server.Dockerfile
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG RUST_VERSION=1.96.1
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+WORKDIR /opt/switchyard
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+
+RUN cargo build --locked --release -p switchyard-server
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chmod=0755 \
+    /opt/switchyard/target/release/switchyard-server \
+    /usr/local/bin/switchyard-server
+
+ENV HOME=/tmp
+
+USER 1000:1000
+EXPOSE 4000
+
+ENTRYPOINT ["switchyard-server"]

--- a/benchmark/switchyard-rust-server.Dockerfile
+++ b/benchmark/switchyard-rust-server.Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder --chmod=0755 \
+COPY --from=builder \
     /opt/switchyard/target/release/switchyard-server \
     /usr/local/bin/switchyard-server
 

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use axum::extract::{rejection::JsonRejection, State};
+use axum::extract::{rejection::JsonRejection, DefaultBodyLimit, State};
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -36,6 +36,9 @@ use crate::response::into_http_response;
 
 /// Default TCP listen backlog used by the Rust server.
 pub const DEFAULT_LISTEN_BACKLOG: u32 = 65_535;
+
+/// Maximum buffered JSON request size accepted by the LLM endpoints.
+pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 const HEADER_SELECTED_MODEL: &str = "x-model-router-selected-model";
 const HEADER_RATIONALE: &str = "x-model-router-rationale";
@@ -204,6 +207,7 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
         .route("/metrics", get(prometheus_metrics))
         .route("/health", get(health))
         .fallback(not_found)
+        .layer(DefaultBodyLimit::max(DEFAULT_MAX_REQUEST_BODY_BYTES))
         .with_state(state)
 }
 

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 use axum::body::{Body, Bytes};
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::{Request as HttpRequest, StatusCode};
 use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response as HttpResponse};
@@ -47,6 +47,7 @@ impl MockUpstream {
         let app = Router::new()
             .route("/v1/chat/completions", post(upstream_chat))
             .route("/v1/messages/count_tokens", post(upstream_count_tokens))
+            .layer(DefaultBodyLimit::disable())
             .with_state(Arc::clone(&calls));
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
@@ -218,6 +219,26 @@ async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
             "missing {expected:?} in metrics:\n{metrics}"
         );
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn accepts_requests_larger_than_the_axum_default_body_limit() -> TestResult {
+    let (_upstream, app) = test_app(&[(ROUTE_MODEL, &["model/a"])]).await?;
+    let content = "x".repeat(2 * 1024 * 1024);
+
+    let response = send(
+        &app,
+        "POST",
+        "/v1/chat/completions",
+        Some(json!({
+            "model": ROUTE_MODEL,
+            "messages": [{"role": "user", "content": content}]
+        })),
+    )
+    .await?;
+
+    assert_eq!(response.status, StatusCode::OK);
     Ok(())
 }
 


### PR DESCRIPTION
## What

This PR adds a separate Dockerfile that builds the Rust-based `switchyard-server`. It also raises the Axum request-body limit to 32 MiB (regression found during a terminal bench 2.1 run).

## Why

As we move from the Python frontend to the Rust frontend, we need an image capable of using the ruse server. The larger body limit supports provider-sized Claude Code requests.

Closes #

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 1,720 passed
- [x] `cargo fmt`, `cargo clippy`, and `cargo test -p switchyard-server`
- [x] Image smoke-tested as an arbitrary UID with a read-only root filesystem

## Checklist

- [x] No new Python classes or public symbols.
- [x] Unit test added for requests exceeding Axum's previous limit.
- [ ] README / `--help` updated if customer-facing surface changed.
- [x] Commits signed off per the DCO.

## Notes for reviewers

The Dockerfile is the exact Cloud Build path qualified end to end with scaled-evals.