### PR TITLE
DO NOT MERGE feat(libsy): add host-driven Relay integration contracts

### DIFF
--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -114,7 +114,8 @@ the id it calls — they can differ (`"strong"` → `"openai/gpt-4o"`) or coinci
 
 ## Running a request
 
-Hold the algorithm as `Arc<dyn Algorithm>` and choose one of two entry points:
+Hold the algorithm as `Arc<dyn Algorithm>` and choose the entry point that matches
+who owns dispatch:
 
 ```rust
 // run: libsy drives the request to completion, serving each call with the target's
@@ -123,11 +124,47 @@ let (trace, response) = algo.clone().run(Context::default(), req).await?;
 
 // run_stream: "ask, don't call" — you drive the stream and make the calls.
 let stream = algo.clone().run_stream(Context::default(), req);
+
+// run_decision_stream: compute a route but do not dispatch the selected target.
+let decisions = algo.clone().run_decision_stream(Context::default(), req);
 ```
 
 Under the hood every model call is *offloaded* to the request's `Step` stream; `run` is
 the convenience that serves each one via the target's client. The step stream is bounded,
 so pulling it paces the algorithm; each run is independent, so many run concurrently.
+
+## Computing a route without target dispatch
+
+`run_decision_stream` is an explicit capability for hosts that need to observe a route
+without executing the selected target. A supported algorithm may still request
+supporting model calls needed to compute its answer, but it terminates with
+`FinalDecision` before target dispatch. This is different from consuming the first
+`Decision` from `run_stream` and dropping the stream: dropping a normal stream cancels
+the in-progress algorithm task.
+
+```rust
+let stream = algo.clone().run_decision_stream(Context::default(), req);
+tokio::pin!(stream);
+while let Some(step) = stream.next().await {
+    match step? {
+        DecisionStep::CallLlm(call) => {
+            // Optional supporting call used by the algorithm to decide.
+            let response = serve_supporting_call(call.get_routed()).await;
+            call.respond(response)?;
+        }
+        DecisionStep::Decision(decision) => { /* intermediate trace */ }
+        DecisionStep::FinalDecision(decision) => {
+            // Observe decision.selected_model(); do not dispatch it.
+        }
+    }
+}
+```
+
+Algorithms opt in by implementing `create_decision_task`. Unsupported algorithms
+terminate with the typed `LibsyError::DecisionOnlyUnsupported` error rather than
+silently weakening their full request/response semantics. The reference `Random` and
+`FallThrough` routers support decision-only execution. Runnable:
+[`decision_only`](examples/decision_only.rs).
 
 ## Streaming responses
 
@@ -208,9 +245,17 @@ pub trait Algorithm: Send + Sync + 'static {
     // interior mutability for state. Offload calls/decisions on `driver`.
     async fn create_run_task(self: Arc<Self>, ctx: Context, driver: Driver, request: Request)
         -> switchyard_libsy::Result<Response>;
+    // Optional: terminate with a final route without dispatching its selected target.
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> switchyard_libsy::Result<Arc<dyn Decision>>;
     async fn process_signals(self: Arc<Self>, signals: Signals)
         -> switchyard_libsy::Result<()>;
-    // provided: run(ctx, request) -> (trace, response), run_stream(ctx, request) -> Stream<Step>
+    // provided: run(...), run_stream(...) -> Stream<Step>,
+    // run_decision_stream(...) -> Stream<DecisionStep>
 }
 
 pub trait Decision: Send + Sync {

--- a/crates/libsy/examples/decision_only.rs
+++ b/crates/libsy/examples/decision_only.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Computes a seeded random route without dispatching the selected target.
+//!
+//! Run with:
+//! `cargo run -p switchyard-libsy --example decision_only`
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use switchyard_libsy::algorithms::Random;
+use switchyard_libsy::{
+    Algorithm, Context, DecisionStep, LibsyError, LlmTarget, LlmTargetSet, Request, Result,
+};
+use switchyard_protocol::text_request;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let targets = LlmTargetSet::new(
+        ["fast", "strong"]
+            .into_iter()
+            .map(|name| LlmTarget {
+                semantic_name: name.to_string(),
+                llm_client: None,
+            })
+            .collect(),
+    );
+    let algorithm: Arc<dyn Algorithm> =
+        Arc::new(Random::new(targets, Some(vec![3.0, 1.0]), Some(42))?);
+    let request = Request {
+        llm_request: text_request(Some("auto".to_string()), "Explain Rust ownership."),
+        raw_request: None,
+        metadata: None,
+    };
+
+    let stream = algorithm.run_decision_stream(Context::default(), request);
+    tokio::pin!(stream);
+    while let Some(step) = stream.next().await {
+        match step? {
+            DecisionStep::CallLlm(_) => {
+                return Err(LibsyError::AlgorithmError {
+                    message: "random routing does not require a supporting LLM call".to_string(),
+                });
+            }
+            DecisionStep::Decision(decision) => {
+                println!("trace: {}", decision.selected_model());
+            }
+            DecisionStep::FinalDecision(decision) => {
+                println!("selected without dispatch: {}", decision.selected_model());
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -162,6 +162,28 @@ where
             .await
     }
 
+    /// Executes the processor/classifier sequence without dispatching the selected
+    /// target, returning the final decision to a decision-only stream.
+    pub(crate) async fn decide(
+        &self,
+        ctx: Context,
+        driver: Driver,
+        mut request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        let session_state = self.session_state(&request);
+        let (_, decision) = match session_state {
+            Some(state) => {
+                let mut state = state.lock().await;
+                self.route(&mut state, &ctx, &driver, &mut request).await?
+            }
+            None => {
+                let mut state = S::default();
+                self.route(&mut state, &ctx, &driver, &mut request).await?
+            }
+        };
+        Ok(decision)
+    }
+
     /// Returns this request's retained state without holding the registry lock.
     fn session_state(&self, request: &Request) -> Option<Arc<AsyncMutex<S>>> {
         let states = self.session_states.as_ref()?;
@@ -261,6 +283,15 @@ where
         request: Request,
     ) -> Result<Response> {
         self.execute(ctx, driver, request).await
+    }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        self.decide(ctx, driver, request).await
     }
 }
 #[cfg(test)]

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -21,8 +21,8 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::core::{Classifier, Event, Processor, Score};
 use crate::{
-    Algorithm, Context, Decision, Driver, LibsyError, LlmTargetSet, Request, Response, Result,
-    RoutedLlmClient,
+    Algorithm, Context, Decision, DecisionMetadata, DecisionRole, Driver, LibsyError, LlmTargetSet,
+    Request, Response, Result, RoutedLlmClient,
 };
 
 type SessionStates<S> = Mutex<HashMap<String, Arc<AsyncMutex<S>>>>;
@@ -34,6 +34,7 @@ pub struct FallThroughDecision {
     /// Human-readable explanation of the selection.
     pub reasoning: String,
     tier: Option<&'static str>,
+    metadata: DecisionMetadata,
 }
 
 impl Decision for FallThroughDecision {
@@ -49,6 +50,10 @@ impl Decision for FallThroughDecision {
         Some(&self.reasoning)
     }
 
+    fn metadata(&self) -> Option<&DecisionMetadata> {
+        Some(&self.metadata)
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -60,6 +65,7 @@ impl Decision for FallThroughDecision {
 pub struct FallThrough<S = ()> {
     name: String,
     decision_reason: fn(&str, &Score) -> String,
+    decision_confidence: fn(&Score) -> Option<f64>,
     processors: Vec<Arc<dyn Processor<S>>>,
     classifiers: Vec<Arc<dyn Classifier<S>>>,
     targets: LlmTargetSet,
@@ -72,6 +78,7 @@ impl FallThrough<()> {
         Self {
             name: "fall_through".to_string(),
             decision_reason: default_decision_reason,
+            decision_confidence: |score| Some(score.confidence),
             processors: Vec::new(),
             classifiers: Vec::new(),
             targets,
@@ -89,6 +96,7 @@ where
         Self {
             name: "fall_through".to_string(),
             decision_reason: default_decision_reason,
+            decision_confidence: |score| Some(score.confidence),
             processors: Vec::new(),
             classifiers: Vec::new(),
             targets,
@@ -105,6 +113,14 @@ where
     /// Sets the decision reasoning for an algorithm assembled from this cascade.
     pub(crate) fn with_decision_reason(mut self, reason: fn(&str, &Score) -> String) -> Self {
         self.decision_reason = reason;
+        self
+    }
+
+    pub(crate) fn with_decision_confidence(
+        mut self,
+        confidence: fn(&Score) -> Option<f64>,
+    ) -> Self {
+        self.decision_confidence = confidence;
         self
     }
 
@@ -236,6 +252,12 @@ where
             selected_model: score.target.clone(),
             reasoning: (self.decision_reason)(&self.name, &score),
             tier: maybe_tier,
+            metadata: driver.decision_metadata(
+                DecisionRole::Final,
+                (self.decision_confidence)(&score),
+                None,
+                None,
+            ),
         });
         driver.info(ctx.clone(), decision.clone()).await?;
 

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -487,6 +487,41 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct MetadataClient {
+        calls: Mutex<
+            Vec<(
+                String,
+                Context,
+                Option<switchyard_protocol::DecisionMetadata>,
+            )>,
+        >,
+    }
+
+    #[async_trait]
+    impl RoutedLlmClient for MetadataClient {
+        async fn call(
+            &self,
+            ctx: Context,
+            request: Request,
+            decision: Arc<dyn crate::Decision>,
+        ) -> std::result::Result<Response, LlmClientError> {
+            let model = decision.selected_model().to_string();
+            self.calls
+                .lock()
+                .push((model.clone(), ctx, decision.metadata().cloned()));
+            let completion = if model == "judge" {
+                r#"{"recommended_route":"efficient","p_solve":0.9,"confidence":0.9,"abstain":false,"capability_boundary":"supported","primary_rule":"SUP-1","crux":"bounded task"}"#.to_string()
+            } else {
+                format!("answer from {model}")
+            };
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(None, completion)),
+                metadata: request.metadata,
+            })
+        }
+    }
+
     fn router(client: Arc<dyn RoutedLlmClient>) -> Result<Arc<LlmTaskClassifier>> {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
@@ -561,6 +596,46 @@ mod tests {
             client.calls(),
             vec!["judge", "efficient", "judge", "efficient"]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn supporting_and_final_calls_share_run_identity_and_have_distinct_roles() -> Result<()> {
+        let client = Arc::new(MetadataClient::default());
+        router(client.clone())?
+            .run(Context::default(), classify_request())
+            .await?;
+
+        let calls = client.calls.lock();
+        assert_eq!(calls.len(), 2);
+        let (judge_model, judge_ctx, judge_metadata) = &calls[0];
+        let (final_model, final_ctx, final_metadata) = &calls[1];
+        let judge_metadata = judge_metadata
+            .as_ref()
+            .ok_or_else(|| LibsyError::AlgorithmError {
+                message: "judge call omitted decision metadata".to_string(),
+            })?;
+        let final_metadata = final_metadata
+            .as_ref()
+            .ok_or_else(|| LibsyError::AlgorithmError {
+                message: "final call omitted decision metadata".to_string(),
+            })?;
+
+        assert_eq!(judge_model, "judge");
+        assert_eq!(final_model, "efficient");
+        assert_eq!(
+            judge_metadata.role,
+            switchyard_protocol::DecisionRole::Judge
+        );
+        assert_eq!(
+            final_metadata.role,
+            switchyard_protocol::DecisionRole::Final
+        );
+        assert_ne!(judge_metadata.decision_id, final_metadata.decision_id);
+        assert_eq!(judge_metadata.run_id, final_metadata.run_id);
+        assert_eq!(judge_metadata.algorithm, final_metadata.algorithm);
+        assert_eq!(judge_metadata.algorithm.name, "llm_task_classifier");
+        assert_eq!(judge_ctx.values, final_ctx.values);
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -171,17 +171,29 @@ impl Algorithm for Random {
     ) -> Result<Response> {
         self.inner.execute(ctx, driver, request).await
     }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn crate::Decision>> {
+        self.inner.decide(ctx, driver, request).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
     use std::collections::HashSet;
 
     use switchyard_protocol::{completion_text, text_request, text_response, Metadata};
 
     use crate::algorithms::AffinityRouter;
-    use crate::{Decision, LlmResponse, LlmTarget, Request, RoutedLlmClient, Signals};
+    use crate::{
+        Decision, DecisionStep, LlmResponse, LlmTarget, Request, RoutedLlmClient, Signals,
+    };
 
     /// Echoes the selected target so tests can inspect which target was called.
     struct EchoClient;
@@ -342,6 +354,88 @@ mod tests {
         assert!(
             (700..=800).contains(&second_count),
             "expected a roughly 25/75 split, selected b/model {second_count} times"
+        );
+        Ok(())
+    }
+
+    async fn decision_only_selections(
+        algorithm: Arc<dyn Algorithm>,
+        count: usize,
+    ) -> Result<Vec<String>> {
+        let mut selected = Vec::with_capacity(count);
+        for _ in 0..count {
+            let stream = algorithm
+                .clone()
+                .run_decision_stream(Context::default(), request());
+            tokio::pin!(stream);
+
+            let mut final_decision = None;
+            while let Some(step) = stream.next().await {
+                match step? {
+                    DecisionStep::CallLlm(_) => {
+                        return Err(LibsyError::AlgorithmError {
+                            message: "random decision-only run requested an LLM call".to_string(),
+                        });
+                    }
+                    DecisionStep::Decision(_) => {}
+                    DecisionStep::FinalDecision(decision) => {
+                        final_decision = Some(decision.selected_model().to_string());
+                    }
+                }
+            }
+            selected.push(final_decision.ok_or_else(|| LibsyError::AlgorithmError {
+                message: "random decision-only run had no final decision".to_string(),
+            })?);
+        }
+        Ok(selected)
+    }
+
+    #[tokio::test]
+    async fn decision_only_selects_without_dispatching_the_target() -> Result<()> {
+        let algorithm: Arc<dyn Algorithm> =
+            Arc::new(Random::new(target_set(&["only/model"]), None, Some(42))?);
+
+        let stream = algorithm.run_decision_stream(Context::default(), request());
+        tokio::pin!(stream);
+        let mut steps = Vec::new();
+        while let Some(step) = stream.next().await {
+            match step? {
+                DecisionStep::CallLlm(_) => {
+                    return Err(LibsyError::AlgorithmError {
+                        message: "random decision-only run dispatched its selected target"
+                            .to_string(),
+                    });
+                }
+                DecisionStep::Decision(decision) => {
+                    assert_eq!(decision.selected_model(), "only/model");
+                    steps.push("decision");
+                }
+                DecisionStep::FinalDecision(decision) => {
+                    assert_eq!(decision.selected_model(), "only/model");
+                    steps.push("final_decision");
+                }
+            }
+        }
+        assert_eq!(steps, vec!["decision", "final_decision"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_seeded_selection_is_reproducible() -> Result<()> {
+        let first: Arc<dyn Algorithm> = Arc::new(algorithm(
+            &["a/model", "b/model"],
+            Some(vec![1.0, 3.0]),
+            Some(42),
+        )?);
+        let second: Arc<dyn Algorithm> = Arc::new(algorithm(
+            &["a/model", "b/model"],
+            Some(vec![1.0, 3.0]),
+            Some(42),
+        )?);
+
+        assert_eq!(
+            decision_only_selections(first, 1_000).await?,
+            decision_only_selections(second, 1_000).await?
         );
         Ok(())
     }

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -144,6 +144,7 @@ impl Random {
         let inner = FallThrough::<()>::new(target_set)
             .with_name("random")
             .with_decision_reason(random_decision_reason)
+            .with_decision_confidence(|_| None)
             .with_classifier(classifier);
         Ok(Self { inner })
     }
@@ -349,6 +350,41 @@ mod tests {
             );
             assert_eq!(trace[0].selected_model(), selected.as_str());
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_random_decisions_have_independent_identity_without_fake_confidence(
+    ) -> Result<()> {
+        let algorithm = shared_algorithm(&["a/model", "b/model"])?;
+        let (first, second) = tokio::join!(
+            algorithm.clone().run(Context::default(), request()),
+            algorithm.run(Context::default(), request())
+        );
+        let (first_trace, _) = first?;
+        let (second_trace, _) = second?;
+
+        let first = first_trace[0]
+            .metadata()
+            .ok_or_else(|| LibsyError::AlgorithmError {
+                message: "random decision omitted structured metadata".to_string(),
+            })?;
+        let second = second_trace[0]
+            .metadata()
+            .ok_or_else(|| LibsyError::AlgorithmError {
+                message: "random decision omitted structured metadata".to_string(),
+            })?;
+
+        assert!(!first.decision_id.is_empty());
+        assert!(!first.run_id.is_empty());
+        assert_ne!(first.decision_id, second.decision_id);
+        assert_ne!(first.run_id, second.run_id);
+        assert_eq!(first.algorithm.name, "random");
+        assert_eq!(first.algorithm.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(first.role, switchyard_protocol::DecisionRole::Final);
+        assert_eq!(first.confidence, None);
+        assert_eq!(first.baseline, None);
+        assert_eq!(first.response_source_decision_id, None);
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -213,6 +213,24 @@ mod tests {
         }
     }
 
+    /// Returns a typed model-availability failure for the selected target.
+    struct ModelUnavailableClient;
+
+    #[async_trait]
+    impl RoutedLlmClient for ModelUnavailableClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> std::result::Result<Response, switchyard_protocol::LlmClientError> {
+            Err(switchyard_protocol::LlmClientError::ModelUnavailable {
+                model: decision.selected_model().to_string(),
+                message: "model is temporarily unavailable".to_string(),
+            })
+        }
+    }
+
     fn request() -> Request {
         Request {
             llm_request: text_request(Some("auto".to_string()), "hi"),
@@ -281,6 +299,35 @@ mod tests {
         );
         assert_eq!(trace.len(), 1);
         assert_eq!(trace[0].selected_model(), "only/model");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn model_unavailable_error_survives_a_random_run() -> Result<()> {
+        let target = LlmTarget {
+            semantic_name: "busy/model".to_string(),
+            llm_client: Some(Arc::new(ModelUnavailableClient)),
+        };
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Random::new(
+            LlmTargetSet::new(vec![target]),
+            None,
+            Some(42),
+        )?);
+
+        let error = algorithm
+            .run(Context::default(), request())
+            .await
+            .err()
+            .ok_or_else(|| LibsyError::AlgorithmError {
+                message: "expected a model-unavailable failure".to_string(),
+            })?;
+        assert!(matches!(
+            error,
+            LibsyError::ClientCall {
+                target,
+                source: switchyard_protocol::LlmClientError::ModelUnavailable { model, .. },
+            } if target == "busy/model" && model == "busy/model"
+        ));
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/util.rs
+++ b/crates/libsy/src/algorithms/util.rs
@@ -11,3 +11,4 @@ pub(crate) mod tool_signals;
 pub use affinity::AffinityRouter;
 pub(crate) use llm_judge::{Judge, JudgeClassifier, JudgeConfig, JudgePolicy};
 pub use subagent::SubagentOverride;
+pub use tool_signals::ToolSignalProcessor;

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -15,8 +15,7 @@ use serde_json::Value;
 use switchyard_protocol::{completion_text, AggLlmResponse};
 
 use crate::{
-    Classification, Classifier, Context, Decision, Driver, LibsyError, LlmTarget, Request, Result,
-    State,
+    Classification, Classifier, Decision, Driver, LibsyError, LlmTarget, Request, Result, State,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -94,11 +93,17 @@ where
 
         let response = driver
             .call_llm_target(
-                Context::default(),
+                driver.context().clone(),
                 &self.target,
                 self.judge.build_request(state, request),
                 Arc::new(JudgeDecision {
                     model: self.target.semantic_name.to_string(),
+                    metadata: driver.decision_metadata(
+                        crate::DecisionRole::Judge,
+                        None,
+                        None,
+                        None,
+                    ),
                 }),
             )
             .await
@@ -158,6 +163,7 @@ fn parse_json_verdict<T: DeserializeOwned>(response: &AggLlmResponse) -> Result<
 
 struct JudgeDecision {
     model: String,
+    metadata: crate::DecisionMetadata,
 }
 
 impl Decision for JudgeDecision {
@@ -171,6 +177,10 @@ impl Decision for JudgeDecision {
 
     fn reasoning(&self) -> Option<&str> {
         Some("llm judge consultation")
+    }
+
+    fn metadata(&self) -> Option<&crate::DecisionMetadata> {
+        Some(&self.metadata)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -293,7 +303,7 @@ mod tests {
     /// Serves the single offloaded judge call with `reply`. The stream is taken first
     /// because the driver refuses to publish a step until a consumer exists.
     async fn score_served_with(reply: Result<Response>) -> Result<String> {
-        let driver = Driver::new();
+        let driver = Driver::new(crate::Context::default());
         let mut steps = Box::pin(driver.stream());
         let classifier = classifier();
         let mut state = State::default();

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -28,6 +28,10 @@ use crate::{observability, DriverError, LibsyError, Result};
 /// `Arc<dyn Algorithm>` object-safe.
 pub type StepStream = Pin<Box<dyn Stream<Item = Result<Step>> + Send>>;
 
+/// A boxed, `Send` stream of [`DecisionStep`]s — the output of
+/// [`Algorithm::run_decision_stream`].
+pub type DecisionStepStream = Pin<Box<dyn Stream<Item = Result<DecisionStep>> + Send>>;
+
 /// A request paired with the routing [`Decision`] that produced it — the offload
 /// payload a host reads (via [`CallLlmRequest::get_routed`]) to serve the call.
 ///
@@ -207,6 +211,19 @@ impl Driver {
         }
     }
 
+    /// Emit the terminal decision-only step. Internal: called once by
+    /// [`Algorithm::run_decision_stream`] when the algorithm finishes.
+    pub(crate) async fn finish_decision(
+        &self,
+        ctx: Context,
+        result: Result<Arc<dyn Decision>>,
+    ) -> Result<()> {
+        match result {
+            Ok(decision) => self.driver.done(ctx, decision).await,
+            Err(err) => self.driver.fail(ctx, err).await,
+        }
+    }
+
     /// Transform the raw driver stream into a stream of [`Step`]s. Internal: the
     /// consumer stream is taken (once) by [`run_stream`](Algorithm::run_stream). A
     /// payload that does not match the expected type for its step becomes an `Err` item.
@@ -233,6 +250,35 @@ impl Driver {
                 }),
         })
     }
+
+    /// Transform the raw driver stream into a stream of [`DecisionStep`]s.
+    /// Internal: the consumer stream is taken once by
+    /// [`Algorithm::run_decision_stream`].
+    pub(crate) fn decision_stream(&self) -> impl Stream<Item = Result<DecisionStep>> {
+        self.driver.stream().map(|item| match item? {
+            DriverStep::Request(req) => {
+                Ok(DecisionStep::CallLlm(Box::new(CallLlmRequest::new(req))))
+            }
+            DriverStep::Info(payload) => payload
+                .downcast::<Arc<dyn Decision>>()
+                .map(|decision| DecisionStep::Decision(*decision))
+                .map_err(|_| {
+                    DriverError::TypeMismatch {
+                        expected: "Arc<dyn Decision>",
+                    }
+                    .into()
+                }),
+            DriverStep::Done(payload) => payload
+                .downcast::<Arc<dyn Decision>>()
+                .map(|decision| DecisionStep::FinalDecision(*decision))
+                .map_err(|_| {
+                    DriverError::TypeMismatch {
+                        expected: "Arc<dyn Decision>",
+                    }
+                    .into()
+                }),
+        })
+    }
 }
 
 impl Default for Driver {
@@ -252,6 +298,22 @@ pub enum Step {
     Decision(Arc<dyn Decision>),
     /// The algorithm finished with its final response — the last step of a run.
     ReturnToAgent(Box<Response>),
+}
+
+/// One item in the stream returned by [`Algorithm::run_decision_stream`].
+///
+/// A decision-only run may still request supporting model calls while computing a
+/// route. It never dispatches the final selected target: successful completion is
+/// represented explicitly by [`FinalDecision`](Self::FinalDecision).
+pub enum DecisionStep {
+    /// The algorithm needs a supporting model call to compute its final decision.
+    /// The host serves and fulfills it exactly like [`Step::CallLlm`].
+    CallLlm(Box<CallLlmRequest>),
+    /// An intermediate decision or trace event published while the algorithm runs.
+    Decision(Arc<dyn Decision>),
+    /// The algorithm completed with the decision the host may observe without
+    /// dispatching its selected target.
+    FinalDecision(Arc<dyn Decision>),
 }
 
 /// Abort guard
@@ -347,6 +409,25 @@ pub trait Algorithm: Send + Sync + 'static {
         request: Request,
     ) -> Result<Response>;
 
+    /// Compute the final routing decision without dispatching its selected target.
+    ///
+    /// Algorithms that support this contract implement the same orchestration they
+    /// use for a normal run up to target dispatch, returning the terminal decision
+    /// instead. Supporting calls needed to compute that decision may still be
+    /// offloaded through `driver`. The default is an explicit typed error because a
+    /// full-lifecycle algorithm cannot necessarily be reduced to one route.
+    #[allow(unused_variables)]
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        Err(LibsyError::DecisionOnlyUnsupported {
+            algorithm: self.name().to_string(),
+        })
+    }
+
     /// Feed the algorithm agentic-stack events (tool results, budgets, etc.). The
     /// reference algorithms ignore signals; a stateful algorithm updates its own
     /// (interior-mutable) state. Takes `self: Arc<Self>` like the other run methods.
@@ -436,6 +517,57 @@ pub trait Algorithm: Send + Sync + 'static {
         let stream: StepStream = Box::pin(stream);
         Box::pin(futures::stream::select(stream, tail).map(move |step| {
             // link abort guard to stream
+            let _keep_alive = &abort_guard;
+            step
+        }))
+    }
+
+    /// Compute one request's final routing decision as a stream without dispatching
+    /// the selected target.
+    ///
+    /// The stream may contain [`DecisionStep::CallLlm`] for supporting calls an
+    /// algorithm requires to decide, followed by informational
+    /// [`DecisionStep::Decision`] items. Success terminates explicitly with
+    /// [`DecisionStep::FinalDecision`]. Algorithms that cannot faithfully provide
+    /// this contract yield [`LibsyError::DecisionOnlyUnsupported`].
+    fn run_decision_stream(self: Arc<Self>, ctx: Context, request: Request) -> DecisionStepStream {
+        let mut ctx = ctx;
+        ctx.values.insert(
+            observability::ALGORITHM_KEY.to_string(),
+            self.name().to_string(),
+        );
+        let driver = Driver::new();
+        let task_driver = driver.clone();
+        let task_ctx = ctx.clone();
+        let stream = task_driver.decision_stream();
+        let span = observability::run_span(self.name(), request.metadata.as_ref());
+        let handle = tokio::spawn(
+            async move {
+                observability::observe_run(
+                    task_ctx.clone(),
+                    self.create_decision_task(task_ctx, task_driver, request),
+                )
+                .await
+            }
+            .instrument(span),
+        );
+        let abort_guard = AbortOnDrop(handle.abort_handle());
+
+        let finish_driver = driver.clone();
+        let finish_ctx = ctx;
+        let tail: DecisionStepStream = Box::pin(
+            futures::stream::once(async move {
+                let result = match handle.await {
+                    Ok(decision) => decision,
+                    Err(source) => Err(LibsyError::AlgorithmTask { source }),
+                };
+                finish_driver.finish_decision(finish_ctx, result).await
+            })
+            .filter_map(|finish_result| async move { finish_result.err().map(Err) }),
+        );
+
+        let stream: DecisionStepStream = Box::pin(stream);
+        Box::pin(futures::stream::select(stream, tail).map(move |step| {
             let _keep_alive = &abort_guard;
             step
         }))
@@ -769,6 +901,101 @@ mod tests {
             final_completion.ok_or_else(|| test_error("no ReturnToAgent step"))?,
             "fulfilled"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_is_an_explicit_typed_capability() -> Result<()> {
+        let stream = orch(target_set(&[("offload/model", false)]))
+            .run_decision_stream(Context::default(), request());
+        tokio::pin!(stream);
+
+        let error = stream
+            .next()
+            .await
+            .ok_or_else(|| test_error("decision-only stream ended without a result"))?
+            .err()
+            .ok_or_else(|| test_error("unsupported algorithm unexpectedly decided"))?;
+        assert!(matches!(
+            error,
+            LibsyError::DecisionOnlyUnsupported { algorithm } if algorithm == "test"
+        ));
+        assert!(
+            stream.next().await.is_none(),
+            "unsupported decision-only stream should terminate after its typed error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_can_offload_supporting_calls_without_dispatching_the_final_target(
+    ) -> Result<()> {
+        struct SupportingCallAlgo {
+            judge: LlmTarget,
+        }
+
+        #[async_trait]
+        impl Algorithm for SupportingCallAlgo {
+            fn name(&self) -> &str {
+                "supporting_call"
+            }
+
+            async fn create_run_task(
+                self: Arc<Self>,
+                _ctx: Context,
+                _driver: Driver,
+                _request: Request,
+            ) -> Result<Response> {
+                Err(test_error("full execution is not used by this test"))
+            }
+
+            async fn create_decision_task(
+                self: Arc<Self>,
+                ctx: Context,
+                driver: Driver,
+                request: Request,
+            ) -> Result<Arc<dyn Decision>> {
+                let judge_decision: Arc<dyn Decision> = Arc::new(TestDecision {
+                    model: self.judge.semantic_name.clone(),
+                });
+                driver
+                    .call_llm_target(ctx, &self.judge, request, judge_decision)
+                    .await?;
+                Ok(Arc::new(TestDecision {
+                    model: "final/model".to_string(),
+                }))
+            }
+        }
+
+        let algorithm: Arc<dyn Algorithm> = Arc::new(SupportingCallAlgo {
+            judge: LlmTarget {
+                semantic_name: "judge/model".to_string(),
+                llm_client: None,
+            },
+        });
+        let stream = algorithm.run_decision_stream(Context::default(), request());
+        tokio::pin!(stream);
+
+        let mut calls = Vec::new();
+        let mut final_model = None;
+        while let Some(step) = stream.next().await {
+            match step? {
+                DecisionStep::CallLlm(call) => {
+                    calls.push(call.get_decision().selected_model().to_string());
+                    call.respond(Ok(Response {
+                        llm_response: LlmResponse::Agg(text_response(None, "judge result")),
+                        metadata: None,
+                    }))?;
+                }
+                DecisionStep::Decision(_) => {}
+                DecisionStep::FinalDecision(decision) => {
+                    final_model = Some(decision.selected_model().to_string());
+                }
+            }
+        }
+
+        assert_eq!(calls, vec!["judge/model"]);
+        assert_eq!(final_model.as_deref(), Some("final/model"));
         Ok(())
     }
 

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -16,12 +16,49 @@ use tracing::Instrument;
 /// [`LlmResponseChunk`] is one streaming event; [`LlmResponse`] is the streamed response
 /// (a live [`LlmResponseStream`] or the terminal aggregate).
 pub use switchyard_protocol::{
-    AggLlmResponse, Context, Decision, LlmClientError, LlmRequest, LlmResponse, LlmResponseChunk,
-    LlmResponseStream, Metadata, Request, Response, RoutedLlmClient, Signals, Usage,
+    AggLlmResponse, AlgorithmIdentity, Context, Decision, DecisionBaseline, DecisionMetadata,
+    DecisionRole, LlmClientError, LlmRequest, LlmResponse, LlmResponseChunk, LlmResponseStream,
+    Metadata, Request, Response, RoutedLlmClient, Signals, Usage,
 };
 
 use super::driver::{DriverRequest, DriverStep, TypeErasedDriver};
 use crate::{observability, DriverError, LibsyError, Result};
+
+const RUN_ID_KEY: &str = "switchyard.run_id";
+const ALGORITHM_VERSION_KEY: &str = "switchyard.algorithm_version";
+
+fn decision_metadata(
+    ctx: &Context,
+    role: DecisionRole,
+    confidence: Option<f64>,
+    baseline: Option<DecisionBaseline>,
+    response_source_decision_id: Option<String>,
+) -> DecisionMetadata {
+    DecisionMetadata {
+        decision_id: generated_id("decision"),
+        run_id: ctx
+            .values
+            .get(RUN_ID_KEY)
+            .cloned()
+            .unwrap_or_else(|| generated_id("run")),
+        algorithm: AlgorithmIdentity {
+            name: observability::algorithm_label(ctx).to_string(),
+            version: ctx
+                .values
+                .get(ALGORITHM_VERSION_KEY)
+                .cloned()
+                .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
+        },
+        role,
+        confidence,
+        baseline,
+        response_source_decision_id,
+    }
+}
+
+fn generated_id(kind: &str) -> String {
+    format!("sy_{kind}_{:032x}", rand::random::<u128>())
+}
 
 /// A boxed, `Send` stream of [`Step`]s — the output of
 /// [`Algorithm::run_stream`]. Boxed so the trait method that produces it keeps
@@ -115,15 +152,42 @@ impl CallLlmRequest {
 #[derive(Clone)]
 pub struct Driver {
     driver: TypeErasedDriver,
+    ctx: Context,
 }
 
 impl Driver {
     /// Build an empty driver with its step channel ready. Created per call by
     /// [`run_stream`](Algorithm::run_stream).
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(ctx: Context) -> Self {
         Self {
             driver: TypeErasedDriver::new(),
+            ctx,
         }
+    }
+
+    pub(crate) fn context(&self) -> &Context {
+        &self.ctx
+    }
+
+    /// Constructs structured metadata for a decision in this run.
+    ///
+    /// Every value is algorithm-owned. Callers should leave confidence,
+    /// baseline, or response provenance unset when the algorithm does not
+    /// define those semantics.
+    pub fn decision_metadata(
+        &self,
+        role: DecisionRole,
+        confidence: Option<f64>,
+        baseline: Option<DecisionBaseline>,
+        response_source_decision_id: Option<String>,
+    ) -> DecisionMetadata {
+        decision_metadata(
+            &self.ctx,
+            role,
+            confidence,
+            baseline,
+            response_source_decision_id,
+        )
     }
 
     /// Offload a model call: publish `routed` as a [`Step::CallLlm`] and await the
@@ -283,7 +347,7 @@ impl Driver {
 
 impl Default for Driver {
     fn default() -> Self {
-        Self::new()
+        Self::new(Context::default())
     }
 }
 
@@ -397,6 +461,14 @@ pub trait Algorithm: Send + Sync + 'static {
     /// emits for its runs (see the crate docs' Observability section).
     fn name(&self) -> &str;
 
+    /// Version of this algorithm implementation recorded on its decisions.
+    ///
+    /// Built-in algorithms use the libsy crate version. External algorithms
+    /// should override this when their implementation is versioned separately.
+    fn version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
     /// Run one request to completion: make model calls with [`Driver::call_llm_target`],
     /// publish [`Decision`]s with [`Driver::info`], and return the final [`Response`].
     /// The method an algorithm implements; [`run`](Self::run) / [`run_stream`](Self::run_stream)
@@ -480,7 +552,13 @@ pub trait Algorithm: Send + Sync + 'static {
             observability::ALGORITHM_KEY.to_string(),
             self.name().to_string(),
         );
-        let driver = Driver::new();
+        ctx.values.insert(
+            ALGORITHM_VERSION_KEY.to_string(),
+            self.version().to_string(),
+        );
+        ctx.values
+            .insert(RUN_ID_KEY.to_string(), generated_id("run"));
+        let driver = Driver::new(ctx.clone());
         let task_driver = driver.clone();
         let task_ctx = ctx.clone();
         let stream = task_driver.stream();
@@ -766,6 +844,79 @@ mod tests {
             error,
             Some(LibsyError::TargetNotFound { target }) if target == "missing"
         ));
+    }
+
+    #[tokio::test]
+    async fn decision_metadata_uses_the_algorithm_version_override() -> Result<()> {
+        struct VersionedDecision {
+            metadata: DecisionMetadata,
+        }
+
+        impl Decision for VersionedDecision {
+            fn selected_model(&self) -> &str {
+                "versioned/model"
+            }
+
+            fn reasoning(&self) -> Option<&str> {
+                None
+            }
+
+            fn metadata(&self) -> Option<&DecisionMetadata> {
+                Some(&self.metadata)
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        struct VersionedAlgo;
+
+        #[async_trait]
+        impl Algorithm for VersionedAlgo {
+            fn name(&self) -> &str {
+                "versioned"
+            }
+
+            fn version(&self) -> &str {
+                "custom-2.4.1"
+            }
+
+            async fn create_run_task(
+                self: Arc<Self>,
+                ctx: Context,
+                driver: Driver,
+                _request: Request,
+            ) -> Result<Response> {
+                let decision: Arc<dyn Decision> = Arc::new(VersionedDecision {
+                    metadata: driver.decision_metadata(DecisionRole::Final, None, None, None),
+                });
+                driver.info(ctx, decision).await?;
+                Ok(Response {
+                    llm_response: LlmResponse::Agg(text_response(
+                        None,
+                        "versioned response".to_string(),
+                    )),
+                    metadata: None,
+                })
+            }
+        }
+
+        let stream = Arc::new(VersionedAlgo).run_stream(Context::default(), request());
+        tokio::pin!(stream);
+
+        while let Some(step) = stream.next().await {
+            if let Step::Decision(decision) = step? {
+                let metadata = decision
+                    .metadata()
+                    .ok_or_else(|| test_error("decision metadata missing"))?;
+                assert_eq!(metadata.algorithm.name, "versioned");
+                assert_eq!(metadata.algorithm.version, "custom-2.4.1");
+                return Ok(());
+            }
+        }
+
+        Err(test_error("decision step missing"))
     }
 
     /// Client that serves a call as a token stream — its `call` returns

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -614,7 +614,13 @@ pub trait Algorithm: Send + Sync + 'static {
             observability::ALGORITHM_KEY.to_string(),
             self.name().to_string(),
         );
-        let driver = Driver::new();
+        ctx.values.insert(
+            ALGORITHM_VERSION_KEY.to_string(),
+            self.version().to_string(),
+        );
+        ctx.values
+            .insert(RUN_ID_KEY.to_string(), generated_id("run"));
+        let driver = Driver::new(ctx.clone());
         let task_driver = driver.clone();
         let task_ctx = ctx.clone();
         let stream = task_driver.decision_stream();
@@ -1076,6 +1082,82 @@ mod tests {
             "unsupported decision-only stream should terminate after its typed error"
         );
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_metadata_uses_the_algorithm_version_and_run_identity() -> Result<()> {
+        struct VersionedDecision {
+            metadata: DecisionMetadata,
+        }
+
+        impl Decision for VersionedDecision {
+            fn selected_model(&self) -> &str {
+                "versioned/model"
+            }
+
+            fn reasoning(&self) -> Option<&str> {
+                None
+            }
+
+            fn metadata(&self) -> Option<&DecisionMetadata> {
+                Some(&self.metadata)
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        struct VersionedDecisionAlgo;
+
+        #[async_trait]
+        impl Algorithm for VersionedDecisionAlgo {
+            fn name(&self) -> &str {
+                "versioned_decision"
+            }
+
+            fn version(&self) -> &str {
+                "custom-2.4.1"
+            }
+
+            async fn create_run_task(
+                self: Arc<Self>,
+                _ctx: Context,
+                _driver: Driver,
+                _request: Request,
+            ) -> Result<Response> {
+                Err(test_error("full execution is not used by this test"))
+            }
+
+            async fn create_decision_task(
+                self: Arc<Self>,
+                _ctx: Context,
+                driver: Driver,
+                _request: Request,
+            ) -> Result<Arc<dyn Decision>> {
+                Ok(Arc::new(VersionedDecision {
+                    metadata: driver.decision_metadata(DecisionRole::Final, None, None, None),
+                }))
+            }
+        }
+
+        let stream =
+            Arc::new(VersionedDecisionAlgo).run_decision_stream(Context::default(), request());
+        tokio::pin!(stream);
+
+        while let Some(step) = stream.next().await {
+            if let DecisionStep::FinalDecision(decision) = step? {
+                let metadata = decision
+                    .metadata()
+                    .ok_or_else(|| test_error("decision metadata missing"))?;
+                assert_eq!(metadata.algorithm.name, "versioned_decision");
+                assert_eq!(metadata.algorithm.version, "custom-2.4.1");
+                assert!(metadata.run_id.starts_with("sy_run_"));
+                return Ok(());
+            }
+        }
+
+        Err(test_error("final decision missing"))
     }
 
     #[tokio::test]

--- a/crates/libsy/src/error.rs
+++ b/crates/libsy/src/error.rs
@@ -55,6 +55,13 @@ pub enum LibsyError {
     #[error("algorithm run ended without a final response")]
     MissingFinalResponse,
 
+    /// The algorithm does not expose a decision-only execution contract.
+    #[error("algorithm {algorithm:?} does not support decision-only execution")]
+    DecisionOnlyUnsupported {
+        /// Algorithm that cannot terminate with a routing decision.
+        algorithm: String,
+    },
+
     /// A target's protocol client failed while serving a routed request.
     #[error("client call to target {target:?} failed: {source}")]
     ClientCall {

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -19,7 +19,10 @@
 //!   returns the final [`Response`]. The provided
 //!   [`run_stream`](Algorithm::run_stream) drives that on its own task and hands
 //!   back a stream of [`Step`]s; [`run`](Algorithm::run) runs
-//!   it to completion with the targets' default clients.
+//!   it to completion with the targets' default clients. Algorithms that can
+//!   faithfully terminate after selecting a route also implement
+//!   [`create_decision_task`](Algorithm::create_decision_task), driven by
+//!   [`run_decision_stream`](Algorithm::run_decision_stream).
 //! - An [`LlmTarget`] names a routing target by its [`semantic_name`](LlmTarget::semantic_name).
 //!   Every call is *offloaded* to the request's stream as a [`Step::CallLlm`]; the
 //!   target's [`RoutedLlmClient`], if any, rides along as
@@ -42,6 +45,12 @@
 //!   [`Step::ReturnToAgent`] carrying the final response. The step stream is bounded,
 //!   so pulling it paces the algorithm one step at a time — an "ask, don't call" mode
 //!   that lets a host that owns its transport keep control of every call.
+//! - [`run_decision_stream`](Algorithm::run_decision_stream) — compute a final
+//!   route without dispatching the selected target. Supporting model calls needed
+//!   by an algorithm may still arrive as [`DecisionStep::CallLlm`]; success ends
+//!   explicitly with [`DecisionStep::FinalDecision`]. Algorithms that cannot be
+//!   reduced faithfully to one route return
+//!   [`LibsyError::DecisionOnlyUnsupported`].
 //!
 //! ## Concurrency
 //!

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -95,6 +95,7 @@ pub mod algorithms;
 
 mod observability;
 pub use algorithms::util::tool_signals::{ToolSignals, DEFAULT_RECENT_WINDOW};
+pub use algorithms::util::ToolSignalProcessor;
 
 /// Registers process-wide compatibility gauges with the global meter provider.
 ///

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -135,10 +135,10 @@ pub(crate) fn run_span(algorithm: &str, metadata: Option<&Metadata>) -> Span {
 /// Runs one algorithm task to completion, recording the run counter, duration
 /// histogram, span outcome, and failure log when it resolves. Executes inside
 /// the `libsy.run` span its caller instruments the task with.
-pub(crate) async fn observe_run(
+pub(crate) async fn observe_run<T>(
     ctx: Context,
-    run: impl Future<Output = Result<Response>>,
-) -> Result<Response> {
+    run: impl Future<Output = Result<T>>,
+) -> Result<T> {
     let started = Instant::now();
     let result = run.await;
     record_run(
@@ -164,7 +164,7 @@ pub(crate) fn record_client_call(result: &Result<Response>) {
 /// Records the end of one algorithm run: the run counter and duration
 /// histogram, the `outcome`/`error` fields on `span`, and a warn log when the
 /// run failed.
-fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, span: &Span) {
+fn record_run<T>(algorithm: &str, duration: Duration, result: &Result<T>, span: &Span) {
     let outcome = outcome_value(result);
     span.record("outcome", outcome);
     if let Err(error) = result {

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -735,7 +735,7 @@ async fn classifier_metrics_count_only_the_final_routed_call() -> switchyard_lib
             &snapshots,
             "switchyard.llm_calls",
             &[
-                ("algorithm", ""),
+                ("algorithm", "llm_task_classifier"),
                 ("selected_model", "classifier"),
                 ("outcome", "ok"),
             ],

--- a/crates/libsy/tests/public_api.rs
+++ b/crates/libsy/tests/public_api.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compile-time coverage for host-facing libsy composition APIs.
+
+use switchyard_libsy::ToolSignalProcessor;
+
+#[test]
+fn host_can_construct_the_public_tool_signal_processor() {
+    let _processor = ToolSignalProcessor::default();
+}

--- a/crates/protocol/src/client.rs
+++ b/crates/protocol/src/client.rs
@@ -73,6 +73,15 @@ pub enum LlmClientError {
         message: String,
     },
 
+    /// The selected model is temporarily unavailable and another target may be tried.
+    #[error("model {model} is unavailable: {message}")]
+    ModelUnavailable {
+        /// Model that could not serve the request.
+        model: String,
+        /// Upstream error message.
+        message: String,
+    },
+
     /// The upstream returned a non-success HTTP response.
     #[error("upstream returned HTTP {status}: {body}")]
     UpstreamHttp {

--- a/crates/protocol/src/client.rs
+++ b/crates/protocol/src/client.rs
@@ -13,12 +13,65 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{Context, Request, Response};
 
 /// A boxed client-specific error preserved as the source of a routed call failure.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Stable identity for the algorithm that produced a routing decision.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AlgorithmIdentity {
+    /// Stable, low-cardinality algorithm name.
+    pub name: String,
+    /// Version of the algorithm implementation.
+    pub version: String,
+}
+
+/// Semantic role a decision plays within one algorithm run.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionRole {
+    /// A supporting model call used to compute another decision.
+    Supporting,
+    /// A candidate response that may or may not be selected.
+    Candidate,
+    /// A judge call used to select among candidates.
+    Judge,
+    /// The final route or response selected for the caller.
+    Final,
+}
+
+/// Counterfactual route supplied by an algorithm that defines a baseline.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DecisionBaseline {
+    /// Semantic target name of the baseline route.
+    pub selected_model: String,
+    /// Optional routing tier of the baseline route.
+    pub routing_tier: Option<String>,
+}
+
+/// Structured, algorithm-owned metadata for one routing decision.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct DecisionMetadata {
+    /// Unique identifier for this decision.
+    pub decision_id: String,
+    /// Identifier shared by every decision and model call in one algorithm run.
+    pub run_id: String,
+    /// Algorithm implementation that produced the decision.
+    pub algorithm: AlgorithmIdentity,
+    /// Role this decision plays in the run.
+    pub role: DecisionRole,
+    /// Optional algorithm-defined confidence in the decision.
+    pub confidence: Option<f64>,
+    /// Optional algorithm-defined counterfactual route.
+    pub baseline: Option<DecisionBaseline>,
+    /// Decision whose provider response became the final response, when distinct
+    /// from this decision.
+    pub response_source_decision_id: Option<String>,
+}
 
 /// Failures a routed LLM client can surface to its caller.
 ///
@@ -132,6 +185,10 @@ pub trait Decision: Send + Sync {
     }
     /// A human-readable explanation of the decision, for logs and traces.
     fn reasoning(&self) -> Option<&str>;
+    /// Structured identity and telemetry supplied by the algorithm.
+    fn metadata(&self) -> Option<&DecisionMetadata> {
+        None
+    }
     /// Downcast handle: a consumer that knows the algorithm can recover the
     /// concrete decision type via `as_any().downcast_ref::<ConcreteDecision>()`.
     fn as_any(&self) -> &dyn std::any::Any;
@@ -173,5 +230,35 @@ pub trait RoutedLlmClient: Send + Sync {
         Err(LlmClientError::Configuration {
             message: "count_tokens is not supported by this client".to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_metadata_round_trips_with_stable_role_names(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let metadata = DecisionMetadata {
+            decision_id: "decision-1".to_string(),
+            run_id: "run-1".to_string(),
+            algorithm: AlgorithmIdentity {
+                name: "ensemble".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            role: DecisionRole::Judge,
+            confidence: Some(0.75),
+            baseline: Some(DecisionBaseline {
+                selected_model: "baseline".to_string(),
+                routing_tier: Some("weak".to_string()),
+            }),
+            response_source_decision_id: Some("candidate-2".to_string()),
+        };
+
+        let value = serde_json::to_value(&metadata)?;
+        assert_eq!(value["role"], "judge");
+        assert_eq!(serde_json::from_value::<DecisionMetadata>(value)?, metadata);
+        Ok(())
     }
 }

--- a/crates/protocol/src/llm.rs
+++ b/crates/protocol/src/llm.rs
@@ -221,6 +221,8 @@ pub struct LlmRequest {
     pub messages: Vec<Message>,
     pub tools: Vec<ToolDefinition>,
     pub tool_choice: Option<ToolChoice>,
+    /// Whether the provider may emit more than one tool call in a model turn.
+    pub parallel_tool_calls: Option<bool>,
     pub sampling: SamplingParams,
     pub output: OutputParams,
     pub reasoning: ReasoningParams,

--- a/crates/protocol/src/llm.rs
+++ b/crates/protocol/src/llm.rs
@@ -119,6 +119,7 @@ pub enum FileSource {
     FileId(String),
     FileData {
         data: String,
+        media_type: Option<String>,
         filename: Option<String>,
     },
     Raw(Value),

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    format::FormatId,
     llm::{AggLlmResponse, ContentBlock, ResponseOutput, Role, StopReason, ToolCall, Usage},
     LlmClientError,
 };
@@ -58,21 +59,7 @@ impl LlmResponse {
             LlmResponse::Stream(mut stream) => {
                 let mut accumulator = ResponseAccumulator::new();
                 while let Some(item) = stream.next().await {
-                    match item? {
-                        LlmResponseChunk::DecodeError { message } => {
-                            return Err(LlmClientError::ResponseTranslation(message));
-                        }
-                        LlmResponseChunk::StreamError { message } => {
-                            // The upstream reported the failure inside the response body, so
-                            // there is no real status line to carry; 502 stands in for "the
-                            // upstream failed" the same way a failed non-streaming call would.
-                            return Err(LlmClientError::UpstreamHttp {
-                                status: MID_STREAM_UPSTREAM_STATUS,
-                                body: message,
-                            });
-                        }
-                        chunk => accumulator.push(chunk),
-                    }
+                    push_checked_chunk(&mut accumulator, item?)?;
                 }
                 Ok(accumulator.finish())
             }
@@ -88,11 +75,59 @@ impl LlmResponse {
     }
 }
 
-/// One provider-neutral streaming event — the normalized counterpart to
-/// [`AggLlmResponse`](crate::AggLlmResponse), sitting between stream decoders and
-/// encoders. `switchyard-translation` re-exports it as `ConversationStreamEvent`.
+// Applies one chunk to an aggregate while surfacing errors nested inside an
+// exact provider-event envelope.
+fn push_checked_chunk(
+    accumulator: &mut ResponseAccumulator,
+    chunk: LlmResponseChunk,
+) -> Result<(), LlmClientError> {
+    match chunk {
+        LlmResponseChunk::ProviderEvent { normalized, .. } => {
+            for chunk in normalized {
+                push_checked_chunk(accumulator, chunk)?;
+            }
+            Ok(())
+        }
+        LlmResponseChunk::DecodeError { message } => {
+            Err(LlmClientError::ResponseTranslation(message))
+        }
+        LlmResponseChunk::StreamError { message } => {
+            // The upstream reported the failure inside the response body, so
+            // there is no real status line to carry; 502 stands in for "the
+            // upstream failed" the same way a failed non-streaming call would.
+            Err(LlmClientError::UpstreamHttp {
+                status: MID_STREAM_UPSTREAM_STATUS,
+                body: message,
+            })
+        }
+        chunk => {
+            accumulator.push(chunk);
+            Ok(())
+        }
+    }
+}
+
+/// One streaming event carried between a host and an algorithm.
+///
+/// Normalized variants expose provider-neutral meaning. [`ProviderEvent`](Self::ProviderEvent)
+/// additionally retains exact source JSON for a lossless same-format round trip while keeping
+/// normalized children available to algorithms and cross-format encoders.
+/// `switchyard-translation` re-exports this type as `ConversationStreamEvent`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LlmResponseChunk {
+    /// One exact provider event paired with the neutral events decoded from it.
+    ///
+    /// Hosts use the raw event for a same-format round trip and the normalized
+    /// events when an algorithm inspects the response or a different target
+    /// format must be encoded.
+    ProviderEvent {
+        /// Provider format that produced `raw`.
+        source: FormatId,
+        /// Exact parsed provider event.
+        raw: Value,
+        /// Provider-neutral events decoded from `raw`, in source order.
+        normalized: Vec<LlmResponseChunk>,
+    },
     MessageStart {
         id: Option<String>,
         model: Option<String>,
@@ -160,6 +195,11 @@ impl ResponseAccumulator {
     /// earlier ones; text, reasoning, and tool-call arguments append.
     pub fn push(&mut self, chunk: LlmResponseChunk) {
         match chunk {
+            LlmResponseChunk::ProviderEvent { normalized, .. } => {
+                for chunk in normalized {
+                    self.push(chunk);
+                }
+            }
             LlmResponseChunk::MessageStart { id, model } => {
                 if id.is_some() {
                     self.id = id;
@@ -303,6 +343,50 @@ mod tests {
                 text: "Hello".to_string()
             }]
         );
+    }
+
+    #[test]
+    fn folds_normalized_chunks_inside_provider_event() {
+        let aggregate = fold(vec![LlmResponseChunk::ProviderEvent {
+            source: crate::WireFormat::OpenAiChat.into(),
+            raw: json!({
+                "choices": [{"delta": {"content": "hello"}}],
+                "system_fingerprint": "fp_exact"
+            }),
+            normalized: vec![LlmResponseChunk::TextDelta {
+                index: 0,
+                text: "hello".to_string(),
+            }],
+        }]);
+
+        assert_eq!(
+            aggregate.outputs[0].content,
+            vec![ContentBlock::Text {
+                text: "hello".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn stream_errors_inside_provider_events_remain_typed() {
+        let response = LlmResponse::Stream(Box::pin(stream::iter([Ok(
+            LlmResponseChunk::ProviderEvent {
+                source: crate::WireFormat::OpenAiChat.into(),
+                raw: json!({"error": {"message": "provider failed"}}),
+                normalized: vec![LlmResponseChunk::StreamError {
+                    message: "provider failed".to_string(),
+                }],
+            },
+        )])));
+
+        let error = block_on(response.into_agg()).err();
+        assert!(matches!(
+            error,
+            Some(LlmClientError::UpstreamHttp {
+                status: MID_STREAM_UPSTREAM_STATUS,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -64,6 +64,12 @@ impl FormatCodec for AnthropicMessagesCodec {
                     .map(ToOwned::to_owned),
                 raw: body.get("thinking").cloned(),
             },
+            parallel_tool_calls: body
+                .get("tool_choice")
+                .and_then(Value::as_object)
+                .and_then(|choice| choice.get("disable_parallel_tool_use"))
+                .and_then(Value::as_bool)
+                .map(|disabled| !disabled),
             stream: body.get("stream").and_then(Value::as_bool).unwrap_or(false),
             preservation: capture_request_preservation(
                 WireFormat::AnthropicMessages,
@@ -192,11 +198,22 @@ impl FormatCodec for AnthropicMessagesCodec {
         if !request.tools.is_empty() {
             body.insert("tools".to_string(), encode_anthropic_tools(&request.tools));
         }
-        if let Some(choice) = &request.tool_choice {
-            body.insert(
-                "tool_choice".to_string(),
-                encode_anthropic_tool_choice(choice),
-            );
+        if request.tool_choice.is_some() || request.parallel_tool_calls.is_some() {
+            let choice = request
+                .tool_choice
+                .as_ref()
+                .map(encode_anthropic_tool_choice)
+                .unwrap_or_else(|| json!({"type": "auto"}));
+            let mut choice = choice.as_object().cloned().unwrap_or_else(|| {
+                Map::from_iter([("type".to_string(), Value::String("auto".to_string()))])
+            });
+            if let Some(parallel_tool_calls) = request.parallel_tool_calls {
+                choice.insert(
+                    "disable_parallel_tool_use".to_string(),
+                    Value::Bool(!parallel_tool_calls),
+                );
+            }
+            body.insert("tool_choice".to_string(), Value::Object(choice));
         }
         if let Some(stop_sequences) =
             anthropic_stop_sequences_from_extensions(&request.extensions.fields)

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -504,11 +504,41 @@ fn decode_anthropic_content_block(
         Some("input_file") | Some("file") => vec![ContentBlock::File {
             source: decode_file_source(block),
         }],
+        Some("document") => vec![ContentBlock::File {
+            source: decode_anthropic_document(block),
+        }],
         _ => vec![ContentBlock::Unknown {
             provider: WireFormat::AnthropicMessages.into(),
             raw: Value::Object(block.clone()),
         }],
     })
+}
+
+fn decode_anthropic_document(block: &Map<String, Value>) -> FileSource {
+    let Some(source) = block.get("source").and_then(Value::as_object) else {
+        return FileSource::Raw(Value::Object(block.clone()));
+    };
+    match source.get("type").and_then(Value::as_str) {
+        Some("file") => source.get("file_id").and_then(Value::as_str).map_or_else(
+            || FileSource::Raw(Value::Object(block.clone())),
+            |file_id| FileSource::FileId(file_id.to_string()),
+        ),
+        Some("base64") => source.get("data").and_then(Value::as_str).map_or_else(
+            || FileSource::Raw(Value::Object(block.clone())),
+            |data| FileSource::FileData {
+                data: data.to_string(),
+                media_type: source
+                    .get("media_type")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                filename: block
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+            },
+        ),
+        _ => FileSource::Raw(Value::Object(block.clone())),
+    }
 }
 
 // Converts Anthropic tool-result content into text-like IR blocks.
@@ -694,6 +724,58 @@ fn encode_anthropic_content_with_policy(
                 )?;
                 blocks.push(json!({"type": "text", "text": json_string(raw)}));
             }
+            ContentBlock::File {
+                source: FileSource::FileId(_),
+            } => {
+                return Err(TranslationError::NonPortableReference { kind: "file_id" });
+            }
+            ContentBlock::File {
+                source:
+                    FileSource::FileData {
+                        data,
+                        media_type,
+                        filename,
+                    },
+            } => {
+                let Some(media_type) = media_type.as_ref() else {
+                    return Err(TranslationError::InvalidValue {
+                        path: "$.messages[].content[].source.media_type".to_string(),
+                        message: "portable inline files require a media type".to_string(),
+                    });
+                };
+                if media_type != "application/pdf" {
+                    return Err(TranslationError::InvalidValue {
+                        path: "$.messages[].content[].source.media_type".to_string(),
+                        message: "Anthropic base64 documents require application/pdf".to_string(),
+                    });
+                }
+                let mut document = json!({
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": data,
+                    },
+                });
+                if let Some(filename) = filename {
+                    document["title"] = Value::String(filename.clone());
+                }
+                blocks.push(document);
+            }
+            ContentBlock::Audio { .. } => {
+                push_lossy(
+                    diagnostics,
+                    policy,
+                    "Anthropic Messages does not support audio content blocks",
+                )?;
+            }
+            ContentBlock::Video { .. } => {
+                push_lossy(
+                    diagnostics,
+                    policy,
+                    "Anthropic Messages does not support video content blocks",
+                )?;
+            }
             other => blocks.extend(encode_one_anthropic_block(other)),
         }
     }
@@ -774,13 +856,18 @@ fn encode_one_anthropic_block(block: &ContentBlock) -> Vec<Value> {
             FileSource::FileId(file_id) => {
                 json!({"type": "document", "source": {"type": "file", "file_id": file_id}})
             }
-            FileSource::FileData { data, filename } => json!({
+            FileSource::FileData {
+                data,
+                media_type,
+                filename,
+            } => json!({
                 "type": "document",
                 "source": {
                     "type": "base64",
                     "data": data,
-                    "filename": filename,
+                    "media_type": media_type,
                 },
+                "title": filename,
             }),
             FileSource::Raw(raw) => raw.clone(),
         }],

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -25,7 +25,8 @@ use crate::util::{
     exact_preserved_request, exact_preserved_response,
 };
 use crate::util::{
-    json_string, push_lossy, stable_id, string_value, validate_request_capabilities,
+    json_string, push_lossy, stable_id, string_value, validate_no_provider_managed_continuation,
+    validate_request_capabilities,
 };
 
 /// Format codec for Anthropic Messages payloads.
@@ -159,6 +160,7 @@ impl FormatCodec for AnthropicMessagesCodec {
             });
         }
         let mut diagnostics = Vec::new();
+        validate_no_provider_managed_continuation(request, &mut diagnostics, policy)?;
         validate_request_capabilities(request, &mut diagnostics, policy)?;
         let mut body = Map::new();
         if let Some(model) = &request.model {

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -126,6 +126,15 @@ fn encode_anthropic_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::AnthropicMessages.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_anthropic_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start {

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -554,12 +554,15 @@ pub(crate) fn decode_file_source(block: &Map<String, Value>) -> FileSource {
             return FileSource::FileId(file_id.to_string());
         }
         if let Some(file_data) = file.get("file_data").and_then(Value::as_str) {
+            let filename = file
+                .get("filename")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            let (data, media_type) = decode_inline_file_data(file_data, filename.as_deref());
             return FileSource::FileData {
-                data: file_data.to_string(),
-                filename: file
-                    .get("filename")
-                    .and_then(Value::as_str)
-                    .map(ToOwned::to_owned),
+                data,
+                media_type,
+                filename,
             };
         }
         return FileSource::Raw(Value::Object(file.clone()));
@@ -567,7 +570,45 @@ pub(crate) fn decode_file_source(block: &Map<String, Value>) -> FileSource {
     if let Some(file_id) = block.get("file_id").and_then(Value::as_str) {
         return FileSource::FileId(file_id.to_string());
     }
+    if let Some(file_data) = block.get("file_data").and_then(Value::as_str) {
+        let filename = block
+            .get("filename")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let (data, media_type) = decode_inline_file_data(file_data, filename.as_deref());
+        return FileSource::FileData {
+            data,
+            media_type,
+            filename,
+        };
+    }
     FileSource::Raw(Value::Object(block.clone()))
+}
+
+fn decode_inline_file_data(data: &str, filename: Option<&str>) -> (String, Option<String>) {
+    if let Some(encoded) = data.strip_prefix("data:") {
+        if let Some((metadata, payload)) = encoded.split_once(',') {
+            if let Some(media_type) = metadata.strip_suffix(";base64") {
+                return (payload.to_string(), Some(media_type.to_string()));
+            }
+        }
+    }
+    (
+        data.to_string(),
+        filename
+            .and_then(media_type_from_filename)
+            .map(str::to_string),
+    )
+}
+
+fn media_type_from_filename(filename: &str) -> Option<&'static str> {
+    let extension = filename.rsplit_once('.')?.1.to_ascii_lowercase();
+    match extension.as_str() {
+        "pdf" => Some("application/pdf"),
+        "txt" | "md" | "csv" => Some("text/plain"),
+        "json" => Some("application/json"),
+        _ => None,
+    }
 }
 
 /// Decodes one OpenAI tool call into a normalized tool call.
@@ -894,7 +935,7 @@ pub(crate) fn encode_openai_content(
                     blocks.push(openai_text_part(&image_source_text(source)));
                 }
             },
-            ContentBlock::File { source } => match openai_file_part(source) {
+            ContentBlock::File { source } => match openai_file_part(source)? {
                 Some(part) => blocks.push(part),
                 None => {
                     push_lossy(
@@ -998,17 +1039,25 @@ fn image_source_text(source: &ImageSource) -> String {
 }
 
 // Maps IR file sources to OpenAI Chat file content parts when possible.
-fn openai_file_part(source: &FileSource) -> Option<Value> {
+fn openai_file_part(source: &FileSource) -> Result<Option<Value>> {
     match source {
-        FileSource::FileId(file_id) => Some(json!({"type": "file", "file": {"file_id": file_id}})),
-        FileSource::FileData { data, filename } => {
-            let mut file = json!({"file_data": data});
+        FileSource::FileId(_) => Err(TranslationError::NonPortableReference { kind: "file_id" }),
+        FileSource::FileData {
+            data,
+            media_type,
+            filename,
+        } => {
+            let file_data = media_type.as_ref().map_or_else(
+                || data.clone(),
+                |media_type| format!("data:{media_type};base64,{data}"),
+            );
+            let mut file = json!({"file_data": file_data});
             if let Some(filename) = filename {
                 file["filename"] = Value::String(filename.clone());
             }
-            Some(json!({"type": "file", "file": file}))
+            Ok(Some(json!({"type": "file", "file": file})))
         }
-        FileSource::Raw(_) => None,
+        FileSource::Raw(_) => Ok(None),
     }
 }
 
@@ -1016,8 +1065,13 @@ fn openai_file_part(source: &FileSource) -> Option<Value> {
 fn file_source_text(source: &FileSource) -> String {
     match source {
         FileSource::FileId(file_id) => json_string(&json!({"file_id": file_id})),
-        FileSource::FileData { data, filename } => json_string(&json!({
+        FileSource::FileData {
+            data,
+            media_type,
+            filename,
+        } => json_string(&json!({
             "file_data": data,
+            "media_type": media_type,
             "filename": filename,
         })),
         FileSource::Raw(raw) => json_string(raw),

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -63,6 +63,7 @@ impl FormatCodec for OpenAiChatCodec {
                     .map(ToOwned::to_owned),
                 raw: None,
             },
+            parallel_tool_calls: body.get("parallel_tool_calls").and_then(Value::as_bool),
             preservation: capture_request_preservation(
                 WireFormat::OpenAiChat,
                 &Value::Object(body.clone()),
@@ -162,6 +163,7 @@ impl FormatCodec for OpenAiChatCodec {
                 "reasoning_effort",
                 "tools",
                 "tool_choice",
+                "parallel_tool_calls",
             ],
         );
 
@@ -213,6 +215,12 @@ impl FormatCodec for OpenAiChatCodec {
             if let Some(choice) = &request.tool_choice {
                 body.insert("tool_choice".to_string(), encode_openai_tool_choice(choice));
             }
+        }
+        if let Some(parallel_tool_calls) = request.parallel_tool_calls {
+            body.insert(
+                "parallel_tool_calls".to_string(),
+                Value::Bool(parallel_tool_calls),
+            );
         }
         if let Some(value) = request.output.max_output_tokens {
             body.insert("max_completion_tokens".to_string(), json!(value));

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -23,7 +23,7 @@ use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
 use crate::util::{
     capture_request_preservation, capture_response_preservation, embed_preservation,
     exact_preserved_request, exact_preserved_response, json_string, object, push_lossy, stable_id,
-    string_value, validate_request_capabilities,
+    string_value, validate_no_provider_managed_continuation, validate_request_capabilities,
 };
 
 /// Format codec for OpenAI Chat Completions payloads.
@@ -185,6 +185,7 @@ impl FormatCodec for OpenAiChatCodec {
             });
         }
         let mut diagnostics = Vec::new();
+        validate_no_provider_managed_continuation(request, &mut diagnostics, policy)?;
         validate_request_capabilities(request, &mut diagnostics, policy)?;
         let mut body = Map::new();
         if let Some(model) = &request.model {

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -154,6 +154,15 @@ fn encode_openai_chat_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::OpenAiChat.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_openai_chat_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -64,6 +64,7 @@ impl FormatCodec for OpenAiResponsesCodec {
                 top_p: body.get("top_p").and_then(Value::as_f64),
                 top_k: None,
             },
+            parallel_tool_calls: body.get("parallel_tool_calls").and_then(Value::as_bool),
             stream: body.get("stream").and_then(Value::as_bool).unwrap_or(false),
             preservation: capture_request_preservation(
                 WireFormat::OpenAiResponses,
@@ -99,6 +100,7 @@ impl FormatCodec for OpenAiResponsesCodec {
                 "input",
                 "tools",
                 "tool_choice",
+                "parallel_tool_calls",
                 "max_output_tokens",
                 "text",
                 "reasoning",
@@ -156,6 +158,12 @@ impl FormatCodec for OpenAiResponsesCodec {
             if let Some(choice) = encode_responses_tool_choice(choice) {
                 body.insert("tool_choice".to_string(), choice);
             }
+        }
+        if let Some(parallel_tool_calls) = request.parallel_tool_calls {
+            body.insert(
+                "parallel_tool_calls".to_string(),
+                Value::Bool(parallel_tool_calls),
+            );
         }
         if let Some(max_output_tokens) = request.output.max_output_tokens {
             body.insert("max_output_tokens".to_string(), json!(max_output_tokens));

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -18,7 +18,7 @@ use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::llm::{
-    AggLlmResponse, ContentBlock, LlmRequest, MediaSource, Message, OutputParams,
+    AggLlmResponse, ContentBlock, FileSource, LlmRequest, MediaSource, Message, OutputParams,
     ProviderExtensions, ReasoningParams, ResponseOutput, Role, SamplingParams, StopReason,
     ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
 };
@@ -629,6 +629,12 @@ fn decode_responses_content(value: &Value) -> Vec<ContentBlock> {
                     Some("input_file") => out.push(ContentBlock::File {
                         source: decode_file_source(block),
                     }),
+                    Some("input_audio") => out.push(ContentBlock::Audio {
+                        source: decode_responses_media_source(block, "input_audio", "audio"),
+                    }),
+                    Some("input_video") => out.push(ContentBlock::Video {
+                        source: decode_responses_media_source(block, "video", "video"),
+                    }),
                     _ => out.push(ContentBlock::Unknown {
                         provider: WireFormat::OpenAiResponses.into(),
                         raw: Value::Object(block.clone()),
@@ -649,6 +655,34 @@ fn decode_responses_content(value: &Value) -> Vec<ContentBlock> {
             text: string_value(other).unwrap_or_default(),
         }],
     }
+}
+
+fn decode_responses_media_source(
+    block: &Map<String, Value>,
+    nested_field: &str,
+    media_kind: &str,
+) -> MediaSource {
+    let payload = block
+        .get(nested_field)
+        .and_then(Value::as_object)
+        .unwrap_or(block);
+    if let Some(data) = payload.get("data").and_then(Value::as_str) {
+        let media_type = payload
+            .get("media_type")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                payload
+                    .get("format")
+                    .and_then(Value::as_str)
+                    .map(|format| format!("{media_kind}/{format}"))
+            });
+        return MediaSource::Base64 {
+            media_type,
+            data: data.to_string(),
+        };
+    }
+    MediaSource::Raw(Value::Object(block.clone()))
 }
 
 // Decodes Responses role strings into normalized roles. Used for decoding
@@ -957,32 +991,46 @@ fn encode_responses_content(
             ContentBlock::Image { source } => {
                 blocks.push(json!({"type": "input_image", "image_url": source}));
             }
-            ContentBlock::Audio { source } => blocks.push(match source {
-                MediaSource::Raw(raw) => json!({"type": "input_text", "text": json_string(raw)}),
-                MediaSource::Url { url, media_type } => json!({
-                    "type": "input_audio",
-                    "audio_url": url,
-                    "media_type": media_type,
-                }),
-                MediaSource::Base64 { media_type, data } => json!({
-                    "type": "input_audio",
-                    "audio": {"media_type": media_type, "data": data},
-                }),
-            }),
-            ContentBlock::Video { source } => blocks.push(match source {
-                MediaSource::Raw(raw) => json!({"type": "input_text", "text": json_string(raw)}),
-                MediaSource::Url { url, media_type } => json!({
-                    "type": "input_video",
-                    "video_url": url,
-                    "media_type": media_type,
-                }),
-                MediaSource::Base64 { media_type, data } => json!({
-                    "type": "input_video",
-                    "video": {"media_type": media_type, "data": data},
-                }),
-            }),
-            ContentBlock::File { source } => {
-                blocks.push(json!({"type": "input_file", "file": source}));
+            ContentBlock::Audio { .. } => {
+                push_lossy(
+                    diagnostics,
+                    policy,
+                    "Responses codec does not have a validated cross-protocol audio mapping",
+                )?;
+            }
+            ContentBlock::Video { .. } => {
+                push_lossy(
+                    diagnostics,
+                    policy,
+                    "Responses codec does not have a validated cross-protocol video mapping",
+                )?;
+            }
+            ContentBlock::File {
+                source: FileSource::FileId(_),
+            } => return Err(TranslationError::NonPortableReference { kind: "file_id" }),
+            ContentBlock::File {
+                source:
+                    FileSource::FileData {
+                        data,
+                        media_type: _,
+                        filename,
+                    },
+            } => {
+                let mut file = json!({"type": "input_file", "file_data": data});
+                if let Some(filename) = filename {
+                    file["filename"] = Value::String(filename.clone());
+                }
+                blocks.push(file);
+            }
+            ContentBlock::File {
+                source: FileSource::Raw(raw),
+            } => {
+                push_lossy(
+                    diagnostics,
+                    policy,
+                    "Responses codec could not map raw file content",
+                )?;
+                blocks.push(json!({"type": "input_text", "text": json_string(raw)}));
             }
             ContentBlock::Unknown { raw, .. } => {
                 push_lossy(

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -154,6 +154,15 @@ fn encode_responses_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::OpenAiResponses.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_responses_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             ensure_responses_created(state)

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -214,6 +214,21 @@ pub fn decode_stream_event(
         })
 }
 
+/// Decodes one provider stream event and retains its exact source JSON.
+pub fn decode_stream_event_preserving(
+    state: &mut StreamTranslationState,
+    source: impl Into<FormatId>,
+    event: &Value,
+) -> LlmResponseChunk {
+    let source = source.into();
+    state.source = Some(source.clone());
+    LlmResponseChunk::ProviderEvent {
+        source: source.clone(),
+        raw: event.clone(),
+        normalized: decode_stream_event(state, source, event),
+    }
+}
+
 /// Encodes one neutral stream event with the built-in codec registry.
 pub fn encode_stream_event(
     state: &mut StreamTranslationState,

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -18,6 +18,7 @@ use crate::error::{Result, TranslationError};
 use crate::format::FormatId;
 use crate::llm::{AggLlmResponse, LlmRequest};
 use crate::policy::TranslationPolicy;
+use crate::LlmResponseChunk;
 
 /// Encoded translation result with any diagnostics emitted along the way.
 #[derive(Debug)]
@@ -243,6 +244,45 @@ impl TranslationEngine {
             .collect())
     }
 
+    /// Decodes one provider event while retaining the exact source JSON.
+    pub fn decode_stream_event(
+        &self,
+        state: &mut StreamTranslationState,
+        source: impl Into<FormatId>,
+        event: &Value,
+    ) -> Result<LlmResponseChunk> {
+        let source = source.into();
+        let source_codec = self.stream_registry.codec(source.clone())?;
+        state.source = Some(source.clone());
+        Ok(LlmResponseChunk::ProviderEvent {
+            source,
+            raw: event.clone(),
+            normalized: source_codec.decode_event(state, event),
+        })
+    }
+
+    /// Encodes one neutral or preserved stream event for a target provider.
+    ///
+    /// A preserved event is replayed exactly when its source and target formats
+    /// match. Cross-format encoding intentionally uses only its normalized
+    /// events.
+    pub fn encode_stream_event(
+        &self,
+        state: &mut StreamTranslationState,
+        target: impl Into<FormatId>,
+        event: LlmResponseChunk,
+    ) -> Result<Vec<Value>> {
+        let target = target.into();
+        let target_codec = self.stream_registry.codec(target.clone())?;
+        state.target = Some(target.clone());
+        Ok(encode_stream_chunk(
+            state,
+            target_codec.as_ref(),
+            &target,
+            event,
+        ))
+    }
+
     /// Finishes target-provider stream emission after the source stream closes.
     pub fn finish_stream(
         &self,
@@ -252,6 +292,28 @@ impl TranslationEngine {
         let target = target.into();
         let target_codec = self.stream_registry.codec(target)?;
         Ok(target_codec.finish(state))
+    }
+}
+
+// Replays an exact same-format event once, or recursively encodes its neutral
+// children for a different provider.
+fn encode_stream_chunk(
+    state: &mut StreamTranslationState,
+    target_codec: &dyn crate::codecs::stream::StreamCodec,
+    target: &FormatId,
+    event: LlmResponseChunk,
+) -> Vec<Value> {
+    match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if &source == target => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))
+            .collect(),
+        event => target_codec.encode_event(state, event),
     }
 }
 

--- a/crates/switchyard-translation/src/error.rs
+++ b/crates/switchyard-translation/src/error.rs
@@ -34,6 +34,9 @@ pub enum TranslationError {
     #[error("invalid value at {path}: {message}")]
     InvalidValue { path: String, message: String },
 
+    #[error("provider-owned {kind} cannot be translated without target affinity")]
+    NonPortableReference { kind: &'static str },
+
     #[error("{0}")]
     Other(String),
 }
@@ -48,6 +51,7 @@ impl TranslationError {
             Self::LossyConversion(_) => "LossyConversion",
             Self::UnknownField { .. } => "UnknownField",
             Self::InvalidValue { .. } => "InvalidValue",
+            Self::NonPortableReference { .. } => "NonPortableReference",
             Self::Other(_) => "Other",
         }
     }

--- a/crates/switchyard-translation/src/util.rs
+++ b/crates/switchyard-translation/src/util.rs
@@ -200,6 +200,15 @@ pub fn validate_request_capabilities(
             "target format/profile does not support structured response formats",
         )?;
     }
+    if policy.target_capabilities.supports_parallel_tool_calls == Some(false)
+        && request.parallel_tool_calls == Some(true)
+    {
+        push_lossy(
+            diagnostics,
+            policy,
+            "target format/profile does not support parallel tool calls",
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/switchyard-translation/src/util.rs
+++ b/crates/switchyard-translation/src/util.rs
@@ -203,6 +203,33 @@ pub fn validate_request_capabilities(
     Ok(())
 }
 
+/// Rejects provider-owned continuation handles before cross-format encoding.
+///
+/// These identifiers refer to state stored by the Responses provider. Another
+/// wire protocol cannot replay that state, so dropping the fields would turn a
+/// continuation request into a different conversation.
+pub fn validate_no_provider_managed_continuation(
+    request: &LlmRequest,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<()> {
+    let fields = ["previous_response_id", "conversation"]
+        .into_iter()
+        .filter(|field| request.extensions.fields.contains_key(*field))
+        .collect::<Vec<_>>();
+    if !fields.is_empty() {
+        push_lossy(
+            diagnostics,
+            policy,
+            format!(
+                "provider-managed continuation state cannot be translated across protocols: {}",
+                fields.join(", ")
+            ),
+        )?;
+    }
+    Ok(())
+}
+
 // Detects whether any message carries tool calls or tool results.
 fn messages_have_tools(messages: &[Message]) -> bool {
     messages_have_block(messages, |block| {

--- a/crates/switchyard-translation/tests/lossless_roundtrip.rs
+++ b/crates/switchyard-translation/tests/lossless_roundtrip.rs
@@ -304,7 +304,10 @@ fn request_fixture(format: WireFormat) -> Value {
                         },
                         {
                             "type": "file",
-                            "file": {"file_id": "file_123"}
+                            "file": {
+                                "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+                                "filename": "report.pdf"
+                            }
                         },
                         {
                             "type": "vendor_block",
@@ -395,9 +398,10 @@ fn request_fixture(format: WireFormat) -> Value {
                             "type": "document",
                             "source": {
                                 "type": "base64",
-                                "data": "ZmlsZQ==",
-                                "filename": "notes.txt"
-                            }
+                                "media_type": "application/pdf",
+                                "data": "JVBERi0xLjQ="
+                            },
+                            "title": "report.pdf"
                         },
                         {"type": "vendor_block", "payload": {"keep": ["this"]}}
                     ]
@@ -470,7 +474,8 @@ fn request_fixture(format: WireFormat) -> Value {
                         },
                         {
                             "type": "input_file",
-                            "file": {"file_id": "file_123"}
+                            "file_data": "JVBERi0xLjQ=",
+                            "filename": "report.pdf"
                         },
                         {
                             "type": "vendor_block",

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -6,7 +6,7 @@
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 use switchyard_translation::{
-    LossyConversionPolicy, TranslationEngine, TranslationPolicy, WireFormat,
+    LossyConversionPolicy, TargetCapabilities, TranslationEngine, TranslationPolicy, WireFormat,
 };
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -771,6 +771,109 @@ fn responses_continuation_state_is_rejected_for_cross_protocol_translation() {
         assert!(message.contains("previous_response_id"));
         assert!(message.contains("conversation"));
     }
+}
+
+// OpenAI's "at most one tool call" constraint maps to Anthropic's inverse flag.
+#[test]
+fn openai_parallel_tool_constraint_maps_to_anthropic() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "Use one tool"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {"type": "object"}
+            }
+        }],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["tool_choice"]["type"], "auto");
+    assert_eq!(output["tool_choice"]["disable_parallel_tool_use"], true);
+    Ok(())
+}
+
+// Anthropic's inverse flag maps back to OpenAI's top-level request constraint.
+#[test]
+fn anthropic_parallel_tool_constraint_maps_to_responses() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude",
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": "Use one tool"}],
+        "tools": [{
+            "name": "lookup",
+            "input_schema": {"type": "object"}
+        }],
+        "tool_choice": {
+            "type": "auto",
+            "disable_parallel_tool_use": true
+        }
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["parallel_tool_calls"], false);
+    Ok(())
+}
+
+// A target explicitly unable to execute calls in parallel must reject a
+// request that requires parallel tool calls under rejecting policy.
+#[test]
+fn target_parallel_tool_capability_is_enforced() {
+    let engine = TranslationEngine::default();
+    let policy = TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        target_capabilities: TargetCapabilities {
+            supports_parallel_tool_calls: Some(false),
+            ..TargetCapabilities::default()
+        },
+        ..TranslationPolicy::default()
+    };
+    let body = json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "Use tools in parallel"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "parameters": {"type": "object"}
+            }
+        }],
+        "parallel_tool_calls": true
+    });
+
+    let error = match engine.translate_request(
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &body,
+        &policy,
+    ) {
+        Ok(_) => panic!("parallel tool requirement must be rejected"),
+        Err(error) => error,
+    };
+    assert!(error
+        .to_string()
+        .contains("target format/profile does not support parallel tool calls"));
 }
 
 // Verifies Codex-style reasoning items attach to the turn's tool-call message

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -5,7 +5,9 @@
 
 use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
-use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
+use switchyard_translation::{
+    LossyConversionPolicy, TranslationEngine, TranslationPolicy, WireFormat,
+};
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -740,6 +742,35 @@ fn responses_chat_compatible_extensions_survive_to_openai_chat() -> TestResult {
     assert_eq!(output["top_logprobs"], 2);
     assert_eq!(output["user"], "u-123");
     Ok(())
+}
+
+// Provider-managed Responses continuation handles cannot be replayed through
+// another API. Rejecting policy must fail instead of silently dropping state.
+#[test]
+fn responses_continuation_state_is_rejected_for_cross_protocol_translation() {
+    let engine = TranslationEngine::default();
+    let policy = TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        ..TranslationPolicy::default()
+    };
+    let body = json!({
+        "model": "gpt-5",
+        "input": "continue",
+        "previous_response_id": "resp_provider_owned",
+        "conversation": "conv_provider_owned"
+    });
+
+    for target in [WireFormat::OpenAiChat, WireFormat::AnthropicMessages] {
+        let error =
+            match engine.translate_request(WireFormat::OpenAiResponses, target, &body, &policy) {
+                Ok(_) => panic!("provider-managed continuation state must not be dropped"),
+                Err(error) => error,
+            };
+        let message = error.to_string();
+        assert!(message.contains("provider-managed continuation state"));
+        assert!(message.contains("previous_response_id"));
+        assert!(message.contains("conversation"));
+    }
 }
 
 // Verifies Codex-style reasoning items attach to the turn's tool-call message

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1471,3 +1471,164 @@ fn anthropic_thinking_is_dropped_from_responses_input() -> TestResult {
         .any(|item| item["type"] == "function_call_output"));
     Ok(())
 }
+
+#[test]
+fn anthropic_inline_pdf_translates_to_a_valid_responses_file() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "JVBERi0xLjQ="
+                },
+                "title": "report.pdf"
+            }]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &strict_policy(),
+        )?
+        .body;
+
+    let file = output["input"][0]["content"]
+        .as_array()
+        .and_then(|content| content.iter().find(|part| part["type"] == "input_file"))
+        .ok_or("expected a Responses input_file content part")?;
+    assert_eq!(file["file_data"], "JVBERi0xLjQ=");
+    assert_eq!(file["filename"], "report.pdf");
+    assert!(file.get("file").is_none());
+    Ok(())
+}
+
+#[test]
+fn responses_inline_pdf_translates_to_a_valid_anthropic_document() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_data": "JVBERi0xLjQ=",
+                "filename": "report.pdf"
+            }]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiResponses,
+            WireFormat::AnthropicMessages,
+            &body,
+            &strict_policy(),
+        )?
+        .body;
+
+    let document = &output["messages"][0]["content"][0];
+    assert_eq!(document["type"], "document");
+    assert_eq!(document["source"]["type"], "base64");
+    assert_eq!(document["source"]["media_type"], "application/pdf");
+    assert_eq!(document["source"]["data"], "JVBERi0xLjQ=");
+    assert_eq!(document["title"], "report.pdf");
+    assert!(document["source"].get("filename").is_none());
+    Ok(())
+}
+
+#[test]
+fn non_pdf_inline_file_is_rejected_for_anthropic() {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_file",
+                "file_data": "bm90ZXM=",
+                "filename": "notes.txt"
+            }]
+        }]
+    });
+
+    let error = engine
+        .translate_request(
+            WireFormat::OpenAiResponses,
+            WireFormat::AnthropicMessages,
+            &body,
+            &strict_policy(),
+        )
+        .expect_err("Anthropic base64 documents require PDF media");
+    assert!(error.to_string().contains("application/pdf"));
+}
+
+#[test]
+fn provider_owned_file_id_is_rejected_across_protocols() {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_file", "file_id": "file-provider-owned"}]
+        }]
+    });
+
+    let error = engine
+        .translate_request(
+            WireFormat::OpenAiResponses,
+            WireFormat::AnthropicMessages,
+            &body,
+            &strict_policy(),
+        )
+        .expect_err("provider-owned file IDs must not cross protocols");
+    assert!(error.to_string().contains("provider-owned file"));
+}
+
+#[test]
+fn unsupported_audio_and_video_are_rejected_instead_of_serialized_as_text() {
+    let engine = TranslationEngine::default();
+    for content in [
+        json!({"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}),
+        json!({"type": "input_video", "video": {"data": "AAAA", "media_type": "video/mp4"}}),
+    ] {
+        let body = json!({
+            "model": "gpt-5",
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [content]
+            }]
+        });
+        let error = engine
+            .translate_request(
+                WireFormat::OpenAiResponses,
+                WireFormat::AnthropicMessages,
+                &body,
+                &strict_policy(),
+            )
+            .expect_err("unsupported media must fail before provider dispatch");
+        assert!(
+            error.to_string().contains("audio") || error.to_string().contains("video"),
+            "{error}"
+        );
+    }
+}
+
+fn strict_policy() -> TranslationPolicy {
+    TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        ..TranslationPolicy::default()
+    }
+}

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -12,6 +12,60 @@ use switchyard_translation::{
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
+// Verifies a libsy round trip can replay an exact same-format provider event.
+#[test]
+fn preserved_same_format_event_replays_unknown_fields_exactly() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state = StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::OpenAiChat);
+    let chunk = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_provider_specific",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "Hi"},
+            "finish_reason": null
+        }]
+    });
+
+    let preserved = engine.decode_stream_event(&mut state, WireFormat::OpenAiChat, &chunk)?;
+    let replayed = engine.encode_stream_event(&mut state, WireFormat::OpenAiChat, preserved)?;
+
+    assert_eq!(replayed, vec![chunk]);
+    Ok(())
+}
+
+// Verifies cross-format encoding uses the neutral events rather than leaking
+// fields that have no representation in the target protocol.
+#[test]
+fn preserved_cross_format_event_translates_normalized_content() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let chunk = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_provider_specific",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "Hi"},
+            "finish_reason": null
+        }]
+    });
+
+    let preserved = engine.decode_stream_event(&mut state, WireFormat::OpenAiChat, &chunk)?;
+    let translated =
+        engine.encode_stream_event(&mut state, WireFormat::AnthropicMessages, preserved)?;
+
+    assert_eq!(translated[2]["delta"]["text"], "Hi");
+    assert!(translated
+        .iter()
+        .all(|event| event.get("system_fingerprint").is_none()));
+    Ok(())
+}
+
 // Verifies an OpenAI text delta opens the expected Anthropic message and content blocks.
 #[test]
 fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResult {


### PR DESCRIPTION
## What

Adds the public libsy, protocol, and translation contracts exercised by NeMo
Relay's in-process Switchyard integration.

The branch contains nine focused commits:

| Capability | Relay requirement | Commit-local size |
| --- | --- | ---: |
| Decision-only execution plus metadata-context initialization | `observe_only` must obtain a real libsy decision without dispatching the selected target | +559/−9 |
| Lossless raw provider stream events | Same-protocol streaming must survive the Relay → libsy → Relay round trip without dropping provider JSON extensions | +260/−18 |
| Public `ToolSignalProcessor` | Host construction of classifier/stage-router algorithms | +13/−0 |
| Typed model-unavailable error | Preserve Relay's retry classification without parsing error strings | +56/−0 |
| Nonportable continuation rejection | Prevent provider-owned continuation state from being translated or sent to a different provider target | +64/−3 |
| Parallel-tool policy preservation | Preserve the one-tool constraint between OpenAI and Anthropic request formats | +153/−6 |
| Structured decision metadata | Stable run/decision identity, algorithm ownership, call roles, confidence, baseline, and response provenance | +393/−12 |
| Portable media contracts | Translate portable files and reject provider-owned or unrepresentable media before dispatch | +407/−47 |

Combined diff: **29 files, +1,903/−93 lines**.

## Why

Relay owns credentials, provider transport, retries, fallback, and its Adaptive
continuation. libsy owns the algorithm lifecycle and may request one or more LLM
calls before choosing the response returned to the agent. These contracts let
Relay drive that lifecycle without a Switchyard service and without
Relay-specific substitutes for missing libsy behavior.

A basic buffered `Random::run_stream` integration worked on the original libsy
pin. This branch is broader than the minimum buffered random route:

- The raw-stream envelope is the direct blocker for lossless streaming.
- Decision-only execution is required only for `observe_only`.
- Typed errors and structured metadata are required for Relay 0.6 retry and
  telemetry parity.
- Continuation, parallel-tool, and media changes enforce safe cross-protocol
  behavior.
- `ToolSignalProcessor` is needed for host-composed classifier/stage-router
  coverage, not the basic random router.

This draft intentionally exposes the complete assessed contract. The commits can
be split into focused PRs; the raw streaming change is independently reviewable
as a seven-file, +260/−18 PR.

Closes #

## How tested

- [ ] `uv run ruff check .` clean — not run; this patch changes Rust crates only.
- [ ] `uv run mypy switchyard` clean — not run; this patch changes Rust crates only.
- [ ] `uv run pytest tests/` green — not run; this patch changes Rust crates only.
- [x] Manual smoke (describe what was run)
  - `cargo test --workspace --exclude switchyard-py`
  - workspace Clippy with warnings denied
  - `cargo fmt --all -- --check`
  - libsy random-router, protocol, buffered translation, and stream translation
    contract suites
  - Relay exact-pin suite: 49 Switchyard tests, three service-free CLI process
    tests, 16 hermetic protocol-matrix tests, and complete Rust/FFI workspace
    validation
  - 85 live provider calls across NVIDIA NIM, Gemini, Azure OpenAI Responses,
    and Anthropic APIs, covering seeded random routing, buffered/streaming 3×3
    protocol paths, tool-call follow-ups, images, PDFs, and continuation fallback

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A:
  Rust-only changes.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if
  intended for downstream use. (N/A: Rust crate API; exports and compile-time
  public API tests are included.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

- This is an umbrella draft for scope review, not a recommendation that all
  capabilities merge as one PR.
- Current upstream `main` advanced after this branch was validated.
  `crates/libsy/src/observability.rs` now conflicts with routing-overhead work
  from #188; the branch must be refreshed and revalidated before becoming ready
  for review.
- Recommended first split: the lossless raw-stream envelope and stream
  translation tests (`f840d414`), because it is the only direct blocker for
  lossless same-protocol streaming in enforce mode.
- Follow-on splits can group decision-only execution, typed errors, decision
  metadata, and cross-protocol safety independently.
