### PR TITLE
feat(translation): preserve raw stream events

### DIFF
--- a/crates/libsy/examples/streaming_agent.rs
+++ b/crates/libsy/examples/streaming_agent.rs
@@ -7,7 +7,8 @@
 //! offloaded as a [`Step::CallLlm`]. The agent serves it with a *streaming* response
 //! ([`LlmResponse::Stream`]) rather than a buffered one. That stream rides untouched
 //! through the algorithm and returns as [`Step::ReturnToAgent`], where the agent drives it
-//! and prints each [`LlmResponseChunk`] as it arrives — true token streaming end to end.
+//! and prints the normalized [`LlmResponseChunk`]s in each event as they arrive — true
+//! token streaming end to end.
 //! Contrast [`Algorithm::run`], which would aggregate the same stream into one buffered
 //! answer. Run with:
 //!   cargo run -p libsy --example streaming_agent
@@ -40,7 +41,8 @@ fn streaming_response(model: &str, tokens: &[&str]) -> Response {
         reason: Some("stop".to_string()),
     });
 
-    let stream: LlmResponseStream = futures::stream::iter(chunks.into_iter().map(Ok)).boxed();
+    let stream: LlmResponseStream =
+        futures::stream::iter(chunks.into_iter().map(|chunk| Ok(chunk.into()))).boxed();
     Response {
         llm_response: LlmResponse::Stream(stream),
         metadata: None,
@@ -81,15 +83,17 @@ async fn main() -> Result<()> {
             }
             Step::ReturnToAgent(response) => match response.llm_response {
                 // The stream reached the agent untouched: print each token as it arrives.
-                LlmResponse::Stream(mut chunks) => {
+                LlmResponse::Stream(mut events) => {
                     print!("agent sees: ");
-                    while let Some(chunk) = chunks.next().await {
-                        let chunk = chunk.map_err(|error| {
+                    while let Some(event) = events.next().await {
+                        let event = event.map_err(|error| {
                             LibsyError::external("reading response stream", error)
                         })?;
-                        if let LlmResponseChunk::TextDelta { text, .. } = chunk {
-                            print!("{text}");
-                            std::io::stdout().flush().ok();
+                        for chunk in event.normalized() {
+                            if let LlmResponseChunk::TextDelta { text, .. } = chunk {
+                                print!("{text}");
+                                std::io::stdout().flush().ok();
+                            }
                         }
                     }
                     println!();

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -330,7 +330,7 @@ mod tests {
     fn streamed(chunks: Vec<LlmResponseChunk>) -> Response {
         Response {
             llm_response: LlmResponse::Stream(
-                futures::stream::iter(chunks.into_iter().map(Ok)).boxed(),
+                futures::stream::iter(chunks.into_iter().map(|chunk| Ok(chunk.into()))).boxed(),
             ),
             metadata: None,
         }
@@ -338,7 +338,7 @@ mod tests {
 
     fn streamed_then_failing(chunk: LlmResponseChunk) -> Response {
         let items = futures::stream::iter([
-            Ok(chunk),
+            Ok(chunk.into()),
             Err(LlmClientError::Timeout {
                 source: Box::new(std::io::Error::other("stream died")),
             }),

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -17,10 +17,13 @@ use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use tracing::Instrument;
 
-/// The request/response protocol types, re-exported from [`switchyard_protocol`].
-/// [`LlmRequest`] is the normalized request; [`AggLlmResponse`] is the buffered response;
-/// [`LlmResponseChunk`] is one streaming event; [`LlmResponse`] is the streamed response
-/// (a live [`LlmResponseStream`] or the terminal aggregate).
+/// The request/response protocol types come from [`switchyard_protocol`].
+/// [`switchyard_protocol::LlmRequest`] is the normalized request;
+/// [`switchyard_protocol::AggLlmResponse`] is the buffered response;
+/// [`switchyard_protocol::LlmResponseChunk`] is normalized streaming content;
+/// [`switchyard_protocol::LlmResponseStreamEvent`] is its host/algorithm envelope; and
+/// [`switchyard_protocol::LlmResponse`] carries either a live
+/// [`switchyard_protocol::LlmResponseStream`] or the terminal aggregate.
 use switchyard_protocol::{
     Context, Decision, LlmClientError, Request, Response, RoutedLlmClient, Signals, Usage,
 };
@@ -971,7 +974,13 @@ mod tests {
             _request: Request,
             _decision: Arc<dyn Decision>,
         ) -> std::result::Result<Response, LlmClientError> {
-            let stream = futures::stream::iter(self.chunks.clone().into_iter().map(Ok)).boxed();
+            let stream = futures::stream::iter(
+                self.chunks
+                    .clone()
+                    .into_iter()
+                    .map(|chunk| Ok(chunk.into())),
+            )
+            .boxed();
             Ok(Response {
                 llm_response: LlmResponse::Stream(stream),
                 metadata: None,

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -48,7 +48,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::{Driver, LibsyError, Result};
 use switchyard_protocol::{
     AggLlmResponse, Context, Decision, LlmClientError, LlmRequest, LlmResponse, LlmResponseChunk,
-    LlmResponseStream, Request, Response, Usage,
+    LlmResponseStream, LlmResponseStreamEvent, Request, Response, Usage,
 };
 
 const METRICS_SCOPE: &str = "switchyard";
@@ -364,7 +364,7 @@ struct ObservedClientStream {
 }
 
 impl Stream for ObservedClientStream {
-    type Item = std::result::Result<LlmResponseChunk, LlmClientError>;
+    type Item = std::result::Result<LlmResponseStreamEvent, LlmClientError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
         match self.stream.as_mut().poll_next(cx) {
@@ -395,32 +395,48 @@ struct ClientStreamObserver {
 }
 
 impl ClientStreamObserver {
-    fn observe(&mut self, item: &std::result::Result<LlmResponseChunk, LlmClientError>) -> bool {
+    fn observe(
+        &mut self,
+        item: &std::result::Result<LlmResponseStreamEvent, LlmClientError>,
+    ) -> bool {
         match item {
-            Ok(LlmResponseChunk::MessageStart { id, model }) => {
-                record_optional(&self.span, "gen_ai.response.id", id.as_deref());
-                record_optional(&self.span, "gen_ai.response.model", model.as_deref());
-            }
-            Ok(LlmResponseChunk::Usage(usage)) => record_gen_ai_usage(&self.span, usage),
-            Ok(LlmResponseChunk::MessageStop { reason }) => {
-                record_finish_reasons(&self.span, reason.iter().cloned());
-            }
-            Ok(LlmResponseChunk::DecodeError { message }) => {
-                record_client_error(&self.span, "response_translation", message);
-                self.terminal = true;
-            }
-            Ok(LlmResponseChunk::StreamError { message }) => {
-                record_client_error(&self.span, "502", message);
-                self.terminal = true;
+            Ok(event) => {
+                for chunk in event.normalized() {
+                    self.observe_chunk(chunk);
+                    if self.terminal {
+                        break;
+                    }
+                }
             }
             Err(error) => {
                 let error_type = llm_client_error_type(error);
                 record_client_error(&self.span, &error_type, error);
                 self.terminal = true;
             }
-            _ => {}
         }
         self.terminal
+    }
+
+    fn observe_chunk(&mut self, chunk: &LlmResponseChunk) {
+        match chunk {
+            LlmResponseChunk::MessageStart { id, model } => {
+                record_optional(&self.span, "gen_ai.response.id", id.as_deref());
+                record_optional(&self.span, "gen_ai.response.model", model.as_deref());
+            }
+            LlmResponseChunk::Usage(usage) => record_gen_ai_usage(&self.span, usage),
+            LlmResponseChunk::MessageStop { reason } => {
+                record_finish_reasons(&self.span, reason.iter().cloned());
+            }
+            LlmResponseChunk::DecodeError { message } => {
+                record_client_error(&self.span, "response_translation", message);
+                self.terminal = true;
+            }
+            LlmResponseChunk::StreamError { message } => {
+                record_client_error(&self.span, "502", message);
+                self.terminal = true;
+            }
+            _ => {}
+        }
     }
 
     fn complete(&mut self) {

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -40,7 +40,8 @@ use switchyard_protocol::{
     Context, Decision, LlmResponse, Metadata, Request, Response, RoutedLlmClient, Usage,
 };
 use switchyard_protocol::{
-    LlmClientError, LlmResponseChunk, StopReason, text_request, text_response,
+    LlmClientError, LlmResponseChunk, LlmResponseStreamEvent, StopReason, text_request,
+    text_response,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -758,16 +759,16 @@ impl RoutedLlmClient for StreamingUsageClient {
             cache: Usage::cache_details(Some(8), None),
             ..Usage::default()
         };
-        let chunks = vec![
-            Ok(LlmResponseChunk::MessageStart {
+        let chunks = vec![Ok(LlmResponseStreamEvent::new(vec![
+            LlmResponseChunk::MessageStart {
                 id: Some("obs-stream-response".to_string()),
                 model: Some(decision.selected_model().to_string()),
-            }),
-            Ok(LlmResponseChunk::Usage(usage)),
-            Ok(LlmResponseChunk::MessageStop {
+            },
+            LlmResponseChunk::Usage(usage),
+            LlmResponseChunk::MessageStop {
                 reason: Some("end_turn".to_string()),
-            }),
-        ];
+            },
+        ]))];
         Ok(Response {
             llm_response: LlmResponse::Stream(Box::pin(futures::stream::iter(chunks))),
             metadata: None,

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -104,7 +104,7 @@ assert_eq!(request.llm_request.tools[0].name, "lookup_metric");
 [`LlmResponse`] contains either a completed [`AggLlmResponse`] or a
 single-consumption [`LlmResponseStream`] of [`LlmResponseStreamEvent`] values.
 Each event carries provider-neutral [`LlmResponseChunk`] values and may retain
-one opaque [`ProviderStreamEvent`] for exact same-format JSON replay. See
+one opaque [`ProviderStreamEvent`] for same-format parsed-JSON-value replay. See
 [`LlmResponse::into_agg`] for aggregation and [`PreservationMetadata`],
 [`Usage`], and [`Metadata`] for the data retained around a response.
 

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -19,7 +19,7 @@ serde_json = "1"
 | Conversation | [`LlmRequest`], [`Message`], [`InstructionBlock`], [`ContentBlock`] |
 | Tools | [`ToolDefinition`], [`ToolChoice`], [`ToolCall`], [`ToolResult`] |
 | Response | [`AggLlmResponse`], [`ResponseOutput`], [`Usage`], [`StopReason`] |
-| Streaming | [`LlmResponse`], [`LlmResponseChunk`], [`LlmResponseStream`] |
+| Streaming | [`LlmResponse`], [`LlmResponseStream`], [`LlmResponseStreamEvent`], [`LlmResponseChunk`], [`ProviderStreamEvent`] |
 | Envelope | [`Context`], [`Request`], [`Response`], [`Metadata`] |
 | Routing I/O | [`Decision`], [`RoutedLlmClient`], [`LlmClientError`] |
 | Wire identity | [`WireFormat`], [`FormatId`] |
@@ -102,7 +102,9 @@ assert_eq!(request.llm_request.tools[0].name, "lookup_metric");
 ## Response forms
 
 [`LlmResponse`] contains either a completed [`AggLlmResponse`] or a
-single-consumption [`LlmResponseStream`] of [`LlmResponseChunk`] values. See
+single-consumption [`LlmResponseStream`] of [`LlmResponseStreamEvent`] values.
+Each event carries provider-neutral [`LlmResponseChunk`] values and may retain
+one opaque [`ProviderStreamEvent`] for exact same-format JSON replay. See
 [`LlmResponse::into_agg`] for aggregation and [`PreservationMetadata`],
 [`Usage`], and [`Metadata`] for the data retained around a response.
 

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -172,14 +172,21 @@ fn push_checked_chunk(
 /// additionally retains the parsed source JSON value, so a same-format round trip replays that
 /// value rather than the original bytes: SSE framing, whitespace, and object key order are not
 /// preserved. Normalized children stay available to algorithms and cross-format encoders.
+///
+/// `ProviderEvent` is intentionally a transport envelope rather than provider-neutral content.
+/// It lives in the protocol crate because [`LlmResponseStream`] crosses the host/algorithm
+/// boundary. Algorithms consume its normalized children; only `switchyard-translation`
+/// interprets its source format and raw value for replay. This mirrors
+/// [`PreservationMetadata`](crate::PreservationMetadata) for buffered bodies without making
+/// provider fields part of the semantic IR.
 /// `switchyard-translation` re-exports this type as `ConversationStreamEvent`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LlmResponseChunk {
     /// One preserved provider event paired with the neutral events decoded from it.
     ProviderEvent {
-        /// Provider format that produced `raw`.
+        /// Opaque source-format identity used by the translation layer.
         source: FormatId,
-        /// Source event as a parsed JSON value.
+        /// Opaque parsed source event retained for translation-layer replay.
         raw: Value,
         /// Provider-neutral events decoded from `raw`, in source order.
         normalized: Vec<LlmResponseChunk>,

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 
 use crate::{
     LlmClientError,
+    format::FormatId,
     llm::{AggLlmResponse, ContentBlock, ResponseOutput, Role, StopReason, ToolCall, Usage},
 };
 
@@ -60,21 +61,7 @@ impl LlmResponse {
             LlmResponse::Stream(mut stream) => {
                 let mut accumulator = ResponseAccumulator::new();
                 while let Some(item) = stream.next().await {
-                    match item? {
-                        LlmResponseChunk::DecodeError { message } => {
-                            return Err(LlmClientError::ResponseTranslation(message));
-                        }
-                        LlmResponseChunk::StreamError { message } => {
-                            // The upstream reported the failure inside the response body, so
-                            // there is no real status line to carry; 502 stands in for "the
-                            // upstream failed" the same way a failed non-streaming call would.
-                            return Err(LlmClientError::UpstreamHttp {
-                                status: MID_STREAM_UPSTREAM_STATUS,
-                                body: message,
-                            });
-                        }
-                        chunk => accumulator.push(chunk),
-                    }
+                    push_checked_chunk(&mut accumulator, item?)?;
                 }
                 Ok(accumulator.finish())
             }
@@ -154,10 +141,48 @@ impl AggLlmResponse {
     }
 }
 
-/// One provider-neutral streaming event — the normalized counterpart to
-/// [`AggLlmResponse`], sitting between stream decoders and encoders.
+fn push_checked_chunk(
+    accumulator: &mut ResponseAccumulator,
+    chunk: LlmResponseChunk,
+) -> Result<(), LlmClientError> {
+    match chunk {
+        LlmResponseChunk::ProviderEvent { normalized, .. } => {
+            for chunk in normalized {
+                push_checked_chunk(accumulator, chunk)?;
+            }
+            Ok(())
+        }
+        LlmResponseChunk::DecodeError { message } => {
+            Err(LlmClientError::ResponseTranslation(message))
+        }
+        LlmResponseChunk::StreamError { message } => Err(LlmClientError::UpstreamHttp {
+            status: MID_STREAM_UPSTREAM_STATUS,
+            body: message,
+        }),
+        chunk => {
+            accumulator.push(chunk);
+            Ok(())
+        }
+    }
+}
+
+/// One streaming event carried between a host and an algorithm.
+///
+/// Normalized variants expose provider-neutral meaning. [`ProviderEvent`](Self::ProviderEvent)
+/// additionally retains exact source JSON for a lossless same-format round trip while keeping
+/// normalized children available to algorithms and cross-format encoders.
+/// `switchyard-translation` re-exports this type as `ConversationStreamEvent`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LlmResponseChunk {
+    /// One exact provider event paired with the neutral events decoded from it.
+    ProviderEvent {
+        /// Provider format that produced `raw`.
+        source: FormatId,
+        /// Exact parsed provider event.
+        raw: Value,
+        /// Provider-neutral events decoded from `raw`, in source order.
+        normalized: Vec<LlmResponseChunk>,
+    },
     /// Starts a response message.
     MessageStart {
         /// Provider response identifier.
@@ -252,6 +277,11 @@ impl ResponseAccumulator {
     /// earlier ones; text, reasoning, and tool-call arguments append.
     pub fn push(&mut self, chunk: LlmResponseChunk) {
         match chunk {
+            LlmResponseChunk::ProviderEvent { normalized, .. } => {
+                for chunk in normalized {
+                    self.push(chunk);
+                }
+            }
             LlmResponseChunk::MessageStart { id, model } => {
                 if id.is_some() {
                     self.id = id;
@@ -395,6 +425,50 @@ mod tests {
                 text: "Hello".to_string()
             }]
         );
+    }
+
+    #[test]
+    fn folds_normalized_chunks_inside_provider_event() {
+        let aggregate = fold(vec![LlmResponseChunk::ProviderEvent {
+            source: crate::WireFormat::OpenAiChat.into(),
+            raw: json!({
+                "choices": [{"delta": {"content": "hello"}}],
+                "system_fingerprint": "fp_exact"
+            }),
+            normalized: vec![LlmResponseChunk::TextDelta {
+                index: 0,
+                text: "hello".to_string(),
+            }],
+        }]);
+
+        assert_eq!(
+            aggregate.outputs[0].content,
+            vec![ContentBlock::Text {
+                text: "hello".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn stream_errors_inside_provider_events_remain_typed() {
+        let response = LlmResponse::Stream(Box::pin(stream::iter([Ok(
+            LlmResponseChunk::ProviderEvent {
+                source: crate::WireFormat::OpenAiChat.into(),
+                raw: json!({"error": {"message": "provider failed"}}),
+                normalized: vec![LlmResponseChunk::StreamError {
+                    message: "provider failed".to_string(),
+                }],
+            },
+        )])));
+
+        let error = block_on(response.into_agg()).err();
+        assert!(matches!(
+            error,
+            Some(LlmClientError::UpstreamHttp {
+                status: MID_STREAM_UPSTREAM_STATUS,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Streaming half of the neutral IR: incremental response chunks ([`LlmResponseChunk`])
-//! and the streamed response ([`LlmResponse`]) that carries either a live stream of them
-//! or the terminal [`AggLlmResponse`].
+//! Streaming half of the neutral IR: incremental response chunks ([`LlmResponseChunk`]),
+//! their stream envelope ([`LlmResponseStreamEvent`]), and the streamed response
+//! ([`LlmResponse`]) that carries either a live stream or the terminal [`AggLlmResponse`].
 
 use std::collections::BTreeMap;
 use std::pin::Pin;
@@ -23,12 +23,96 @@ use crate::{
 /// code to propagate; 502 matches how a failed upstream call surfaces elsewhere.
 const MID_STREAM_UPSTREAM_STATUS: u16 = 502;
 
-/// A boxed, `Send` stream of [`LlmResponseChunk`]s — the token-by-token output of a
-/// streaming backend. Each item may fail independently mid-stream.
+/// A boxed, `Send` stream of response events. Each item may fail independently mid-stream.
 pub type LlmResponseStream =
-    Pin<Box<dyn Stream<Item = Result<LlmResponseChunk, LlmClientError>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<LlmResponseStreamEvent, LlmClientError>> + Send>>;
 
-/// A model response: either a live [`Stream`](LlmResponse::Stream) of chunks or a
+/// Parsed provider event retained for same-format replay.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderStreamEvent {
+    source: FormatId,
+    raw: Value,
+}
+
+impl ProviderStreamEvent {
+    /// Source wire format of the retained event.
+    pub fn source(&self) -> &FormatId {
+        &self.source
+    }
+
+    /// Parsed provider JSON retained for replay.
+    pub fn raw(&self) -> &Value {
+        &self.raw
+    }
+
+    /// Consumes the preservation value into its source format and parsed JSON.
+    pub fn into_parts(self) -> (FormatId, Value) {
+        (self.source, self.raw)
+    }
+}
+
+/// One streaming item crossing the host/algorithm boundary.
+///
+/// `normalized` contains only provider-neutral chunks. `preservation` is opaque to
+/// algorithms and is interpreted by `switchyard-translation` for same-format replay.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LlmResponseStreamEvent {
+    preservation: Option<ProviderStreamEvent>,
+    normalized: Vec<LlmResponseChunk>,
+}
+
+impl LlmResponseStreamEvent {
+    /// Creates an event containing only normalized chunks.
+    pub fn new(normalized: Vec<LlmResponseChunk>) -> Self {
+        Self {
+            preservation: None,
+            normalized,
+        }
+    }
+
+    /// Creates an event with parsed provider JSON retained for replay.
+    pub fn preserved(
+        source: impl Into<FormatId>,
+        raw: Value,
+        normalized: Vec<LlmResponseChunk>,
+    ) -> Self {
+        Self {
+            preservation: Some(ProviderStreamEvent {
+                source: source.into(),
+                raw,
+            }),
+            normalized,
+        }
+    }
+
+    /// Retained provider event, when this event came directly from a provider.
+    pub fn preservation(&self) -> Option<&ProviderStreamEvent> {
+        self.preservation.as_ref()
+    }
+
+    /// Provider-neutral chunks carried by this event.
+    pub fn normalized(&self) -> &[LlmResponseChunk] {
+        &self.normalized
+    }
+
+    /// Consumes the event into its preservation and normalized content.
+    pub fn into_parts(self) -> (Option<ProviderStreamEvent>, Vec<LlmResponseChunk>) {
+        (self.preservation, self.normalized)
+    }
+
+    /// Replaces semantic content and drops raw replay data that no longer describes it.
+    pub fn replace_normalized(self, normalized: Vec<LlmResponseChunk>) -> Self {
+        Self::new(normalized)
+    }
+}
+
+impl From<LlmResponseChunk> for LlmResponseStreamEvent {
+    fn from(chunk: LlmResponseChunk) -> Self {
+        Self::new(vec![chunk])
+    }
+}
+
+/// A model response: either a live [`Stream`](LlmResponse::Stream) of events or a
 /// terminal buffered [`LlmResponse::Agg`] response.
 ///
 /// Not `Clone` — the `Stream` variant owns a single-consumption stream. A buffered
@@ -51,7 +135,7 @@ impl LlmResponse {
     }
 
     /// Reduce to the buffered aggregate: return an `Agg` unchanged, or drive a `Stream`
-    /// to completion, folding its chunks into an [`AggLlmResponse`] via
+    /// to completion, folding its normalized chunks into an [`AggLlmResponse`] via
     /// [`ResponseAccumulator`]. A stream item error aborts with `Err`, as does an
     /// in-band [`LlmResponseChunk::DecodeError`] (as `ResponseTranslation`) or
     /// [`LlmResponseChunk::StreamError`] (as `UpstreamHttp`).
@@ -61,7 +145,9 @@ impl LlmResponse {
             LlmResponse::Stream(mut stream) => {
                 let mut accumulator = ResponseAccumulator::new();
                 while let Some(item) = stream.next().await {
-                    push_checked_chunk(&mut accumulator, item?)?;
+                    for chunk in item?.normalized {
+                        push_checked_chunk(&mut accumulator, chunk)?;
+                    }
                 }
                 Ok(accumulator.finish())
             }
@@ -137,7 +223,9 @@ impl AggLlmResponse {
             });
         }
         chunks.push(LlmResponseChunk::Usage(self.usage));
-        Box::pin(futures::stream::iter(chunks.into_iter().map(Ok)))
+        Box::pin(futures::stream::iter(
+            chunks.into_iter().map(|chunk| Ok(chunk.into())),
+        ))
     }
 }
 
@@ -146,12 +234,6 @@ fn push_checked_chunk(
     chunk: LlmResponseChunk,
 ) -> Result<(), LlmClientError> {
     match chunk {
-        LlmResponseChunk::ProviderEvent { normalized, .. } => {
-            for chunk in normalized {
-                push_checked_chunk(accumulator, chunk)?;
-            }
-            Ok(())
-        }
         LlmResponseChunk::DecodeError { message } => {
             Err(LlmClientError::ResponseTranslation(message))
         }
@@ -166,31 +248,9 @@ fn push_checked_chunk(
     }
 }
 
-/// One streaming event carried between a host and an algorithm.
-///
-/// Normalized variants expose provider-neutral meaning. [`ProviderEvent`](Self::ProviderEvent)
-/// additionally retains the parsed source JSON value, so a same-format round trip replays that
-/// value rather than the original bytes: SSE framing, whitespace, and object key order are not
-/// preserved. Normalized children stay available to algorithms and cross-format encoders.
-///
-/// `ProviderEvent` is intentionally a transport envelope rather than provider-neutral content.
-/// It lives in the protocol crate because [`LlmResponseStream`] crosses the host/algorithm
-/// boundary. Algorithms consume its normalized children; only `switchyard-translation`
-/// interprets its source format and raw value for replay. This mirrors
-/// [`PreservationMetadata`](crate::PreservationMetadata) for buffered bodies without making
-/// provider fields part of the semantic IR.
-/// `switchyard-translation` re-exports this type as `ConversationStreamEvent`.
+/// One provider-neutral streaming response chunk.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LlmResponseChunk {
-    /// One preserved provider event paired with the neutral events decoded from it.
-    ProviderEvent {
-        /// Opaque source-format identity used by the translation layer.
-        source: FormatId,
-        /// Opaque parsed source event retained for translation-layer replay.
-        raw: Value,
-        /// Provider-neutral events decoded from `raw`, in source order.
-        normalized: Vec<LlmResponseChunk>,
-    },
     /// Starts a response message.
     MessageStart {
         /// Provider response identifier.
@@ -285,11 +345,6 @@ impl ResponseAccumulator {
     /// earlier ones; text, reasoning, and tool-call arguments append.
     pub fn push(&mut self, chunk: LlmResponseChunk) {
         match chunk {
-            LlmResponseChunk::ProviderEvent { normalized, .. } => {
-                for chunk in normalized {
-                    self.push(chunk);
-                }
-            }
             LlmResponseChunk::MessageStart { id, model } => {
                 if id.is_some() {
                     self.id = id;
@@ -436,18 +491,21 @@ mod tests {
     }
 
     #[test]
-    fn folds_normalized_chunks_inside_provider_event() {
-        let aggregate = fold(vec![LlmResponseChunk::ProviderEvent {
-            source: crate::WireFormat::OpenAiChat.into(),
-            raw: json!({
+    fn aggregates_normalized_chunks_inside_stream_event() {
+        let response = LlmResponse::Stream(Box::pin(stream::iter([Ok(
+            LlmResponseStreamEvent::preserved(
+                crate::WireFormat::OpenAiChat,
+                json!({
                 "choices": [{"delta": {"content": "hello"}}],
                 "system_fingerprint": "fp_exact"
-            }),
-            normalized: vec![LlmResponseChunk::TextDelta {
-                index: 0,
-                text: "hello".to_string(),
-            }],
-        }]);
+                }),
+                vec![LlmResponseChunk::TextDelta {
+                    index: 0,
+                    text: "hello".to_string(),
+                }],
+            ),
+        )])));
+        let aggregate = block_on(response.into_agg()).expect("stream event should aggregate");
 
         assert_eq!(
             aggregate.outputs[0].content,
@@ -458,15 +516,40 @@ mod tests {
     }
 
     #[test]
-    fn stream_errors_inside_provider_events_remain_typed() {
+    fn replacing_normalized_content_drops_preservation() {
+        let event = LlmResponseStreamEvent::preserved(
+            crate::WireFormat::OpenAiChat,
+            json!({"choices": [{"delta": {"content": "old"}}]}),
+            vec![LlmResponseChunk::TextDelta {
+                index: 0,
+                text: "old".to_string(),
+            }],
+        )
+        .replace_normalized(vec![LlmResponseChunk::TextDelta {
+            index: 0,
+            text: "new".to_string(),
+        }]);
+
+        assert!(event.preservation().is_none());
+        assert_eq!(
+            event.normalized(),
+            &[LlmResponseChunk::TextDelta {
+                index: 0,
+                text: "new".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn stream_errors_inside_preserved_events_remain_typed() {
         let response = LlmResponse::Stream(Box::pin(stream::iter([Ok(
-            LlmResponseChunk::ProviderEvent {
-                source: crate::WireFormat::OpenAiChat.into(),
-                raw: json!({"error": {"message": "provider failed"}}),
-                normalized: vec![LlmResponseChunk::StreamError {
+            LlmResponseStreamEvent::preserved(
+                crate::WireFormat::OpenAiChat,
+                json!({"error": {"message": "provider failed"}}),
+                vec![LlmResponseChunk::StreamError {
                     message: "provider failed".to_string(),
                 }],
-            },
+            ),
         )])));
 
         let error = block_on(response.into_agg()).err();

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -169,16 +169,17 @@ fn push_checked_chunk(
 /// One streaming event carried between a host and an algorithm.
 ///
 /// Normalized variants expose provider-neutral meaning. [`ProviderEvent`](Self::ProviderEvent)
-/// additionally retains exact source JSON for a lossless same-format round trip while keeping
-/// normalized children available to algorithms and cross-format encoders.
+/// additionally retains the parsed source JSON value, so a same-format round trip replays that
+/// value rather than the original bytes: SSE framing, whitespace, and object key order are not
+/// preserved. Normalized children stay available to algorithms and cross-format encoders.
 /// `switchyard-translation` re-exports this type as `ConversationStreamEvent`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LlmResponseChunk {
-    /// One exact provider event paired with the neutral events decoded from it.
+    /// One preserved provider event paired with the neutral events decoded from it.
     ProviderEvent {
         /// Provider format that produced `raw`.
         source: FormatId,
-        /// Exact parsed provider event.
+        /// Source event as a parsed JSON value.
         raw: Value,
         /// Provider-neutral events decoded from `raw`, in source order.
         normalized: Vec<LlmResponseChunk>,

--- a/crates/switchyard-server/src/usage_metrics.rs
+++ b/crates/switchyard-server/src/usage_metrics.rs
@@ -52,16 +52,22 @@ pub(crate) fn observe(
             let wrapped = async_stream::stream! {
                 let mut latest_usage = None;
                 while let Some(item) = stream.next().await {
-                    let failed = matches!(
-                        &item,
-                        Err(_)
-                            | Ok(
+                    let failed = match &item {
+                        Err(_) => true,
+                        Ok(event) => event.normalized().iter().any(|chunk| {
+                            matches!(
+                                chunk,
                                 LlmResponseChunk::StreamError { .. }
                                     | LlmResponseChunk::DecodeError { .. }
                             )
-                    );
-                    if let Ok(LlmResponseChunk::Usage(usage)) = &item {
-                        latest_usage = Some(usage.clone());
+                        }),
+                    };
+                    if let Ok(event) = &item {
+                        for chunk in event.normalized() {
+                            if let LlmResponseChunk::Usage(usage) = chunk {
+                                latest_usage = Some(usage.clone());
+                            }
+                        }
                     }
                     if failed {
                         record_stream_error(&stats, &model, tier.as_deref());

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
+    StreamCodec, StreamTranslationState, record_source_identity,
     target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
@@ -126,18 +126,6 @@ fn encode_anthropic_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
-        LlmResponseChunk::ProviderEvent {
-            source,
-            raw,
-            normalized,
-        } if source == WireFormat::AnthropicMessages.into() => {
-            mark_replayed_terminal(state, &normalized);
-            vec![raw]
-        }
-        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
-            .into_iter()
-            .flat_map(|event| encode_anthropic_stream(state, event))
-            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start {
@@ -196,6 +184,7 @@ fn encode_anthropic_stream(
         LlmResponseChunk::StreamError { message } | LlmResponseChunk::DecodeError { message } => {
             vec![json!({"type": "error", "error": {"message": message}})]
         }
+        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -37,6 +37,28 @@ impl StreamCodec for AnthropicMessagesStreamCodec {
         encode_anthropic_stream(state, event)
     }
 
+    fn observe_replayed_event(
+        &self,
+        state: &mut StreamTranslationState,
+        raw: &Value,
+        normalized: Vec<LlmResponseChunk>,
+    ) {
+        let normalized_stop = normalized
+            .iter()
+            .any(|chunk| matches!(chunk, LlmResponseChunk::MessageStop { .. }));
+        for chunk in normalized {
+            drop(encode_anthropic_stream(state, chunk));
+        }
+
+        match raw.get("type").and_then(Value::as_str) {
+            // Anthropic carries the stop reason and usage in `message_delta`, but the separate
+            // `message_stop` event is what actually terminates the stream.
+            Some("message_delta") if normalized_stop => state.emitted_message_delta = true,
+            Some("message_stop") => state.finished = true,
+            _ => {}
+        }
+    }
+
     fn finish(&self, state: &mut StreamTranslationState) -> Vec<Value> {
         finish_anthropic_stream(state)
     }
@@ -230,14 +252,17 @@ fn finish_anthropic_stream(state: &mut StreamTranslationState) -> Vec<Value> {
         out.push(json!({"type": "content_block_stop", "index": 0}));
     }
 
-    out.push(json!({
-        "type": "message_delta",
-        "delta": {
-            "stop_reason": anthropic_stop_reason(state.stop_reason.as_deref()),
-            "stop_sequence": Value::Null,
-        },
-        "usage": anthropic_stream_usage(state),
-    }));
+    if !state.emitted_message_delta {
+        out.push(json!({
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": anthropic_stop_reason(state.stop_reason.as_deref()),
+                "stop_sequence": Value::Null,
+            },
+            "usage": anthropic_stream_usage(state),
+        }));
+        state.emitted_message_delta = true;
+    }
     out.push(json!({"type": "message_stop"}));
     state.finished = true;
     out

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -126,6 +126,15 @@ fn encode_anthropic_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::AnthropicMessages.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_anthropic_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start {

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -184,7 +184,6 @@ fn encode_anthropic_stream(
         LlmResponseChunk::StreamError { message } | LlmResponseChunk::DecodeError { message } => {
             vec![json!({"type": "error", "error": {"message": message}})]
         }
-        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, record_source_identity,
+    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
     target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
@@ -129,8 +129,11 @@ fn encode_anthropic_stream(
         LlmResponseChunk::ProviderEvent {
             source,
             raw,
-            normalized: _,
-        } if source == WireFormat::AnthropicMessages.into() => vec![raw],
+            normalized,
+        } if source == WireFormat::AnthropicMessages.into() => {
+            mark_replayed_terminal(state, &normalized);
+            vec![raw]
+        }
         LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
             .into_iter()
             .flat_map(|event| encode_anthropic_stream(state, event))
@@ -198,6 +201,9 @@ fn encode_anthropic_stream(
 
 // Emits any missing Anthropic terminal events and closes open content blocks.
 fn finish_anthropic_stream(state: &mut StreamTranslationState) -> Vec<Value> {
+    if state.finished {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     if !state.emitted_message_start {
         out.extend(encode_anthropic_stream(

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -156,6 +156,9 @@ fn encode_openai_chat_stream(
     match event {
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
+            // `finish_openai_chat_stream` uses this flag to decide whether a clean EOF needs a
+            // synthesized terminal chunk. Set it on the encode path as well as the decode path.
+            state.saw_message_start = true;
             if state.emitted_message_start
                 || (!state_source_is(state, WireFormat::AnthropicMessages)
                     && !state_source_is(state, WireFormat::OpenAiResponses))

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -223,7 +223,6 @@ fn encode_openai_chat_stream(
         LlmResponseChunk::DecodeError { message } | LlmResponseChunk::StreamError { message } => {
             vec![json!({"error": {"message": message}})]
         }
-        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -7,8 +7,8 @@ use serde_json::{Map, Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
-    state_source_is, string_field, target_model_or_source_model,
+    StreamCodec, StreamTranslationState, record_source_identity, state_source_is, string_field,
+    target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
 use crate::llm::Usage;
@@ -154,18 +154,6 @@ fn encode_openai_chat_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
-        LlmResponseChunk::ProviderEvent {
-            source,
-            raw,
-            normalized,
-        } if source == WireFormat::OpenAiChat.into() => {
-            mark_replayed_terminal(state, &normalized);
-            vec![raw]
-        }
-        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
-            .into_iter()
-            .flat_map(|event| encode_openai_chat_stream(state, event))
-            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start
@@ -235,6 +223,7 @@ fn encode_openai_chat_stream(
         LlmResponseChunk::DecodeError { message } | LlmResponseChunk::StreamError { message } => {
             vec![json!({"error": {"message": message}})]
         }
+        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -7,8 +7,8 @@ use serde_json::{Map, Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, record_source_identity, state_source_is, string_field,
-    target_model_or_source_model,
+    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
+    state_source_is, string_field, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
 use crate::llm::Usage;
@@ -157,8 +157,11 @@ fn encode_openai_chat_stream(
         LlmResponseChunk::ProviderEvent {
             source,
             raw,
-            normalized: _,
-        } if source == WireFormat::OpenAiChat.into() => vec![raw],
+            normalized,
+        } if source == WireFormat::OpenAiChat.into() => {
+            mark_replayed_terminal(state, &normalized);
+            vec![raw]
+        }
         LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
             .into_iter()
             .flat_map(|event| encode_openai_chat_stream(state, event))

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -154,6 +154,15 @@ fn encode_openai_chat_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::OpenAiChat.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_openai_chat_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             if state.emitted_message_start

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
+    StreamCodec, StreamTranslationState, record_source_identity,
     target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
@@ -154,18 +154,6 @@ fn encode_responses_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
-        LlmResponseChunk::ProviderEvent {
-            source,
-            raw,
-            normalized,
-        } if source == WireFormat::OpenAiResponses.into() => {
-            mark_replayed_terminal(state, &normalized);
-            vec![raw]
-        }
-        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
-            .into_iter()
-            .flat_map(|event| encode_responses_stream(state, event))
-            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             ensure_responses_created(state)
@@ -192,6 +180,7 @@ fn encode_responses_stream(
         LlmResponseChunk::DecodeError { message } | LlmResponseChunk::StreamError { message } => {
             vec![json!({"type": "error", "message": message})]
         }
+        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 
 use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    StreamCodec, StreamTranslationState, record_source_identity,
+    StreamCodec, StreamTranslationState, mark_replayed_terminal, record_source_identity,
     target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
@@ -157,8 +157,11 @@ fn encode_responses_stream(
         LlmResponseChunk::ProviderEvent {
             source,
             raw,
-            normalized: _,
-        } if source == WireFormat::OpenAiResponses.into() => vec![raw],
+            normalized,
+        } if source == WireFormat::OpenAiResponses.into() => {
+            mark_replayed_terminal(state, &normalized);
+            vec![raw]
+        }
         LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
             .into_iter()
             .flat_map(|event| encode_responses_stream(state, event))
@@ -194,6 +197,9 @@ fn encode_responses_stream(
 
 // Emits final OpenAI Responses completion events from accumulated state.
 fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
+    if state.finished {
+        return Vec::new();
+    }
     let mut out = ensure_responses_created(state);
     if state.response_text_started
         && let Some(output_index) = state.response_text_output_index

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -154,6 +154,15 @@ fn encode_responses_stream(
     event: LlmResponseChunk,
 ) -> Vec<Value> {
     match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if source == WireFormat::OpenAiResponses.into() => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_responses_stream(state, event))
+            .collect(),
         LlmResponseChunk::MessageStart { id, model } => {
             record_source_identity(state, id, model);
             ensure_responses_created(state)

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -180,7 +180,6 @@ fn encode_responses_stream(
         LlmResponseChunk::DecodeError { message } | LlmResponseChunk::StreamError { message } => {
             vec![json!({"type": "error", "message": message})]
         }
-        LlmResponseChunk::ProviderEvent { .. } => Vec::new(),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -215,7 +215,7 @@ pub fn decode_stream_event(
         })
 }
 
-/// Decodes one provider stream event and retains its exact source JSON.
+/// Decodes one provider stream event and retains its parsed source JSON value.
 pub fn decode_stream_event_preserving(
     state: &mut StreamTranslationState,
     source: impl Into<FormatId>,

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -231,17 +231,21 @@ pub(crate) fn mark_replayed_terminal(
 }
 
 /// Decodes one provider stream event and retains its parsed source JSON value.
+///
+/// Takes ownership of `event` so preservation does not deep-copy provider JSON
+/// on the per-event streaming path.
 pub fn decode_stream_event_preserving(
     state: &mut StreamTranslationState,
     source: impl Into<FormatId>,
-    event: &Value,
+    event: Value,
 ) -> LlmResponseChunk {
     let source = source.into();
     state.source = Some(source.clone());
+    let normalized = decode_stream_event(state, source.clone(), &event);
     LlmResponseChunk::ProviderEvent {
-        source: source.clone(),
-        raw: event.clone(),
-        normalized: decode_stream_event(state, source, event),
+        source,
+        raw: event,
+        normalized,
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -40,6 +40,7 @@ pub struct StreamTranslationState {
     pub(crate) output_tokens_seen: u64,
     pub(crate) saw_backend_usage: bool,
     pub(crate) stop_reason: Option<String>,
+    pub(crate) emitted_message_delta: bool,
 
     pub(crate) next_content_index: usize,
     pub(crate) text_block_index: Option<usize>,
@@ -108,6 +109,30 @@ pub trait StreamCodec: Send + Sync {
         state: &mut StreamTranslationState,
         event: LlmResponseChunk,
     ) -> Vec<Value>;
+
+    /// Advances encoder state after an exact same-format event replay.
+    ///
+    /// Exact replay returns the preserved provider JSON instead of the JSON emitted by
+    /// [`Self::encode_event`]. The encoder must nevertheless observe the normalized chunks so
+    /// [`Self::finish`] can close an incomplete stream without duplicating an already replayed
+    /// terminal event. Codecs whose terminal state cannot be inferred from `MessageStop` alone
+    /// may override this hook and inspect `raw`.
+    fn observe_replayed_event(
+        &self,
+        state: &mut StreamTranslationState,
+        _raw: &Value,
+        normalized: Vec<LlmResponseChunk>,
+    ) {
+        let replayed_terminal = normalized
+            .iter()
+            .any(|chunk| matches!(chunk, LlmResponseChunk::MessageStop { .. }));
+        for chunk in normalized {
+            drop(self.encode_event(state, chunk));
+        }
+        if replayed_terminal {
+            state.finished = true;
+        }
+    }
 
     /// Emits any terminal provider events needed after the source stream ends.
     ///
@@ -215,21 +240,6 @@ pub fn decode_stream_event(
         })
 }
 
-// Replaying a preserved event emits its retained JSON without running the encoder, so the
-// terminal bookkeeping the encoder would have done has to happen here. Without it `finish`
-// still believes the stream is unterminated and synthesizes a second terminal sequence.
-pub(crate) fn mark_replayed_terminal(
-    state: &mut StreamTranslationState,
-    normalized: &[LlmResponseChunk],
-) {
-    if normalized
-        .iter()
-        .any(|event| matches!(event, LlmResponseChunk::MessageStop { .. }))
-    {
-        state.finished = true;
-    }
-}
-
 pub(crate) fn encode_response_stream_event(
     state: &mut StreamTranslationState,
     target_codec: &dyn StreamCodec,
@@ -240,7 +250,11 @@ pub(crate) fn encode_response_stream_event(
     if let Some(preservation) = preservation {
         let (source, raw) = preservation.into_parts();
         if &source == target {
-            mark_replayed_terminal(state, &normalized);
+            // Exact replay bypasses the target encoder's emitted JSON, but the encoder must
+            // still observe every normalized chunk. Otherwise `finish` starts from empty state:
+            // a clean EOF after a nonterminal provider event can omit or synthesize malformed
+            // terminal events, while a replayed terminal can be emitted twice.
+            target_codec.observe_replayed_event(state, &raw, normalized);
             return vec![raw];
         }
     }

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -230,27 +230,25 @@ pub(crate) fn mark_replayed_terminal(
     }
 }
 
-pub(crate) fn encode_stream_chunk(
+pub(crate) fn encode_response_stream_event(
     state: &mut StreamTranslationState,
     target_codec: &dyn StreamCodec,
     target: &FormatId,
-    event: LlmResponseChunk,
+    event: crate::LlmResponseStreamEvent,
 ) -> Vec<Value> {
-    match event {
-        LlmResponseChunk::ProviderEvent {
-            source,
-            raw,
-            normalized,
-        } if &source == target => {
+    let (preservation, normalized) = event.into_parts();
+    if let Some(preservation) = preservation {
+        let (source, raw) = preservation.into_parts();
+        if &source == target {
             mark_replayed_terminal(state, &normalized);
-            vec![raw]
+            return vec![raw];
         }
-        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
-            .into_iter()
-            .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))
-            .collect(),
-        event => target_codec.encode_event(state, event),
     }
+
+    normalized
+        .into_iter()
+        .flat_map(|chunk| target_codec.encode_event(state, chunk))
+        .collect()
 }
 
 /// Encodes one neutral stream event with the built-in codec registry.
@@ -259,10 +257,9 @@ pub fn encode_stream_event(
     target: impl Into<FormatId>,
     event: LlmResponseChunk,
 ) -> Vec<Value> {
-    let target = target.into();
     StreamCodecRegistry::with_builtins()
-        .codec(target.clone())
-        .map(|codec| encode_stream_chunk(state, codec.as_ref(), &target, event))
+        .codec(target)
+        .map(|codec| codec.encode_event(state, event))
         .unwrap_or_else(|error| vec![json!({"error": {"message": error.to_string()}})])
 }
 

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -215,6 +215,21 @@ pub fn decode_stream_event(
         })
 }
 
+// Replaying a preserved event emits its retained JSON without running the encoder, so the
+// terminal bookkeeping the encoder would have done has to happen here. Without it `finish`
+// still believes the stream is unterminated and synthesizes a second terminal sequence.
+pub(crate) fn mark_replayed_terminal(
+    state: &mut StreamTranslationState,
+    normalized: &[LlmResponseChunk],
+) {
+    if normalized
+        .iter()
+        .any(|event| matches!(event, LlmResponseChunk::MessageStop { .. }))
+    {
+        state.finished = true;
+    }
+}
+
 /// Decodes one provider stream event and retains its parsed source JSON value.
 pub fn decode_stream_event_preserving(
     state: &mut StreamTranslationState,

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -253,25 +253,6 @@ pub(crate) fn encode_stream_chunk(
     }
 }
 
-/// Decodes one provider stream event and retains its parsed source JSON value.
-///
-/// Takes ownership of `event` so preservation does not deep-copy provider JSON
-/// on the per-event streaming path.
-pub fn decode_stream_event_preserving(
-    state: &mut StreamTranslationState,
-    source: impl Into<FormatId>,
-    event: Value,
-) -> LlmResponseChunk {
-    let source = source.into();
-    state.source = Some(source.clone());
-    let normalized = decode_stream_event(state, source.clone(), &event);
-    LlmResponseChunk::ProviderEvent {
-        source,
-        raw: event,
-        normalized,
-    }
-}
-
 /// Encodes one neutral stream event with the built-in codec registry.
 pub fn encode_stream_event(
     state: &mut StreamTranslationState,

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -230,6 +230,29 @@ pub(crate) fn mark_replayed_terminal(
     }
 }
 
+pub(crate) fn encode_stream_chunk(
+    state: &mut StreamTranslationState,
+    target_codec: &dyn StreamCodec,
+    target: &FormatId,
+    event: LlmResponseChunk,
+) -> Vec<Value> {
+    match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized,
+        } if &source == target => {
+            mark_replayed_terminal(state, &normalized);
+            vec![raw]
+        }
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))
+            .collect(),
+        event => target_codec.encode_event(state, event),
+    }
+}
+
 /// Decodes one provider stream event and retains its parsed source JSON value.
 ///
 /// Takes ownership of `event` so preservation does not deep-copy provider JSON
@@ -255,9 +278,10 @@ pub fn encode_stream_event(
     target: impl Into<FormatId>,
     event: LlmResponseChunk,
 ) -> Vec<Value> {
+    let target = target.into();
     StreamCodecRegistry::with_builtins()
-        .codec(target)
-        .map(|codec| codec.encode_event(state, event))
+        .codec(target.clone())
+        .map(|codec| encode_stream_chunk(state, codec.as_ref(), &target, event))
         .unwrap_or_else(|error| vec![json!({"error": {"message": error.to_string()}})])
 }
 

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -215,6 +215,21 @@ pub fn decode_stream_event(
         })
 }
 
+/// Decodes one provider stream event and retains its exact source JSON.
+pub fn decode_stream_event_preserving(
+    state: &mut StreamTranslationState,
+    source: impl Into<FormatId>,
+    event: &Value,
+) -> LlmResponseChunk {
+    let source = source.into();
+    state.source = Some(source.clone());
+    LlmResponseChunk::ProviderEvent {
+        source: source.clone(),
+        raw: event.clone(),
+        normalized: decode_stream_event(state, source, event),
+    }
+}
+
 /// Encodes one neutral stream event with the built-in codec registry.
 pub fn encode_stream_event(
     state: &mut StreamTranslationState,

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -18,6 +18,7 @@ use crate::error::{Result, TranslationError};
 use crate::format::FormatId;
 use crate::llm::{AggLlmResponse, LlmRequest};
 use crate::policy::TranslationPolicy;
+use crate::LlmResponseChunk;
 
 /// Encoded translation result with any diagnostics emitted along the way.
 #[derive(Debug)]
@@ -243,6 +244,45 @@ impl TranslationEngine {
             .collect())
     }
 
+    /// Decodes one provider event while retaining the exact source JSON.
+    pub fn decode_stream_event(
+        &self,
+        state: &mut StreamTranslationState,
+        source: impl Into<FormatId>,
+        event: &Value,
+    ) -> Result<LlmResponseChunk> {
+        let source = source.into();
+        let source_codec = self.stream_registry.codec(source.clone())?;
+        state.source = Some(source.clone());
+        Ok(LlmResponseChunk::ProviderEvent {
+            source,
+            raw: event.clone(),
+            normalized: source_codec.decode_event(state, event),
+        })
+    }
+
+    /// Encodes one neutral or preserved stream event for a target provider.
+    ///
+    /// A preserved event is replayed exactly when its source and target formats
+    /// match. Cross-format encoding intentionally uses only its normalized
+    /// events.
+    pub fn encode_stream_event(
+        &self,
+        state: &mut StreamTranslationState,
+        target: impl Into<FormatId>,
+        event: LlmResponseChunk,
+    ) -> Result<Vec<Value>> {
+        let target = target.into();
+        let target_codec = self.stream_registry.codec(target.clone())?;
+        state.target = Some(target.clone());
+        Ok(encode_stream_chunk(
+            state,
+            target_codec.as_ref(),
+            &target,
+            event,
+        ))
+    }
+
     /// Finishes target-provider stream emission after the source stream closes.
     pub fn finish_stream(
         &self,
@@ -252,6 +292,26 @@ impl TranslationEngine {
         let target = target.into();
         let target_codec = self.stream_registry.codec(target)?;
         Ok(target_codec.finish(state))
+    }
+}
+
+fn encode_stream_chunk(
+    state: &mut StreamTranslationState,
+    target_codec: &dyn crate::codecs::stream::StreamCodec,
+    target: &FormatId,
+    event: LlmResponseChunk,
+) -> Vec<Value> {
+    match event {
+        LlmResponseChunk::ProviderEvent {
+            source,
+            raw,
+            normalized: _,
+        } if &source == target => vec![raw],
+        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
+            .into_iter()
+            .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))
+            .collect(),
+        event => target_codec.encode_event(state, event),
     }
 }
 

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use crate::LlmResponseStreamEvent;
 use crate::codecs::FormatCodec;
 use crate::codecs::anthropic::AnthropicMessagesCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
@@ -20,7 +21,6 @@ use crate::error::{Result, TranslationError};
 use crate::format::FormatId;
 use crate::llm::{AggLlmResponse, LlmRequest};
 use crate::policy::TranslationPolicy;
-use crate::LlmResponseStreamEvent;
 
 /// Encoded translation result with any diagnostics emitted along the way.
 #[derive(Debug)]

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -12,7 +12,9 @@ use crate::codecs::FormatCodec;
 use crate::codecs::anthropic::AnthropicMessagesCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
 use crate::codecs::responses::OpenAiResponsesCodec;
-use crate::codecs::stream::{StreamCodecRegistry, StreamTranslationState};
+use crate::codecs::stream::{
+    StreamCodecRegistry, StreamTranslationState, mark_replayed_terminal,
+};
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::FormatId;
@@ -305,8 +307,11 @@ fn encode_stream_chunk(
         LlmResponseChunk::ProviderEvent {
             source,
             raw,
-            normalized: _,
-        } if &source == target => vec![raw],
+            normalized,
+        } if &source == target => {
+            mark_replayed_terminal(state, &normalized);
+            vec![raw]
+        }
         LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
             .into_iter()
             .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -13,14 +13,14 @@ use crate::codecs::anthropic::AnthropicMessagesCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
 use crate::codecs::responses::OpenAiResponsesCodec;
 use crate::codecs::stream::{
-    StreamCodecRegistry, StreamTranslationState, encode_stream_chunk,
+    StreamCodecRegistry, StreamTranslationState, encode_response_stream_event,
 };
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::FormatId;
 use crate::llm::{AggLlmResponse, LlmRequest};
 use crate::policy::TranslationPolicy;
-use crate::LlmResponseChunk;
+use crate::LlmResponseStreamEvent;
 
 /// Encoded translation result with any diagnostics emitted along the way.
 #[derive(Debug)]
@@ -255,16 +255,12 @@ impl TranslationEngine {
         state: &mut StreamTranslationState,
         source: impl Into<FormatId>,
         event: Value,
-    ) -> Result<LlmResponseChunk> {
+    ) -> Result<LlmResponseStreamEvent> {
         let source = source.into();
         let source_codec = self.stream_registry.codec(source.clone())?;
         state.source = Some(source.clone());
         let normalized = source_codec.decode_event(state, &event);
-        Ok(LlmResponseChunk::ProviderEvent {
-            source,
-            raw: event,
-            normalized,
-        })
+        Ok(LlmResponseStreamEvent::preserved(source, event, normalized))
     }
 
     /// Encodes one neutral or preserved stream event for a target provider.
@@ -276,12 +272,12 @@ impl TranslationEngine {
         &self,
         state: &mut StreamTranslationState,
         target: impl Into<FormatId>,
-        event: LlmResponseChunk,
+        event: LlmResponseStreamEvent,
     ) -> Result<Vec<Value>> {
         let target = target.into();
         let target_codec = self.stream_registry.codec(target.clone())?;
         state.target = Some(target.clone());
-        Ok(encode_stream_chunk(
+        Ok(encode_response_stream_event(
             state,
             target_codec.as_ref(),
             &target,

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -247,19 +247,23 @@ impl TranslationEngine {
     }
 
     /// Decodes one provider event while retaining its parsed source JSON value.
+    ///
+    /// Takes ownership of `event` so preservation does not deep-copy provider JSON
+    /// on the per-event streaming path.
     pub fn decode_stream_event(
         &self,
         state: &mut StreamTranslationState,
         source: impl Into<FormatId>,
-        event: &Value,
+        event: Value,
     ) -> Result<LlmResponseChunk> {
         let source = source.into();
         let source_codec = self.stream_registry.codec(source.clone())?;
         state.source = Some(source.clone());
+        let normalized = source_codec.decode_event(state, &event);
         Ok(LlmResponseChunk::ProviderEvent {
             source,
-            raw: event.clone(),
-            normalized: source_codec.decode_event(state, event),
+            raw: event,
+            normalized,
         })
     }
 

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -13,7 +13,7 @@ use crate::codecs::anthropic::AnthropicMessagesCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
 use crate::codecs::responses::OpenAiResponsesCodec;
 use crate::codecs::stream::{
-    StreamCodecRegistry, StreamTranslationState, mark_replayed_terminal,
+    StreamCodecRegistry, StreamTranslationState, encode_stream_chunk,
 };
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
@@ -298,29 +298,6 @@ impl TranslationEngine {
         let target = target.into();
         let target_codec = self.stream_registry.codec(target)?;
         Ok(target_codec.finish(state))
-    }
-}
-
-fn encode_stream_chunk(
-    state: &mut StreamTranslationState,
-    target_codec: &dyn crate::codecs::stream::StreamCodec,
-    target: &FormatId,
-    event: LlmResponseChunk,
-) -> Vec<Value> {
-    match event {
-        LlmResponseChunk::ProviderEvent {
-            source,
-            raw,
-            normalized,
-        } if &source == target => {
-            mark_replayed_terminal(state, &normalized);
-            vec![raw]
-        }
-        LlmResponseChunk::ProviderEvent { normalized, .. } => normalized
-            .into_iter()
-            .flat_map(|event| encode_stream_chunk(state, target_codec, target, event))
-            .collect(),
-        event => target_codec.encode_event(state, event),
     }
 }
 

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -244,7 +244,7 @@ impl TranslationEngine {
             .collect())
     }
 
-    /// Decodes one provider event while retaining the exact source JSON.
+    /// Decodes one provider event while retaining its parsed source JSON value.
     pub fn decode_stream_event(
         &self,
         state: &mut StreamTranslationState,
@@ -263,9 +263,9 @@ impl TranslationEngine {
 
     /// Encodes one neutral or preserved stream event for a target provider.
     ///
-    /// A preserved event is replayed exactly when its source and target formats
-    /// match. Cross-format encoding intentionally uses only its normalized
-    /// events.
+    /// A preserved event replays its retained JSON value unchanged when its
+    /// source and target formats match. Cross-format encoding intentionally
+    /// uses only its normalized events.
     pub fn encode_stream_event(
         &self,
         state: &mut StreamTranslationState,

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -96,6 +96,7 @@ pub fn encode_stream(
             message: err.to_string(),
         })?;
 
+    let served_model_for_events = served_model.clone();
     let mut state = StreamTranslationState {
         target: Some(target_format.clone()),
         target_model: served_model,
@@ -106,18 +107,59 @@ pub fn encode_stream(
     let events = try_stream! {
         while let Some(item) = chunks.next().await {
             let event = item?;
-            for value in
+            for mut value in
                 encode_response_stream_event(&mut state, codec.as_ref(), &target_format, event)
             {
+                stamp_streamed_response_model(
+                    &mut value,
+                    target,
+                    served_model_for_events.as_deref(),
+                );
                 yield value;
             }
         }
-        for value in codec.finish(&mut state) {
+        for mut value in codec.finish(&mut state) {
+            stamp_streamed_response_model(
+                &mut value,
+                target,
+                served_model_for_events.as_deref(),
+            );
             yield value;
         }
     };
 
     Ok(Box::pin(events))
+}
+
+// The raw-response helper promises that the caller sees the model that served the
+// request. Same-format preservation bypasses provider codecs, so apply that
+// helper-specific override after replay without disturbing any other raw fields.
+fn stamp_streamed_response_model(
+    event: &mut Value,
+    target: WireFormat,
+    served_model: Option<&str>,
+) {
+    let Some(served_model) = served_model else {
+        return;
+    };
+
+    match target {
+        WireFormat::OpenAiChat => {
+            if let Some(event) = event.as_object_mut() {
+                event.insert("model".to_string(), Value::String(served_model.to_string()));
+            }
+        }
+        WireFormat::OpenAiResponses => {
+            if let Some(response) = event.get_mut("response").and_then(Value::as_object_mut) {
+                response.insert("model".to_string(), Value::String(served_model.to_string()));
+            }
+        }
+        WireFormat::AnthropicMessages => {
+            if let Some(message) = event.get_mut("message").and_then(Value::as_object_mut) {
+                message.insert("model".to_string(), Value::String(served_model.to_string()));
+            }
+        }
+    }
 }
 
 /// Decodes a byte stream of `source`-format SSE frames into neutral IR chunks.
@@ -224,7 +266,7 @@ mod tests {
 
     use super::{
         decode_aggregated_response, decode_request, decode_stream, encode_aggregated_response,
-        encode_request, encode_stream,
+        encode_request, encode_stream, stamp_streamed_response_model,
     };
     use crate::{LlmResponseStream, WireFormat};
 
@@ -444,6 +486,61 @@ mod tests {
 
         assert_eq!(replayed, vec![provider_event]);
         Ok(())
+    }
+
+    #[test]
+    fn openai_chat_replay_stamps_the_served_model_without_losing_extensions() {
+        let mut event = json!({
+            "choices": [{"delta": {"content": "Hello"}}],
+            "system_fingerprint": "fp_provider_specific",
+        });
+
+        stamp_streamed_response_model(&mut event, WireFormat::OpenAiChat, Some("served/model"));
+
+        assert_eq!(event["model"], "served/model");
+        assert_eq!(event["system_fingerprint"], "fp_provider_specific");
+    }
+
+    #[test]
+    fn responses_replay_stamps_the_served_model_inside_response() {
+        let mut event = json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_1",
+                "model": "provider/model",
+                "provider_extension": true,
+            },
+        });
+
+        stamp_streamed_response_model(
+            &mut event,
+            WireFormat::OpenAiResponses,
+            Some("served/model"),
+        );
+
+        assert_eq!(event["response"]["model"], "served/model");
+        assert_eq!(event["response"]["provider_extension"], true);
+    }
+
+    #[test]
+    fn anthropic_replay_stamps_the_served_model_inside_message() {
+        let mut event = json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "model": "provider/model",
+                "provider_extension": true,
+            },
+        });
+
+        stamp_streamed_response_model(
+            &mut event,
+            WireFormat::AnthropicMessages,
+            Some("served/model"),
+        );
+
+        assert_eq!(event["message"]["model"], "served/model");
+        assert_eq!(event["message"]["provider_extension"], true);
     }
 
     #[test]

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -15,10 +15,11 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use serde_json::Value;
 use switchyard_protocol::LlmClientError;
 
+use crate::codecs::stream::encode_response_stream_event;
 use crate::sse;
 use crate::{
-    AggLlmResponse, LlmRequest, LlmResponseStream, Result, StreamCodecRegistry,
-    StreamTranslationState, TranslationEngine, TranslationPolicy, WireFormat,
+    AggLlmResponse, FormatId, LlmRequest, LlmResponseStream, LlmResponseStreamEvent, Result,
+    StreamCodecRegistry, StreamTranslationState, TranslationEngine, TranslationPolicy, WireFormat,
 };
 
 static DEFAULT_TRANSLATION_POLICY: LazyLock<TranslationPolicy> =
@@ -85,17 +86,18 @@ pub fn encode_stream(
     target: WireFormat,
     served_model: Option<String>,
 ) -> std::result::Result<RawEventStream, LlmClientError> {
+    let target_format: FormatId = target.into();
     // The target is always a built-in wire format, so this lookup cannot fail; a
     // failure returns as an `Err` rather than a panic.
     let codec = StreamCodecRegistry::with_builtins()
-        .codec(target)
+        .codec(target_format.clone())
         // Currently the only error is that the codec is missing, which is Configuration
         .map_err(|err| LlmClientError::Configuration {
             message: err.to_string(),
         })?;
 
     let mut state = StreamTranslationState {
-        target: Some(target.into()),
+        target: Some(target_format.clone()),
         target_model: served_model,
         ..Default::default()
     };
@@ -103,8 +105,10 @@ pub fn encode_stream(
 
     let events = try_stream! {
         while let Some(item) = chunks.next().await {
-            let chunk = item?;
-            for value in codec.encode_event(&mut state, chunk) {
+            let event = item?;
+            for value in
+                encode_response_stream_event(&mut state, codec.as_ref(), &target_format, event)
+            {
                 yield value;
             }
         }
@@ -130,10 +134,11 @@ where
     S: Stream<Item = std::result::Result<Vec<u8>, LlmClientError>> + Send + 'static,
 {
     let marker = sse::done_marker(source);
+    let source_format: FormatId = source.into();
     // The source is always a built-in wire format, so this lookup cannot fail; a
     // failure returns as an `Err` rather than a panic.
     let codec = StreamCodecRegistry::with_builtins()
-        .codec(source)
+        .codec(source_format.clone())
         .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?;
     // Adapt the byte-chunk stream into an async line reader. The BufReader
     // reassembles data split across network chunks (including multi-byte UTF-8),
@@ -145,7 +150,10 @@ where
         Box::pin(bytes.map(|item| item.map_err(std::io::Error::other)));
     let lines = futures::io::BufReader::new(io_bytes.into_async_read()).lines();
 
-    let mut state = StreamTranslationState::default();
+    let mut state = StreamTranslationState {
+        source: Some(source_format.clone()),
+        ..StreamTranslationState::default()
+    };
     let mut frame = String::new();
     let stream = Box::pin(try_stream! {
         futures::pin_mut!(lines);
@@ -160,9 +168,12 @@ where
                     sse::SseFrame::Empty => {}
                     sse::SseFrame::Done => break,
                     sse::SseFrame::Data(value) => {
-                        for event in codec.decode_event(&mut state, &value) {
-                            yield event;
-                        }
+                        let normalized = codec.decode_event(&mut state, &value);
+                        yield LlmResponseStreamEvent::preserved(
+                            source_format.clone(),
+                            value,
+                            normalized,
+                        );
                     }
                 }
             } else {
@@ -178,9 +189,8 @@ where
             let parsed = sse::parse_json_sse_frame(&frame, marker)
                 .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?;
             if let sse::SseFrame::Data(value) = parsed {
-                for event in codec.decode_event(&mut state, &value) {
-                    yield event;
-                }
+                let normalized = codec.decode_event(&mut state, &value);
+                yield LlmResponseStreamEvent::preserved(source_format, value, normalized);
             }
         }
     });
@@ -208,7 +218,9 @@ mod tests {
     use futures::executor::block_on;
     use futures::{Stream, StreamExt, stream};
     use serde_json::{Value, json};
-    use switchyard_protocol::{LlmClientError, LlmResponseChunk, completion_text};
+    use switchyard_protocol::{
+        LlmClientError, LlmResponseChunk, LlmResponseStreamEvent, completion_text,
+    };
 
     use super::{
         decode_aggregated_response, decode_request, decode_stream, encode_aggregated_response,
@@ -223,19 +235,23 @@ mod tests {
     fn decode_all(
         bytes: impl Stream<Item = Result<Vec<u8>, LlmClientError>> + Send + 'static,
         source: WireFormat,
-    ) -> Result<Vec<LlmResponseChunk>, LlmClientError> {
+    ) -> Result<Vec<LlmResponseStreamEvent>, LlmClientError> {
         block_on(decode_stream(bytes, source)?.collect::<Vec<_>>())
             .into_iter()
             .collect()
     }
 
     // Concatenates the text of every `TextDelta` chunk.
-    fn text_of(chunks: &[LlmResponseChunk]) -> String {
-        chunks
+    fn text_of(events: &[LlmResponseStreamEvent]) -> String {
+        events
             .iter()
-            .filter_map(|chunk| match chunk {
-                LlmResponseChunk::TextDelta { text, .. } => Some(text.as_str()),
-                _ => None,
+            .flat_map(LlmResponseStreamEvent::normalized)
+            .filter_map(|chunk| {
+                if let LlmResponseChunk::TextDelta { text, .. } = chunk {
+                    Some(text.as_str())
+                } else {
+                    None
+                }
             })
             .collect()
     }
@@ -281,14 +297,17 @@ mod tests {
             Ok(LlmResponseChunk::TextDelta {
                 index: 0,
                 text: "Hello".to_string(),
-            }),
+            }
+            .into()),
             Ok(LlmResponseChunk::TextDelta {
                 index: 0,
                 text: " world".to_string(),
-            }),
+            }
+            .into()),
             Ok(LlmResponseChunk::MessageStop {
                 reason: Some("stop".to_string()),
-            }),
+            }
+            .into()),
         ])
         .boxed();
 
@@ -321,11 +340,13 @@ mod tests {
             Ok(LlmResponseChunk::MessageStart {
                 id: Some("msg_1".to_string()),
                 model: Some("upstream/model".to_string()),
-            }),
+            }
+            .into()),
             Ok(LlmResponseChunk::TextDelta {
                 index: 0,
                 text: "hi".to_string(),
-            }),
+            }
+            .into()),
         ])
         .boxed();
 
@@ -353,11 +374,13 @@ mod tests {
             Ok(LlmResponseChunk::MessageStart {
                 id: Some("msg_1".to_string()),
                 model: Some("upstream/model".to_string()),
-            }),
+            }
+            .into()),
             Ok(LlmResponseChunk::TextDelta {
                 index: 0,
                 text: "hi".to_string(),
-            }),
+            }
+            .into()),
         ])
         .boxed();
 
@@ -374,7 +397,7 @@ mod tests {
     #[test]
     fn encode_stream_propagates_chunk_errors() -> Result<(), BoxError> {
         let chunks: LlmResponseStream =
-            stream::iter(vec![Err::<LlmResponseChunk, LlmClientError>(
+            stream::iter(vec![Err::<LlmResponseStreamEvent, LlmClientError>(
                 LlmClientError::General("chunk exploded".to_string()),
             )])
             .boxed();
@@ -394,6 +417,32 @@ mod tests {
         let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
         let chunks = decode_all(bytes, WireFormat::OpenAiChat)?;
         assert_eq!(text_of(&chunks), "Hello world");
+        Ok(())
+    }
+
+    #[test]
+    fn stream_helpers_replay_same_format_provider_fields() -> Result<(), BoxError> {
+        let provider_event = json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "system_fingerprint": "fp_provider_specific",
+            "choices": [{
+                "index": 0,
+                "delta": {"content": "Hello"},
+                "finish_reason": "stop"
+            }]
+        });
+        let bytes = stream::once({
+            let frame = format!("data: {provider_event}\n\n").into_bytes();
+            async move { Ok::<Vec<u8>, LlmClientError>(frame) }
+        });
+        let decoded = decode_stream(bytes, WireFormat::OpenAiChat)?;
+        let replayed =
+            block_on(encode_stream(decoded, WireFormat::OpenAiChat, None)?.collect::<Vec<_>>())
+                .into_iter()
+                .collect::<Result<Vec<Value>, BoxError>>()?;
+
+        assert_eq!(replayed, vec![provider_event]);
         Ok(())
     }
 

--- a/crates/switchyard-translation/src/lib.rs
+++ b/crates/switchyard-translation/src/lib.rs
@@ -17,8 +17,9 @@ mod sse;
 pub mod stream;
 pub mod util;
 
-pub use switchyard_protocol::stream::LlmResponseChunk;
-pub use switchyard_protocol::stream::LlmResponseStream;
+pub use switchyard_protocol::stream::{
+    LlmResponseChunk, LlmResponseStream, LlmResponseStreamEvent, ProviderStreamEvent,
+};
 pub use switchyard_protocol::{format, llm};
 
 pub use diagnostic::*;

--- a/crates/switchyard-translation/tests/extension_points.rs
+++ b/crates/switchyard-translation/tests/extension_points.rs
@@ -86,6 +86,26 @@ fn custom_stream_codec_can_participate_in_registered_stream_translation() -> Tes
     Ok(())
 }
 
+#[test]
+fn custom_stream_codec_replays_preserved_same_format_event() -> TestResult {
+    let mut registry = StreamCodecRegistry::new();
+    registry.register(CustomStreamCodec);
+    let engine = TranslationEngine::with_registries(FormatRegistry::new(), registry);
+    let format = FormatId::new("custom_stream");
+    let mut state = StreamTranslationState::new(format.clone(), format.clone());
+    let event = json!({
+        "kind": "delta",
+        "text": "hello",
+        "vendor_only": {"must": "survive"}
+    });
+
+    let preserved = engine.decode_stream_event(&mut state, format.clone(), event.clone())?;
+    let replayed = engine.encode_stream_event(&mut state, format, preserved)?;
+
+    assert_eq!(replayed, vec![event]);
+    Ok(())
+}
+
 // Verifies target capability policy can reject unsupported request features.
 #[test]
 fn capability_profile_can_fail_fast_when_target_cannot_accept_request_features() {

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -119,6 +119,84 @@ fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn replayed_nonterminal_event_advances_encoder_state_before_finish() -> TestResult {
+    let engine = TranslationEngine::default();
+    let format = WireFormat::OpenAiChat;
+    let event = json!({
+        "id": "chatcmpl-clean-eof",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "delta": {"role": "assistant", "content": "Hi"},
+            "finish_reason": null
+        }]
+    });
+    let mut decode_state = StreamTranslationState::new(format, format);
+    let preserved = engine.decode_stream_event(&mut decode_state, format, event.clone())?;
+
+    // Provider decoding and caller encoding are independent stream boundaries in a host such as
+    // NeMo Relay. Replay must therefore advance a fresh encoder state using the normalized view.
+    let mut encode_state = StreamTranslationState::new(format, format);
+    assert_eq!(
+        engine.encode_stream_event(&mut encode_state, format, preserved)?,
+        vec![event]
+    );
+    let finish = engine.finish_stream(&mut encode_state, format)?;
+
+    assert_eq!(finish.len(), 1);
+    assert_eq!(finish[0]["id"], "chatcmpl-clean-eof");
+    assert_eq!(finish[0]["model"], "gpt-4o");
+    assert_eq!(finish[0]["choices"][0]["finish_reason"], "stop");
+    Ok(())
+}
+
+#[test]
+fn replayed_anthropic_terminal_delta_finishes_with_message_stop_only() -> TestResult {
+    let engine = TranslationEngine::default();
+    let format = WireFormat::AnthropicMessages;
+    let events = [
+        json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_clean_eof",
+                "model": "claude",
+                "usage": {"input_tokens": 3, "output_tokens": 0}
+            }
+        }),
+        json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+            "usage": {"output_tokens": 2}
+        }),
+    ];
+    let mut decode_state = StreamTranslationState::new(format, format);
+    let mut encode_state = StreamTranslationState::new(format, format);
+
+    for event in events {
+        let preserved = engine.decode_stream_event(&mut decode_state, format, event.clone())?;
+        assert_eq!(
+            engine.encode_stream_event(&mut encode_state, format, preserved)?,
+            vec![event]
+        );
+    }
+
+    let finish = engine.finish_stream(&mut encode_state, format)?;
+    assert_eq!(
+        finish
+            .iter()
+            .filter(|event| event["type"] == "message_stop")
+            .count(),
+        1
+    );
+    assert!(
+        finish.iter().all(|event| event["type"] != "message_delta"),
+        "the replayed terminal delta must not be synthesized a second time"
+    );
+    Ok(())
+}
+
 // Cross-format encoding discards provider-specific fields and uses normalized chunks.
 #[test]
 fn preserved_cross_format_event_uses_normalized_content() -> TestResult {

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -8,9 +8,93 @@ use serde_json::json;
 use switchyard_protocol::{ResponseAccumulator, StopReason};
 use switchyard_translation::{
     LlmResponseChunk, StreamTranslationState, TranslationEngine, WireFormat, decode_stream_event,
+    decode_stream_event_preserving, encode_stream_event,
 };
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+#[test]
+fn preserved_same_format_events_replay_unknown_fields_exactly() -> TestResult {
+    let cases = [
+        (
+            WireFormat::OpenAiChat,
+            json!({
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "system_fingerprint": "fp_provider_specific",
+                "choices": [{
+                    "index": 0,
+                    "delta": {"content": "Hi"},
+                    "finish_reason": null
+                }]
+            }),
+        ),
+        (
+            WireFormat::OpenAiResponses,
+            json!({
+                "type": "response.output_text.delta",
+                "item_id": "item-1",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": "Hi",
+                "sequence_number": 2,
+                "provider_extension": {"exact": true}
+            }),
+        ),
+        (
+            WireFormat::AnthropicMessages,
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hi"},
+                "provider_extension": {"exact": true}
+            }),
+        ),
+    ];
+
+    for (format, event) in cases {
+        let engine = TranslationEngine::default();
+        let mut state = StreamTranslationState::new(format, format);
+        let preserved = engine.decode_stream_event(&mut state, format, &event)?;
+        let replayed = engine.encode_stream_event(&mut state, format, preserved)?;
+        assert_eq!(replayed, vec![event.clone()]);
+
+        let mut state = StreamTranslationState::new(format, format);
+        let preserved = decode_stream_event_preserving(&mut state, format, &event);
+        let replayed = encode_stream_event(&mut state, format, preserved);
+        assert_eq!(replayed, vec![event]);
+    }
+    Ok(())
+}
+
+#[test]
+fn preserved_cross_format_event_uses_normalized_content() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let event = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_provider_specific",
+        "choices": [{
+            "index": 0,
+            "delta": {"content": "Hi"},
+            "finish_reason": null
+        }]
+    });
+
+    let preserved = engine.decode_stream_event(&mut state, WireFormat::OpenAiChat, &event)?;
+    let translated =
+        engine.encode_stream_event(&mut state, WireFormat::AnthropicMessages, preserved)?;
+
+    assert_eq!(translated[2]["delta"]["text"], "Hi");
+    assert!(translated
+        .iter()
+        .all(|event| event.get("system_fingerprint").is_none()));
+    Ok(())
+}
 
 // Verifies an OpenAI text delta opens the expected Anthropic message and content blocks.
 #[test]

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -8,7 +8,6 @@ use serde_json::json;
 use switchyard_protocol::{ResponseAccumulator, StopReason};
 use switchyard_translation::{
     LlmResponseChunk, StreamTranslationState, TranslationEngine, WireFormat, decode_stream_event,
-    decode_stream_event_preserving, encode_stream_event,
 };
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -58,19 +57,14 @@ fn preserved_same_format_events_replay_unknown_fields_exactly() -> TestResult {
         let mut state = StreamTranslationState::new(format, format);
         let preserved = engine.decode_stream_event(&mut state, format, event.clone())?;
         let replayed = engine.encode_stream_event(&mut state, format, preserved)?;
-        assert_eq!(replayed, vec![event.clone()]);
-
-        let mut state = StreamTranslationState::new(format, format);
-        let preserved = decode_stream_event_preserving(&mut state, format, event.clone());
-        let replayed = encode_stream_event(&mut state, format, preserved);
         assert_eq!(replayed, vec![event]);
     }
     Ok(())
 }
 
 // Replay emits the preserved event without running the encoder, so the encoder never sees the
-// stop it would normally record. Both replay paths must still leave the stream marked finished
-// or `finish_stream` synthesizes a terminal the client already received.
+// stop it would normally record. Replay must still leave the stream marked finished or
+// `finish_stream` synthesizes a terminal the client already received.
 #[test]
 fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
     let cases = [
@@ -119,18 +113,6 @@ fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
         assert!(
             engine.finish_stream(&mut state, format)?.is_empty(),
             "{format:?} engine replay already delivered a terminal event",
-        );
-
-        let mut state = StreamTranslationState::new(format, format);
-        let mut replayed = Vec::new();
-        for event in &events {
-            let preserved = decode_stream_event_preserving(&mut state, format, event.clone());
-            replayed.extend(encode_stream_event(&mut state, format, preserved));
-        }
-        assert_eq!(replayed, events, "{format:?} codec replay");
-        assert!(
-            engine.finish_stream(&mut state, format)?.is_empty(),
-            "{format:?} codec replay already delivered a terminal event",
         );
     }
     Ok(())

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -56,12 +56,12 @@ fn preserved_same_format_events_replay_unknown_fields_exactly() -> TestResult {
     for (format, event) in cases {
         let engine = TranslationEngine::default();
         let mut state = StreamTranslationState::new(format, format);
-        let preserved = engine.decode_stream_event(&mut state, format, &event)?;
+        let preserved = engine.decode_stream_event(&mut state, format, event.clone())?;
         let replayed = engine.encode_stream_event(&mut state, format, preserved)?;
         assert_eq!(replayed, vec![event.clone()]);
 
         let mut state = StreamTranslationState::new(format, format);
-        let preserved = decode_stream_event_preserving(&mut state, format, &event);
+        let preserved = decode_stream_event_preserving(&mut state, format, event.clone());
         let replayed = encode_stream_event(&mut state, format, preserved);
         assert_eq!(replayed, vec![event]);
     }
@@ -112,7 +112,7 @@ fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
         let mut state = StreamTranslationState::new(format, format);
         let mut replayed = Vec::new();
         for event in &events {
-            let preserved = engine.decode_stream_event(&mut state, format, event)?;
+            let preserved = engine.decode_stream_event(&mut state, format, event.clone())?;
             replayed.extend(engine.encode_stream_event(&mut state, format, preserved)?);
         }
         assert_eq!(replayed, events, "{format:?} engine replay");
@@ -124,7 +124,7 @@ fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
         let mut state = StreamTranslationState::new(format, format);
         let mut replayed = Vec::new();
         for event in &events {
-            let preserved = decode_stream_event_preserving(&mut state, format, event);
+            let preserved = decode_stream_event_preserving(&mut state, format, event.clone());
             replayed.extend(encode_stream_event(&mut state, format, preserved));
         }
         assert_eq!(replayed, events, "{format:?} codec replay");
@@ -153,7 +153,7 @@ fn preserved_cross_format_event_uses_normalized_content() -> TestResult {
         }]
     });
 
-    let preserved = engine.decode_stream_event(&mut state, WireFormat::OpenAiChat, &event)?;
+    let preserved = engine.decode_stream_event(&mut state, WireFormat::OpenAiChat, event)?;
     let translated =
         engine.encode_stream_event(&mut state, WireFormat::AnthropicMessages, preserved)?;
 

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -68,6 +68,74 @@ fn preserved_same_format_events_replay_unknown_fields_exactly() -> TestResult {
     Ok(())
 }
 
+// Replay emits the preserved event without running the encoder, so the encoder never sees the
+// stop it would normally record. Both replay paths must still leave the stream marked finished
+// or `finish_stream` synthesizes a terminal the client already received.
+#[test]
+fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
+    let cases = [
+        (
+            WireFormat::OpenAiChat,
+            vec![
+                json!({
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion.chunk",
+                    "model": "gpt-4o",
+                    "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": null}]
+                }),
+                json!({
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion.chunk",
+                    "model": "gpt-4o",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]
+                }),
+            ],
+        ),
+        (
+            WireFormat::AnthropicMessages,
+            vec![
+                json!({"type": "message_start", "message": {"id": "msg_1", "model": "claude"}}),
+                json!({"type": "message_stop"}),
+            ],
+        ),
+        (
+            WireFormat::OpenAiResponses,
+            vec![
+                json!({"type": "response.created", "response": {"id": "resp_1", "model": "gpt-4o"}}),
+                json!({"type": "response.completed", "response": {"id": "resp_1", "model": "gpt-4o"}}),
+            ],
+        ),
+    ];
+
+    let engine = TranslationEngine::default();
+    for (format, events) in cases {
+        let mut state = StreamTranslationState::new(format, format);
+        let mut replayed = Vec::new();
+        for event in &events {
+            let preserved = engine.decode_stream_event(&mut state, format, event)?;
+            replayed.extend(engine.encode_stream_event(&mut state, format, preserved)?);
+        }
+        assert_eq!(replayed, events, "{format:?} engine replay");
+        assert!(
+            engine.finish_stream(&mut state, format)?.is_empty(),
+            "{format:?} engine replay already delivered a terminal event",
+        );
+
+        let mut state = StreamTranslationState::new(format, format);
+        let mut replayed = Vec::new();
+        for event in &events {
+            let preserved = decode_stream_event_preserving(&mut state, format, event);
+            replayed.extend(encode_stream_event(&mut state, format, preserved));
+        }
+        assert_eq!(replayed, events, "{format:?} codec replay");
+        assert!(
+            engine.finish_stream(&mut state, format)?.is_empty(),
+            "{format:?} codec replay already delivered a terminal event",
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn preserved_cross_format_event_uses_normalized_content() -> TestResult {
     let engine = TranslationEngine::default();

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -12,6 +12,7 @@ use switchyard_translation::{
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
+// Same-format replay returns the same parsed JSON value, including provider-specific fields.
 #[test]
 fn preserved_same_format_events_replay_unknown_fields_exactly() -> TestResult {
     let cases = [
@@ -118,6 +119,7 @@ fn replayed_terminal_event_suppresses_synthesized_finish() -> TestResult {
     Ok(())
 }
 
+// Cross-format encoding discards provider-specific fields and uses normalized chunks.
 #[test]
 fn preserved_cross_format_event_uses_normalized_content() -> TestResult {
     let engine = TranslationEngine::default();
@@ -140,9 +142,11 @@ fn preserved_cross_format_event_uses_normalized_content() -> TestResult {
         engine.encode_stream_event(&mut state, WireFormat::AnthropicMessages, preserved)?;
 
     assert_eq!(translated[2]["delta"]["text"], "Hi");
-    assert!(translated
-        .iter()
-        .all(|event| event.get("system_fingerprint").is_none()));
+    assert!(
+        translated
+            .iter()
+            .all(|event| event.get("system_fingerprint").is_none())
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## What

This PR adds a composed streaming-response event to Switchyard so a host can send a provider response through `libsy::Algorithm::run_stream` without discarding provider-specific JSON fields.

The implementation:

- keeps `LlmResponseChunk` provider-neutral;
- changes `LlmResponseStream` to carry `LlmResponseStreamEvent`;
- represents each stream item as normalized chunks plus optional `ProviderStreamEvent { source, raw }` preservation;
- exposes preserving decode and encode operations through `TranslationEngine`, the API used by the concrete downstream Relay consumer;
- replays `raw` when the source and target formats match;
- encodes `normalized` chunks when the target format differs;
- centralizes the replay-versus-translation decision above provider codecs;
- folds normalized chunks during aggregate conversion while preserving typed decode and upstream-stream errors; and
- covers OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages with same-format and cross-format contract tests.

The fields are intentionally accessed through constructors and accessors. Replacing normalized content creates a normalized-only event and drops preservation, preventing stale provider JSON from being replayed after an algorithm changes the semantic content.

This is intentionally limited to the streaming translation contract.

### Lifecycle

```mermaid
sequenceDiagram
    participant Provider
    participant Host as Host / Relay
    participant Libsy as libsy run_stream
    participant Caller

    Provider-->>Host: Raw JSON stream event<br/>text delta + provider extension
    Host->>Host: Decode to LlmResponseStreamEvent<br/>preservation + normalized chunks
    Host-->>Libsy: Respond to CallLlm with event stream
    Note over Libsy: Algorithms inspect or aggregate<br/>provider-neutral normalized chunks
    Libsy-->>Host: ReturnToAgent(event stream)

    alt Caller format matches provider format
        Host-->>Caller: Replay preserved raw JSON
    else Caller format differs
        Host->>Host: Encode normalized chunks<br/>into caller format
        Host-->>Caller: Cross-format stream event
    end
```

## Why

`run_stream` deliberately gives the embedding host control of provider dispatch. The host fulfills each `CallLlm`, but the resulting stream still passes back through libsy so an algorithm can inspect it, aggregate it, or select it as the final response.

Before this change, decoding a provider event produced only provider-neutral chunks. That is sufficient for cross-format translation, but it cannot faithfully replay a same-format stream after the libsy round trip.

For example, an OpenAI-compatible provider may emit:

```json
{
  "id": "chatcmpl-1",
  "object": "chat.completion.chunk",
  "system_fingerprint": "fp_abc",
  "choices": [
    {
      "index": 0,
      "delta": {"content": "Hello"},
      "finish_reason": null
    }
  ]
}
```

Switchyard normalizes the semantic content to approximately:

```rust
LlmResponseChunk::TextDelta {
    index: 0,
    text: "Hello".into(),
}
```

That normalized chunk has no representation for `system_fingerprint`. The composed stream item carries both:

```rust
LlmResponseStreamEvent {
    preservation: Some(ProviderStreamEvent {
        source: FormatId::from(WireFormat::OpenAiChat),
        raw: provider_event,
    }),
    normalized: vec![text_delta],
}
```

Algorithms consume the normalized meaning. `switchyard-translation` alone interprets preservation: it replays the parsed raw JSON for same-format output and ignores it when encoding a different protocol.

The concrete downstream consumer is [NVIDIA-NeMo/Switchyard#220](https://github.com/NVIDIA-NeMo/Switchyard/pull/220), paired with [NVIDIA/NeMo-Relay#594](https://github.com/NVIDIA/NeMo-Relay/pull/594). Its streaming adapter calls `TranslationEngine::decode_stream_event` for each host-dispatched provider event and `TranslationEngine::encode_stream_event` after `ReturnToAgent`; a Switchyard backend, server route, or PyO3 binding is therefore not required for this contract.

This enables library-first integrations such as NeMo Relay to:

1. run a Switchyard algorithm in process;
2. perform the actual provider call in the host;
3. return the real response stream through `CallLlmRequest::respond`;
4. let libsy continue through `ReturnToAgent`; and
5. preserve provider extensions when the final wire format is unchanged.

For cross-format routes, only fields represented by the neutral IR are translated. In the example above, OpenAI `system_fingerprint` is intentionally absent from an Anthropic Messages output because Anthropic has no corresponding field.

### Boundaries and compatibility

- Preservation is exact for the parsed `serde_json::Value`, not for the original SSE bytes. Comments, SSE `id` fields, whitespace, and JSON key ordering are not retained.
- Provider-only fields are replayed only for same-format output. They are never injected into a different provider protocol.
- `LlmResponseChunk` remains provider-neutral. Preservation is composed beside normalized chunks at the `LlmResponseStreamEvent` boundary.
- The `LlmResponseStream` item type changes from `LlmResponseChunk` to `LlmResponseStreamEvent`, so downstream stream producers and consumers must wrap or unwrap normalized chunks.
- Algorithms using aggregate conversion continue to see normalized content because aggregation folds every event's normalized chunks.
- An algorithm that replaces normalized content must also drop preservation; the provided `replace_normalized` API enforces that behavior.

Closes: N/A — this is an integration-discovered library contract gap.

## How tested

- [ ] `uv run ruff check .` clean — not applicable; no Python changed
- [ ] `uv run mypy switchyard` clean — not applicable; no Python changed
- [ ] `uv run pytest tests/` green — not applicable; no Python changed
- [x] Manual smoke (described below)

Rust validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo test -p switchyard-protocol`
- `cargo test -p switchyard-translation`
- `cargo test -p switchyard-libsy`
- `cargo test -p switchyard-llm-client`
- `cargo test -p switchyard-server`
- `cargo test --workspace --all-targets`

The same-format helper-path test sends an OpenAI Chat stream event containing `system_fingerprint` through `decode_stream` and `encode_stream` and verifies exact parsed-JSON replay. Separate decode and encode state tests also cover clean EOF and Anthropic EOF between `message_delta` and `message_stop`. Cross-format tests verify that normalized content is encoded instead.

`cargo test --workspace --all-targets` passes on the current macOS checkout, including `switchyard-py`; Linux CI remains authoritative for release validation.

Integration validation used NeMo Relay as the host-side dispatcher with no Switchyard service or `switchyard-llm-client`. Hermetic buffered and streaming routes cover OpenAI Chat, OpenAI Responses, and Anthropic Messages caller APIs; a fresh real-provider smoke routed buffered and streaming calls across two local Ollama models with genuine Switchyard marks.

## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class. — not applicable; Rust-only change
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. — not applicable; Rust crate API
- [x] Unit tests added for new components / bug fixes.
- [ ] README / `--help` updated if customer-facing surface changed. — not required; no CLI/configuration change
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

Please focus on the ownership boundary between `preservation` and `normalized`, and on the `LlmResponseStreamEvent` host/algorithm contract before Switchyard 0.2 stabilizes. The same-format path never reconstructs an event from the normalized IR; the cross-format path never copies unknown provider fields into the target protocol.

Preservation decoding is exposed through `TranslationEngine` and the stream helper used by `switchyard-llm-client`. Both encoding surfaces delegate to the same shared preservation dispatcher. Provider codecs handle only normalized chunks, including when the engine uses a custom registered codec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composed streaming-event preservation so same-format events retain provider-specific data.
  * Added streaming decode and encode APIs for translating individual events between supported formats.
  * Improved cross-format streaming translation using provider-neutral normalized content.

* **Bug Fixes**
  * Prevented duplicate terminal output after replaying a terminal provider event.
  * Improved handling and reporting of errors occurring during streamed provider events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

