### PR TITLE
feat(libsy): skip targets whose declared context window is too small

### DIFF
--- a/crates/libsy/examples/ensemble.rs
+++ b/crates/libsy/examples/ensemble.rs
@@ -432,6 +432,7 @@ async fn main() -> Result<()> {
             .map(|model| LlmTarget {
                 semantic_name: model.to_string(),
                 llm_client: Some(client.clone()),
+                max_context_tokens: None,
             })
             .collect(),
     );
@@ -537,6 +538,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         let mut targets: Vec<LlmTarget> = candidates.iter().map(|n| target(n)).collect();
         targets.push(target(judge));
@@ -560,6 +562,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         let mut targets: Vec<LlmTarget> = candidates.iter().map(|n| target(n)).collect();
         targets.push(target(judge));
@@ -728,6 +731,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         let algo = EnsembleOrchAlgo::new(
             vec!["a/model".to_string(), "b/model".to_string()],

--- a/crates/libsy/examples/research_agent.rs
+++ b/crates/libsy/examples/research_agent.rs
@@ -59,6 +59,7 @@ fn targets() -> LlmTargetSet {
     let target = |name: &str| LlmTarget {
         semantic_name: name.to_string(),
         llm_client: Some(client.clone()),
+        max_context_tokens: None,
     };
     LlmTargetSet::new(vec![target(CLASSIFIER), target(STRONG), target(WEAK)])
 }

--- a/crates/libsy/examples/research_agent_core.rs
+++ b/crates/libsy/examples/research_agent_core.rs
@@ -46,6 +46,7 @@ fn targets() -> LlmTargetSet {
     let target = |name: &str| LlmTarget {
         semantic_name: name.to_string(),
         llm_client: None,
+        max_context_tokens: None,
     };
     LlmTargetSet::new(vec![target(CLASSIFIER), target(STRONG), target(WEAK)])
 }

--- a/crates/libsy/examples/streaming_agent.rs
+++ b/crates/libsy/examples/streaming_agent.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<()> {
     let targets = LlmTargetSet::new(vec![LlmTarget {
         semantic_name: "stream/model".to_string(),
         llm_client: None,
+        max_context_tokens: None,
     }]);
     let algo: Arc<dyn Algorithm> = Arc::new(Random::new(targets, None, None)?);
 

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -24,6 +24,7 @@ use crate::{
     Algorithm, Context, Decision, Driver, LibsyError, LlmClientError, LlmTarget, LlmTargetSet,
     Request, Response, Result, RoutedLlmClient,
 };
+use switchyard_protocol::ContentBlock;
 
 type SessionStates<S> = Mutex<HashMap<String, Arc<AsyncMutex<S>>>>;
 
@@ -175,6 +176,14 @@ where
         request: Request,
     ) -> Result<Response> {
         loop {
+            if exceeds_window(&target, &request) && ctx.exclude_target(&target.semantic_name) {
+                if let Ok(next) = self.targets.resolve_target(&target.semantic_name, &ctx) {
+                    decision = self.fallback_decision(&target, &next);
+                    target = next;
+                    driver.info(ctx.clone(), decision.clone()).await?;
+                    continue;
+                }
+            }
             let result = driver
                 .call_llm_target(ctx.clone(), &target, request.clone(), decision.clone())
                 .await;
@@ -296,6 +305,27 @@ where
     }
 }
 
+/// Rough estimate at four characters per token.
+fn estimated_tokens(request: &Request) -> usize {
+    let text: usize = request
+        .llm_request
+        .messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .map(|block| match block {
+            ContentBlock::Text { text } | ContentBlock::Reasoning { text, .. } => text.len(),
+            _ => 0,
+        })
+        .sum();
+    text / 4
+}
+
+fn exceeds_window(target: &LlmTarget, request: &Request) -> bool {
+    target
+        .max_context_tokens
+        .is_some_and(|window| estimated_tokens(request) > window)
+}
+
 fn default_decision_reason(_name: &str, winner: &Score) -> String {
     format!(
         "fall-through selected {} (confidence {:.3})",
@@ -398,6 +428,7 @@ mod tests {
                 .map(|name| LlmTarget {
                     semantic_name: name.to_string(),
                     llm_client: Some(Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>),
+                    max_context_tokens: None,
                 })
                 .collect(),
         )
@@ -523,9 +554,62 @@ mod tests {
                     llm_client: Some(Arc::new(OverflowClient {
                         overflowing: overflowing.to_vec(),
                     }) as Arc<dyn RoutedLlmClient>),
+                    max_context_tokens: None,
                 })
                 .collect(),
         )
+    }
+
+    fn sized_targets(specs: &[(&str, Option<usize>)]) -> LlmTargetSet {
+        LlmTargetSet::new(
+            specs
+                .iter()
+                .map(|(name, window)| LlmTarget {
+                    semantic_name: name.to_string(),
+                    llm_client: Some(Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>),
+                    max_context_tokens: *window,
+                })
+                .collect(),
+        )
+    }
+
+    fn request_of(chars: usize) -> Request {
+        let mut r = request();
+        r.llm_request.messages = vec![Message::text(Role::User, "w".repeat(chars))];
+        r
+    }
+
+    #[tokio::test]
+    async fn a_target_too_small_for_the_request_is_skipped() -> Result<()> {
+        let router = Arc::new(
+            FallThrough::<()>::new(sized_targets(&[("weak", Some(1_000)), ("strong", None)]))
+                .with_classifier(fixed(vec![score("weak", 0.9)])),
+        );
+        let (model, _) = run_request(&router, request_of(40_000)).await?;
+        assert_eq!(model, "strong");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_request_that_fits_uses_the_selected_target() -> Result<()> {
+        let router = Arc::new(
+            FallThrough::<()>::new(sized_targets(&[("weak", Some(1_000)), ("strong", None)]))
+                .with_classifier(fixed(vec![score("weak", 0.9)])),
+        );
+        let (model, _) = run_request(&router, request_of(400)).await?;
+        assert_eq!(model, "weak");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_target_big_enough_still_makes_the_call() -> Result<()> {
+        let router = Arc::new(
+            FallThrough::<()>::new(sized_targets(&[("weak", Some(10)), ("strong", Some(10))]))
+                .with_classifier(fixed(vec![score("weak", 0.9)])),
+        );
+        let (model, _) = run_request(&router, request_of(40_000)).await?;
+        assert_eq!(model, "strong");
+        Ok(())
     }
 
     #[tokio::test]
@@ -780,6 +864,7 @@ mod tests {
         let targets = LlmTargetSet::new(vec![LlmTarget {
             semantic_name: "strong".to_string(),
             llm_client: Some(Arc::new(CapturingClient(seen_by_model.clone()))),
+            max_context_tokens: None,
         }]);
         let router = FallThrough::new(targets)
             .with_processor(Arc::new(Appender("first")))

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -491,6 +491,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         Ok(Arc::new(LlmTaskClassifier::new(
             target("judge"),
@@ -570,6 +571,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         let router = Arc::new(LlmTaskClassifier::new(
             target("judge"),
@@ -600,6 +602,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: Some(client.clone()),
+            max_context_tokens: None,
         };
         let router = Arc::new(LlmTaskClassifier::new(
             target("judge"),
@@ -650,6 +653,7 @@ mod tests {
         let target = |name: &str| LlmTarget {
             semantic_name: name.to_string(),
             llm_client: None,
+            max_context_tokens: None,
         };
         for bad in [1.5, -0.1, f64::NAN, f64::INFINITY] {
             assert!(

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -108,6 +108,7 @@ mod tests {
         let algorithm: Arc<dyn Algorithm> = Arc::new(super::Passthrough::new(LlmTarget {
             semantic_name: MODEL_ID.to_string(),
             llm_client: Some(Arc::new(EchoClient)),
+            max_context_tokens: None,
         }));
         let (trace, response) = algorithm.run(Context::default(), request).await?;
 

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -225,6 +225,7 @@ mod tests {
             .map(|name| LlmTarget {
                 semantic_name: (*name).to_string(),
                 llm_client: Some(Arc::new(EchoClient)),
+                max_context_tokens: None,
             })
             .collect();
         LlmTargetSet::new(targets)

--- a/crates/libsy/src/algorithms/subagent_affinity_tests.rs
+++ b/crates/libsy/src/algorithms/subagent_affinity_tests.rs
@@ -63,6 +63,7 @@ fn targets() -> LlmTargetSet {
             .map(|name| LlmTarget {
                 semantic_name: (*name).to_string(),
                 llm_client: Some(Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>),
+                max_context_tokens: None,
             })
             .collect(),
     )

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -239,6 +239,7 @@ mod tests {
             LlmTarget {
                 semantic_name: "judge".to_string(),
                 llm_client: None,
+                max_context_tokens: None,
             },
             TestPolicy,
         )

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -295,6 +295,8 @@ pub struct LlmTarget {
     /// The client that serves this target's calls by default, or `None` (then the
     /// stream consumer must serve them).
     pub llm_client: Option<Arc<dyn RoutedLlmClient>>,
+    /// Context window in tokens. `None` means unconstrained.
+    pub max_context_tokens: Option<usize>,
 }
 
 /// The set of targets an algorithm may route among. An algorithm is constructed
@@ -658,6 +660,7 @@ mod tests {
             .map(|(name, has_client)| LlmTarget {
                 semantic_name: name.to_string(),
                 llm_client: has_client.then(|| Arc::new(EchoClient) as Arc<dyn RoutedLlmClient>),
+                max_context_tokens: None,
             })
             .collect();
         LlmTargetSet::new(targets)
@@ -699,6 +702,7 @@ mod tests {
         let target = LlmTarget {
             semantic_name: "stream/model".to_string(),
             llm_client: Some(Arc::new(StreamingClient { chunks }) as Arc<dyn RoutedLlmClient>),
+            max_context_tokens: None,
         };
         orch(LlmTargetSet::new(vec![target]))
     }
@@ -930,6 +934,7 @@ mod tests {
             llm_client: Some(Arc::new(BarrierClient {
                 barrier: barrier.clone(),
             })),
+            max_context_tokens: None,
         }]);
         // One shared algorithm driven by many concurrent requests.
         let algo = orch(targets);
@@ -1298,8 +1303,10 @@ mod tests {
             llm_client: Some(Arc::new(GatedEchoClient {
                 gate: started.clone(),
             })),
+            max_context_tokens: None,
         };
         let loser = LlmTarget {
+            max_context_tokens: None,
             semantic_name: "loser".to_string(),
             llm_client: Some(Arc::new(LoserClient {
                 started,
@@ -1414,6 +1421,7 @@ mod tests {
 
         let all_started = Arc::new(tokio::sync::Notify::new());
         let target = LlmTarget {
+            max_context_tokens: None,
             semantic_name: "pending".to_string(),
             llm_client: Some(Arc::new(EnterThenPend {
                 started: Arc::new(AtomicUsize::new(0)),

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -412,6 +412,7 @@ fn algo(name: &str, model: &str, client: Option<Arc<dyn RoutedLlmClient>>) -> Ar
         target_set: LlmTargetSet::new(vec![LlmTarget {
             semantic_name: model.to_string(),
             llm_client: client,
+            max_context_tokens: None,
         }]),
     })
 }
@@ -740,6 +741,7 @@ async fn classifier_metrics_count_only_the_final_routed_call() -> switchyard_lib
     let target = |name: &str| LlmTarget {
         semantic_name: name.to_string(),
         llm_client: Some(client.clone()),
+        max_context_tokens: None,
     };
     let targets = LlmTargetSet::new(vec![target("weak"), target("strong")]);
     let weak = targets.get_target("weak")?;

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -63,6 +63,7 @@ impl PyLlmTarget {
             llm_client: Some(Arc::new(PythonLlmClient {
                 inner: self.client.clone_ref(py),
             })),
+            max_context_tokens: None,
         }
     }
 }

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -129,6 +129,7 @@ impl ServerConfig {
                     LlmTarget {
                         semantic_name: config.id.clone(),
                         llm_client: Some(Arc::clone(client)),
+                        max_context_tokens: config.max_context_tokens,
                     },
                 ))
             })
@@ -153,6 +154,8 @@ struct LlmClientConfig {
 struct TargetConfig {
     id: String,
     llm_client: String,
+    #[serde(default)]
+    max_context_tokens: Option<usize>,
     #[serde(default)]
     extra_body: BTreeMap<String, Value>,
 }

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -173,6 +173,7 @@ fn random_state(base_url: &str, routes: &[(&str, &[&str])]) -> TestResult<Server
                     .map(|model| LlmTarget {
                         semantic_name: (*model).to_string(),
                         llm_client: Some(Arc::clone(&client)),
+                        max_context_tokens: None,
                     })
                     .collect(),
             );
@@ -597,10 +598,12 @@ fn stage_router_state(upstream: &MockUpstream, mode: PickerMode) -> TestResult<S
         LlmTarget {
             semantic_name: "strong".to_string(),
             llm_client: Some(strong),
+            max_context_tokens: None,
         },
         LlmTarget {
             semantic_name: "weak".to_string(),
             llm_client: Some(weak),
+            max_context_tokens: None,
         },
     ]);
     let stage: Arc<dyn Algorithm> = Arc::new(


### PR DESCRIPTION
Adds `max_context_tokens` so a user can declare a model's context window on the target in their routes config:

```toml
[targets.weak]
id = "nvidia/nvidia/nemotron-3-super-120b-long-ctx"
llm_client = "inference_hub"
max_context_tokens = 128000
```

Routing then skips that target when the request is estimated to be too large. Unset means unconstrained, so nothing changes for existing configs.

The check runs per request and needs no session state. So if context length shrinks back under a models max context length the model returns to being an eligible target.

The estimate logic is a rough approximation (four characters per token). If an estimate is wrong such that the estimate is under the declared `max_context_tokens` but actually exceeds the models context size we fall back to the existing retry logic. The existing retry logic will move to the next available model in the pool.

This improves upon the current design by ensuring we don't waste a round trip to the model provider repeatedly (each request) once a model's max context size is exceeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-target context-window limits.
  * Server target configuration can now specify maximum context tokens.
  * Fall-through routing proactively skips targets when requests are estimated to exceed their configured context window.

* **Bug Fixes**
  * Improved fallback behavior for requests exceeding a target’s context limit.
  * Added coverage for context-window-aware routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->