### PR TITLE
feat(libsy): add decision-only Python routing

### DIFF
--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -27,6 +27,13 @@ use crate::{
 
 type SessionStates<S> = Mutex<HashMap<String, Arc<AsyncMutex<S>>>>;
 
+/// Selection output shared by decision-only and response-producing execution.
+struct PreparedRoute {
+    request: Request,
+    target: LlmTarget,
+    decision: Arc<dyn Decision>,
+}
+
 /// The decision a fall-through run produces: the selected model plus a human-readable reason.
 pub struct FallThroughDecision {
     /// Target selected by the classifier cascade.
@@ -177,6 +184,34 @@ where
         driver: Driver,
         request: Request,
     ) -> Result<Response> {
+        let prepared = self.prepare_route(&ctx, &driver, request).await?;
+        self.call_with_overflow_fallback(
+            ctx,
+            &driver,
+            prepared.target,
+            prepared.decision,
+            prepared.request,
+        )
+        .await
+    }
+
+    /// Selects and publishes one route without executing its target.
+    pub(crate) async fn select(
+        &self,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        Ok(self.prepare_route(&ctx, &driver, request).await?.decision)
+    }
+
+    /// Runs processors and classifiers through the final pre-call routing boundary.
+    async fn prepare_route(
+        &self,
+        ctx: &Context,
+        driver: &Driver,
+        request: Request,
+    ) -> Result<PreparedRoute> {
         // The request is threaded mutably through the whole fold: any component may rewrite
         // it, later components see the rewrite, and the final value reaches the model.
         let mut request = request;
@@ -184,16 +219,19 @@ where
         let (target, decision) = match session_state {
             Some(state) => {
                 let mut state = state.lock().await;
-                self.route(&mut state, &ctx, &driver, &mut request).await?
+                self.route(&mut state, ctx, driver, &mut request).await?
             }
             None => {
                 let mut state = S::default();
-                self.route(&mut state, &ctx, &driver, &mut request).await?
+                self.route(&mut state, ctx, driver, &mut request).await?
             }
         };
 
-        self.call_with_overflow_fallback(ctx, &driver, target, decision, request)
-            .await
+        Ok(PreparedRoute {
+            request,
+            target,
+            decision,
+        })
     }
 
     /// Calls `target`, falling back to the next eligible target whenever one overflows its
@@ -356,6 +394,15 @@ where
     ) -> Result<Response> {
         self.execute(ctx, driver, request).await
     }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        self.select(ctx, driver, request).await
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -516,6 +563,27 @@ mod tests {
     }
 
     // --- tests -------------------------------------------------------------------------
+
+    /// Decision-only selection stops after publishing the prepared route.
+    #[tokio::test]
+    async fn decision_only_selects_without_a_target_client() -> Result<()> {
+        let router = Arc::new(
+            FallThrough::<()>::new(LlmTargetSet::new(vec![LlmTarget {
+                semantic_name: "strong".to_string(),
+                llm_client: None,
+            }]))
+            .with_classifier(fixed(vec![score("strong", 0.9)])),
+        );
+
+        let decision = router.decide(Context::default(), request()).await?;
+
+        assert_eq!(decision.selected_model(), "strong");
+        assert_eq!(
+            decision.reasoning(),
+            Some("fall-through selected strong (confidence 0.900)")
+        );
+        Ok(())
+    }
 
     /// Overflows for the named targets and echoes for the rest.
     struct OverflowClient {

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -262,6 +262,28 @@ struct TaskClassifier {
     capable_target: String,
 }
 
+/// Preserves the task classifier's tier label when its terminal fallback decides.
+struct TaskClassifierFallback {
+    inner: DefaultTarget,
+    tiers: Arc<TaskClassifier>,
+}
+
+#[async_trait]
+impl Classifier<State> for TaskClassifierFallback {
+    fn routing_tier(&self, selected_model: &str) -> Option<&'static str> {
+        self.tiers.routing_tier(selected_model)
+    }
+
+    async fn score(
+        &self,
+        state: &mut State,
+        request: &mut Request,
+        driver: Option<&Driver>,
+    ) -> Result<Classification> {
+        self.inner.score(state, request, driver).await
+    }
+}
+
 /// A task-level capability routing algorithm with an internal fall-through cascade.
 pub struct LlmTaskClassifier {
     route: FallThrough<State>,
@@ -316,7 +338,10 @@ impl LlmTaskClassifier {
         }
         // The judge abstains when it cannot tell; the capable tier catches those turns
         // rather than letting the cascade come back empty-handed.
-        let capable_fallback = DefaultTarget::new(classifier.capable_target.clone());
+        let capable_fallback = TaskClassifierFallback {
+            inner: DefaultTarget::new(classifier.capable_target.clone()),
+            tiers: classifier.clone(),
+        };
         Ok(Self {
             route: route
                 .with_classifier(classifier.clone())
@@ -406,6 +431,15 @@ impl Algorithm for LlmTaskClassifier {
         request: Request,
     ) -> Result<Response> {
         self.route.execute(ctx, driver, request).await
+    }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn crate::Decision>> {
+        self.route.select(ctx, driver, request).await
     }
 }
 
@@ -564,6 +598,68 @@ mod tests {
             "Now run the test suite and report the result.",
         ));
         request
+    }
+
+    /// Decision-only classification calls its judge but not the selected target.
+    #[tokio::test]
+    async fn decision_only_calls_the_judge_and_returns_the_efficient_tier() -> Result<()> {
+        let client = Arc::new(PerRequestClient::default());
+        let router = router(client.clone())?;
+
+        let decision = router
+            .decide(Context::default(), classify_request())
+            .await?;
+
+        assert_eq!(decision.selected_model(), "efficient");
+        assert_eq!(decision.routing_tier(), Some("weak"));
+        assert_eq!(client.calls(), vec!["judge"]);
+        Ok(())
+    }
+
+    /// Decision replay binds session affinity before a decision-only call returns.
+    #[tokio::test]
+    async fn decision_only_reuses_session_affinity_without_a_second_judge_call() -> Result<()> {
+        let client = Arc::new(PerRequestClient::default());
+        let target = |name: &str| LlmTarget {
+            semantic_name: name.to_string(),
+            llm_client: Some(client.clone()),
+        };
+        let router = Arc::new(LlmTaskClassifier::new(
+            target("judge"),
+            target("efficient"),
+            target("capable"),
+            TaskClassifierConfig {
+                session_affinity: true,
+                ..test_config(TEST_THRESHOLD)
+            },
+        )?);
+
+        let first = router
+            .clone()
+            .decide(Context::default(), classify_session_request())
+            .await?;
+        let second = router
+            .decide(Context::default(), classify_session_request())
+            .await?;
+
+        assert_eq!(first.selected_model(), "efficient");
+        assert_eq!(second.selected_model(), "efficient");
+        assert_eq!(client.calls(), vec!["judge"]);
+        Ok(())
+    }
+
+    /// Existing judge fail-open policy also applies to decision-only routing.
+    #[tokio::test]
+    async fn decision_only_unreachable_judge_routes_capable() -> Result<()> {
+        let router = router(Arc::new(UnreachableJudgeClient))?;
+
+        let decision = router
+            .decide(Context::default(), classify_request())
+            .await?;
+
+        assert_eq!(decision.selected_model(), "capable");
+        assert_eq!(decision.routing_tier(), Some("strong"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -21,6 +21,17 @@ pub struct NoopDecision {
     model: String,
 }
 
+impl Noop {
+    /// Build the synthetic selection shared by normal and decision-only execution.
+    fn decision(request: &Request) -> Arc<dyn Decision> {
+        let model = request
+            .requested_model()
+            .unwrap_or("switchyard/noop")
+            .to_string();
+        Arc::new(NoopDecision { model })
+    }
+}
+
 impl Decision for NoopDecision {
     fn selected_model(&self) -> &str {
         &self.model
@@ -45,13 +56,8 @@ impl Algorithm for Noop {
         driver: Driver,
         request: Request,
     ) -> Result<Response> {
-        let model = request
-            .requested_model()
-            .unwrap_or("switchyard/noop")
-            .to_string();
-        let decision: Arc<dyn Decision> = Arc::new(NoopDecision {
-            model: model.clone(),
-        });
+        let decision = Self::decision(&request);
+        let model = decision.selected_model().to_string();
         driver.info(ctx, decision.clone()).await?;
 
         let llm_response = LlmResponse::Agg(AggLlmResponse {
@@ -71,6 +77,17 @@ impl Algorithm for Noop {
             metadata: request.metadata.clone(),
         };
         Ok(response)
+    }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        let decision = Self::decision(&request);
+        driver.info(ctx, decision.clone()).await?;
+        Ok(decision)
     }
 }
 
@@ -100,6 +117,29 @@ mod tests {
         };
         assert_eq!(decision.selected_model(), TEST_MODEL);
         assert_eq!(response.selected_model(), Some(TEST_MODEL));
+        Ok(())
+    }
+
+    /// Decision-only no-op preserves the requested model without building a response.
+    #[tokio::test]
+    async fn test_noop_decision_only() -> Result<()> {
+        const TEST_MODEL: &str = "test_noop_decision_only";
+        let request = Request {
+            llm_request: LlmRequest {
+                model: Some(TEST_MODEL.to_string()),
+                messages: vec![Message::text(Role::User, "hi")],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        };
+
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Noop {});
+        let decision = algorithm.decide(Context::default(), request).await?;
+
+        assert_eq!(decision.selected_model(), TEST_MODEL);
+        assert_eq!(decision.reasoning(), None);
+        assert_eq!(decision.routing_tier(), None);
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -20,6 +20,13 @@ impl Passthrough {
     pub fn new(target: LlmTarget) -> Self {
         Passthrough { target }
     }
+
+    /// Build the fixed selection shared by normal and decision-only execution.
+    fn decision(&self) -> Arc<dyn Decision> {
+        Arc::new(PassthroughDecision {
+            model_id: self.target.semantic_name.clone(),
+        })
+    }
 }
 
 pub struct PassthroughDecision {
@@ -59,13 +66,22 @@ impl Algorithm for Passthrough {
         driver: Driver,
         request: Request,
     ) -> Result<Response> {
-        let decision: Arc<dyn Decision> = Arc::new(PassthroughDecision {
-            model_id: self.target.semantic_name.clone(),
-        });
+        let decision = self.decision();
         driver.info(ctx.clone(), decision.clone()).await?;
         driver
             .call_llm_target(ctx, &self.target, request, decision)
             .await
+    }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        _request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        let decision = self.decision();
+        driver.info(ctx, decision.clone()).await?;
+        Ok(decision)
     }
 }
 
@@ -121,6 +137,28 @@ mod tests {
         );
         assert_eq!(trace.len(), 1);
         assert_eq!(trace[0].selected_model(), MODEL_ID);
+        Ok(())
+    }
+
+    /// Decision-only passthrough selects its clientless target without executing it.
+    #[tokio::test]
+    async fn test_passthrough_decision_only() -> crate::error::Result<()> {
+        const MODEL_ID: &str = "testing/passthrough-decision";
+        let request = Request {
+            llm_request: text_request(Some("auto".to_string()), "hi"),
+            raw_request: None,
+            metadata: None,
+        };
+        let algorithm: Arc<dyn Algorithm> = Arc::new(super::Passthrough::new(LlmTarget {
+            semantic_name: MODEL_ID.to_string(),
+            llm_client: None,
+        }));
+
+        let decision = algorithm.decide(Context::default(), request).await?;
+
+        assert_eq!(decision.selected_model(), MODEL_ID);
+        assert_eq!(decision.reasoning(), None);
+        assert_eq!(decision.routing_tier(), None);
         Ok(())
     }
 }

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -171,6 +171,15 @@ impl Algorithm for Random {
     ) -> Result<Response> {
         self.inner.execute(ctx, driver, request).await
     }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn crate::Decision>> {
+        self.inner.select(ctx, driver, request).await
+    }
 }
 
 #[cfg(test)]
@@ -269,6 +278,29 @@ mod tests {
         );
         assert_eq!(trace.len(), 1);
         assert_eq!(trace[0].selected_model(), "only/model");
+        Ok(())
+    }
+
+    /// Decision-only random routing needs target names but no final clients.
+    #[tokio::test]
+    async fn decision_only_selects_without_a_target_client() -> Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Random::new(
+            LlmTargetSet::new(vec![LlmTarget {
+                semantic_name: "only/model".to_string(),
+                llm_client: None,
+            }]),
+            None,
+            Some(42),
+        )?);
+
+        let decision = algorithm.decide(Context::default(), request()).await?;
+
+        assert_eq!(decision.selected_model(), "only/model");
+        assert_eq!(
+            decision.reasoning(),
+            Some("random routing selected target 'only/model'")
+        );
+        assert_eq!(decision.routing_tier(), None);
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/stage.rs
+++ b/crates/libsy/src/algorithms/stage.rs
@@ -28,8 +28,8 @@ use super::util::stage::{
 use super::util::tool_signals::ToolSignalProcessor;
 use super::{DefaultTarget, FallThrough, LlmTaskClassifier};
 use crate::{
-    Algorithm, Classification, Classifier, Context, Driver, LibsyError, LlmTarget, LlmTargetSet,
-    Request, Response, Result, RoutedLlmClient, State, DEFAULT_RECENT_WINDOW,
+    Algorithm, Classification, Classifier, Context, Decision, Driver, LibsyError, LlmTarget,
+    LlmTargetSet, Request, Response, Result, RoutedLlmClient, State, DEFAULT_RECENT_WINDOW,
 };
 
 /// Telemetry name for a router this module assembles.
@@ -42,12 +42,15 @@ const STAGE_ROUTER: &str = "stage_router";
 struct SourceStamp {
     inner: Arc<dyn Classifier<State>>,
     source: DecisionSource,
+    targets: StageTargets,
 }
 
 #[async_trait]
 impl Classifier<State> for SourceStamp {
     fn routing_tier(&self, selected_model: &str) -> Option<&'static str> {
-        self.inner.routing_tier(selected_model)
+        self.inner
+            .routing_tier(selected_model)
+            .or_else(|| self.targets.label_for(selected_model))
     }
 
     async fn score(
@@ -155,6 +158,15 @@ impl Algorithm for StageRouter {
     ) -> Result<Response> {
         self.route.execute(ctx, driver, request).await
     }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        self.route.select(ctx, driver, request).await
+    }
 }
 
 /// Wires the cascade the wrapper drives.
@@ -181,7 +193,8 @@ fn build_route(
     // classifier is a constant rather than a per-turn lookup.
     let fall_open = targets.name(config.mode.default_tier()).to_string();
 
-    let mut classifier = StageClassifier::new(targets, config.mode, config.confidence_threshold);
+    let mut classifier =
+        StageClassifier::new(targets.clone(), config.mode, config.confidence_threshold);
     if let Some(notes) = config.handoff_notes {
         classifier = classifier.with_handoff_notes(notes);
     }
@@ -205,6 +218,7 @@ fn build_route(
                 fallback.config,
             )?),
             source: DecisionSource::LlmClassifier,
+            targets: targets.clone(),
         }));
     }
     // Nothing behind this, so the turn lands on the picker's default tier —
@@ -212,6 +226,7 @@ fn build_route(
     router = router.with_classifier(Arc::new(SourceStamp {
         inner: Arc::new(DefaultTarget::new(fall_open)),
         source: DecisionSource::FallOpen,
+        targets,
     }));
     // Runs on the post-decision hook, so it applies to the target the cascade
     // settled on, whichever classifier picked it. With no prompts configured it
@@ -281,6 +296,7 @@ mod tests {
         let stamp = SourceStamp {
             inner,
             source: DecisionSource::LlmClassifier,
+            targets: StageTargets::new("strong", "weak"),
         };
         let mut state = State::default();
         stamp
@@ -616,6 +632,61 @@ mod tests {
             judged.contains("fix the build"),
             "the judge should see the opening task: {judged}"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_signal_selects_a_clientless_capable_target() -> Result<()> {
+        let router = Arc::new(StageRouter::new(
+            tier_target("strong"),
+            tier_target("weak"),
+            config(),
+        )?);
+
+        let decision = router
+            .decide(Context::default(), turn_request(true))
+            .await?;
+
+        assert_eq!(decision.selected_model(), "strong");
+        assert_eq!(decision.routing_tier(), Some("strong"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_fall_open_preserves_the_efficient_tier() -> Result<()> {
+        let router = Arc::new(StageRouter::new(
+            tier_target("strong"),
+            tier_target("weak"),
+            config(),
+        )?);
+
+        let decision = router
+            .decide(Context::default(), turn_request(false))
+            .await?;
+
+        assert_eq!(decision.selected_model(), "weak");
+        assert_eq!(decision.routing_tier(), Some("weak"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_only_ambiguous_turn_calls_only_the_judge() -> Result<()> {
+        let client = Arc::new(RecordingClient::default());
+        let router = Arc::new(StageRouter::new(
+            tier_target("strong"),
+            tier_target("weak"),
+            config_with_judge(&client, 0.1),
+        )?);
+
+        let decision = router
+            .decide(Context::default(), turn_request(false))
+            .await?;
+
+        assert_eq!(decision.selected_model(), "strong");
+        assert_eq!(decision.routing_tier(), Some("strong"));
+        let calls = client.calls.lock();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].target, JUDGE);
         Ok(())
     }
 }

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -282,6 +282,46 @@ impl Drop for AbortOnDrop {
     }
 }
 
+/// Which model calls a managed algorithm runner may serve.
+#[derive(Clone, Copy)]
+enum CallPolicy {
+    All,
+    AuxiliaryOnly,
+}
+
+/// Serve one offloaded call according to the managed runner's policy.
+#[tracing::instrument(
+    target = "libsy",
+    name = "libsy.client_call",
+    skip_all,
+    fields(
+        algorithm = observability::algorithm_label(&call.get_routed().ctx),
+        selected_model = call.get_decision().selected_model(),
+        outcome = tracing::field::Empty,
+        error = tracing::field::Empty,
+    )
+)]
+async fn serve_call(call: CallLlmRequest, policy: CallPolicy) -> Result<()> {
+    let target = call.get_decision().selected_model().to_string();
+    if matches!(policy, CallPolicy::AuxiliaryOnly) && call.get_decision().is_routed_call() {
+        return call.respond(Err(LibsyError::RoutedCallDuringDecision { target }));
+    }
+
+    let routed = call.get_routed().clone();
+    let client = routed
+        .default_client
+        .clone()
+        .ok_or_else(|| LibsyError::MissingClient {
+            target: target.clone(),
+        })?;
+    let result = client
+        .call(routed.ctx, routed.request, routed.decision)
+        .await
+        .map_err(|source| LibsyError::client_call(target, source));
+    observability::record_client_call(&result);
+    call.respond(result)
+}
+
 /// A named routing target: a `semantic_name` an algorithm routes by, and an optional
 /// [`RoutedLlmClient`] to serve its calls. An algorithm hands a target to
 /// [`Driver::call_llm_target`]; the client rides along as
@@ -379,6 +419,21 @@ pub trait Algorithm: Send + Sync + 'static {
         driver: Driver,
         request: Request,
     ) -> Result<Response>;
+
+    /// Select one target without executing the selected routed call.
+    ///
+    /// Algorithms that support [`decide`](Self::decide) override this task hook
+    /// and may use `driver` for auxiliary non-routed calls.
+    async fn create_decision_task(
+        self: Arc<Self>,
+        _ctx: Context,
+        _driver: Driver,
+        _request: Request,
+    ) -> Result<Arc<dyn Decision>> {
+        Err(LibsyError::DecisionUnsupported {
+            algorithm: self.name().to_string(),
+        })
+    }
 
     /// Feed the algorithm agentic-stack events (tool results, budgets, etc.). The
     /// reference algorithms ignore signals; a stateful algorithm updates its own
@@ -484,40 +539,6 @@ pub trait Algorithm: Send + Sync + 'static {
         ctx: Context,
         request: Request,
     ) -> Result<(Vec<Arc<dyn Decision>>, Response)> {
-        // Serve one offloaded call with its target's default client. A failed *model*
-        // call is forwarded to the algorithm via `respond`; this errors only on an
-        // infrastructure failure (no default client, or the promise was dropped).
-        // `serve` makes the one API call libsy itself performs, so it gets its
-        // own `libsy.client_call` span.
-        #[tracing::instrument(
-            target = "libsy",
-            name = "libsy.client_call",
-            skip_all,
-            fields(
-                algorithm = observability::algorithm_label(&call.get_routed().ctx),
-                selected_model = call.get_decision().selected_model(),
-                outcome = tracing::field::Empty,
-                error = tracing::field::Empty,
-            )
-        )]
-        async fn serve(call: CallLlmRequest) -> Result<()> {
-            let routed = call.get_routed().clone();
-            let target = routed.decision.selected_model().to_string();
-            let client =
-                routed
-                    .default_client
-                    .clone()
-                    .ok_or_else(|| LibsyError::MissingClient {
-                        target: target.clone(),
-                    })?;
-            let result = client
-                .call(routed.ctx, routed.request, routed.decision)
-                .await
-                .map_err(|source| LibsyError::client_call(target, source));
-            observability::record_client_call(&result);
-            call.respond(result)
-        }
-
         let stream = self.run_stream(ctx, request);
         tokio::pin!(stream);
 
@@ -535,7 +556,9 @@ pub trait Algorithm: Send + Sync + 'static {
                     match step {
                         None => break, // stream has ended, no more steps
                         Some(item) => match item? {
-                            Step::CallLlm(call) => in_flight.push(serve(*call)),
+                            Step::CallLlm(call) => {
+                                in_flight.push(serve_call(*call, CallPolicy::All))
+                            }
                             Step::Decision(decision) => trace.push(decision),
                             Step::ReturnToAgent(response) => {
                                 final_response = Some(*response);
@@ -549,6 +572,71 @@ pub trait Algorithm: Send + Sync + 'static {
         final_response
             .map(|response| (trace, response))
             .ok_or(LibsyError::MissingFinalResponse)
+    }
+
+    /// Select one target and return its routing decision without serving the
+    /// selected final model call.
+    ///
+    /// Auxiliary calls are served when their decision reports
+    /// [`Decision::is_routed_call`] as `false`. A routed call is rejected before
+    /// its default client is accessed.
+    async fn decide(self: Arc<Self>, ctx: Context, request: Request) -> Result<Arc<dyn Decision>> {
+        let mut ctx = ctx;
+        ctx.values.insert(
+            observability::ALGORITHM_KEY.to_string(),
+            self.name().to_string(),
+        );
+        let span = observability::decision_span(self.name(), request.metadata.as_ref());
+        let observed_ctx = ctx.clone();
+        observability::observe_decision(observed_ctx, async move {
+            let driver = Driver::new();
+            let task_driver = driver.clone();
+            let task_ctx = ctx;
+            let stream = task_driver.stream();
+            let handle = tokio::spawn(
+                self.create_decision_task(task_ctx, task_driver, request)
+                    .instrument(tracing::Span::current()),
+            );
+            let _abort_guard = AbortOnDrop(handle.abort_handle());
+            tokio::pin!(stream);
+            tokio::pin!(handle);
+
+            let mut in_flight = futures::stream::FuturesUnordered::new();
+            loop {
+                tokio::select! {
+                    Some(result) = in_flight.next() => result?,
+                    result = &mut handle => {
+                        return match result {
+                            Ok(decision) => decision,
+                            Err(source) => Err(LibsyError::AlgorithmTask { source }),
+                        };
+                    }
+                    step = stream.next() => {
+                        match step {
+                            None => {
+                                return Err(LibsyError::AlgorithmError {
+                                    message: "decision driver stream ended before task".to_string(),
+                                });
+                            }
+                            Some(item) => match item? {
+                                Step::CallLlm(call) => {
+                                    in_flight.push(serve_call(*call, CallPolicy::AuxiliaryOnly));
+                                }
+                                Step::Decision(_) => {}
+                                Step::ReturnToAgent(_) => {
+                                    return Err(LibsyError::AlgorithmError {
+                                        message: "decision driver returned an agent response"
+                                            .to_string(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .instrument(span)
+        .await
     }
 }
 
@@ -1444,5 +1532,365 @@ mod tests {
                 Ok(())
             }
         }
+    }
+
+    /// An algorithm without a decision task keeps normal execution compatible.
+    struct RunOnlyAlgorithm;
+
+    #[async_trait]
+    impl Algorithm for RunOnlyAlgorithm {
+        fn name(&self) -> &str {
+            "run-only"
+        }
+
+        async fn create_run_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Response> {
+            Err(test_error("normal execution is not used by this test"))
+        }
+    }
+
+    #[tokio::test]
+    async fn decision_returns_typed_unsupported_error_for_run_only_algorithm() -> Result<()> {
+        let result = Arc::new(RunOnlyAlgorithm)
+            .decide(Context::default(), request())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(LibsyError::DecisionUnsupported { algorithm }) if algorithm == "run-only"
+        ));
+        Ok(())
+    }
+
+    /// A routing-only call is safe for the decision runner to serve.
+    struct AuxiliaryDecision {
+        model: String,
+    }
+
+    impl Decision for AuxiliaryDecision {
+        fn selected_model(&self) -> &str {
+            &self.model
+        }
+
+        fn is_routed_call(&self) -> bool {
+            false
+        }
+
+        fn reasoning(&self) -> Option<&str> {
+            Some("routing-only test call")
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// Counts calls so decision tests observe which client was actually invoked.
+    struct CountingClient {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl RoutedLlmClient for CountingClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> std::result::Result<Response, LlmClientError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(
+                    None,
+                    decision.selected_model().to_string(),
+                )),
+                metadata: None,
+            })
+        }
+    }
+
+    /// Exercises both permitted auxiliary calls and forbidden routed calls.
+    struct DecisionCallAlgorithm {
+        target: LlmTarget,
+        call_is_routed: bool,
+    }
+
+    #[async_trait]
+    impl Algorithm for DecisionCallAlgorithm {
+        fn name(&self) -> &str {
+            "decision-call"
+        }
+
+        async fn create_run_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Response> {
+            Err(test_error("normal execution is not used by this test"))
+        }
+
+        async fn create_decision_task(
+            self: Arc<Self>,
+            ctx: Context,
+            driver: Driver,
+            request: Request,
+        ) -> Result<Arc<dyn Decision>> {
+            let decision: Arc<dyn Decision> = if self.call_is_routed {
+                Arc::new(TestDecision {
+                    model: self.target.semantic_name.clone(),
+                })
+            } else {
+                Arc::new(AuxiliaryDecision {
+                    model: self.target.semantic_name.clone(),
+                })
+            };
+            driver
+                .call_llm_target(ctx.clone(), &self.target, request, decision)
+                .await?;
+            let final_decision: Arc<dyn Decision> = Arc::new(TestDecision {
+                model: "selected".to_string(),
+            });
+            driver.info(ctx, final_decision.clone()).await?;
+            Ok(final_decision)
+        }
+    }
+
+    #[tokio::test]
+    async fn decision_serves_auxiliary_call_and_returns_final_decision() -> Result<()> {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let algorithm = Arc::new(DecisionCallAlgorithm {
+            target: LlmTarget {
+                semantic_name: "judge".to_string(),
+                llm_client: Some(Arc::new(CountingClient {
+                    calls: calls.clone(),
+                })),
+            },
+            call_is_routed: false,
+        });
+
+        let decision = algorithm.decide(Context::default(), request()).await?;
+
+        assert_eq!(decision.selected_model(), "selected");
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn decision_rejects_routed_call_before_invoking_client() -> Result<()> {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let algorithm = Arc::new(DecisionCallAlgorithm {
+            target: LlmTarget {
+                semantic_name: "final".to_string(),
+                llm_client: Some(Arc::new(CountingClient {
+                    calls: calls.clone(),
+                })),
+            },
+            call_is_routed: true,
+        });
+
+        let result = algorithm.decide(Context::default(), request()).await;
+
+        assert!(matches!(
+            result,
+            Err(LibsyError::RoutedCallDuringDecision { target }) if target == "final"
+        ));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    /// Waits for every auxiliary call to enter, proving the runner serves them concurrently.
+    struct BarrierClient {
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait]
+    impl RoutedLlmClient for BarrierClient {
+        async fn call(
+            &self,
+            _ctx: Context,
+            _request: Request,
+            decision: Arc<dyn Decision>,
+        ) -> std::result::Result<Response, LlmClientError> {
+            self.barrier.wait().await;
+            Ok(Response {
+                llm_response: LlmResponse::Agg(text_response(
+                    None,
+                    decision.selected_model().to_string(),
+                )),
+                metadata: None,
+            })
+        }
+    }
+
+    /// Offloads two independent auxiliary calls before returning its selection.
+    struct ConcurrentDecisionCalls {
+        target: LlmTarget,
+    }
+
+    #[async_trait]
+    impl Algorithm for ConcurrentDecisionCalls {
+        fn name(&self) -> &str {
+            "concurrent-decision-calls"
+        }
+
+        async fn create_run_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Response> {
+            Err(test_error("normal execution is not used by this test"))
+        }
+
+        async fn create_decision_task(
+            self: Arc<Self>,
+            ctx: Context,
+            driver: Driver,
+            request: Request,
+        ) -> Result<Arc<dyn Decision>> {
+            let first: Arc<dyn Decision> = Arc::new(AuxiliaryDecision {
+                model: self.target.semantic_name.clone(),
+            });
+            let second = first.clone();
+            let (first_result, second_result) = tokio::join!(
+                driver.call_llm_target(ctx.clone(), &self.target, request.clone(), first),
+                driver.call_llm_target(ctx, &self.target, request, second)
+            );
+            first_result?;
+            second_result?;
+            Ok(Arc::new(TestDecision {
+                model: "selected".to_string(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn decision_serves_multiple_auxiliary_calls_concurrently() -> Result<()> {
+        let algorithm = Arc::new(ConcurrentDecisionCalls {
+            target: LlmTarget {
+                semantic_name: "judge".to_string(),
+                llm_client: Some(Arc::new(BarrierClient {
+                    barrier: Arc::new(tokio::sync::Barrier::new(2)),
+                })),
+            },
+        });
+
+        let decision = tokio::time::timeout(
+            Duration::from_millis(500),
+            algorithm.decide(Context::default(), request()),
+        )
+        .await
+        .map_err(|error| LibsyError::external("waiting for concurrent decision calls", error))??;
+
+        assert_eq!(decision.selected_model(), "selected");
+        Ok(())
+    }
+
+    /// Marks when a pending decision task is dropped by cancellation.
+    struct DecisionDropGuard {
+        dropped: Arc<tokio::sync::Notify>,
+    }
+
+    impl Drop for DecisionDropGuard {
+        fn drop(&mut self) {
+            self.dropped.notify_one();
+        }
+    }
+
+    /// Starts a decision task that only cancellation can finish.
+    struct PendingDecision {
+        started: Arc<tokio::sync::Notify>,
+        dropped: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Algorithm for PendingDecision {
+        fn name(&self) -> &str {
+            "pending-decision"
+        }
+
+        async fn create_run_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Response> {
+            Err(test_error("normal execution is not used by this test"))
+        }
+
+        async fn create_decision_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Arc<dyn Decision>> {
+            let _drop_guard = DecisionDropGuard {
+                dropped: self.dropped.clone(),
+            };
+            self.started.notify_one();
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelling_decision_cancels_the_algorithm_task() -> Result<()> {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(tokio::sync::Notify::new());
+        let algorithm = Arc::new(PendingDecision {
+            started: started.clone(),
+            dropped: dropped.clone(),
+        });
+        let handle = tokio::spawn(algorithm.decide(Context::default(), request()));
+
+        started.notified().await;
+        handle.abort();
+        let _ = handle.await;
+        tokio::time::timeout(Duration::from_millis(500), dropped.notified())
+            .await
+            .map_err(|error| LibsyError::external("waiting for decision cancellation", error))?;
+        Ok(())
+    }
+
+    /// Panics from the decision hook so the managed API can translate the join error.
+    struct PanickingDecision;
+
+    #[async_trait]
+    impl Algorithm for PanickingDecision {
+        fn name(&self) -> &str {
+            "panicking-decision"
+        }
+
+        async fn create_run_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Response> {
+            Err(test_error("normal execution is not used by this test"))
+        }
+
+        async fn create_decision_task(
+            self: Arc<Self>,
+            _ctx: Context,
+            _driver: Driver,
+            _request: Request,
+        ) -> Result<Arc<dyn Decision>> {
+            panic!("decision task panic");
+        }
+    }
+
+    #[tokio::test]
+    async fn decision_task_panic_surfaces_as_an_error() -> Result<()> {
+        let result = Arc::new(PanickingDecision)
+            .decide(Context::default(), request())
+            .await;
+
+        assert!(matches!(result, Err(LibsyError::AlgorithmTask { .. })));
+        Ok(())
     }
 }

--- a/crates/libsy/src/error.rs
+++ b/crates/libsy/src/error.rs
@@ -32,6 +32,20 @@ pub enum LibsyError {
         message: String,
     },
 
+    /// The algorithm does not implement decision-only execution.
+    #[error("algorithm {algorithm:?} does not support decision-only execution")]
+    DecisionUnsupported {
+        /// Stable algorithm name.
+        algorithm: String,
+    },
+
+    /// A decision task attempted to execute its selected final target.
+    #[error("decision-only execution rejected routed call to target {target:?}")]
+    RoutedCallDuringDecision {
+        /// Selected target that must not be executed.
+        target: String,
+    },
+
     /// A routed target had no default client for [`crate::Algorithm::run`].
     #[error("target {target:?} has no client to serve the call")]
     MissingClient {

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -32,7 +32,7 @@
 
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use opentelemetry::metrics::{Meter, ObservableGauge};
@@ -132,6 +132,41 @@ pub(crate) fn run_span(algorithm: &str, metadata: Option<&Metadata>) -> Span {
     span
 }
 
+/// Span covering one managed decision-only operation.
+///
+/// Correlation fields match [`run_span`], while outcome and error are filled
+/// when the decision task resolves.
+pub(crate) fn decision_span(algorithm: &str, metadata: Option<&Metadata>) -> Span {
+    let span = tracing::info_span!(
+        target: TRACING_TARGET,
+        "libsy.decide",
+        algorithm,
+        session_id = tracing::field::Empty,
+        agent_id = tracing::field::Empty,
+        task_id = tracing::field::Empty,
+        correlation_id = tracing::field::Empty,
+        extra_metadata = tracing::field::Empty,
+        outcome = tracing::field::Empty,
+        error = tracing::field::Empty,
+    );
+    if let Some(metadata) = metadata {
+        for (field, value) in [
+            ("session_id", &metadata.session_id),
+            ("agent_id", &metadata.agent_id),
+            ("task_id", &metadata.task_id),
+            ("correlation_id", &metadata.correlation_id),
+        ] {
+            if let Some(value) = value {
+                span.record(field, value.as_str());
+            }
+        }
+        if let Some(extra) = &metadata.extra_metadata {
+            span.record("extra_metadata", tracing::field::debug(extra));
+        }
+    }
+    span
+}
+
 /// Runs one algorithm task to completion, recording the run counter, duration
 /// histogram, routing overhead, span outcome, and failure log when it resolves.
 /// Executes inside the `libsy.run` span its caller instruments the task with.
@@ -149,6 +184,22 @@ pub(crate) async fn observe_run(
     if result.is_ok() {
         record_routing_overhead(algorithm, duration, driver.routed_call_duration());
     }
+    result
+}
+
+/// Runs one managed decision operation to completion and records its telemetry.
+pub(crate) async fn observe_decision(
+    ctx: Context,
+    decision: impl Future<Output = Result<Arc<dyn Decision>>>,
+) -> Result<Arc<dyn Decision>> {
+    let started = Instant::now();
+    let result = decision.await;
+    record_decision_run(
+        algorithm_label(&ctx),
+        started.elapsed(),
+        &result,
+        &Span::current(),
+    );
     result
 }
 
@@ -190,6 +241,40 @@ fn record_run(algorithm: &str, duration: Duration, result: &Result<Response>, sp
         .add(1, &attributes);
     meter
         .f64_histogram("switchyard.run_duration_ms")
+        .build()
+        .record(duration.as_secs_f64() * 1000.0, &attributes);
+}
+
+/// Records the outcome of one decision-only operation.
+fn record_decision_run(
+    algorithm: &str,
+    duration: Duration,
+    result: &Result<Arc<dyn Decision>>,
+    span: &Span,
+) {
+    let outcome = outcome_value(result);
+    span.record("outcome", outcome);
+    if let Err(error) = result {
+        span.record("error", tracing::field::display(error));
+        tracing::warn!(
+            target: TRACING_TARGET,
+            algorithm,
+            error = %error,
+            "algorithm decision failed"
+        );
+    }
+
+    let attributes = [
+        KeyValue::new("algorithm", algorithm.to_string()),
+        KeyValue::new("outcome", outcome),
+    ];
+    let meter = meter();
+    meter
+        .u64_counter("switchyard.decision_runs")
+        .build()
+        .add(1, &attributes);
+    meter
+        .f64_histogram("switchyard.decision_duration_ms")
         .build()
         .record(duration.as_secs_f64() * 1000.0, &attributes);
 }

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -388,6 +388,25 @@ impl Algorithm for SingleCallAlgo {
             .call_llm_target(ctx, &target, request, decision)
             .await
     }
+
+    async fn create_decision_task(
+        self: Arc<Self>,
+        ctx: Context,
+        driver: Driver,
+        _request: Request,
+    ) -> switchyard_libsy::Result<Arc<dyn Decision>> {
+        let target = self
+            .target_set
+            .targets()
+            .first()
+            .ok_or(LibsyError::NoTargets)?;
+        let decision: Arc<dyn Decision> = Arc::new(StaticDecision {
+            reasoning: format!("picked '{}'", target.semantic_name),
+            model: target.semantic_name.clone(),
+        });
+        driver.info(ctx, decision.clone()).await?;
+        Ok(decision)
+    }
 }
 
 fn request_with_metadata(session_id: &str, correlation_id: &str) -> Request {
@@ -424,6 +443,165 @@ fn find_span(spans: &[SpanRecord], name: &str, field: &str, value: &str) -> Span
         Some(span) => span.clone(),
         None => panic!("no '{name}' span with {field}={value} in {spans:?}"),
     }
+}
+
+#[tokio::test]
+async fn decision_records_only_decision_metrics() -> switchyard_libsy::Result<()> {
+    let _guard = serialize_test().lock().await;
+    let (store, exporter, provider) = telemetry();
+    const ALGO: &str = "obs-decision-algo";
+    const MODEL: &str = "obs-decision-model";
+    let before = flushed_metrics(exporter, provider);
+    let total_requests_before =
+        u64_gauge_value(&before, "switchyard.total_requests").unwrap_or_default();
+    let total_errors_before =
+        u64_gauge_value(&before, "switchyard.total_errors").unwrap_or_default();
+
+    let decision = algo(ALGO, MODEL, None)
+        .decide(
+            Context::default(),
+            request_with_metadata("obs-decision-session", "obs-decision-correlation"),
+        )
+        .await?;
+    assert_eq!(decision.selected_model(), MODEL);
+
+    let snapshots = flushed_metrics(exporter, provider);
+    let decision_attrs = [("algorithm", ALGO), ("outcome", "ok")];
+    let model_attrs = [("algorithm", ALGO), ("selected_model", MODEL)];
+    assert_eq!(
+        u64_counter_value(&snapshots, "switchyard.decision_runs", &decision_attrs),
+        Some(1)
+    );
+    assert_eq!(
+        f64_histogram_count(
+            &snapshots,
+            "switchyard.decision_duration_ms",
+            &decision_attrs,
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        u64_counter_value(&snapshots, "switchyard.decisions", &model_attrs),
+        Some(1)
+    );
+    assert_eq!(
+        u64_counter_value(&snapshots, "switchyard.runs", &decision_attrs),
+        None
+    );
+    assert_eq!(
+        u64_counter_value(
+            &snapshots,
+            "switchyard.llm_calls",
+            &[
+                ("algorithm", ALGO),
+                ("selected_model", MODEL),
+                ("outcome", "ok"),
+            ],
+        ),
+        None
+    );
+    assert_eq!(
+        u64_counter_value(&snapshots, "switchyard.requests", &[("model", MODEL)]),
+        None
+    );
+    assert_eq!(
+        f64_histogram_count(
+            &snapshots,
+            "switchyard.model_call_latency_ms",
+            &[("model", MODEL)],
+        ),
+        None
+    );
+    assert_eq!(
+        u64_gauge_value(&snapshots, "switchyard.total_requests"),
+        Some(total_requests_before)
+    );
+    assert_eq!(
+        u64_gauge_value(&snapshots, "switchyard.total_errors"),
+        Some(total_errors_before)
+    );
+
+    let spans = store.spans();
+    let decision_span = find_span(&spans, "libsy.decide", "algorithm", ALGO);
+    assert_eq!(decision_span.parent, None);
+    assert_eq!(
+        decision_span.fields.get("session_id").map(String::as_str),
+        Some("obs-decision-session")
+    );
+    assert_eq!(
+        decision_span
+            .fields
+            .get("correlation_id")
+            .map(String::as_str),
+        Some("obs-decision-correlation")
+    );
+    assert_eq!(
+        decision_span.fields.get("outcome").map(String::as_str),
+        Some("ok")
+    );
+    assert!(spans.iter().all(|span| span.name != "libsy.run"
+        || span.fields.get("algorithm").map(String::as_str) != Some(ALGO)));
+    Ok(())
+}
+
+#[tokio::test]
+async fn managed_decision_failure_records_error_telemetry() -> switchyard_libsy::Result<()> {
+    let _guard = serialize_test().lock().await;
+    let (store, exporter, provider) = telemetry();
+    let target = |name: &str| LlmTarget {
+        semantic_name: name.to_string(),
+        llm_client: None,
+    };
+    let router = Arc::new(LlmTaskClassifier::new(
+        target("missing-decision-judge"),
+        target("decision-weak"),
+        target("decision-strong"),
+        TaskClassifierConfig {
+            base_threshold: 0.5,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+            recent_turn_window: None,
+        },
+    )?);
+
+    let result = router
+        .decide(
+            Context::default(),
+            Request {
+                llm_request: text_request(Some("auto".to_string()), "classify without a judge"),
+                raw_request: None,
+                metadata: None,
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(LibsyError::MissingClient { target }) if target == "missing-decision-judge"
+    ));
+    let snapshots = flushed_metrics(exporter, provider);
+    let error_attrs = [("algorithm", "llm_task_classifier"), ("outcome", "error")];
+    assert_eq!(
+        u64_counter_value(&snapshots, "switchyard.decision_runs", &error_attrs),
+        Some(1)
+    );
+    assert_eq!(
+        f64_histogram_count(&snapshots, "switchyard.decision_duration_ms", &error_attrs,),
+        Some(1)
+    );
+    let spans = store.spans();
+    assert!(spans.iter().any(|span| {
+        span.name == "libsy.decide"
+            && span.fields.get("algorithm").map(String::as_str) == Some("llm_task_classifier")
+            && span.fields.get("outcome").map(String::as_str) == Some("error")
+            && span
+                .fields
+                .get("error")
+                .is_some_and(|error| error.contains("missing-decision-judge"))
+    }));
+    Ok(())
 }
 
 #[tokio::test]
@@ -721,6 +899,95 @@ async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::
                     .is_some_and(|message| message.contains("algorithm run failed"))
         }),
         "no run-failure log for {ALGO} in {events:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn classifier_decision_records_judge_work_but_no_routed_call() -> switchyard_libsy::Result<()>
+{
+    let _guard = serialize_test().lock().await;
+    let (_store, exporter, provider) = telemetry();
+    let before = flushed_metrics(exporter, provider);
+    let total_requests_before =
+        u64_gauge_value(&before, "switchyard.total_requests").unwrap_or_default();
+
+    let client = Arc::new(ClassifierClient {
+        classifier_delay: Duration::from_millis(1),
+        routed_delay: Duration::from_millis(1),
+    });
+    let target = |name: &str| LlmTarget {
+        semantic_name: name.to_string(),
+        llm_client: Some(client.clone()),
+    };
+    let targets = LlmTargetSet::new(vec![target("decision-weak"), target("decision-strong")]);
+    let weak = targets.get_target("decision-weak")?;
+    let strong = targets.get_target("decision-strong")?;
+    let router = Arc::new(LlmTaskClassifier::new(
+        target("decision-classifier"),
+        weak,
+        strong,
+        TaskClassifierConfig {
+            base_threshold: 0.5,
+            min_confidence: 0.0,
+            capability_elevated_floor: None,
+            session_affinity: false,
+            message_hash_fallback: false,
+            recent_turn_window: None,
+        },
+    )?);
+
+    let decision = router
+        .decide(
+            Context::default(),
+            Request {
+                llm_request: text_request(Some("auto".to_string()), "classify without serving"),
+                raw_request: None,
+                metadata: None,
+            },
+        )
+        .await?;
+
+    assert_eq!(decision.selected_model(), "decision-weak");
+    assert_eq!(decision.routing_tier(), Some("weak"));
+    let snapshots = flushed_metrics(exporter, provider);
+    assert_eq!(
+        u64_counter_value(
+            &snapshots,
+            "switchyard.decision_runs",
+            &[("algorithm", "llm_task_classifier"), ("outcome", "ok")],
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        u64_counter_value(
+            &snapshots,
+            "switchyard.llm_calls",
+            &[
+                ("algorithm", ""),
+                ("selected_model", "decision-classifier"),
+                ("outcome", "ok"),
+            ],
+        ),
+        Some(1)
+    );
+    for model in ["decision-classifier", "decision-weak", "decision-strong"] {
+        assert_eq!(
+            u64_counter_value(&snapshots, "switchyard.requests", &[("model", model)]),
+            None
+        );
+        assert_eq!(
+            f64_histogram_count(
+                &snapshots,
+                "switchyard.model_call_latency_ms",
+                &[("model", model)],
+            ),
+            None
+        );
+    }
+    assert_eq!(
+        u64_gauge_value(&snapshots, "switchyard.total_requests"),
+        Some(total_requests_before)
     );
     Ok(())
 }

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -9,7 +9,11 @@ use async_trait::async_trait;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use serde_json::{json, Value};
-use switchyard_libsy::algorithms::{Noop, Random};
+use switchyard_libsy::algorithms::{
+    LlmFallback, LlmTaskClassifier, Noop, Passthrough, Random, StageRouter, StageRouterConfig,
+    TargetPrompts, TaskClassifierConfig,
+};
+use switchyard_libsy::stage_router::{HandoffNoteConfig, PickerMode};
 use switchyard_libsy::{
     AggLlmResponse, Algorithm, Context, Decision, LibsyError as RustLibsyError, LlmClientError,
     LlmResponse, LlmTarget, LlmTargetSet, Metadata, Request, Response, RoutedLlmClient,
@@ -49,20 +53,22 @@ impl RoutedLlmClient for PythonLlmClient {
     }
 }
 
-/// A required-client routing target used by Python-created algorithms.
+/// A named routing target with an optional Python-hosted client.
 #[pyclass(name = "LlmTarget", module = "switchyard.libsy", frozen)]
 struct PyLlmTarget {
     name: String,
-    client: Py<PyAny>,
+    client: Option<Py<PyAny>>,
 }
 
 impl PyLlmTarget {
     fn clone_core(&self, py: Python<'_>) -> LlmTarget {
         LlmTarget {
             semantic_name: self.name.clone(),
-            llm_client: Some(Arc::new(PythonLlmClient {
-                inner: self.client.clone_ref(py),
-            })),
+            llm_client: self.client.as_ref().map(|client| {
+                Arc::new(PythonLlmClient {
+                    inner: client.clone_ref(py),
+                }) as Arc<dyn RoutedLlmClient>
+            }),
         }
     }
 }
@@ -70,15 +76,18 @@ impl PyLlmTarget {
 #[pymethods]
 impl PyLlmTarget {
     #[new]
-    fn new(py: Python<'_>, name: String, client: Py<PyAny>) -> PyResult<Self> {
-        let call = client
-            .bind(py)
-            .getattr("call")
-            .map_err(|_| PyTypeError::new_err("client must define async call(request)"))?;
-        if !call.is_callable() {
-            return Err(PyTypeError::new_err(
-                "client.call must be callable as async call(request)",
-            ));
+    #[pyo3(signature = (name, client=None))]
+    fn new(py: Python<'_>, name: String, client: Option<Py<PyAny>>) -> PyResult<Self> {
+        if let Some(client) = &client {
+            let call = client
+                .bind(py)
+                .getattr("call")
+                .map_err(|_| PyTypeError::new_err("client must define async call(request)"))?;
+            if !call.is_callable() {
+                return Err(PyTypeError::new_err(
+                    "client.call must be callable as async call(request)",
+                ));
+            }
         }
         Ok(Self { name, client })
     }
@@ -105,6 +114,27 @@ impl PyAlgorithm {
     }
 }
 
+/// Serialize the stable metadata shared by run traces and decision-only results.
+fn serialize_decision(decision: &dyn Decision) -> Value {
+    json!({
+        "selected_model": decision.selected_model(),
+        "reasoning": decision.reasoning(),
+        "routing_tier": decision.routing_tier(),
+    })
+}
+
+/// Convert a normalized Python request and optional headers into libsy input.
+fn request_from_python(
+    request: &Bound<'_, PyAny>,
+    headers: Option<std::collections::BTreeMap<String, String>>,
+) -> PyResult<Request> {
+    Ok(Request {
+        llm_request: from_python(request)?,
+        raw_request: None,
+        metadata: headers.map(|headers| Metadata::from_headers(&headers)),
+    })
+}
+
 #[pymethods]
 impl PyAlgorithm {
     /// Run to completion using the clients configured on the algorithm's targets.
@@ -121,11 +151,7 @@ impl PyAlgorithm {
         headers: Option<std::collections::BTreeMap<String, String>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let algorithm = Arc::clone(&self.inner);
-        let request = Request {
-            llm_request: from_python(request)?,
-            raw_request: None,
-            metadata: headers.map(|headers| Metadata::from_headers(&headers)),
-        };
+        let request = request_from_python(request, headers)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let (decisions, response) = algorithm
                 .run(Context::default(), request)
@@ -138,14 +164,28 @@ impl PyAlgorithm {
                 .map_err(py_libsy_error)?;
             let decisions = decisions
                 .iter()
-                .map(|decision| {
-                    json!({
-                        "selected_model": decision.selected_model(),
-                        "reasoning": decision.reasoning(),
-                    })
-                })
+                .map(|decision| serialize_decision(decision.as_ref()))
                 .collect::<Vec<Value>>();
             Python::attach(|py| Ok((to_python(py, &decisions)?, to_python(py, &response)?)))
+        })
+    }
+
+    /// Select one configured target without executing the selected model.
+    #[pyo3(signature = (request, headers=None))]
+    fn decide<'py>(
+        &self,
+        py: Python<'py>,
+        request: &Bound<'_, PyAny>,
+        headers: Option<std::collections::BTreeMap<String, String>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let algorithm = Arc::clone(&self.inner);
+        let request = request_from_python(request, headers)?;
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let decision = algorithm
+                .decide(Context::default(), request)
+                .await
+                .map_err(py_libsy_error)?;
+            Python::attach(|py| to_python(py, &serialize_decision(decision.as_ref())))
         })
     }
 
@@ -158,6 +198,165 @@ impl PyAlgorithm {
 #[pyfunction(name = "noop")]
 fn noop_algorithm() -> PyAlgorithm {
     PyAlgorithm::new(Arc::new(Noop {}))
+}
+
+/// Construct fixed passthrough routing to one target.
+#[pyfunction(name = "passthrough")]
+fn passthrough_algorithm(py: Python<'_>, target: Py<PyLlmTarget>) -> PyResult<PyAlgorithm> {
+    let target = target.bind(py).try_borrow()?.clone_core(py);
+    Ok(PyAlgorithm::new(Arc::new(Passthrough::new(target))))
+}
+
+/// Construct judge-backed efficient/capable task routing.
+#[pyfunction(name = "llm_classifier")]
+#[pyo3(signature = (
+    *,
+    judge,
+    efficient,
+    capable,
+    base_threshold,
+    min_confidence=0.0,
+    capability_elevated_floor=None,
+    session_affinity=false,
+    message_hash_fallback=false,
+    recent_turn_window=None,
+))]
+#[allow(clippy::too_many_arguments)]
+fn llm_classifier_algorithm(
+    py: Python<'_>,
+    judge: Py<PyLlmTarget>,
+    efficient: Py<PyLlmTarget>,
+    capable: Py<PyLlmTarget>,
+    base_threshold: f64,
+    min_confidence: f64,
+    capability_elevated_floor: Option<f64>,
+    session_affinity: bool,
+    message_hash_fallback: bool,
+    recent_turn_window: Option<usize>,
+) -> PyResult<PyAlgorithm> {
+    let judge = judge.bind(py).try_borrow()?.clone_core(py);
+    let efficient = efficient.bind(py).try_borrow()?.clone_core(py);
+    let capable = capable.bind(py).try_borrow()?.clone_core(py);
+    let algorithm = LlmTaskClassifier::new(
+        judge,
+        efficient,
+        capable,
+        TaskClassifierConfig {
+            base_threshold,
+            min_confidence,
+            capability_elevated_floor,
+            session_affinity,
+            message_hash_fallback,
+            recent_turn_window,
+        },
+    )
+    .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok(PyAlgorithm::new(Arc::new(algorithm)))
+}
+
+/// Construct signal-driven capable/efficient routing with an optional judge.
+#[pyfunction(name = "stage_router")]
+#[pyo3(signature = (
+    *,
+    capable,
+    efficient,
+    picker,
+    confidence_threshold,
+    recent_turn_window=None,
+    handoff_escalation_note=None,
+    handoff_deescalation_note=None,
+    handoff_only_on_wrong_signal_escalation=true,
+    capable_system_prompt=None,
+    efficient_system_prompt=None,
+    judge=None,
+    classifier_base_threshold=None,
+    classifier_min_confidence=0.0,
+    classifier_capability_elevated_floor=None,
+    classifier_recent_turn_window=None,
+))]
+#[allow(clippy::too_many_arguments)]
+fn stage_router_algorithm(
+    py: Python<'_>,
+    capable: Py<PyLlmTarget>,
+    efficient: Py<PyLlmTarget>,
+    picker: &str,
+    confidence_threshold: f64,
+    recent_turn_window: Option<usize>,
+    handoff_escalation_note: Option<String>,
+    handoff_deescalation_note: Option<String>,
+    handoff_only_on_wrong_signal_escalation: bool,
+    capable_system_prompt: Option<String>,
+    efficient_system_prompt: Option<String>,
+    judge: Option<Py<PyLlmTarget>>,
+    classifier_base_threshold: Option<f64>,
+    classifier_min_confidence: f64,
+    classifier_capability_elevated_floor: Option<f64>,
+    classifier_recent_turn_window: Option<usize>,
+) -> PyResult<PyAlgorithm> {
+    let mode = match picker {
+        "capable_first" => PickerMode::CapableFirst,
+        "efficient_first" => PickerMode::EfficientFirst,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "picker must be 'capable_first' or 'efficient_first', got {other:?}"
+            )))
+        }
+    };
+    if handoff_deescalation_note.is_some() && handoff_escalation_note.is_none() {
+        return Err(PyValueError::new_err(
+            "handoff_deescalation_note requires handoff_escalation_note",
+        ));
+    }
+    if judge.is_none()
+        && (classifier_min_confidence != 0.0
+            || classifier_capability_elevated_floor.is_some()
+            || classifier_recent_turn_window.is_some())
+    {
+        return Err(PyValueError::new_err(
+            "classifier configuration options require judge",
+        ));
+    }
+    if judge.is_some() != classifier_base_threshold.is_some() {
+        return Err(PyValueError::new_err(
+            "judge and classifier_base_threshold must be provided together",
+        ));
+    }
+
+    let capable = capable.bind(py).try_borrow()?.clone_core(py);
+    let efficient = efficient.bind(py).try_borrow()?.clone_core(py);
+    let mut config = StageRouterConfig::new(mode, confidence_threshold);
+    config.recent_window = recent_turn_window;
+    config.handoff_notes = handoff_escalation_note.map(|escalation_note| {
+        HandoffNoteConfig::new(
+            escalation_note,
+            handoff_deescalation_note,
+            handoff_only_on_wrong_signal_escalation,
+        )
+    });
+    let mut tier_prompts = TargetPrompts::default();
+    if let Some(prompt) = capable_system_prompt {
+        tier_prompts = tier_prompts.with(capable.semantic_name.clone(), prompt);
+    }
+    if let Some(prompt) = efficient_system_prompt {
+        tier_prompts = tier_prompts.with(efficient.semantic_name.clone(), prompt);
+    }
+    config.tier_prompts = tier_prompts;
+    if let (Some(judge), Some(base_threshold)) = (judge, classifier_base_threshold) {
+        config.llm_fallback = Some(LlmFallback {
+            judge_target: judge.bind(py).try_borrow()?.clone_core(py),
+            config: TaskClassifierConfig {
+                base_threshold,
+                min_confidence: classifier_min_confidence,
+                capability_elevated_floor: classifier_capability_elevated_floor,
+                session_affinity: false,
+                message_hash_fallback: false,
+                recent_turn_window: classifier_recent_turn_window,
+            },
+        });
+    }
+    let algorithm = StageRouter::new(capable, efficient, config)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok(PyAlgorithm::new(Arc::new(algorithm)))
 }
 
 /// Construct random routing over targets with optional relative weights and seed.
@@ -199,8 +398,11 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let libsy_module = PyModule::new(module.py(), "libsy")?;
     libsy_module.add_class::<PyAlgorithm>()?;
     libsy_module.add_class::<PyLlmTarget>()?;
+    libsy_module.add_function(wrap_pyfunction!(llm_classifier_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(noop_algorithm, &libsy_module)?)?;
+    libsy_module.add_function(wrap_pyfunction!(passthrough_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(random_algorithm, &libsy_module)?)?;
+    libsy_module.add_function(wrap_pyfunction!(stage_router_algorithm, &libsy_module)?)?;
     libsy_module.add("LibsyError", module.getattr("LibsyError")?)?;
     module.add_submodule(&libsy_module)?;
     Ok(())

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,5 +137,6 @@ own explicit TOML configuration for LLM clients, targets, and libsy algorithms.
 | Topic | Read |
 |---|---|
 | Known limitations and workarounds for 0.1.0 | [Known Issues](known_issues.md) |
+| Select a configured model in Python without executing it | [libsy Python API](libsy.md) |
 | CLI syntax, flags, resolution rules, and environment variables | [CLI Reference](cli_reference.md) |
 | Context-window overflow retry and fallback behavior | [Context-Window Handling](operations/context_window.md) |

--- a/docs/libsy.md
+++ b/docs/libsy.md
@@ -1,0 +1,340 @@
+# libsy Python API
+
+The `switchyard.libsy` API embeds Switchyard's Rust-owned routing algorithms
+directly in a Python process. Use it when a host application needs to choose a
+model itself instead of sending traffic through Switchyard's HTTP proxy or YAML
+route bundles.
+
+`Algorithm.decide()` selects one configured target and returns its routing
+metadata without executing that selected target. It does not expose an HTTP
+endpoint.
+
+## Decide without running the selected model
+
+Targets are fixed when an algorithm is constructed. A call to `decide()` takes
+only the normalized request and optional request headers:
+
+```python
+import asyncio
+
+from switchyard.libsy import LlmTarget, algorithms
+
+
+request = {
+    "model": "auto",
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Explain this traceback"},
+            ],
+        }
+    ],
+}
+
+
+async def main() -> None:
+    router = algorithms.random(
+        [LlmTarget("fast"), LlmTarget("quality")],
+        weights=[3, 1],
+        seed=42,
+    )
+
+    decision = await router.decide(request)
+    print(decision)
+
+
+asyncio.run(main())
+```
+
+The seeded example returns:
+
+```python
+{
+    "selected_model": "fast",
+    "reasoning": "random routing selected target 'fast'",
+    "routing_tier": None,
+}
+```
+
+All three keys are always present. `reasoning` and `routing_tier` are `None`
+when the algorithm does not assign them.
+
+The `fast` and `quality` targets do not need clients because `decide()` never
+executes either candidate.
+
+## Normalized requests
+
+`run()` and `decide()` accept libsy's normalized request dictionary, not an
+OpenAI or Anthropic wire payload. In particular, every message's `content` is a
+list of typed blocks:
+
+```python
+request = {
+    "model": "auto",
+    "messages": [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Summarize this change"}],
+        }
+    ],
+}
+```
+
+Do not pass a bare content string such as `"content": "Summarize this change"`.
+Provider-specific request conversion belongs in the client or host integration
+that surrounds libsy.
+
+## Available algorithms
+
+The Python bindings support the same five algorithm types as Switchyard's Rust
+server:
+
+| Factory | Selection |
+|---|---|
+| `algorithms.noop()` | Select the inbound request model, or `switchyard/noop` when absent. |
+| `algorithms.passthrough(target)` | Always select one configured target. |
+| `algorithms.random(targets, *, weights=None, seed=None)` | Choose from one or more targets using optional relative weights. |
+| `algorithms.llm_classifier(...)` | Ask a judge whether the efficient or capable target should handle the request. |
+| `algorithms.stage_router(...)` | Route coding-agent turns from tool signals, with an optional LLM classifier fallback. |
+
+The generic Rust `FallThrough` composition is not exposed as a Python factory.
+
+### Passthrough
+
+```python
+router = algorithms.passthrough(LlmTarget("model-a"))
+decision = await router.decide(request)
+```
+
+Passthrough decisions have `reasoning=None` and `routing_tier=None`.
+
+### Weighted random
+
+Weights are relative and follow target order. A zero weight disables a target;
+at least one weight must be positive. Supplying a seed makes the shared
+selection sequence reproducible:
+
+```python
+router = algorithms.random(
+    [
+        LlmTarget("efficient"),
+        LlmTarget("capable"),
+    ],
+    weights=[3, 1],
+    seed=42,
+)
+```
+
+Calls to `run()` and `decide()` on the same router consume the same random
+sequence.
+
+## LLM classifier
+
+The LLM classifier is decision-only with respect to the selected candidate,
+but it may call its judge as an auxiliary routing operation. Give the judge a
+client and leave the efficient and capable candidates clientless:
+
+```python
+from collections.abc import Mapping
+
+
+class JudgeClient:
+    async def call(
+        self,
+        request: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        # Call a provider here and return a normalized aggregate response.
+        ...
+
+
+router = algorithms.llm_classifier(
+    judge=LlmTarget("judge", JudgeClient()),
+    efficient=LlmTarget("fast"),
+    capable=LlmTarget("strong"),
+    base_threshold=0.5,
+    min_confidence=0.6,
+    capability_elevated_floor=0.75,
+    session_affinity=True,
+    message_hash_fallback=False,
+    recent_turn_window=3,
+)
+
+decision = await router.decide(request)
+```
+
+`base_threshold` is required. The other controls are:
+
+| Argument | Default | Meaning |
+|---|---:|---|
+| `min_confidence` | `0.0` | Minimum judge confidence that permits the efficient route. |
+| `capability_elevated_floor` | `None` | Higher solve-probability floor for uncertain, unmatched, or unsupported tasks. `None` reuses `base_threshold`. |
+| `session_affinity` | `False` | Retain the first assignment for subsequent requests in the same session. |
+| `message_hash_fallback` | `False` | Derive affinity from the first user message when session metadata is absent. Requires `session_affinity=True`. |
+| `recent_turn_window` | `None` | Include the opening task and this many recent conversation turns in the judge request. `None` judges only the newest user message. |
+
+Classifier decisions use `routing_tier="weak"` for the efficient target and
+`routing_tier="strong"` for the capable target when their target names differ.
+A judge failure or malformed verdict follows the existing fail-open policy and
+selects the capable target.
+
+The selected efficient or capable client is never accessed by `decide()`.
+
+## Stage router
+
+The stage router first scores normalized coding-agent tool calls and results. A
+decisive signal selects the capable or efficient target without any model call.
+If the signals are ambiguous, the router can call an optional judge before
+falling open to the tier selected by `picker`.
+
+```python
+stage_request = {
+    "model": "auto",
+    "messages": [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Fix the failing build"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_call",
+                    "id": "call-1",
+                    "name": "Bash",
+                    "arguments": {"command": "cargo test"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_call_id": "call-1",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "fatal runtime error: out of memory",
+                        }
+                    ],
+                    "is_error": True,
+                }
+            ],
+        },
+    ],
+}
+
+router = algorithms.stage_router(
+    capable=LlmTarget("strong"),
+    efficient=LlmTarget("fast"),
+    picker="efficient_first",
+    confidence_threshold=0.5,
+)
+
+decision = await router.decide(stage_request)
+```
+
+This request selects `strong` with `routing_tier="strong"` and does not require
+a client on either candidate.
+
+The full factory exposes the configuration that affects the Rust StageRouter:
+
+```python
+router = algorithms.stage_router(
+    capable=LlmTarget("strong"),
+    efficient=LlmTarget("fast"),
+    picker="efficient_first",
+    confidence_threshold=0.5,
+    recent_turn_window=4,
+    handoff_escalation_note="Continue the failed diagnosis.",
+    handoff_deescalation_note="The build is healthy again.",
+    handoff_only_on_wrong_signal_escalation=True,
+    capable_system_prompt="Solve difficult failures.",
+    efficient_system_prompt="Handle routine work.",
+    judge=LlmTarget("judge", JudgeClient()),
+    classifier_base_threshold=0.5,
+    classifier_min_confidence=0.6,
+    classifier_capability_elevated_floor=0.75,
+    classifier_recent_turn_window=3,
+)
+```
+
+The arguments behave as follows:
+
+| Argument | Default | Meaning |
+|---|---:|---|
+| `picker` | Required | `"capable_first"` falls open to the capable tier; `"efficient_first"` falls open to the efficient tier. |
+| `confidence_threshold` | Required | Minimum tool-signal confidence needed for a decisive signal route. |
+| `recent_turn_window` | `None` | Number of recent tool results scored. `None` uses the Rust default. |
+| `handoff_escalation_note` | `None` | Note appended when handing a qualifying turn to the capable tier. |
+| `handoff_deescalation_note` | `None` | Optional note appended when handing work back to the efficient tier. Requires an escalation note. |
+| `handoff_only_on_wrong_signal_escalation` | `True` | Restrict the escalation note to signal-driven escalation instead of an ambiguous capable default. |
+| `capable_system_prompt` | `None` | System prompt applied when `run()` executes the capable target. |
+| `efficient_system_prompt` | `None` | System prompt applied when `run()` executes the efficient target. |
+| `judge` | `None` | Optional auxiliary judge target used only when tool signals abstain. |
+| `classifier_base_threshold` | `None` | Solve-probability threshold for the optional judge. Must be supplied together with `judge`. |
+| `classifier_min_confidence` | `0.0` | Minimum confidence accepted from the optional judge. |
+| `classifier_capability_elevated_floor` | `None` | Higher judge threshold for uncertain, unmatched, or unsupported tasks. |
+| `classifier_recent_turn_window` | `None` | Conversation window sent to the optional judge. |
+
+Handoff notes and tier prompts affect the request executed by `run()`.
+`decide()` still processes the same routing state and metadata, but returns
+before executing the selected target. StageRouter does not expose classifier
+session affinity because its judge is a per-turn fallback inside the signal
+cascade.
+
+## Request headers and session affinity
+
+Pass headers separately from the normalized request:
+
+```python
+decision = await router.decide(
+    request,
+    headers={"x-switchyard-session-id": "conversation-42"},
+)
+```
+
+Headers are normalized into libsy metadata in the same way as an HTTP host.
+With classifier session affinity enabled, a retained assignment can avoid a
+later judge call.
+
+## `run()` versus `decide()`
+
+| Method | Selected target executed? | Result |
+|---|---|---|
+| `await algorithm.decide(request, headers=None)` | No | One decision dictionary. |
+| `await algorithm.run(request, headers=None)` | Yes, except for no-op | `(decision_trace, normalized_response)`. |
+
+Every target reachable through `run()` needs a client. A target used only as a
+candidate for `decide()` can omit it:
+
+```python
+target = LlmTarget("fast")
+```
+
+Decision dictionaries in both `decide()` results and `run()` traces contain
+`selected_model`, `reasoning`, and `routing_tier`.
+
+## Errors and limitations
+
+- Invalid target objects, algorithm configuration, and normalized request
+  shapes raise `TypeError` or `ValueError` at the Python boundary.
+- Managed execution failures raise `switchyard.libsy.LibsyError`.
+- An LLM classifier needs a client on its judge target. Its efficient and
+  capable targets do not need clients for `decide()`.
+- A stage router needs a client only on its optional judge target for
+  `decide()`; its capable and efficient candidates can remain clientless.
+- `decide()` returns the initial route. It cannot predict context-window
+  fallback because that requires executing a target and observing an overflow.
+- Candidate sets cannot be replaced per request.
+- Decision streaming is not exposed.
+- A custom Rust algorithm must implement the decision task contract before
+  `decide()` can drive it.
+
+## Related documentation
+
+- [Routing Overview](routing_algorithms/overview.md)
+- [Random Routing](routing_algorithms/random_routing.md)
+- [LLM Classifier Routing](routing_algorithms/llm_classifier_routing.md)
+- [Core Concepts](core_concepts.md)

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -158,3 +158,8 @@ constructs LLM clients, targets, and libsy algorithms. It does not load Python
 route bundles. See the
 [Rust server README](../../crates/switchyard-server/README.md) for its supported
 configuration.
+
+Python hosts that need only a model selection can instead use the
+[libsy Python API](../libsy.md). Its `decide()` method runs routing in process
+without exposing another YAML route type or HTTP endpoint, and it does not
+execute the selected final target.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Operations:
       - Context-Window Handling: operations/context_window.md
   - Reference:
+      - libsy Python API: libsy.md
       - CLI Reference: cli_reference.md
 
 exclude_docs: |

--- a/switchyard/libsy/algorithms.py
+++ b/switchyard/libsy/algorithms.py
@@ -3,7 +3,10 @@
 
 """Factories for Rust-owned libsy algorithms."""
 
+from switchyard_rust.libsy import llm_classifier as llm_classifier
 from switchyard_rust.libsy import noop as noop
+from switchyard_rust.libsy import passthrough as passthrough
 from switchyard_rust.libsy import random as random
+from switchyard_rust.libsy import stage_router as stage_router
 
-__all__ = ["noop", "random"]
+__all__ = ["llm_classifier", "noop", "passthrough", "random", "stage_router"]

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -10,7 +10,18 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from switchyard_rust.core import _load_native
 
-_EXPORTS = frozenset({"Algorithm", "LibsyError", "LlmTarget", "noop", "random"})
+_EXPORTS = frozenset(
+    {
+        "Algorithm",
+        "LibsyError",
+        "LlmTarget",
+        "llm_classifier",
+        "noop",
+        "passthrough",
+        "random",
+        "stage_router",
+    }
+)
 
 
 class LlmClient(Protocol):
@@ -26,7 +37,7 @@ class LlmClient(Protocol):
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import final
+    from typing import Literal, TypedDict, final
 
     from switchyard_rust.core import SwitchyardRuntimeError
 
@@ -34,13 +45,26 @@ if TYPE_CHECKING:
 
     @final
     class LlmTarget:
-        def __init__(self, name: str, client: LlmClient) -> None: ...
+        def __init__(self, name: str, client: LlmClient | None = None) -> None: ...
 
         @property
         def name(self) -> str: ...
 
+    class DecisionResult(TypedDict):
+        """Metadata returned by decision-only routing."""
+
+        selected_model: str
+        reasoning: str | None
+        routing_tier: str | None
+
     @final
     class Algorithm:
+        async def decide(
+            self,
+            request: Mapping[str, object],
+            headers: Mapping[str, str] | None = None,
+        ) -> DecisionResult: ...
+
         async def run(
             self,
             request: Mapping[str, object],
@@ -49,7 +73,46 @@ if TYPE_CHECKING:
 
     def noop() -> Algorithm: ...
 
-    def random(targets: Sequence[LlmTarget]) -> Algorithm: ...
+    def llm_classifier(
+        *,
+        judge: LlmTarget,
+        efficient: LlmTarget,
+        capable: LlmTarget,
+        base_threshold: float,
+        min_confidence: float = 0.0,
+        capability_elevated_floor: float | None = None,
+        session_affinity: bool = False,
+        message_hash_fallback: bool = False,
+        recent_turn_window: int | None = None,
+    ) -> Algorithm: ...
+
+    def passthrough(target: LlmTarget) -> Algorithm: ...
+
+    def random(
+        targets: Sequence[LlmTarget],
+        *,
+        weights: Sequence[float] | None = None,
+        seed: int | None = None,
+    ) -> Algorithm: ...
+
+    def stage_router(
+        *,
+        capable: LlmTarget,
+        efficient: LlmTarget,
+        picker: Literal["capable_first", "efficient_first"],
+        confidence_threshold: float,
+        recent_turn_window: int | None = None,
+        handoff_escalation_note: str | None = None,
+        handoff_deescalation_note: str | None = None,
+        handoff_only_on_wrong_signal_escalation: bool = True,
+        capable_system_prompt: str | None = None,
+        efficient_system_prompt: str | None = None,
+        judge: LlmTarget | None = None,
+        classifier_base_threshold: float | None = None,
+        classifier_min_confidence: float = 0.0,
+        classifier_capability_elevated_floor: float | None = None,
+        classifier_recent_turn_window: int | None = None,
+    ) -> Algorithm: ...
 
 
 def __getattr__(name: str) -> object:

--- a/tests/test_libsy_minimal_bindings.py
+++ b/tests/test_libsy_minimal_bindings.py
@@ -22,6 +22,41 @@ def request_body() -> dict[str, Any]:
     }
 
 
+def stage_request(*, failed: bool) -> dict[str, Any]:
+    result = "fatal runtime error: out of memory" if failed else "ok"
+    return {
+        "model": "auto",
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "fix the build"}],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "id": "call_1",
+                        "name": "Bash",
+                        "arguments": {"command": "cargo test"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_call_id": "call_1",
+                        "content": [{"type": "text", "text": result}],
+                        "is_error": failed,
+                    }
+                ],
+            },
+        ],
+    }
+
+
 class EchoClient:
     def __init__(self, model: str) -> None:
         self.model = model
@@ -41,6 +76,50 @@ class EchoClient:
         }
 
 
+class JudgeClient:
+    def __init__(
+        self,
+        *,
+        p_solve: float = 0.9,
+        confidence: float = 0.9,
+        capability_boundary: str = "supported",
+        fail: bool = False,
+        malformed: bool = False,
+    ) -> None:
+        self.p_solve = p_solve
+        self.confidence = confidence
+        self.capability_boundary = capability_boundary
+        self.fail = fail
+        self.malformed = malformed
+        self.calls: list[dict[str, Any]] = []
+
+    async def call(self, request: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(request)
+        if self.fail:
+            raise RuntimeError("judge failed")
+        verdict = "not json"
+        if not self.malformed:
+            verdict = (
+                '{"recommended_route":"efficient",'
+                f'"p_solve":{self.p_solve},'
+                f'"confidence":{self.confidence},'
+                '"abstain":false,'
+                f'"capability_boundary":"{self.capability_boundary}",'
+                '"primary_rule":"SUP-1",'
+                '"crux":"bounded task"}'
+            )
+        return {
+            "model": "judge",
+            "outputs": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": verdict}],
+                    "stop_reason": "end_turn",
+                }
+            ],
+        }
+
+
 async def test_random_runs_with_a_python_client() -> None:
     client = EchoClient("fast")
     algorithm = algorithms.random([LlmTarget("fast", client)])
@@ -51,6 +130,7 @@ async def test_random_runs_with_a_python_client() -> None:
         {
             "selected_model": "fast",
             "reasoning": "random routing selected target 'fast'",
+            "routing_tier": None,
         }
     ]
     assert client.calls[0]["messages"][0]["content"] == [
@@ -95,6 +175,366 @@ async def test_noop_needs_no_client() -> None:
 
     assert decisions[0]["selected_model"] == "auto"
     assert response["outputs"][0]["content"] == [{"type": "text", "text": "OK"}]
+
+
+async def test_random_decides_with_a_clientless_target() -> None:
+    algorithm = algorithms.random([LlmTarget("fast")], seed=42)
+
+    decision = await algorithm.decide(request_body())
+
+    assert decision == {
+        "selected_model": "fast",
+        "reasoning": "random routing selected target 'fast'",
+        "routing_tier": None,
+    }
+
+
+async def test_random_decision_weights_and_seed_share_the_run_sequence() -> None:
+    targets = [LlmTarget("fast"), LlmTarget("capable")]
+    first = algorithms.random(targets, weights=[1, 3], seed=42)
+    second = algorithms.random(targets, weights=[1, 3], seed=42)
+
+    first_decisions = [
+        (await first.decide(request_body()))["selected_model"] for _ in range(100)
+    ]
+    second_decisions = [
+        (await second.decide(request_body()))["selected_model"] for _ in range(100)
+    ]
+
+    assert first_decisions == second_decisions
+    assert 65 <= second_decisions.count("capable") <= 85
+
+    def runnable():
+        return algorithms.random(
+            [
+                LlmTarget("fast", EchoClient("fast")),
+                LlmTarget("capable", EchoClient("capable")),
+            ],
+            weights=[1, 3],
+            seed=42,
+        )
+
+    mixed = runnable()
+    runs_only = runnable()
+    mixed_sequence = [
+        (await mixed.decide(request_body()))["selected_model"],
+        (await mixed.run(request_body()))[1]["model"],
+        (await mixed.decide(request_body()))["selected_model"],
+        (await mixed.run(request_body()))[1]["model"],
+    ]
+    run_sequence = [
+        (await runs_only.run(request_body()))[1]["model"] for _ in range(4)
+    ]
+
+    assert mixed_sequence == run_sequence
+
+
+async def test_noop_decides_without_a_client() -> None:
+    decision = await algorithms.noop().decide(request_body())
+
+    assert decision == {
+        "selected_model": "auto",
+        "reasoning": None,
+        "routing_tier": None,
+    }
+
+
+async def test_passthrough_decides_with_a_clientless_target() -> None:
+    algorithm = algorithms.passthrough(LlmTarget("fast"))
+
+    decision = await algorithm.decide(request_body())
+
+    assert decision == {
+        "selected_model": "fast",
+        "reasoning": None,
+        "routing_tier": None,
+    }
+
+
+async def test_run_rejects_a_clientless_selected_target() -> None:
+    algorithm = algorithms.random([LlmTarget("fast")])
+
+    with pytest.raises(LibsyError, match="has no client"):
+        await algorithm.run(request_body())
+
+
+async def test_run_trace_includes_routing_tier() -> None:
+    algorithm = algorithms.random([LlmTarget("fast", EchoClient("fast"))])
+
+    decisions, _ = await algorithm.run(request_body())
+
+    assert decisions == [
+        {
+            "selected_model": "fast",
+            "reasoning": "random routing selected target 'fast'",
+            "routing_tier": None,
+        }
+    ]
+
+
+async def test_classifier_decides_and_calls_only_the_judge() -> None:
+    judge = JudgeClient()
+    fast = EchoClient("fast")
+    strong = EchoClient("strong")
+    algorithm = algorithms.llm_classifier(
+        judge=LlmTarget("judge", judge),
+        efficient=LlmTarget("fast", fast),
+        capable=LlmTarget("strong", strong),
+        base_threshold=0.5,
+    )
+
+    decision = await algorithm.decide(request_body())
+
+    assert decision == {
+        "selected_model": "fast",
+        "reasoning": "fall-through selected fast (confidence 1.000)",
+        "routing_tier": "weak",
+    }
+    assert len(judge.calls) == 1
+    assert fast.calls == []
+    assert strong.calls == []
+
+
+async def test_classifier_decides_capable_and_fails_open() -> None:
+    capable = algorithms.llm_classifier(
+        judge=LlmTarget("judge", JudgeClient(p_solve=0.1)),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+    )
+    failed_judge = algorithms.llm_classifier(
+        judge=LlmTarget("judge", JudgeClient(fail=True)),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+    )
+    malformed_judge = algorithms.llm_classifier(
+        judge=LlmTarget("judge", JudgeClient(malformed=True)),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+    )
+
+    capable_decision = await capable.decide(request_body())
+    failed_decision = await failed_judge.decide(request_body())
+    malformed_decision = await malformed_judge.decide(request_body())
+
+    assert capable_decision["selected_model"] == "strong"
+    assert capable_decision["routing_tier"] == "strong"
+    assert failed_decision["selected_model"] == "strong"
+    assert failed_decision["routing_tier"] == "strong"
+    assert malformed_decision["selected_model"] == "strong"
+    assert malformed_decision["routing_tier"] == "strong"
+
+
+async def test_classifier_decision_honors_confidence_and_elevated_floor() -> None:
+    low_confidence = algorithms.llm_classifier(
+        judge=LlmTarget("judge", JudgeClient(confidence=0.8)),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+        min_confidence=0.9,
+    )
+    elevated_boundary = algorithms.llm_classifier(
+        judge=LlmTarget(
+            "judge",
+            JudgeClient(p_solve=0.7, capability_boundary="uncertain"),
+        ),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+        capability_elevated_floor=0.8,
+    )
+
+    low_confidence_decision = await low_confidence.decide(request_body())
+    elevated_boundary_decision = await elevated_boundary.decide(request_body())
+
+    assert low_confidence_decision["selected_model"] == "strong"
+    assert elevated_boundary_decision["selected_model"] == "strong"
+
+
+async def test_classifier_accepts_a_recent_turn_window() -> None:
+    judge = JudgeClient()
+    algorithm = algorithms.llm_classifier(
+        judge=LlmTarget("judge", judge),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+        recent_turn_window=3,
+    )
+
+    decision = await algorithm.decide(request_body())
+
+    assert decision["selected_model"] == "fast"
+    assert len(judge.calls) == 1
+
+
+async def test_stage_router_decides_from_tool_signals_without_clients() -> None:
+    algorithm = algorithms.stage_router(
+        capable=LlmTarget("strong"),
+        efficient=LlmTarget("fast"),
+        picker="efficient_first",
+        confidence_threshold=0.5,
+    )
+
+    capable = await algorithm.decide(stage_request(failed=True))
+    efficient = await algorithm.decide(stage_request(failed=False))
+
+    assert capable["selected_model"] == "strong"
+    assert capable["routing_tier"] == "strong"
+    assert efficient["selected_model"] == "fast"
+    assert efficient["routing_tier"] == "weak"
+
+
+async def test_stage_router_decision_calls_only_its_optional_judge() -> None:
+    judge = JudgeClient(p_solve=0.1)
+    algorithm = algorithms.stage_router(
+        capable=LlmTarget("strong"),
+        efficient=LlmTarget("fast"),
+        picker="efficient_first",
+        confidence_threshold=0.5,
+        judge=LlmTarget("judge", judge),
+        classifier_base_threshold=0.5,
+    )
+
+    decision = await algorithm.decide(stage_request(failed=False))
+
+    assert decision["selected_model"] == "strong"
+    assert decision["routing_tier"] == "strong"
+    assert len(judge.calls) == 1
+
+
+async def test_stage_router_accepts_the_full_configuration() -> None:
+    algorithm = algorithms.stage_router(
+        capable=LlmTarget("strong"),
+        efficient=LlmTarget("fast"),
+        picker="capable_first",
+        confidence_threshold=0.5,
+        recent_turn_window=2,
+        handoff_escalation_note="Continue the failed diagnosis.",
+        handoff_deescalation_note="The build is healthy again.",
+        handoff_only_on_wrong_signal_escalation=False,
+        capable_system_prompt="Solve difficult failures.",
+        efficient_system_prompt="Handle routine work.",
+        judge=LlmTarget("judge", JudgeClient()),
+        classifier_base_threshold=0.5,
+        classifier_min_confidence=0.2,
+        classifier_capability_elevated_floor=0.8,
+        classifier_recent_turn_window=4,
+    )
+
+    decision = await algorithm.decide(stage_request(failed=True))
+
+    assert decision["selected_model"] == "strong"
+    assert decision["routing_tier"] == "strong"
+
+
+def test_stage_router_rejects_invalid_configuration() -> None:
+    target = LlmTarget("target")
+
+    with pytest.raises(ValueError, match="picker"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="unknown",
+            confidence_threshold=0.5,
+        )
+
+    with pytest.raises(ValueError, match="confidence_threshold"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="efficient_first",
+            confidence_threshold=1.5,
+        )
+
+    with pytest.raises(ValueError, match="judge and classifier_base_threshold"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="efficient_first",
+            confidence_threshold=0.5,
+            judge=target,
+        )
+
+    with pytest.raises(ValueError, match="judge and classifier_base_threshold"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="efficient_first",
+            confidence_threshold=0.5,
+            classifier_base_threshold=0.5,
+        )
+
+    with pytest.raises(ValueError, match="requires handoff_escalation_note"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="efficient_first",
+            confidence_threshold=0.5,
+            handoff_deescalation_note="healthy",
+        )
+
+    with pytest.raises(ValueError, match="require judge"):
+        algorithms.stage_router(
+            capable=target,
+            efficient=target,
+            picker="efficient_first",
+            confidence_threshold=0.5,
+            classifier_min_confidence=0.2,
+        )
+
+
+async def test_classifier_decision_preserves_session_affinity() -> None:
+    judge = JudgeClient()
+    algorithm = algorithms.llm_classifier(
+        judge=LlmTarget("judge", judge),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+        session_affinity=True,
+    )
+    headers = {"x-switchyard-session-id": "session-1"}
+
+    first = await algorithm.decide(request_body(), headers=headers)
+    second = await algorithm.decide(request_body(), headers=headers)
+
+    assert first["selected_model"] == "fast"
+    assert second["selected_model"] == "fast"
+    assert len(judge.calls) == 1
+
+
+async def test_classifier_requires_a_judge_client_when_deciding() -> None:
+    algorithm = algorithms.llm_classifier(
+        judge=LlmTarget("judge"),
+        efficient=LlmTarget("fast"),
+        capable=LlmTarget("strong"),
+        base_threshold=0.5,
+    )
+
+    with pytest.raises(LibsyError, match="judge.*has no client"):
+        await algorithm.decide(request_body())
+
+
+def test_classifier_rejects_invalid_configuration() -> None:
+    target = LlmTarget("target")
+
+    with pytest.raises(ValueError, match="base_threshold"):
+        algorithms.llm_classifier(
+            judge=target,
+            efficient=target,
+            capable=target,
+            base_threshold=1.5,
+        )
+
+    with pytest.raises(ValueError, match="message_hash_fallback requires session_affinity"):
+        algorithms.llm_classifier(
+            judge=target,
+            efficient=target,
+            capable=target,
+            base_threshold=0.5,
+            message_hash_fallback=True,
+        )
 
 
 def test_algorithm_exposes_only_managed_execution() -> None:


### PR DESCRIPTION
## Summary

- add a managed decision-only API that selects one configured model without executing the selected target
- support noop, passthrough, weighted random, LLM classifier, and StageRouter algorithms
- expose a first-class Python `stage_router(...)` factory with tool-signal, handoff-note, tier-prompt, and optional judge configuration
- preserve decision reasoning and routing-tier metadata, including fall-open paths
- document the public `switchyard.libsy` API and normalized request contract

## Why

Python integrations such as router plugins need Switchyard's routing decision independently from final inference. This API lets the host retain transport ownership while allowing auxiliary routing calls, such as an LLM classifier judge.

## Behavior

`await algorithm.decide(request, headers=None)` returns `selected_model`, `reasoning`, and `routing_tier`. It may execute auxiliary routing calls, but it never calls the selected destination model. Candidate sets remain fixed at construction time.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run ruff check .`
- `uv run mypy switchyard`
- `uv run pytest tests/ -q -m "not integration"` — 1735 passed, 12 skipped
- `cd docs && make publish`

No files under `docs/superpowers/` are included in this PR.
