### PR TITLE
fix(libsy): preserve classifier system instruction

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
-use switchyard_protocol::{LlmRequest, Message, OutputParams, Role};
+use switchyard_protocol::{InstructionBlock, LlmRequest, Message, OutputParams, Role};
 
 use super::util::{AffinityRouter, Judge, JudgeClassifier, JudgeConfig, JudgePolicy};
 use super::{DefaultTarget, FallThrough};
@@ -95,7 +95,7 @@ impl Judge for CapabilityJudge {
     fn build_request(&self, _state: &State, request: &Request) -> Request {
         // Task-based routing judges the newest user message alone. A configured
         // window widens that to the surrounding conversation.
-        let mut messages = match self.recent_turn_window {
+        let messages = match self.recent_turn_window {
             Some(window) => trim_messages(&request.llm_request.messages, window),
             None => request
                 .llm_request
@@ -107,13 +107,13 @@ impl Judge for CapabilityJudge {
                 .into_iter()
                 .collect::<Vec<_>>(),
         };
-        messages.insert(
-            0,
-            Message::text(Role::System, self.config.system_prompt.clone()),
-        );
         Request {
             llm_request: LlmRequest {
                 model: request.llm_request.model.clone(),
+                instructions: vec![InstructionBlock {
+                    role: Role::System,
+                    content: Message::text(Role::System, self.config.system_prompt.clone()).content,
+                }],
                 messages,
                 output: OutputParams {
                     response_format: self.config.response_schema.clone(),
@@ -863,7 +863,13 @@ mod tests {
         let judge_request = judge.build_request(&State::default(), &request);
 
         assert_eq!(judge_request.llm_request.model, request.llm_request.model);
-        assert_eq!(judge_request.llm_request.messages.len(), 2);
+        assert_eq!(judge_request.llm_request.instructions.len(), 1);
+        assert_eq!(judge_request.llm_request.instructions[0].role, Role::System);
+        assert_eq!(
+            judge_request.llm_request.instructions[0].content,
+            Message::text(Role::System, judge.config.system_prompt.clone()).content
+        );
+        assert_eq!(judge_request.llm_request.messages.len(), 1);
         let contents = judge_request
             .llm_request
             .messages


### PR DESCRIPTION
## What

Make the libsy LLM capability classifier place its governing policy in
`LlmRequest.instructions` as a system `InstructionBlock`. Keep only the task
conversation in `LlmRequest.messages`, and extend the existing request-builder
test to lock in that separation.

This is a focused libsy correctness fix. It is independent of raw-stream
preservation PR #192 and does not change streaming types, translation APIs, or
Relay code.

## Why

`switchyard-protocol` deliberately separates model instructions from ordinary
conversation messages. The classifier labeled its policy `Role::System`, but
inserted it into `messages`. On the OpenAI Chat translation path, ordinary
messages with that role are encoded as user content, so a provider received:

```text
user: <classifier policy>
user: <task to classify>
```

instead of:

```text
system: <classifier policy>
user: <task to classify>
```

That breaks the classifier router specifically because its judge call depends
on a library-authored policy prompt. The random router does not synthesize a
judge prompt and is unaffected.

The issue was reproduced through NeMo Relay's real `Algorithm::run_stream`
dispatcher against the unmodified Switchyard baseline: a provider-boundary
assertion expected the classifier policy to have role `system` but observed
`user`. Applying only this change made the same buffered and streaming process
tests pass. A real Inference Hub smoke test then completed classifier and
selected-target calls for both buffered and streaming requests.

This restores the protocol and translation invariant at the source rather than
adding a Relay-specific translation workaround. It is not presented as a
general prompt-injection mitigation.

No linked issue.

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green (1,723 passed, 35 skipped)
- [x] Manual smoke: NeMo Relay process E2E for buffered and streaming classifier routes, followed by real Inference Hub buffered and streaming routes

Additional Rust validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p switchyard-libsy` (195 unit, 3 observability, and 4 prompt tests passed)

## Checklist

- [x] N/A — this is a Rust-only change to an existing type.
- [x] N/A — no new Python public symbols.
- [x] Unit tests added for new components / bug fixes.
- [x] N/A — no customer-facing surface changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The key invariant is that classifier-owned policy belongs in
`LlmRequest.instructions`, while the conversation being classified remains in
`LlmRequest.messages`. Please pay particular attention to preserving that split
as prompt-window behavior evolves.

This branch is based directly on current `main` and contains one commit changing
only `crates/libsy/src/algorithms/llm_class.rs`; it is not stacked on PR #192.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved capability evaluation reliability by separating system guidance from conversation content.
  - Preserved relevant message history while reducing unnecessary context passed during evaluation.
  - Updated validation coverage to ensure requests maintain the expected structure and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->