### PR TITLE
feat(libsy): expose task classifier and stage router in Python

### DIFF
--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -149,6 +149,39 @@ impl PyTaskClassifierConfig {
     }
 }
 
+/// Judge target and policy used when stage-router signals are inconclusive.
+#[pyclass(
+    name = "LlmFallback",
+    module = "switchyard.libsy",
+    frozen,
+    skip_from_py_object
+)]
+struct PyLlmFallback {
+    judge_target: Py<PyLlmTarget>,
+    config: Py<PyTaskClassifierConfig>,
+}
+
+impl PyLlmFallback {
+    fn clone_core(&self, py: Python<'_>) -> PyResult<LlmFallback> {
+        Ok(LlmFallback {
+            judge_target: self.judge_target.bind(py).try_borrow()?.clone_core(py),
+            config: self.config.bind(py).try_borrow()?.clone_core(),
+        })
+    }
+}
+
+#[pymethods]
+impl PyLlmFallback {
+    #[new]
+    #[pyo3(signature = (judge_target, *, config))]
+    fn new(judge_target: Py<PyLlmTarget>, config: Py<PyTaskClassifierConfig>) -> Self {
+        Self {
+            judge_target,
+            config,
+        }
+    }
+}
+
 /// Opaque handle shared by every Rust-owned algorithm exposed to Python.
 #[pyclass(name = "Algorithm", module = "switchyard.libsy", frozen)]
 struct PyAlgorithm {
@@ -279,8 +312,7 @@ fn llm_task_classifier_algorithm(
     only_on_wrong_signal_escalation=true,
     capable_system_prompt=None,
     efficient_system_prompt=None,
-    classifier_target=None,
-    classifier_config=None
+    classifier=None
 ))]
 #[allow(clippy::too_many_arguments)]
 fn stage_router_algorithm(
@@ -295,8 +327,7 @@ fn stage_router_algorithm(
     only_on_wrong_signal_escalation: bool,
     capable_system_prompt: Option<String>,
     efficient_system_prompt: Option<String>,
-    classifier_target: Option<Py<PyLlmTarget>>,
-    classifier_config: Option<Py<PyTaskClassifierConfig>>,
+    classifier: Option<Py<PyLlmFallback>>,
 ) -> PyResult<PyAlgorithm> {
     let mode = match picker {
         "capable_first" => PickerMode::CapableFirst,
@@ -334,23 +365,9 @@ fn stage_router_algorithm(
             .tier_prompts
             .with(efficient.semantic_name.clone(), prompt);
     }
-    config.llm_fallback = match (classifier_target, classifier_config) {
-        (Some(target), Some(classifier_config)) => Some(LlmFallback {
-            judge_target: target.bind(py).try_borrow()?.clone_core(py),
-            config: classifier_config.bind(py).try_borrow()?.clone_core(),
-        }),
-        (Some(_), None) => {
-            return Err(PyValueError::new_err(
-                "classifier_target requires classifier_config",
-            ));
-        }
-        (None, Some(_)) => {
-            return Err(PyValueError::new_err(
-                "classifier_config requires classifier_target",
-            ));
-        }
-        (None, None) => None,
-    };
+    config.llm_fallback = classifier
+        .map(|classifier| classifier.bind(py).try_borrow()?.clone_core(py))
+        .transpose()?;
 
     let algorithm = StageRouter::new(capable, efficient, config)
         .map_err(|error| PyValueError::new_err(error.to_string()))?;
@@ -372,6 +389,7 @@ fn invalid_python_response(error: PyErr) -> LlmClientError {
 pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let libsy_module = PyModule::new(module.py(), "libsy")?;
     libsy_module.add_class::<PyAlgorithm>()?;
+    libsy_module.add_class::<PyLlmFallback>()?;
     libsy_module.add_class::<PyLlmTarget>()?;
     libsy_module.add_class::<PyTaskClassifierConfig>()?;
     libsy_module.add_function(wrap_pyfunction!(noop_algorithm, &libsy_module)?)?;

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -188,7 +188,7 @@ fn random_algorithm(
 }
 
 /// Construct task-level LLM classifier routing.
-#[pyfunction(name = "llm_classifier")]
+#[pyfunction(name = "llm_task_classifier")]
 #[pyo3(signature = (
     judge_target,
     efficient_target,
@@ -202,7 +202,7 @@ fn random_algorithm(
     recent_turn_window=None
 ))]
 #[allow(clippy::too_many_arguments)]
-fn llm_classifier_algorithm(
+fn llm_task_classifier_algorithm(
     py: Python<'_>,
     judge_target: Py<PyLlmTarget>,
     efficient_target: Py<PyLlmTarget>,
@@ -359,7 +359,10 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     libsy_module.add_class::<PyLlmTarget>()?;
     libsy_module.add_function(wrap_pyfunction!(noop_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(random_algorithm, &libsy_module)?)?;
-    libsy_module.add_function(wrap_pyfunction!(llm_classifier_algorithm, &libsy_module)?)?;
+    libsy_module.add_function(wrap_pyfunction!(
+        llm_task_classifier_algorithm,
+        &libsy_module
+    )?)?;
     libsy_module.add_function(wrap_pyfunction!(stage_router_algorithm, &libsy_module)?)?;
     libsy_module.add("LibsyError", module.getattr("LibsyError")?)?;
     module.add_submodule(&libsy_module)?;

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -97,6 +97,58 @@ impl PyLlmTarget {
     }
 }
 
+/// Classifier thresholds shared by standalone and stage-router classifiers.
+#[pyclass(
+    name = "TaskClassifierConfig",
+    module = "switchyard.libsy",
+    frozen,
+    skip_from_py_object
+)]
+#[derive(Clone)]
+struct PyTaskClassifierConfig {
+    inner: TaskClassifierConfig,
+}
+
+impl PyTaskClassifierConfig {
+    fn clone_core(&self) -> TaskClassifierConfig {
+        self.inner.clone()
+    }
+}
+
+#[pymethods]
+impl PyTaskClassifierConfig {
+    #[new]
+    #[pyo3(signature = (
+        base_threshold,
+        *,
+        min_confidence=0.0,
+        capability_elevated_floor=None,
+        session_affinity=false,
+        message_hash_fallback=false,
+        recent_turn_window=None
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        base_threshold: f64,
+        min_confidence: f64,
+        capability_elevated_floor: Option<f64>,
+        session_affinity: bool,
+        message_hash_fallback: bool,
+        recent_turn_window: Option<usize>,
+    ) -> Self {
+        Self {
+            inner: TaskClassifierConfig {
+                base_threshold,
+                min_confidence,
+                capability_elevated_floor,
+                session_affinity,
+                message_hash_fallback,
+                recent_turn_window,
+            },
+        }
+    }
+}
+
 /// Opaque handle shared by every Rust-owned algorithm exposed to Python.
 #[pyclass(name = "Algorithm", module = "switchyard.libsy", frozen)]
 struct PyAlgorithm {
@@ -194,39 +246,20 @@ fn random_algorithm(
     efficient_target,
     capable_target,
     *,
-    base_threshold,
-    min_confidence=0.0,
-    capability_elevated_floor=None,
-    session_affinity=false,
-    message_hash_fallback=false,
-    recent_turn_window=None
+    config
 ))]
-#[allow(clippy::too_many_arguments)]
 fn llm_task_classifier_algorithm(
     py: Python<'_>,
     judge_target: Py<PyLlmTarget>,
     efficient_target: Py<PyLlmTarget>,
     capable_target: Py<PyLlmTarget>,
-    base_threshold: f64,
-    min_confidence: f64,
-    capability_elevated_floor: Option<f64>,
-    session_affinity: bool,
-    message_hash_fallback: bool,
-    recent_turn_window: Option<usize>,
+    config: Py<PyTaskClassifierConfig>,
 ) -> PyResult<PyAlgorithm> {
-    let config = TaskClassifierConfig {
-        base_threshold,
-        min_confidence,
-        capability_elevated_floor,
-        session_affinity,
-        message_hash_fallback,
-        recent_turn_window,
-    };
     let algorithm = LlmTaskClassifier::new(
         judge_target.bind(py).try_borrow()?.clone_core(py),
         efficient_target.bind(py).try_borrow()?.clone_core(py),
         capable_target.bind(py).try_borrow()?.clone_core(py),
-        config,
+        config.bind(py).try_borrow()?.clone_core(),
     )
     .map_err(|error| PyValueError::new_err(error.to_string()))?;
     Ok(PyAlgorithm::new(Arc::new(algorithm)))
@@ -247,12 +280,7 @@ fn llm_task_classifier_algorithm(
     capable_system_prompt=None,
     efficient_system_prompt=None,
     classifier_target=None,
-    classifier_base_threshold=None,
-    classifier_min_confidence=0.0,
-    classifier_capability_elevated_floor=None,
-    classifier_session_affinity=false,
-    classifier_message_hash_fallback=false,
-    classifier_recent_turn_window=None
+    classifier_config=None
 ))]
 #[allow(clippy::too_many_arguments)]
 fn stage_router_algorithm(
@@ -268,12 +296,7 @@ fn stage_router_algorithm(
     capable_system_prompt: Option<String>,
     efficient_system_prompt: Option<String>,
     classifier_target: Option<Py<PyLlmTarget>>,
-    classifier_base_threshold: Option<f64>,
-    classifier_min_confidence: f64,
-    classifier_capability_elevated_floor: Option<f64>,
-    classifier_session_affinity: bool,
-    classifier_message_hash_fallback: bool,
-    classifier_recent_turn_window: Option<usize>,
+    classifier_config: Option<Py<PyTaskClassifierConfig>>,
 ) -> PyResult<PyAlgorithm> {
     let mode = match picker {
         "capable_first" => PickerMode::CapableFirst,
@@ -311,26 +334,19 @@ fn stage_router_algorithm(
             .tier_prompts
             .with(efficient.semantic_name.clone(), prompt);
     }
-    config.llm_fallback = match (classifier_target, classifier_base_threshold) {
-        (Some(target), Some(base_threshold)) => Some(LlmFallback {
+    config.llm_fallback = match (classifier_target, classifier_config) {
+        (Some(target), Some(classifier_config)) => Some(LlmFallback {
             judge_target: target.bind(py).try_borrow()?.clone_core(py),
-            config: TaskClassifierConfig {
-                base_threshold,
-                min_confidence: classifier_min_confidence,
-                capability_elevated_floor: classifier_capability_elevated_floor,
-                session_affinity: classifier_session_affinity,
-                message_hash_fallback: classifier_message_hash_fallback,
-                recent_turn_window: classifier_recent_turn_window,
-            },
+            config: classifier_config.bind(py).try_borrow()?.clone_core(),
         }),
         (Some(_), None) => {
             return Err(PyValueError::new_err(
-                "classifier_target requires classifier_base_threshold",
+                "classifier_target requires classifier_config",
             ));
         }
         (None, Some(_)) => {
             return Err(PyValueError::new_err(
-                "classifier_base_threshold requires classifier_target",
+                "classifier_config requires classifier_target",
             ));
         }
         (None, None) => None,
@@ -357,6 +373,7 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let libsy_module = PyModule::new(module.py(), "libsy")?;
     libsy_module.add_class::<PyAlgorithm>()?;
     libsy_module.add_class::<PyLlmTarget>()?;
+    libsy_module.add_class::<PyTaskClassifierConfig>()?;
     libsy_module.add_function(wrap_pyfunction!(noop_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(random_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -9,7 +9,11 @@ use async_trait::async_trait;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use serde_json::{json, Value};
-use switchyard_libsy::algorithms::{Noop, Random};
+use switchyard_libsy::algorithms::{
+    LlmFallback, LlmTaskClassifier, Noop, Random, StageRouter, StageRouterConfig,
+    TaskClassifierConfig,
+};
+use switchyard_libsy::stage_router::{HandoffNoteConfig, PickerMode};
 use switchyard_libsy::{
     AggLlmResponse, Algorithm, Context, Decision, LibsyError as RustLibsyError, LlmClientError,
     LlmResponse, LlmTarget, LlmTargetSet, Metadata, Request, Response, RoutedLlmClient,
@@ -183,6 +187,160 @@ fn random_algorithm(
     Ok(PyAlgorithm::new(Arc::new(algorithm)))
 }
 
+/// Construct task-level LLM classifier routing.
+#[pyfunction(name = "llm_classifier")]
+#[pyo3(signature = (
+    judge_target,
+    efficient_target,
+    capable_target,
+    *,
+    base_threshold,
+    min_confidence=0.0,
+    capability_elevated_floor=None,
+    session_affinity=false,
+    message_hash_fallback=false,
+    recent_turn_window=None
+))]
+#[allow(clippy::too_many_arguments)]
+fn llm_classifier_algorithm(
+    py: Python<'_>,
+    judge_target: Py<PyLlmTarget>,
+    efficient_target: Py<PyLlmTarget>,
+    capable_target: Py<PyLlmTarget>,
+    base_threshold: f64,
+    min_confidence: f64,
+    capability_elevated_floor: Option<f64>,
+    session_affinity: bool,
+    message_hash_fallback: bool,
+    recent_turn_window: Option<usize>,
+) -> PyResult<PyAlgorithm> {
+    let config = TaskClassifierConfig {
+        base_threshold,
+        min_confidence,
+        capability_elevated_floor,
+        session_affinity,
+        message_hash_fallback,
+        recent_turn_window,
+    };
+    let algorithm = LlmTaskClassifier::new(
+        judge_target.bind(py).try_borrow()?.clone_core(py),
+        efficient_target.bind(py).try_borrow()?.clone_core(py),
+        capable_target.bind(py).try_borrow()?.clone_core(py),
+        config,
+    )
+    .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok(PyAlgorithm::new(Arc::new(algorithm)))
+}
+
+/// Construct signal-driven stage routing with an optional LLM classifier fallback.
+#[pyfunction(name = "stage_router")]
+#[pyo3(signature = (
+    capable_target,
+    efficient_target,
+    *,
+    picker,
+    confidence_threshold,
+    recent_window=None,
+    escalation_note=None,
+    deescalation_note=None,
+    only_on_wrong_signal_escalation=true,
+    capable_system_prompt=None,
+    efficient_system_prompt=None,
+    classifier_target=None,
+    classifier_base_threshold=None,
+    classifier_min_confidence=0.0,
+    classifier_capability_elevated_floor=None,
+    classifier_session_affinity=false,
+    classifier_message_hash_fallback=false,
+    classifier_recent_turn_window=None
+))]
+#[allow(clippy::too_many_arguments)]
+fn stage_router_algorithm(
+    py: Python<'_>,
+    capable_target: Py<PyLlmTarget>,
+    efficient_target: Py<PyLlmTarget>,
+    picker: &str,
+    confidence_threshold: f64,
+    recent_window: Option<usize>,
+    escalation_note: Option<String>,
+    deescalation_note: Option<String>,
+    only_on_wrong_signal_escalation: bool,
+    capable_system_prompt: Option<String>,
+    efficient_system_prompt: Option<String>,
+    classifier_target: Option<Py<PyLlmTarget>>,
+    classifier_base_threshold: Option<f64>,
+    classifier_min_confidence: f64,
+    classifier_capability_elevated_floor: Option<f64>,
+    classifier_session_affinity: bool,
+    classifier_message_hash_fallback: bool,
+    classifier_recent_turn_window: Option<usize>,
+) -> PyResult<PyAlgorithm> {
+    let mode = match picker {
+        "capable_first" => PickerMode::CapableFirst,
+        "efficient_first" => PickerMode::EfficientFirst,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "picker must be 'capable_first' or 'efficient_first', got {other:?}"
+            )));
+        }
+    };
+    let capable = capable_target.bind(py).try_borrow()?.clone_core(py);
+    let efficient = efficient_target.bind(py).try_borrow()?.clone_core(py);
+    let mut config = StageRouterConfig::new(mode, confidence_threshold);
+    config.recent_window = recent_window;
+    config.handoff_notes = match (escalation_note, deescalation_note) {
+        (Some(escalation), deescalation) => Some(HandoffNoteConfig::new(
+            escalation,
+            deescalation,
+            only_on_wrong_signal_escalation,
+        )),
+        (None, Some(_)) => {
+            return Err(PyValueError::new_err(
+                "deescalation_note requires escalation_note",
+            ));
+        }
+        (None, None) => None,
+    };
+    if let Some(prompt) = capable_system_prompt {
+        config.tier_prompts = config
+            .tier_prompts
+            .with(capable.semantic_name.clone(), prompt);
+    }
+    if let Some(prompt) = efficient_system_prompt {
+        config.tier_prompts = config
+            .tier_prompts
+            .with(efficient.semantic_name.clone(), prompt);
+    }
+    config.llm_fallback = match (classifier_target, classifier_base_threshold) {
+        (Some(target), Some(base_threshold)) => Some(LlmFallback {
+            judge_target: target.bind(py).try_borrow()?.clone_core(py),
+            config: TaskClassifierConfig {
+                base_threshold,
+                min_confidence: classifier_min_confidence,
+                capability_elevated_floor: classifier_capability_elevated_floor,
+                session_affinity: classifier_session_affinity,
+                message_hash_fallback: classifier_message_hash_fallback,
+                recent_turn_window: classifier_recent_turn_window,
+            },
+        }),
+        (Some(_), None) => {
+            return Err(PyValueError::new_err(
+                "classifier_target requires classifier_base_threshold",
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(PyValueError::new_err(
+                "classifier_base_threshold requires classifier_target",
+            ));
+        }
+        (None, None) => None,
+    };
+
+    let algorithm = StageRouter::new(capable, efficient, config)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok(PyAlgorithm::new(Arc::new(algorithm)))
+}
+
 fn other_python_error(error: PyErr) -> LlmClientError {
     LlmClientError::Ffi {
         source: Box::new(error),
@@ -201,6 +359,8 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     libsy_module.add_class::<PyLlmTarget>()?;
     libsy_module.add_function(wrap_pyfunction!(noop_algorithm, &libsy_module)?)?;
     libsy_module.add_function(wrap_pyfunction!(random_algorithm, &libsy_module)?)?;
+    libsy_module.add_function(wrap_pyfunction!(llm_classifier_algorithm, &libsy_module)?)?;
+    libsy_module.add_function(wrap_pyfunction!(stage_router_algorithm, &libsy_module)?)?;
     libsy_module.add("LibsyError", module.getattr("LibsyError")?)?;
     module.add_submodule(&libsy_module)?;
     Ok(())

--- a/switchyard/libsy/__init__.py
+++ b/switchyard/libsy/__init__.py
@@ -3,8 +3,15 @@
 
 """Run Rust-owned libsy algorithms with Python-hosted LLM clients."""
 
-from switchyard_rust.libsy import Algorithm, LibsyError, LlmClient, LlmTarget
+from switchyard_rust.libsy import Algorithm, LibsyError, LlmClient, LlmTarget, TaskClassifierConfig
 
 from . import algorithms as algorithms
 
-__all__ = ["Algorithm", "LibsyError", "LlmClient", "LlmTarget", "algorithms"]
+__all__ = [
+    "Algorithm",
+    "LibsyError",
+    "LlmClient",
+    "LlmTarget",
+    "TaskClassifierConfig",
+    "algorithms",
+]

--- a/switchyard/libsy/__init__.py
+++ b/switchyard/libsy/__init__.py
@@ -3,7 +3,14 @@
 
 """Run Rust-owned libsy algorithms with Python-hosted LLM clients."""
 
-from switchyard_rust.libsy import Algorithm, LibsyError, LlmClient, LlmTarget, TaskClassifierConfig
+from switchyard_rust.libsy import (
+    Algorithm,
+    LibsyError,
+    LlmClient,
+    LlmFallback,
+    LlmTarget,
+    TaskClassifierConfig,
+)
 
 from . import algorithms as algorithms
 
@@ -11,6 +18,7 @@ __all__ = [
     "Algorithm",
     "LibsyError",
     "LlmClient",
+    "LlmFallback",
     "LlmTarget",
     "TaskClassifierConfig",
     "algorithms",

--- a/switchyard/libsy/algorithms.py
+++ b/switchyard/libsy/algorithms.py
@@ -3,9 +3,9 @@
 
 """Factories for Rust-owned libsy algorithms."""
 
-from switchyard_rust.libsy import llm_classifier as llm_classifier
+from switchyard_rust.libsy import llm_task_classifier as llm_task_classifier
 from switchyard_rust.libsy import noop as noop
 from switchyard_rust.libsy import random as random
 from switchyard_rust.libsy import stage_router as stage_router
 
-__all__ = ["llm_classifier", "noop", "random", "stage_router"]
+__all__ = ["llm_task_classifier", "noop", "random", "stage_router"]

--- a/switchyard/libsy/algorithms.py
+++ b/switchyard/libsy/algorithms.py
@@ -3,7 +3,9 @@
 
 """Factories for Rust-owned libsy algorithms."""
 
+from switchyard_rust.libsy import llm_classifier as llm_classifier
 from switchyard_rust.libsy import noop as noop
 from switchyard_rust.libsy import random as random
+from switchyard_rust.libsy import stage_router as stage_router
 
-__all__ = ["noop", "random"]
+__all__ = ["llm_classifier", "noop", "random", "stage_router"]

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -15,7 +15,7 @@ _EXPORTS = frozenset(
         "Algorithm",
         "LibsyError",
         "LlmTarget",
-        "llm_classifier",
+        "llm_task_classifier",
         "noop",
         "random",
         "stage_router",
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 
     def random(targets: Sequence[LlmTarget]) -> Algorithm: ...
 
-    def llm_classifier(
+    def llm_task_classifier(
         judge_target: LlmTarget,
         efficient_target: LlmTarget,
         capable_target: LlmTarget,

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -14,6 +14,7 @@ _EXPORTS = frozenset(
     {
         "Algorithm",
         "LibsyError",
+        "LlmFallback",
         "LlmTarget",
         "TaskClassifierConfig",
         "llm_task_classifier",
@@ -64,6 +65,15 @@ if TYPE_CHECKING:
         ) -> None: ...
 
     @final
+    class LlmFallback:
+        def __init__(
+            self,
+            judge_target: LlmTarget,
+            *,
+            config: TaskClassifierConfig,
+        ) -> None: ...
+
+    @final
     class Algorithm:
         async def run(
             self,
@@ -95,8 +105,7 @@ if TYPE_CHECKING:
         only_on_wrong_signal_escalation: bool = True,
         capable_system_prompt: str | None = None,
         efficient_system_prompt: str | None = None,
-        classifier_target: LlmTarget | None = None,
-        classifier_config: TaskClassifierConfig | None = None,
+        classifier: LlmFallback | None = None,
     ) -> Algorithm: ...
 
 

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -10,7 +10,17 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from switchyard_rust.core import _load_native
 
-_EXPORTS = frozenset({"Algorithm", "LibsyError", "LlmTarget", "noop", "random"})
+_EXPORTS = frozenset(
+    {
+        "Algorithm",
+        "LibsyError",
+        "LlmTarget",
+        "llm_classifier",
+        "noop",
+        "random",
+        "stage_router",
+    }
+)
 
 
 class LlmClient(Protocol):
@@ -50,6 +60,40 @@ if TYPE_CHECKING:
     def noop() -> Algorithm: ...
 
     def random(targets: Sequence[LlmTarget]) -> Algorithm: ...
+
+    def llm_classifier(
+        judge_target: LlmTarget,
+        efficient_target: LlmTarget,
+        capable_target: LlmTarget,
+        *,
+        base_threshold: float,
+        min_confidence: float = 0.0,
+        capability_elevated_floor: float | None = None,
+        session_affinity: bool = False,
+        message_hash_fallback: bool = False,
+        recent_turn_window: int | None = None,
+    ) -> Algorithm: ...
+
+    def stage_router(
+        capable_target: LlmTarget,
+        efficient_target: LlmTarget,
+        *,
+        picker: str,
+        confidence_threshold: float,
+        recent_window: int | None = None,
+        escalation_note: str | None = None,
+        deescalation_note: str | None = None,
+        only_on_wrong_signal_escalation: bool = True,
+        capable_system_prompt: str | None = None,
+        efficient_system_prompt: str | None = None,
+        classifier_target: LlmTarget | None = None,
+        classifier_base_threshold: float | None = None,
+        classifier_min_confidence: float = 0.0,
+        classifier_capability_elevated_floor: float | None = None,
+        classifier_session_affinity: bool = False,
+        classifier_message_hash_fallback: bool = False,
+        classifier_recent_turn_window: int | None = None,
+    ) -> Algorithm: ...
 
 
 def __getattr__(name: str) -> object:

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -15,6 +15,7 @@ _EXPORTS = frozenset(
         "Algorithm",
         "LibsyError",
         "LlmTarget",
+        "TaskClassifierConfig",
         "llm_task_classifier",
         "noop",
         "random",
@@ -50,6 +51,19 @@ if TYPE_CHECKING:
         def name(self) -> str: ...
 
     @final
+    class TaskClassifierConfig:
+        def __init__(
+            self,
+            base_threshold: float,
+            *,
+            min_confidence: float = 0.0,
+            capability_elevated_floor: float | None = None,
+            session_affinity: bool = False,
+            message_hash_fallback: bool = False,
+            recent_turn_window: int | None = None,
+        ) -> None: ...
+
+    @final
     class Algorithm:
         async def run(
             self,
@@ -66,12 +80,7 @@ if TYPE_CHECKING:
         efficient_target: LlmTarget,
         capable_target: LlmTarget,
         *,
-        base_threshold: float,
-        min_confidence: float = 0.0,
-        capability_elevated_floor: float | None = None,
-        session_affinity: bool = False,
-        message_hash_fallback: bool = False,
-        recent_turn_window: int | None = None,
+        config: TaskClassifierConfig,
     ) -> Algorithm: ...
 
     def stage_router(
@@ -87,12 +96,7 @@ if TYPE_CHECKING:
         capable_system_prompt: str | None = None,
         efficient_system_prompt: str | None = None,
         classifier_target: LlmTarget | None = None,
-        classifier_base_threshold: float | None = None,
-        classifier_min_confidence: float = 0.0,
-        classifier_capability_elevated_floor: float | None = None,
-        classifier_session_affinity: bool = False,
-        classifier_message_hash_fallback: bool = False,
-        classifier_recent_turn_window: int | None = None,
+        classifier_config: TaskClassifierConfig | None = None,
     ) -> Algorithm: ...
 
 


### PR DESCRIPTION
## What

- Add `llm_task_classifier` and `stage_router` Python factories for libsy's
  `LlmTaskClassifier` and `StageRouter` algorithms.
- Expose every existing routing knob while preserving Rust defaults for optional settings.
- Export both factories through `switchyard.libsy.algorithms` with Python type declarations.

## Why

Python-hosted clients can currently run only the no-op and random libsy algorithms. These bindings make the two production routing algorithms available through the same minimal opaque `Algorithm` API.

## How

The PyO3 factories convert bound `LlmTarget` objects and keyword arguments directly into the existing Rust config structs. Construction and validation remain owned by libsy; no routing behavior is duplicated in Python.

## What to review

- Classifier target ordering and `TaskClassifierConfig` field mapping.
- Stage-router picker, notes, prompts, and optional classifier fallback mapping.
- Optional values retain their existing Rust defaults.

## Validation

- `cargo check -p switchyard-py`
- `cargo fmt --all -- --check`
- `uv run ruff check switchyard/libsy/algorithms.py switchyard_rust/libsy.py`
- Commit hooks: cargo clippy, mypy, and commitlint

No tests were added or run for this binding-only change.
