### PR TITLE
docs(server): document stage_router as a supported route type

### DIFF
--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -42,6 +42,14 @@ base_threshold = 0.5
 id = "switchyard/passthrough"
 type = "passthrough"
 target = "model_a"
+
+[routes.stage]
+id = "switchyard/stage"
+type = "stage_router"
+capable_target = "model_a"
+efficient_target = "model_b"
+picker = "efficient_first"
+confidence_threshold = 0.5
 ```
 
 ```bash
@@ -59,8 +67,8 @@ upstream, and a route's `id` is the model clients send to select that algorithm.
 
 Each target references an entry under `llm_clients`. All configured clients use
 `TranslatingLlmClient`; supported formats are `openai_chat`, `openai_responses`, and
-`anthropic_messages`. Supported algorithms are `noop`, `random`, `passthrough`, and
-`llm_classifier`. An `api_key_env` value names an environment variable; the TOML
+`anthropic_messages`. Supported algorithms are `noop`, `random`, `passthrough`,
+`llm_classifier`, and `stage_router`. An `api_key_env` value names an environment variable; the TOML
 never contains the secret itself. If omitted, the client sends no authentication.
 Target-level `extra_body` values are shallow-merged into the upstream request when
 the request does not already contain that key.
@@ -86,6 +94,12 @@ Session affinity retains a decision for the process lifetime, including a `stron
 fallback produced while the judge was unreachable. `message_hash_fallback` keys on request
 content rather than a session id, so unrelated callers sending identical text share one
 assignment.
+
+A `stage_router` route scores tool-result and agent-progress signals from recent turns to pick a
+tier per turn, without an extra classifier call on every turn. `capable_target`,
+`efficient_target`, `picker` (`efficient_first` or `capable_first`), and `confidence_threshold`
+are required. Optional handoff notes, per-tier system prompts, and a capability-judge fallback are
+documented in [Stage-Router Routing](../../docs/routing_algorithms/stage_router_routing.md).
 
 ## Metrics
 


### PR DESCRIPTION
Adds stage_router to the switchyard-server README, includes example config and some tidying up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance and an example for the `stage_router` routing algorithm.
  * Documented required routing settings, including target selection, picker, and confidence threshold.
  * Explained how routing tiers are selected using recent tool results and agent progress signals.
  * Added a link to detailed Stage-Router Routing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->