### PR TITLE
fix(libsy): restore judge classification test

### DIFF
--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -357,7 +357,7 @@ mod tests {
             classifier.score(&mut state, &mut request, Some(&driver)),
             serve
         );
-        selected(classification?.0)
+        selected(classification?)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Restore the `LlmJudge` test helper to pass the `Classification` enum directly to `selected`.

## Why

PR #204 changed the helper to access tuple field `.0`, but `Classification` is an enum. This prevents `cargo clippy --workspace --all-targets -- -D warnings` from compiling on `main` and makes every subsequent CI run fail.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p switchyard-libsy`
- `uv run ruff check .`
- `uv run maturin develop`
- `uv run pytest tests/` (`1729 passed, 35 skipped`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy selection by preserving the complete classifier result when evaluating served content.
  * Ensured judge-based scoring uses the full classification outcome for more accurate decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->