### PR TITLE
feat(switchyard-server): `/v1/stats/reset`

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -254,6 +254,7 @@ pub fn build_switchyard_router(state: ServerState) -> Router {
         .route("/v1/messages/count_tokens", post(anthropic_count_tokens))
         .route("/v1/models", get(models))
         .route("/v1/stats", get(get_stats))
+        .route("/v1/stats/reset", post(reset_stats))
         .route("/metrics", get(prometheus_metrics))
         .route("/health", get(health))
         .fallback(not_found)
@@ -718,6 +719,11 @@ async fn models(State(state): State<ServerState>) -> Json<Value> {
 
 async fn get_stats(State(state): State<ServerState>) -> Json<StatsSnapshot> {
     Json(state.stats.snapshot())
+}
+
+async fn reset_stats(State(state): State<ServerState>) -> Json<Value> {
+    state.stats.reset();
+    Json(json!({"status": "reset"}))
 }
 
 async fn health() -> Json<Value> {

--- a/crates/switchyard-server/src/stats/accumulator.rs
+++ b/crates/switchyard-server/src/stats/accumulator.rs
@@ -134,6 +134,11 @@ impl StatsAccumulator {
         inner.snapshot()
     }
 
+    /// Clears all accumulated stats.
+    pub(crate) fn reset(&self) {
+        *self.lock() = StatsAccumulatorInner::default();
+    }
+
     fn lock(&self) -> MutexGuard<'_, StatsAccumulatorInner> {
         self.inner.lock()
     }
@@ -560,6 +565,24 @@ mod tests {
             snapshot.tiers["strong"].models,
             BTreeSet::from(["model/other".to_string(), "model/strong".to_string()])
         );
+    }
+
+    #[test]
+    fn reset_clears_backend_classifier_and_cache_eligibility_state() {
+        let stats = StatsAccumulator::default();
+        stats.record_success("model/a", 10.0, Some("strong"));
+        stats.record_usage("model/a", usage(10, 5), 15.0, Some("strong"));
+        stats.record_routing_overhead(5.0);
+        stats.record_classifier_success("model/classifier", Some(usage(4, 1)), 2.0);
+        let probe = prefix_probe(&json!({
+            "messages": [{"role": "user", "content": "repeat me"}],
+        }));
+        stats.prefix_eligibility("model/a", &probe);
+
+        stats.reset();
+
+        assert_eq!(stats.snapshot(), StatsSnapshot::default());
+        assert_eq!(stats.prefix_eligibility("model/a", &probe), 0.0);
     }
 
     #[test]

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -297,6 +297,40 @@ async fn stats_accumulates_buffered_success_error_and_shared_routes() -> TestRes
 }
 
 #[tokio::test]
+async fn stats_reset_returns_confirmation_and_clears_all_stats() -> TestResult {
+    let (_upstream, app) = test_app(&[(ROUTE_MODEL, &["model/a"])]).await?;
+    assert_eq!(
+        send(
+            &app,
+            "POST",
+            "/v1/chat/completions",
+            Some(json!({
+                "model": ROUTE_MODEL,
+                "messages": [{"role": "user", "content": "hello"}]
+            })),
+        )
+        .await?
+        .status,
+        StatusCode::OK
+    );
+
+    let reset = send(&app, "POST", "/v1/stats/reset", None).await?;
+    assert_eq!(reset.status, StatusCode::OK);
+    assert_eq!(reset.json()?, json!({"status": "reset"}));
+
+    let stats = send(&app, "GET", "/v1/stats", None).await?.json()?;
+    assert_eq!(stats["total_requests"], 0);
+    assert_eq!(stats["total_errors"], 0);
+    assert_eq!(stats["total_tokens"], empty_token_totals());
+    assert_eq!(stats["models"], json!({}));
+    assert_eq!(stats["tiers"], json!({}));
+    assert_eq!(stats["routing_overhead"]["count"], 0);
+    assert_eq!(stats["classifier"]["total_requests"], 0);
+    assert_eq!(stats["classifier"]["models"], json!({}));
+    Ok(())
+}
+
+#[tokio::test]
 async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
     const MODEL: &str = "model/metrics-buffered";
     let (_upstream, app) = test_app(&[(ROUTE_MODEL, &[MODEL])]).await?;


### PR DESCRIPTION
Clears the stats.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to reset runtime statistics.
  * Reset responses now confirm successful completion.
  * All tracked request, token, routing, classifier, model, tier, and cache statistics are cleared.

* **Bug Fixes**
  * Ensured statistics reset consistently returns empty counters and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->