### PR TITLE
chore(switchyard-server): A single version of reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1107,7 +1106,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -1122,7 +1121,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "thiserror 2.0.18",
 ]
 
@@ -1594,47 +1593,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1658,15 +1616,19 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -1720,7 +1682,6 @@ checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2019,7 +1980,7 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "rand 0.8.7",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "switchyard-libsy",
@@ -2060,7 +2021,7 @@ dependencies = [
  "futures-util",
  "httpdate",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "switchyard-protocol",
  "switchyard-translation",
@@ -2645,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2681,15 +2642,6 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "0.3"
 httpdate = "1"
 parking_lot = "0.12"
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 switchyard-components = { path = "crates/switchyard-components", version = "0.1.0" }

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -23,8 +23,8 @@ libsy = { package = "switchyard-libsy", path = "../libsy" }
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "metrics", "reqwest-blocking-client", "reqwest-rustls", "trace"] }
 opentelemetry-prometheus = "0.32"
-parking_lot.workspace = true
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics", "trace"] }
+parking_lot.workspace = true
 prometheus = "0.14"
 serde.workspace = true
 toml = "1.1"

--- a/crates/switchyard-server/src/metrics.rs
+++ b/crates/switchyard-server/src/metrics.rs
@@ -21,7 +21,7 @@ const ROUTING_OVERHEAD_BUCKETS_MS: &[f64] = &[
 
 struct Metrics {
     registry: Registry,
-    _provider: SdkMeterProvider,
+    provider: SdkMeterProvider,
 }
 
 static METRICS: OnceLock<Result<Metrics, String>> = OnceLock::new();
@@ -59,15 +59,12 @@ fn initialize() -> Result<Metrics, String> {
         .build()
         .record(1, &[KeyValue::new("version", env!("CARGO_PKG_VERSION"))]);
     seed_outcome_metrics();
-    Ok(Metrics {
-        registry,
-        _provider: provider,
-    })
+    Ok(Metrics { registry, provider })
 }
 
 pub(crate) fn flush() {
     if let Some(Ok(metrics)) = METRICS.get() {
-        if let Err(error) = metrics._provider.force_flush() {
+        if let Err(error) = metrics.provider.force_flush() {
             tracing::warn!(error = %error, "failed to flush OpenTelemetry metrics");
         }
     }


### PR DESCRIPTION
Debug binary shrinks from 192 MiB to 180 MiB.

Also minor rename of `_provider` var.

Fast follow to https://github.com/NVIDIA-NeMo/Switchyard/pull/210

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the networking library and TLS configuration to newer supported components.
  * Refined internal dependency organization and telemetry handling.
  * No user-facing features or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->