### PR TITLE
fix(server): reuse observability filter for OTEL spans

### DIFF
--- a/crates/switchyard-server/src/observability.rs
+++ b/crates/switchyard-server/src/observability.rs
@@ -15,9 +15,7 @@ use tracing_subscriber::{EnvFilter, Layer as _};
 
 use crate::{metrics, ServerError, ServerResult};
 
-const DEFAULT_LOG_FILTER: &str = "switchyard_server=info";
-const OPENTELEMETRY_LOG_FILTER: &str = "opentelemetry=warn";
-const OTEL_SPAN_FILTER: &str = "libsy=info";
+const DEFAULT_LOG_FILTER: &str = "switchyard_server=info,libsy=info,opentelemetry=warn";
 const DEFAULT_SERVICE_NAME: &str = "switchyard-server";
 
 struct Observability {
@@ -83,13 +81,7 @@ fn initialize() -> Result<Observability, String> {
     let tracer_provider = otlp_enabled("TRACES")
         .then(build_tracer_provider)
         .transpose()?;
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_FILTER))
-        .add_directive(
-            OPENTELEMETRY_LOG_FILTER
-                .parse()
-                .map_err(|error| format!("invalid OpenTelemetry log filter: {error}"))?,
-        );
+    let filter = log_filter()?;
     let format = tracing_subscriber::fmt::layer()
         .with_ansi(false)
         .with_writer(std::io::stderr)
@@ -102,7 +94,7 @@ fn initialize() -> Result<Observability, String> {
             .with(
                 tracing_opentelemetry::layer()
                     .with_tracer(tracer)
-                    .with_filter(EnvFilter::new(OTEL_SPAN_FILTER)),
+                    .with_filter(log_filter()?),
             )
             .try_init()
             .map_err(|error| format!("failed to initialize tracing: {error}"))?;
@@ -114,6 +106,12 @@ fn initialize() -> Result<Observability, String> {
     }
 
     Ok(Observability { tracer_provider })
+}
+
+fn log_filter() -> Result<EnvFilter, String> {
+    EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(DEFAULT_LOG_FILTER))
+        .map_err(|error| format!("invalid tracing filter: {error}"))
 }
 
 fn build_tracer_provider() -> Result<SdkTracerProvider, String> {


### PR DESCRIPTION
## What

Follow-up to #210 for Graham's observability review comment:

- Fold `libsy=info` into the default comma-separated observability filter.
- Remove the hard-coded `OTEL_SPAN_FILTER` path.
- Apply the same `RUST_LOG`/default filter construction to the OpenTelemetry tracing layer.

## Why

The previous OTEL span filter was fixed at compile time, so users could override log formatting with `RUST_LOG` but not the spans exported through OTEL. Using the same filter builder keeps logs and exported spans aligned.

## How

Adds a small `log_filter()` helper that reads `RUST_LOG` through `EnvFilter::try_from_default_env()` and falls back to:

```text
switchyard_server=info,libsy=info,opentelemetry=warn
```

Both the formatting layer and the OTEL layer now use that same filter behavior.

## Review

This intentionally only addresses https://github.com/NVIDIA-NeMo/Switchyard/pull/210#discussion_r3686129788 and https://github.com/NVIDIA-NeMo/Switchyard/pull/210#discussion_r3686134772.

No new tests were added; this is a focused observability wiring cleanup.

## Validation

- `cargo fmt --all --check`
- `cargo test -p switchyard-server`
- `cargo clippy -p switchyard-server --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved logging and observability configuration for more consistent application and telemetry output.
  * Default logging now includes relevant application and OpenTelemetry messages.
  * Environment-based log filtering is applied consistently across standard logs and telemetry traces.
  * Added a reliable fallback configuration when custom logging settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->