### PR TITLE
fix(llm-client): filter inbound Anthropic beta headers

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -42,6 +42,7 @@ const RESERVED_HEADERS: &[&str] = &[
     "cookie",
     "set-cookie",
     "x-api-key",
+    "anthropic-beta",
     "anthropic-version",
     "content-type",
 ];


### PR DESCRIPTION
## What

Filter caller-supplied `anthropic-beta` headers from upstream LLM requests.

## Why

Claude Code can send beta identifiers that an upstream Anthropic deployment does not support, causing otherwise valid requests to fail with HTTP 400.

## How

Add `anthropic-beta` to the LLM client's reserved header set. Backends can still set an explicit supported value through `extra_headers`.

## What To Review

- The single reserved-header addition.

## Validation

- Live Claude Code request to `azure/anthropic/claude-haiku-4-5` failed before the filter and succeeded after it.
- No tests added or run, as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved the `anthropic-beta` header to prevent caller-provided metadata from being forwarded or overriding the client’s configured value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->