### PR TITLE
chore: rc prep and version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "!v*-*"
   workflow_dispatch:
     inputs:
       build_dev_artifact:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "switchyard-components"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-libsy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-llm-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-py"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-skill-distillation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "switchyard-translation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.2.0"
 authors = ["NVIDIA Corporation"]
 edition = "2021"
 license = "Apache-2.0"
@@ -32,12 +33,12 @@ rand = "0.8"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-switchyard-components = { path = "crates/switchyard-components", version = "0.1.0" }
-switchyard-libsy = { path = "crates/libsy", version = "0.1.0" }
-switchyard-llm-client = { path = "crates/libsy-llm-client", version = "0.1.0" }
-switchyard-protocol = { path = "crates/protocol", version = "0.1.0" }
-switchyard-server = { path = "crates/switchyard-server", version = "0.1.0" }
-switchyard-translation = { path = "crates/switchyard-translation", version = "0.1.0" }
+switchyard-components = { path = "crates/switchyard-components", version = "0.2.0" }
+switchyard-libsy = { path = "crates/libsy", version = "0.2.0" }
+switchyard-llm-client = { path = "crates/libsy-llm-client", version = "0.2.0" }
+switchyard-protocol = { path = "crates/protocol", version = "0.2.0" }
+switchyard-server = { path = "crates/switchyard-server", version = "0.2.0" }
+switchyard-translation = { path = "crates/switchyard-translation", version = "0.2.0" }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes", "std"] }

--- a/crates/libsy-llm-client/Cargo.toml
+++ b/crates/libsy-llm-client/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-llm-client"
-version = "0.1.0"
+version.workspace = true
 description = "HTTP LLM client speaking Switchyard's neutral IR directly"
 authors.workspace = true
 edition.workspace = true

--- a/crates/libsy/Cargo.toml
+++ b/crates/libsy/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-libsy"
-version = "0.1.0"
+version.workspace = true
 description = "Switchyard library crate"
 authors.workspace = true
 edition.workspace = true

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-protocol"
-version = "0.1.0"
+version.workspace = true
 description = "Provider-neutral LLM protocol types for Switchyard"
 authors.workspace = true
 edition.workspace = true

--- a/crates/switchyard-components/Cargo.toml
+++ b/crates/switchyard-components/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-components"
-version = "0.1.0"
+version.workspace = true
 description = "Concrete Switchyard backends and processors"
 authors.workspace = true
 edition.workspace = true

--- a/crates/switchyard-py/Cargo.toml
+++ b/crates/switchyard-py/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-py"
-version = "0.1.0"
+version.workspace = true
 description = "PyO3 bindings for Switchyard Rust crates"
 authors.workspace = true
 edition.workspace = true

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-server"
-version = "0.1.0"
+version.workspace = true
 description = "Rust HTTP server surface for libsy algorithms"
 authors.workspace = true
 edition.workspace = true

--- a/crates/switchyard-skill-distillation/Cargo.toml
+++ b/crates/switchyard-skill-distillation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-skill-distillation"
-version = "0.1.0"
+version.workspace = true
 description = "Source-neutral Rust contracts for Switchyard skill distillation"
 authors.workspace = true
 edition.workspace = true

--- a/crates/switchyard-translation/Cargo.toml
+++ b/crates/switchyard-translation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "switchyard-translation"
-version = "0.1.0"
+version.workspace = true
 description = "Pure Rust request, response, and stream translation for Switchyard"
 authors.workspace = true
 edition.workspace = true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ nav:
   - Home: index.md
   - Get Started:
       - Getting Started: getting_started.md
-      - Known Issues in 0.1.0: known_issues.md
+      - Known Issues: known_issues.md
   - Concepts:
       - Core Concepts: core_concepts.md
       - Architecture: architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nemo-switchyard"
-version = "0.1.0"
+version = "0.2.0"
 description = "Typed, composable LLM routing with request/response translation and multi-backend orchestration"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2186,7 +2186,7 @@ wheels = [
 
 [[package]]
 name = "nemo-switchyard"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps the workspace and Python package to 0.2.0 ahead of the first release candidate.

- Crates inherit `version` from `[workspace.package]`, so future bumps are one line
- Publish workflow now skips prerelease tags (`!v*-*`)
- Drops the hardcoded version from the known-issues nav label

Without this, the release tag check fails, since it requires the tag to equal `v` + the pyproject version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Updated the project version to 0.2.0 across supported packages and distributions.
  * Improved release handling so prerelease tags are not published automatically.

* **Documentation**
  * Simplified the navigation label for known issues by removing the outdated version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->