### PR TITLE
docs(server): document the HTTP endpoints

### DIFF
--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -101,6 +101,24 @@ tier per turn, without an extra classifier call on every turn. `capable_target`,
 are required. Optional handoff notes, per-tier system prompts, and a capability-judge fallback are
 documented in [Stage-Router Routing](../../docs/routing_algorithms/stage_router_routing.md).
 
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/v1/chat/completions` | OpenAI Chat Completions |
+| `POST` | `/v1/messages` | Anthropic Messages |
+| `POST` | `/v1/responses` | OpenAI Responses |
+| `POST` | `/v1/messages/count_tokens` | Anthropic token count |
+| `GET` | `/v1/models` | Routes served by this deployment |
+| `GET` | `/v1/stats` | Per-model request, token, and cost totals |
+| `POST` | `/v1/stats/reset` | Clear accumulated stats |
+| `GET` | `/metrics` | Prometheus text, see [Metrics](#metrics) |
+| `GET` | `/health` | Liveness |
+
+Requests name a route by its `id`, so `POST /v1/chat/completions` with `"model": "switchyard/general"`
+routes through the `[routes.general]` entry above. Any of the three request formats can address any
+route, and the server translates between them.
+
 ## Metrics
 
 `GET /metrics` exposes Prometheus text from the server's process-wide OpenTelemetry provider.


### PR DESCRIPTION
Adds an endpoint table to the switchyard-server README.

Previously only `GET /metrics` was documented, so the other eight routes were discoverable only by reading `lib.rs`. Table verified against the router registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Endpoints section documenting supported API routes, including chat, messaging, response, token counting, model, statistics, metrics, and health endpoints.
  * Documented model-based route selection and cross-format request translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->