### PR TITLE
fix(observability): classify spans for Intake

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -192,6 +192,7 @@ impl TranslatingLlmClient {
                 attempt = attempt + 1,
                 max_attempts,
                 retry = attempt > 0,
+                openinference.span.kind = "CHAIN",
                 outcome = tracing::field::Empty,
                 status_code = tracing::field::Empty,
                 will_retry = tracing::field::Empty,

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -192,6 +192,7 @@ impl Driver {
         fields(
             algorithm = observability::algorithm_label(&routed.ctx),
             selected_model = routed.decision.selected_model(),
+            openinference.span.kind = "CHAIN",
             outcome = tracing::field::Empty,
             error = tracing::field::Empty,
             input_tokens = tracing::field::Empty,
@@ -689,6 +690,7 @@ pub trait Algorithm: Send + Sync + 'static {
                 selected_model = call.get_decision().selected_model(),
                 otel.kind = "client",
                 otel.name = %format_args!("chat {}", call.get_decision().selected_model()),
+                openinference.span.kind = "LLM",
                 gen_ai.operation.name = "chat",
                 gen_ai.request.model = call.get_decision().selected_model(),
                 gen_ai.request.stream = tracing::field::Empty,

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -116,6 +116,7 @@ pub(crate) fn run_span(algorithm: &str, request: &Request) -> Span {
         "libsy.run",
         algorithm,
         switchyard.algorithm = algorithm,
+        openinference.span.kind = "CHAIN",
         switchyard.route = tracing::field::Empty,
         session_id = tracing::field::Empty,
         session.id = tracing::field::Empty,

--- a/crates/switchyard-server/src/observability.rs
+++ b/crates/switchyard-server/src/observability.rs
@@ -55,6 +55,7 @@ pub(crate) fn request_span(headers: &HeaderMap) -> tracing::Span {
         target: "switchyard_server",
         "switchyard.request",
         otel.kind = "server",
+        openinference.span.kind = "CHAIN",
     );
     let _ = span.set_parent(parent);
     span


### PR DESCRIPTION
## What
Add OpenInference span kinds to Switchyard OTEL spans.

## Why
Intake derives its displayed kind from `openinference.span.kind`, so spans carrying only GenAI attributes render as `UNKNOWN`.

## How
- classify request and orchestration spans as `CHAIN`
- classify the GenAI client-call span as `LLM`
- match the convention emitted by NeMo Relay

## What to review
Confirm the five existing span sites use the intended OpenInference classification.

## Validation
No tests run, per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Added OpenInference span-kind metadata to application runs, server requests, algorithm operations, and LLM calls.
  * Improved tracing consistency for request attempts and chained operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->