### PR TITLE
fix(server): quote startup curl example

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -967,13 +967,15 @@ fn startup_banner(options: &ServerRunOptions, state: &ServerState, color: bool) 
         "model": example_model,
         "messages": [{"role": "user", "content": "Hello from Switchyard"}],
     });
+    let example_url = shell_quote(&format!("{request_url}/v1/chat/completions"));
+    let example_body = shell_quote(&example_body.to_string());
     format!(
-        "{}\nSwitchyard libsy server\n  listening: {}\n  routes: {}\n\nendpoints:\n{}\n\nexample:\n  curl -s {}/v1/chat/completions \\\n    -H 'Content-Type: application/json' \\\n    -d '{}'",
+        "{}\nSwitchyard libsy server\n  listening: {}\n  routes: {}\n\nendpoints:\n{}\n\nexample:\n  curl -s {} \\\n    -H 'Content-Type: application/json' \\\n    -d {}",
         render_startup_banner_art(color),
         listen_url,
         route_list,
         endpoint_listing(state.routing_log.is_some()),
-        request_url,
+        example_url,
         example_body,
     )
 }
@@ -1004,6 +1006,7 @@ fn url_for_addr(scheme: &'static str, addr: SocketAddr) -> String {
     format!("{scheme}://{}:{}", host_for_url(addr.ip()), addr.port())
 }
 
+// Use loopback in request examples when the listener binds all interfaces.
 fn request_url_for_addr(scheme: &'static str, addr: SocketAddr) -> String {
     let host = if addr.ip().is_unspecified() {
         match addr.ip() {
@@ -1016,11 +1019,16 @@ fn request_url_for_addr(scheme: &'static str, addr: SocketAddr) -> String {
     format!("{scheme}://{host}:{}", addr.port())
 }
 
+// Bracket IPv6 literals so they are valid inside a URL authority.
 fn host_for_url(ip: std::net::IpAddr) -> String {
     match ip {
         std::net::IpAddr::V4(ip) => ip.to_string(),
         std::net::IpAddr::V6(ip) => format!("[{ip}]"),
     }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn endpoint_listing(has_routing_log: bool) -> String {


### PR DESCRIPTION
## What

Quotes the startup banner's example `curl` command so it remains copy-pasteable when:

- the request URL contains IPv6 brackets, such as `http://[::1]:4000`
- the generated JSON body contains an apostrophe from a configured route id

Also adds two concise comments documenting the non-obvious URL normalization behavior that CodeRabbit flagged.

## Why

CodeRabbit was right: PR #234 could print invalid shell when a valid configured route id contained an apostrophe. A live server repro with route id `switchyard/it's-valid` showed the original banner emitted:

```bash
-d '{"model":"switchyard/it's-valid",...}'
```

which breaks single-quoted shell parsing.

## How

Adds a tiny `shell_quote` helper for the generated URL and JSON body. It wraps values in single quotes and escapes embedded apostrophes using the standard `'\''` shell representation.

## Validation

- `cargo check -p switchyard-server`
- commit hooks ran `cargo fmt` and `cargo clippy`
- live local server check:
  - config used no-op route id `switchyard/it's-valid`
  - server bound to IPv6 unspecified address with `--host :: --port 0`
  - banner printed quoted `http://[::1]:...`
  - curl to `/v1/chat/completions` returned `200` with model `switchyard/it's-valid`

No test files were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup-banner request examples with safer shell quoting for URLs and JSON payloads.
  * Corrected generated URLs for wildcard listeners and IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->