### PR TITLE
chore: Upgrade Rust edition to 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,22 +1476,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -1508,31 +1497,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1985,7 +1955,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2006,7 +1976,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "parking_lot",
- "rand 0.8.7",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "switchyard-llm-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "crates/libsy",
     "crates/libsy-llm-client",
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 version = "0.2.0"
 authors = ["NVIDIA Corporation"]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA-NeMo/Switchyard"
 rust-version = "1.96.1"
@@ -29,7 +29,7 @@ futures = "0.3"
 futures-util = "0.3"
 httpdate = "1"
 parking_lot = "0.12"
-rand = "0.8"
+rand = "0.10"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -300,8 +300,11 @@ mod tests {
     #[test]
     fn openai_detects_canonical_and_wrapped_overflow() {
         let backend = Backend::OpenAiChat(config("x"));
-        assert!(backend
-            .is_context_overflow(r#"{"error":{"code":"context_length_exceeded","message":"x"}}"#));
+        assert!(
+            backend.is_context_overflow(
+                r#"{"error":{"code":"context_length_exceeded","message":"x"}}"#
+            )
+        );
         // NVIDIA/LiteLLM message wrap with no structured code.
         assert!(backend.is_context_overflow(
             r#"{"error":{"message":"the model's context length is only 131072 tokens"}}"#
@@ -312,8 +315,11 @@ mod tests {
     #[test]
     fn anthropic_detects_prompt_too_long() {
         let backend = Backend::Anthropic(config("x"));
-        assert!(backend
-            .is_context_overflow(r#"{"error":{"message":"prompt is too long: 200000 tokens"}}"#));
+        assert!(
+            backend.is_context_overflow(
+                r#"{"error":{"message":"prompt is too long: 200000 tokens"}}"#
+            )
+        );
         assert!(!backend.is_context_overflow(r#"{"error":{"message":"overloaded"}}"#));
     }
 }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -9,15 +9,15 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use reqwest::header::{HeaderMap, RETRY_AFTER};
 use reqwest::RequestBuilder;
+use reqwest::header::{HeaderMap, RETRY_AFTER};
 use serde_json::{Map, Value};
 use switchyard_protocol::{
     Context, Decision, LlmRequest, LlmResponse, Metadata, Request, Response, RoutedLlmClient,
 };
 use switchyard_translation::{
-    decode_aggregated_response, decode_request, decode_stream, encode_aggregated_response,
-    encode_request, encode_stream, WireFormat,
+    WireFormat, decode_aggregated_response, decode_request, decode_stream,
+    encode_aggregated_response, encode_request, encode_stream,
 };
 use tracing::Instrument;
 
@@ -515,7 +515,7 @@ impl RoutedLlmClient for TranslatingLlmClient {
             EncodedResponse::Streaming(_) => {
                 return Err(LlmClientError::InvalidRequest {
                     message: "count_tokens does not support streaming requests".to_string(),
-                })
+                });
             }
         };
         serde_json::from_slice(&body).map_err(|error| LlmClientError::InvalidResponse {
@@ -714,12 +714,12 @@ mod tests {
     use std::collections::BTreeMap;
     use std::error::Error;
     use std::io::{Read, Write};
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::JoinHandle;
 
     use serde_json::json;
-    use switchyard_protocol::{completion_text, text_request, LlmRequest};
+    use switchyard_protocol::{LlmRequest, completion_text, text_request};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -852,8 +852,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_model_errors(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn missing_model_errors()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let client = TranslatingLlmClient::new(&[])?;
         let Err(error) = client
             .call_rewrite_model(Context::default(), request_for(None, false), None)
@@ -869,8 +869,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_model_errors(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn unknown_model_errors()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let client = TranslatingLlmClient::new(&[])?;
         let Err(error) = client
             .call_rewrite_model(Context::default(), request_for(Some("gpt"), false), None)
@@ -887,8 +887,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_model_format_errors(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn unknown_model_format_errors()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         // "gpt" exists but only over OpenAI Chat; the request pins Anthropic.
         let client = TranslatingLlmClient::new(&chat_map("https://example.test/v1"))?;
         let Err(error) = client
@@ -911,23 +911,27 @@ mod tests {
     }
 
     #[test]
-    fn backend_for_resolves_configured_format(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    fn backend_for_resolves_configured_format()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let client = TranslatingLlmClient::new(&chat_map("https://example.test/v1"))?;
         // "gpt" is served over OpenAI Chat only; other formats and models miss.
         assert!(client.backend_for("gpt", WireFormat::OpenAiChat).is_some());
-        assert!(client
-            .backend_for("gpt", WireFormat::AnthropicMessages)
-            .is_none());
-        assert!(client
-            .backend_for("missing", WireFormat::OpenAiChat)
-            .is_none());
+        assert!(
+            client
+                .backend_for("gpt", WireFormat::AnthropicMessages)
+                .is_none()
+        );
+        assert!(
+            client
+                .backend_for("missing", WireFormat::OpenAiChat)
+                .is_none()
+        );
         Ok(())
     }
 
     #[tokio::test]
-    async fn model_name_arg_wins_over_request_model(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn model_name_arg_wins_over_request_model()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let client = TranslatingLlmClient::new(&[])?;
         // Arg "b" is looked up (and reported), not the request's "a".
         let Err(error) = client
@@ -945,8 +949,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn buffered_openai_chat_round_trips(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn buffered_openai_chat_round_trips()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -975,8 +979,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_json_is_a_response_translation_error(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn invalid_json_is_a_response_translation_error()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = Arc::clone(&calls);
@@ -1007,8 +1011,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_body_io_failure_is_a_transport_error(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn response_body_io_failure_is_a_transport_error()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let (base_url, server) = truncated_response_server("application/json", "{}")?;
         let client = TranslatingLlmClient::new(&chat_map(&base_url))?;
         let result = client
@@ -1028,14 +1032,16 @@ mod tests {
             panic!("expected the reqwest transport source");
         };
         assert!(source.is_decode());
-        assert!(!std::error::Error::source(&source)
-            .is_some_and(|source| source.is::<serde_json::Error>()));
+        assert!(
+            !std::error::Error::source(&source)
+                .is_some_and(|source| source.is::<serde_json::Error>())
+        );
         Ok(())
     }
 
     #[tokio::test]
-    async fn response_body_transport_failures_are_retried(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn response_body_transport_failures_are_retried()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let truncated_responses = [
             "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
              Content-Length: 102\r\nConnection: close\r\n\r\n{}",
@@ -1063,8 +1069,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_body_io_failure_preserves_transport_error(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn streaming_body_io_failure_preserves_transport_error()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let body = "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n";
         let (base_url, server) = truncated_response_server("text/event-stream", body)?;
         let client = TranslatingLlmClient::new(&chat_map_with_retries(&base_url, 2))?;
@@ -1085,8 +1091,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rewrites_model_to_resolved_upstream_id(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn rewrites_model_to_resolved_upstream_id()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         // Inbound body says "switchyard"; the upstream must receive "gpt".
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -1114,8 +1120,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extra_body_adds_defaults_without_overriding_the_request(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn extra_body_adds_defaults_without_overriding_the_request()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -1164,8 +1170,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_openai_chat_aggregates(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn streaming_openai_chat_aggregates()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
              data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n\
@@ -1196,8 +1202,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_openai_chat_preserves_usage_opt_out(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn streaming_openai_chat_preserves_usage_opt_out()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -1233,8 +1239,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upstream_500_is_upstream_http(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn upstream_500_is_upstream_http()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
@@ -1257,8 +1263,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retryable_http_failure_recovers_within_budget(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn retryable_http_failure_recovers_within_budget()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = Arc::clone(&calls);
@@ -1288,8 +1294,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deterministic_http_failure_is_not_retried(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn deterministic_http_failure_is_not_retried()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = Arc::clone(&calls);
@@ -1322,8 +1328,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_exhaustion_returns_the_final_upstream_error(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn retry_exhaustion_returns_the_final_upstream_error()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = Arc::clone(&calls);
@@ -1358,8 +1364,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn timeout_is_retried_before_a_response_is_returned(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn timeout_is_retried_before_a_response_is_returned()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = Arc::clone(&calls);
@@ -1464,8 +1470,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn routed_llm_client_exposes_timeout_variant(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn routed_llm_client_exposes_timeout_variant()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .respond_with(
@@ -1497,8 +1503,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn context_overflow_400_is_mapped(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn context_overflow_400_is_mapped()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(400).set_body_json(json!({
@@ -1523,8 +1529,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forwards_metadata_headers_except_reserved(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn forwards_metadata_headers_except_reserved()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(wiremock::matchers::header("x-request-id", "abc"))
@@ -1587,8 +1593,8 @@ mod tests {
     // Exercises the `RoutedLlmClient` impl: `call` resolves the upstream model from the
     // decision (the request carries none) and round-trips a buffered response.
     #[tokio::test]
-    async fn routed_llm_client_serves_the_decision_model(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn routed_llm_client_serves_the_decision_model()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -1617,8 +1623,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_raw_request_is_a_request_translation_error(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn invalid_raw_request_is_a_request_translation_error()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let client = TranslatingLlmClient::new(&[])?;
         let Err(error) = client
             .call_rewrite_model_raw(
@@ -1643,8 +1649,8 @@ mod tests {
     // Raw path, buffered: decode an OpenAI Chat body -> call -> encode back to OpenAI
     // Chat JSON, with the served `model` restamped over the id the caller addressed.
     #[tokio::test]
-    async fn call_rewrite_model_raw_round_trips_buffered_json(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn call_rewrite_model_raw_round_trips_buffered_json()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -1688,8 +1694,8 @@ mod tests {
     // Raw path, streaming: an inbound `stream: true` request yields an unframed stream
     // of OpenAI Chat chunk objects whose deltas reassemble the completion.
     #[tokio::test]
-    async fn call_rewrite_model_raw_streams_wire_events(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn call_rewrite_model_raw_streams_wire_events()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         use futures::TryStreamExt;
 
         let server = MockServer::start().await;
@@ -1736,8 +1742,8 @@ mod tests {
 
     // Raw path forwards caller headers (minus the reserved set) to the upstream.
     #[tokio::test]
-    async fn call_rewrite_model_raw_forwards_headers(
-    ) -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    async fn call_rewrite_model_raw_forwards_headers()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(wiremock::matchers::header("x-request-id", "abc"))

--- a/crates/libsy-llm-client/src/error.rs
+++ b/crates/libsy-llm-client/src/error.rs
@@ -35,11 +35,9 @@ where
             .get("error")
             .and_then(|err| err.get("message"))
             .and_then(Value::as_str)
-        {
-            if contains_any(message, phrases) {
+            && contains_any(message, phrases) {
                 return true;
             }
-        }
     }
     // Some upstream proxies return plain-text bodies; fall through to a string
     // match on the raw body.

--- a/crates/libsy-llm-client/src/error.rs
+++ b/crates/libsy-llm-client/src/error.rs
@@ -35,9 +35,10 @@ where
             .get("error")
             .and_then(|err| err.get("message"))
             .and_then(Value::as_str)
-            && contains_any(message, phrases) {
-                return true;
-            }
+            && contains_any(message, phrases)
+        {
+            return true;
+        }
     }
     // Some upstream proxies return plain-text bodies; fall through to a string
     // match on the raw body.

--- a/crates/libsy-llm-client/src/lib.rs
+++ b/crates/libsy-llm-client/src/lib.rs
@@ -17,7 +17,7 @@ pub mod error;
 pub mod metrics;
 pub mod raw;
 
-pub use backend::{Backend, HttpBackendConfig, DEFAULT_MAX_RETRIES};
+pub use backend::{Backend, DEFAULT_MAX_RETRIES, HttpBackendConfig};
 pub use client::{ModelConfig, TranslatingLlmClient};
 pub use error::{LlmClientError, Result};
 pub use raw::RawResponse;

--- a/crates/libsy-llm-client/src/metrics.rs
+++ b/crates/libsy-llm-client/src/metrics.rs
@@ -3,7 +3,7 @@
 
 //! Metric labelling inherited from Python
 
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 
 pub(crate) const fn is_retryable_http_status(status: u16) -> bool {
     status == 408 || status == 429 || (status >= 500 && status <= 599)

--- a/crates/libsy/examples/ensemble.rs
+++ b/crates/libsy/examples/ensemble.rs
@@ -27,8 +27,8 @@ use parking_lot::Mutex;
 use switchyard_libsy::{Algorithm, Driver, LibsyError, LlmTarget, LlmTargetSet, Result};
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
 use switchyard_protocol::{
-    completion_text, prompt_text, text_request, Context, Decision, Request, Response,
-    RoutedLlmClient,
+    Context, Decision, Request, Response, RoutedLlmClient, completion_text, prompt_text,
+    text_request,
 };
 
 const CANDIDATE_MODELS: [&str; 3] = [
@@ -469,8 +469,8 @@ mod tests {
     use super::*;
     use switchyard_libsy::LlmTarget;
     use switchyard_protocol::{
-        completion_text, prompt_text, text_request, text_response, LlmResponse, Response,
-        RoutedLlmClient, Signals,
+        LlmResponse, Response, RoutedLlmClient, Signals, completion_text, prompt_text,
+        text_request, text_response,
     };
 
     /// Mock client that answers candidate calls with `answer from {model}` and,
@@ -742,10 +742,12 @@ mod tests {
                 target("judge/haiku"),
             ]),
         );
-        assert!(orch(algo)
-            .run(Context::default(), request("x"))
-            .await
-            .is_err());
+        assert!(
+            orch(algo)
+                .run(Context::default(), request("x"))
+                .await
+                .is_err()
+        );
         Ok(())
     }
 

--- a/crates/libsy/examples/research_agent.rs
+++ b/crates/libsy/examples/research_agent.rs
@@ -18,8 +18,8 @@ use switchyard_libsy::{
     Algorithm, LibsyError, LlmTarget, LlmTargetSet, LlmTaskClassifier, Result, TaskClassifierConfig,
 };
 use switchyard_protocol::{
-    completion_text, text_request, text_response, Context, Decision, LlmResponse, Request,
-    Response, RoutedLlmClient,
+    Context, Decision, LlmResponse, Request, Response, RoutedLlmClient, completion_text,
+    text_request, text_response,
 };
 
 const CLASSIFIER: &str = "classifier/model";

--- a/crates/libsy/examples/research_agent_core.rs
+++ b/crates/libsy/examples/research_agent_core.rs
@@ -16,7 +16,7 @@ use switchyard_libsy::{
     TaskClassifierConfig,
 };
 use switchyard_protocol::{
-    completion_text, text_request, text_response, Context, Decision, LlmResponse, Request, Response,
+    Context, Decision, LlmResponse, Request, Response, completion_text, text_request, text_response,
 };
 use tokio_stream::StreamExt;
 

--- a/crates/libsy/examples/streaming_agent.rs
+++ b/crates/libsy/examples/streaming_agent.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use futures::StreamExt;
 use switchyard_libsy::{Algorithm, LibsyError, LlmTarget, LlmTargetSet, Random, Result, Step};
 use switchyard_protocol::{
-    completion_text, text_request, Context, LlmResponse, LlmResponseChunk, LlmResponseStream,
-    Request, Response,
+    Context, LlmResponse, LlmResponseChunk, LlmResponseStream, Request, Response, completion_text,
+    text_request,
 };
 
 /// The "real" model call the agent makes to fulfill an offloaded promise: a response

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -356,8 +356,8 @@ mod tests {
     use crate::{SystemPromptProcessor, TargetPrompts};
 
     use switchyard_protocol::{
-        completion_text, text_request, text_response, LlmClientError, LlmRequest, LlmResponse,
-        Message, Metadata, Role,
+        LlmClientError, LlmRequest, LlmResponse, Message, Metadata, Role, completion_text,
+        text_request, text_response,
     };
 
     #[derive(Debug, thiserror::Error)]
@@ -922,9 +922,11 @@ mod tests {
 
         assert_eq!(text, "strong");
         assert_eq!(trace[0].selected_model(), "strong");
-        assert!(trace[0]
-            .reasoning()
-            .is_some_and(|r| r.contains("fell back to strong")));
+        assert!(
+            trace[0]
+                .reasoning()
+                .is_some_and(|r| r.contains("fell back to strong"))
+        );
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -574,7 +574,7 @@ mod tests {
 
     use super::*;
     use switchyard_protocol::{
-        completion_text, text_request, text_response, LlmClientError, Metadata,
+        LlmClientError, Metadata, completion_text, text_request, text_response,
     };
 
     use crate::core::algorithm::Algorithm;
@@ -1112,12 +1112,16 @@ mod tests {
             .ok_or_else(|| LibsyError::AlgorithmError {
                 message: "rendered response schema has no primary rule enum".to_string(),
             })?;
-        assert!(rule_values
-            .iter()
-            .any(|value| value.as_str() == Some("SUP-1")));
-        assert!(rule_values
-            .iter()
-            .any(|value| value.as_str() == Some("none")));
+        assert!(
+            rule_values
+                .iter()
+                .any(|value| value.as_str() == Some("SUP-1"))
+        );
+        assert!(
+            rule_values
+                .iter()
+                .any(|value| value.as_str() == Some("none"))
+        );
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -10,8 +10,8 @@ use switchyard_protocol::{
     AggLlmResponse, ContentBlock, LlmResponse, Request, Response, ResponseOutput, Role, StopReason,
 };
 
-use crate::core::algorithm::{Algorithm, Driver};
 use crate::Result;
+use crate::core::algorithm::{Algorithm, Driver};
 use switchyard_protocol::{Context, Decision};
 
 /// A routing algorithm that does not route. It returns a hard-coded response.

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use switchyard_protocol::{Request, Response};
 
-use crate::core::algorithm::{Algorithm, Driver, LlmTarget};
 use crate::Result;
+use crate::core::algorithm::{Algorithm, Driver, LlmTarget};
 use switchyard_protocol::{Context, Decision, RoutedLlmClient};
 
 /// See module comment
@@ -78,8 +78,8 @@ mod tests {
     use super::Passthrough;
     use crate::core::algorithm::{Algorithm, LlmTarget};
     use switchyard_protocol::{
-        completion_text, text_request, text_response, Context, Decision, LlmResponse, Request,
-        Response, RoutedLlmClient,
+        Context, Decision, LlmResponse, Request, Response, RoutedLlmClient, completion_text,
+        text_request, text_response,
     };
 
     /// Echoes the selected target so tests can inspect which target was called.

--- a/crates/libsy/src/algorithms/rand.rs
+++ b/crates/libsy/src/algorithms/rand.rs
@@ -11,9 +11,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use rand::distributions::{Distribution, WeightedIndex};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::distr::{Distribution, weighted::WeightedIndex};
+use rand::rngs::StdRng;
 
 use crate::algorithms::fall_through::{FallThrough, FallThroughDecision};
 use crate::core::algorithm::{Algorithm, Driver, LlmTargetSet};
@@ -79,7 +79,7 @@ impl RandomClassifier {
             WeightedIndex::new(weights).map_err(|error| invalid_weights(error.to_string()))?;
         let rng = match seed {
             Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
+            None => rand::make_rng(),
         };
         Ok(Self {
             targets,
@@ -181,11 +181,11 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    use switchyard_protocol::{completion_text, text_request, text_response, Metadata};
+    use switchyard_protocol::{Metadata, completion_text, text_request, text_response};
 
+    use crate::DriverError;
     use crate::algorithms::util::affinity::AffinityRouter;
     use crate::core::algorithm::LlmTarget;
-    use crate::DriverError;
     use switchyard_protocol::{Decision, LlmResponse, Request, RoutedLlmClient, Signals};
 
     /// Echoes the selected target so tests can inspect which target was called.
@@ -448,10 +448,12 @@ mod tests {
         let decision = &trace[0];
 
         assert_eq!(decision.selected_model(), "only/model");
-        assert!(decision
-            .reasoning()
-            .unwrap_or_default()
-            .contains("only/model"));
+        assert!(
+            decision
+                .reasoning()
+                .unwrap_or_default()
+                .contains("only/model")
+        );
         let concrete = decision
             .as_any()
             .downcast_ref::<RandomDecision>()

--- a/crates/libsy/src/algorithms/stage.rs
+++ b/crates/libsy/src/algorithms/stage.rs
@@ -23,10 +23,10 @@ use super::fall_through::{DefaultTarget, FallThrough};
 use super::llm_class::{LlmTaskClassifier, TaskClassifierConfig};
 use super::util::prompts::{SystemPromptProcessor, TargetPrompts};
 use super::util::stage::{
-    record_decision_source, DecisionSource, HandoffNoteConfig, PickerMode, StageClassifier,
-    StageTargets,
+    DecisionSource, HandoffNoteConfig, PickerMode, StageClassifier, StageTargets,
+    record_decision_source,
 };
-use super::util::tool_signals::{ToolSignalProcessor, DEFAULT_RECENT_WINDOW};
+use super::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignalProcessor};
 use crate::core::algorithm::{Algorithm, Driver, LlmTarget, LlmTargetSet};
 use crate::core::classifier::{Classification, Classifier};
 use crate::core::state::State;
@@ -229,7 +229,7 @@ mod tests {
     use parking_lot::Mutex;
     use serde_json::json;
     use switchyard_protocol::{
-        text_response, ContentBlock, LlmRequest, Message, Role, ToolCall, ToolResult, WireFormat,
+        ContentBlock, LlmRequest, Message, Role, ToolCall, ToolResult, WireFormat, text_response,
     };
 
     use super::*;

--- a/crates/libsy/src/algorithms/subagent_affinity_tests.rs
+++ b/crates/libsy/src/algorithms/subagent_affinity_tests.rs
@@ -15,12 +15,12 @@ use async_trait::async_trait;
 use super::fall_through::FallThrough;
 use super::util::affinity::AffinityRouter;
 use super::util::subagent::SubagentOverride;
+use crate::Result;
 use crate::core::algorithm::{Algorithm, Driver, LlmTarget, LlmTargetSet};
 use crate::core::classifier::{Classification, Classifier, Score};
-use crate::Result;
 use switchyard_protocol::{
-    completion_text, text_request, text_response, Context, Decision, LlmResponse, Metadata,
-    Request, Response, RoutedLlmClient,
+    Context, Decision, LlmResponse, Metadata, Request, Response, RoutedLlmClient, completion_text,
+    text_request, text_response,
 };
 
 /// A client that echoes the routed target name back as the completion.

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -107,8 +107,8 @@ impl AffinityRouter {
 
     /// Derives the stable identity this router should retain for `request`.
     fn affinity_key(&self, request: &Request) -> Option<AffinityKey> {
-        if let Some(metadata) = request.metadata.as_ref() {
-            if let Some(session) = metadata.session_id.clone() {
+        if let Some(metadata) = request.metadata.as_ref()
+            && let Some(session) = metadata.session_id.clone() {
                 return if metadata.is_subagent {
                     metadata
                         .agent_id
@@ -120,7 +120,6 @@ impl AffinityRouter {
                     Some(AffinityKey::Session(session))
                 };
             }
-        }
 
         // If headers are not present and we are not a subagent, use the message hash based fallback key to do task based routing
         let is_subagent = request
@@ -144,8 +143,8 @@ where
     S: Send + 'static,
 {
     async fn process(&self, _state: &mut S, event: Event<'_>) -> crate::Result<()> {
-        if let Event::Decision { request, decision } = event {
-            if let Some(key) = self.affinity_key(request) {
+        if let Event::Decision { request, decision } = event
+            && let Some(key) = self.affinity_key(request) {
                 let model = decision.selected_model();
                 let mut assignments = self.assignments.lock();
                 if self.should_latch(model) && !assignments.contains_key(&key) {
@@ -153,7 +152,6 @@ where
                     assignments.insert(key, model.to_string());
                 }
             }
-        }
         Ok(())
     }
 }
@@ -202,11 +200,10 @@ where
 
 /// Evicts one arbitrary assignment when the map has reached [`MAX_ASSIGNMENTS`].
 fn evict_if_full(assignments: &mut HashMap<AffinityKey, String>) {
-    if assignments.len() >= MAX_ASSIGNMENTS {
-        if let Some(evicted) = assignments.keys().next().cloned() {
+    if assignments.len() >= MAX_ASSIGNMENTS
+        && let Some(evicted) = assignments.keys().next().cloned() {
             assignments.remove(&evicted);
         }
-    }
 }
 
 #[cfg(test)]

--- a/crates/libsy/src/algorithms/util/affinity.rs
+++ b/crates/libsy/src/algorithms/util/affinity.rs
@@ -17,7 +17,7 @@
 //! session. [`AffinityRouter::for_subagents`] narrows affinity to explicitly identified
 //! child agents, leaving root traffic to later classifiers on every turn.
 
-use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 
 use async_trait::async_trait;
@@ -108,18 +108,19 @@ impl AffinityRouter {
     /// Derives the stable identity this router should retain for `request`.
     fn affinity_key(&self, request: &Request) -> Option<AffinityKey> {
         if let Some(metadata) = request.metadata.as_ref()
-            && let Some(session) = metadata.session_id.clone() {
-                return if metadata.is_subagent {
-                    metadata
-                        .agent_id
-                        .clone()
-                        .map(|agent| AffinityKey::Subagent { session, agent })
-                } else if self.subagents_only {
-                    None
-                } else {
-                    Some(AffinityKey::Session(session))
-                };
-            }
+            && let Some(session) = metadata.session_id.clone()
+        {
+            return if metadata.is_subagent {
+                metadata
+                    .agent_id
+                    .clone()
+                    .map(|agent| AffinityKey::Subagent { session, agent })
+            } else if self.subagents_only {
+                None
+            } else {
+                Some(AffinityKey::Session(session))
+            };
+        }
 
         // If headers are not present and we are not a subagent, use the message hash based fallback key to do task based routing
         let is_subagent = request
@@ -144,14 +145,15 @@ where
 {
     async fn process(&self, _state: &mut S, event: Event<'_>) -> crate::Result<()> {
         if let Event::Decision { request, decision } = event
-            && let Some(key) = self.affinity_key(request) {
-                let model = decision.selected_model();
-                let mut assignments = self.assignments.lock();
-                if self.should_latch(model) && !assignments.contains_key(&key) {
-                    evict_if_full(&mut assignments);
-                    assignments.insert(key, model.to_string());
-                }
+            && let Some(key) = self.affinity_key(request)
+        {
+            let model = decision.selected_model();
+            let mut assignments = self.assignments.lock();
+            if self.should_latch(model) && !assignments.contains_key(&key) {
+                evict_if_full(&mut assignments);
+                assignments.insert(key, model.to_string());
             }
+        }
         Ok(())
     }
 }
@@ -201,9 +203,10 @@ where
 /// Evicts one arbitrary assignment when the map has reached [`MAX_ASSIGNMENTS`].
 fn evict_if_full(assignments: &mut HashMap<AffinityKey, String>) {
     if assignments.len() >= MAX_ASSIGNMENTS
-        && let Some(evicted) = assignments.keys().next().cloned() {
-            assignments.remove(&evicted);
-        }
+        && let Some(evicted) = assignments.keys().next().cloned()
+    {
+        assignments.remove(&evicted);
+    }
 }
 
 #[cfg(test)]
@@ -213,7 +216,7 @@ mod tests {
     use std::sync::Arc;
 
     use switchyard_protocol::{
-        text_request, ContentBlock, Decision, LlmRequest, Message, Metadata,
+        ContentBlock, Decision, LlmRequest, Message, Metadata, text_request,
     };
 
     /// Boxed, thread-safe error type keeping the test helpers ergonomic.
@@ -471,9 +474,11 @@ mod tests {
             "Reimplement this binary from two input/output pairs.",
             Some("Now run the test suite."),
         );
-        assert!(scores(&router, &mut state, &mut other_task)
-            .await?
-            .is_empty());
+        assert!(
+            scores(&router, &mut state, &mut other_task)
+                .await?
+                .is_empty()
+        );
         Ok(())
     }
 
@@ -524,9 +529,11 @@ mod tests {
             "Implement the parser.",
             None,
         );
-        assert!(scores(&router, &mut state, &mut other_session)
-            .await?
-            .is_empty());
+        assert!(
+            scores(&router, &mut state, &mut other_session)
+                .await?
+                .is_empty()
+        );
         Ok(())
     }
 

--- a/crates/libsy/src/algorithms/util/escalation.rs
+++ b/crates/libsy/src/algorithms/util/escalation.rs
@@ -380,9 +380,11 @@ mod tests {
         assert_eq!(built.llm_request.messages.len(), 2);
         assert_eq!(built.llm_request.messages[0].role, Role::System);
         assert_eq!(built.llm_request.messages[1].role, Role::User);
-        assert!(built.llm_request.messages[1]
-            .text_content("")
-            .is_some_and(|text| text.contains("Conversation turn 4")));
+        assert!(
+            built.llm_request.messages[1]
+                .text_content("")
+                .is_some_and(|text| text.contains("Conversation turn 4"))
+        );
         // Bounded output, so a reasoning judge cannot run away mid-verdict.
         assert_eq!(
             built.llm_request.output.max_output_tokens,

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use switchyard_protocol::{completion_text, AggLlmResponse};
+use switchyard_protocol::{AggLlmResponse, completion_text};
 
 use crate::core::algorithm::{Driver, LlmTarget};
 use crate::core::classifier::{Classification, Classifier};
@@ -222,7 +222,7 @@ mod tests {
 
     use futures::StreamExt;
     use serde::Deserialize;
-    use switchyard_protocol::{text_request, text_response, ContentBlock, LlmClientError};
+    use switchyard_protocol::{ContentBlock, LlmClientError, text_request, text_response};
 
     use crate::core::algorithm::Step;
     use crate::core::classifier::Score;

--- a/crates/libsy/src/algorithms/util/prompts.rs
+++ b/crates/libsy/src/algorithms/util/prompts.rs
@@ -20,8 +20,8 @@ use std::collections::BTreeMap;
 use async_trait::async_trait;
 use switchyard_protocol::{ContentBlock, InstructionBlock, Message, Request, Role};
 
-use crate::core::processor::{Event, Processor};
 use crate::Result;
+use crate::core::processor::{Event, Processor};
 
 /// Appends `note` to the request as conversation text.
 ///
@@ -111,7 +111,7 @@ impl<S: Send> Processor<S> for SystemPromptProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use switchyard_protocol::{text_request, LlmRequest, ToolResult};
+    use switchyard_protocol::{LlmRequest, ToolResult, text_request};
 
     const NOTE: &str = "recovering from an error";
     const STRONG_PROMPT: &str = "diagnose before you edit";

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -24,10 +24,10 @@ use serde::Deserialize;
 
 use super::prompts;
 use super::tool_signals::ToolSignals;
+use crate::Result;
 use crate::core::algorithm::Driver;
 use crate::core::classifier::{Classification, Classifier, Score};
 use crate::core::state::{State, StateValue};
-use crate::Result;
 use switchyard_protocol::Request;
 
 /// Turn depth below which stall signals stay quiet — early no-write turns are
@@ -527,7 +527,7 @@ impl Classifier<State> for StageClassifier {
 mod tests {
     use super::*;
     use serde_json::json;
-    use switchyard_protocol::{text_request, Metadata, Request, WireFormat};
+    use switchyard_protocol::{Metadata, Request, WireFormat, text_request};
 
     fn signal_from(messages: serde_json::Value) -> ToolSignals {
         let raw_request = Some(json!({"model": "m", "messages": messages}));

--- a/crates/libsy/src/algorithms/util/subagent.rs
+++ b/crates/libsy/src/algorithms/util/subagent.rs
@@ -17,9 +17,9 @@
 
 use async_trait::async_trait;
 
+use crate::Result;
 use crate::core::algorithm::Driver;
 use crate::core::classifier::{Classification, Classifier, Score};
-use crate::Result;
 use switchyard_protocol::{Metadata, Request, Response};
 
 /// Scores a fixed worker target for delegated sub-agent work; abstains otherwise.

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -299,8 +299,8 @@ fn classify_tool_call(name: &str, command: Option<&str>) -> ToolCategory {
     if PLAN_TOOL_NAMES.contains(&lower.as_str()) {
         return ToolCategory::Plan;
     }
-    if BASH_TOOL_NAMES.contains(&lower.as_str()) {
-        if let Some(cmd) = command {
+    if BASH_TOOL_NAMES.contains(&lower.as_str())
+        && let Some(cmd) = command {
             // Write/edit redirection trumps read-like operands.
             if BASH_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
                 return ToolCategory::Write;
@@ -312,7 +312,6 @@ fn classify_tool_call(name: &str, command: Option<&str>) -> ToolCategory {
                 return ToolCategory::Read;
             }
         }
-    }
     ToolCategory::Other
 }
 

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -300,18 +300,19 @@ fn classify_tool_call(name: &str, command: Option<&str>) -> ToolCategory {
         return ToolCategory::Plan;
     }
     if BASH_TOOL_NAMES.contains(&lower.as_str())
-        && let Some(cmd) = command {
-            // Write/edit redirection trumps read-like operands.
-            if BASH_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
-                return ToolCategory::Write;
-            }
-            if BASH_EDIT_PATTERNS.iter().any(|p| cmd.contains(p)) {
-                return ToolCategory::Edit;
-            }
-            if BASH_READ_PATTERNS.iter().any(|p| cmd.contains(p)) {
-                return ToolCategory::Read;
-            }
+        && let Some(cmd) = command
+    {
+        // Write/edit redirection trumps read-like operands.
+        if BASH_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
+            return ToolCategory::Write;
         }
+        if BASH_EDIT_PATTERNS.iter().any(|p| cmd.contains(p)) {
+            return ToolCategory::Edit;
+        }
+        if BASH_READ_PATTERNS.iter().any(|p| cmd.contains(p)) {
+            return ToolCategory::Read;
+        }
+    }
     ToolCategory::Other
 }
 
@@ -823,7 +824,10 @@ mod tests {
     fn compaction_marker_sets_compacted() {
         // The compaction summary is a user message carrying Claude Code's preamble.
         let request = with_messages(vec![
-            Message::text(Role::User, "This session is being continued from a previous conversation that ran out of context."),
+            Message::text(
+                Role::User,
+                "This session is being continued from a previous conversation that ran out of context.",
+            ),
             bash("ls"),
         ]);
         assert!(ToolSignals::from_request(&request, None).compacted);

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -26,7 +26,7 @@ use switchyard_protocol::{
 };
 
 use super::driver::{DriverRequest, DriverStep, TypeErasedDriver};
-use crate::{observability, DriverError, LibsyError, Result};
+use crate::{DriverError, LibsyError, Result, observability};
 
 /// A boxed, `Send` stream of [`Step`]s — the output of
 /// [`Algorithm::run_stream`]. Boxed so the trait method that produces it keeps
@@ -285,7 +285,7 @@ impl Driver {
     /// Transform the raw driver stream into a stream of [`Step`]s. Internal: the
     /// consumer stream is taken (once) by [`run_stream`](Algorithm::run_stream). A
     /// payload that does not match the expected type for its step becomes an `Err` item.
-    pub(crate) fn stream(&self) -> impl Stream<Item = Result<Step>> {
+    pub(crate) fn stream(&self) -> impl Stream<Item = Result<Step>> + use<> {
         self.driver.stream().map(|item| match item? {
             DriverStep::Request(req) => Ok(Step::CallLlm(Box::new(CallLlmRequest::new(req)))),
             DriverStep::Info(payload) => payload
@@ -786,7 +786,7 @@ mod tests {
     use super::*;
     use futures::StreamExt;
     use switchyard_protocol::{
-        completion_text, text_request, text_response, LlmResponse, LlmResponseChunk,
+        LlmResponse, LlmResponseChunk, completion_text, text_request, text_response,
     };
 
     #[derive(Debug, thiserror::Error)]
@@ -1706,9 +1706,10 @@ mod tests {
         match result {
             Ok(_) => Err(test_error("expected the terminal error, got a response")),
             Err(err) => {
-                assert!(err
-                    .to_string()
-                    .contains("terminal error while calls pending"));
+                assert!(
+                    err.to_string()
+                        .contains("terminal error while calls pending")
+                );
                 Ok(())
             }
         }

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -443,11 +443,10 @@ impl SessionEvictions {
     fn record(&self, session: Option<&str>, target: &str) {
         let Some(session) = session else { return };
         let mut sessions = self.sessions.lock();
-        if sessions.len() >= MAX_EVICTION_SESSIONS && !sessions.contains_key(session) {
-            if let Some(oldest) = sessions.keys().next().cloned() {
+        if sessions.len() >= MAX_EVICTION_SESSIONS && !sessions.contains_key(session)
+            && let Some(oldest) = sessions.keys().next().cloned() {
                 sessions.remove(&oldest);
             }
-        }
         sessions
             .entry(session.to_string())
             .or_default()

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -443,10 +443,12 @@ impl SessionEvictions {
     fn record(&self, session: Option<&str>, target: &str) {
         let Some(session) = session else { return };
         let mut sessions = self.sessions.lock();
-        if sessions.len() >= MAX_EVICTION_SESSIONS && !sessions.contains_key(session)
-            && let Some(oldest) = sessions.keys().next().cloned() {
-                sessions.remove(&oldest);
-            }
+        if sessions.len() >= MAX_EVICTION_SESSIONS
+            && !sessions.contains_key(session)
+            && let Some(oldest) = sessions.keys().next().cloned()
+        {
+            sessions.remove(&oldest);
+        }
         sessions
             .entry(session.to_string())
             .or_default()

--- a/crates/libsy/src/core/driver.rs
+++ b/crates/libsy/src/core/driver.rs
@@ -55,7 +55,7 @@ use parking_lot::Mutex;
 use futures::{Stream, StreamExt};
 use switchyard_protocol::Context;
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 use tokio_stream::wrappers::ReceiverStream;
 
 type BoxAny = Box<dyn Any + Send>;
@@ -238,7 +238,7 @@ impl TypeErasedDriver {
 
     /// Take the single consumer stream of [`DriverStep`]s. Callable once: a second
     /// call yields a one-item stream carrying an `Err`, since the receiver is gone.
-    pub fn stream(&self) -> impl Stream<Item = Result<DriverStep>> {
+    pub fn stream(&self) -> impl Stream<Item = Result<DriverStep>> + use<> {
         let receiver = self
             .inner
             .step_rx
@@ -434,10 +434,12 @@ mod tests {
         // Drop the consumer stream (and its receiver) before producing anything.
         drop(driver.stream());
 
-        assert!(driver
-            .fulfill_request::<u32, u32>(Context::default(), 1u32)
-            .await
-            .is_err());
+        assert!(
+            driver
+                .fulfill_request::<u32, u32>(Context::default(), 1u32)
+                .await
+                .is_err()
+        );
         assert!(driver.info(Context::default(), 1u32).await.is_err());
         assert!(driver.done(Context::default(), 1u32).await.is_err());
         Ok(())
@@ -584,7 +586,7 @@ mod tests {
             Ok(()) => {
                 return Err(test_error(
                     "expected ensure_started to reject an untaken stream",
-                ))
+                ));
             }
             Err(err) => assert!(matches!(err, LibsyError::Driver(DriverError::NotStarted))),
         }

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -96,16 +96,16 @@ pub use algorithms::rand::{Random, RandomClassifier, RandomDecision};
 pub use algorithms::stage::{LlmFallback, StageRouter, StageRouterConfig};
 pub use algorithms::util::affinity::AffinityRouter;
 pub use algorithms::util::escalation::EscalationJudgeConfig;
-pub use algorithms::util::prompts::{append_note, SystemPromptProcessor, TargetPrompts};
+pub use algorithms::util::prompts::{SystemPromptProcessor, TargetPrompts, append_note};
 pub use algorithms::util::subagent::SubagentOverride;
-pub use algorithms::util::tool_signals::{ToolSignals, DEFAULT_RECENT_WINDOW};
+pub use algorithms::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignals};
 
 // Stage-router scoring and tier selection — the shared signal-driven routing
 // core (scorer, picker, and the `StageClassifier`).
 pub use algorithms::util::stage::{
-    dimensions_from_signal, pick_tier, score_signal, CodingAgentDimensions, DecisionSource,
-    HandoffNoteConfig, PickOutcome, PickerMode, ScoreResult, StageClassifier, StageTargets, Tier,
-    DECISION_SOURCE_KEY,
+    CodingAgentDimensions, DECISION_SOURCE_KEY, DecisionSource, HandoffNoteConfig, PickOutcome,
+    PickerMode, ScoreResult, StageClassifier, StageTargets, Tier, dimensions_from_signal,
+    pick_tier, score_signal,
 };
 
 mod observability;

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -33,14 +33,14 @@
 use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context as TaskContext, Poll};
 use std::time::{Duration, Instant};
 
 use futures::Stream;
 use opentelemetry::metrics::{Meter, ObservableGauge};
-use opentelemetry::{global, Array as OtelArray, KeyValue, StringValue, Value as OtelValue};
+use opentelemetry::{Array as OtelArray, KeyValue, StringValue, Value as OtelValue, global};
 use switchyard_protocol::StopReason;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -97,11 +97,7 @@ pub(crate) fn initialize_metrics() {
 
 /// `outcome` attribute value for a result: `ok` or `error`.
 fn outcome_value<T>(result: &Result<T>) -> &'static str {
-    if result.is_ok() {
-        "ok"
-    } else {
-        "error"
-    }
+    if result.is_ok() { "ok" } else { "error" }
 }
 
 /// Span covering one algorithm run (the whole `create_run_task` execution).
@@ -169,9 +165,9 @@ pub(crate) async fn observe_run(
     if result.is_ok()
         && let Some(overhead) =
             record_routing_overhead(algorithm, duration, driver.routed_call_duration())
-        {
-            driver.observe_routing_overhead(overhead);
-        }
+    {
+        driver.observe_routing_overhead(overhead);
+    }
     result
 }
 

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -166,13 +166,12 @@ pub(crate) async fn observe_run(
     let duration = started.elapsed();
     let algorithm = algorithm_label(&ctx);
     record_run(algorithm, duration, &result, &Span::current());
-    if result.is_ok() {
-        if let Some(overhead) =
+    if result.is_ok()
+        && let Some(overhead) =
             record_routing_overhead(algorithm, duration, driver.routed_call_duration())
         {
             driver.observe_routing_overhead(overhead);
         }
-    }
     result
 }
 

--- a/crates/libsy/tests/observability.rs
+++ b/crates/libsy/tests/observability.rs
@@ -28,19 +28,19 @@ use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id, Record};
 use tracing::{Event, Subscriber};
 use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::Layer;
 use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::Layer;
 
 use switchyard_libsy::{
     Algorithm, Driver, LibsyError, LlmTarget, LlmTargetSet, LlmTaskClassifier, Step,
     TaskClassifierConfig,
 };
 use switchyard_protocol::{
-    text_request, text_response, LlmClientError, LlmResponseChunk, StopReason,
+    Context, Decision, LlmResponse, Metadata, Request, Response, RoutedLlmClient, Usage,
 };
 use switchyard_protocol::{
-    Context, Decision, LlmResponse, Metadata, Request, Response, RoutedLlmClient, Usage,
+    LlmClientError, LlmResponseChunk, StopReason, text_request, text_response,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -626,10 +626,12 @@ async fn successful_run_records_metrics_spans_and_decision_log() -> switchyard_l
         Some("ok")
     );
     // Host-defined labels ride in generically via Metadata.extra_metadata.
-    assert!(run_span
-        .fields
-        .get("extra_metadata")
-        .is_some_and(|extra| extra.contains("tenant") && extra.contains("obs-tenant-1")));
+    assert!(
+        run_span
+            .fields
+            .get("extra_metadata")
+            .is_some_and(|extra| extra.contains("tenant") && extra.contains("obs-tenant-1"))
+    );
 
     // The default-client serve inside `run` gets its own client-call span.
     let client_span = find_span(&spans, "libsy.client_call", "selected_model", MODEL);
@@ -977,10 +979,12 @@ async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::
         run_span.fields.get("outcome").map(String::as_str),
         Some("error")
     );
-    assert!(run_span
-        .fields
-        .get("error")
-        .is_some_and(|error| error.contains("synthetic upstream failure")));
+    assert!(
+        run_span
+            .fields
+            .get("error")
+            .is_some_and(|error| error.contains("synthetic upstream failure"))
+    );
     let call_span = find_span(&spans, "libsy.llm_call", "selected_model", MODEL);
     assert_eq!(
         call_span.fields.get("outcome").map(String::as_str),

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    llm::{AggLlmResponse, ContentBlock, ResponseOutput, Role, StopReason, ToolCall, Usage},
     LlmClientError,
+    llm::{AggLlmResponse, ContentBlock, ResponseOutput, Role, StopReason, ToolCall, Usage},
 };
 
 /// Status reported for an upstream error delivered inside a streaming body. The

--- a/crates/switchyard-components/src/backends/anthropic.rs
+++ b/crates/switchyard-components/src/backends/anthropic.rs
@@ -9,25 +9,25 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::{
-    merge_target_extra_body, BackendFormat, BoxResponseStream, ChatRequest, ChatRequestType,
-    ChatResponse, LlmBackend, LlmTarget, LlmTargetId, ProxyContext, Result, StreamEvent,
-    SwitchyardError,
+    BackendFormat, BoxResponseStream, ChatRequest, ChatRequestType, ChatResponse, LlmBackend,
+    LlmTarget, LlmTargetId, ProxyContext, Result, StreamEvent, SwitchyardError,
+    merge_target_extra_body,
 };
 use async_stream::try_stream;
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use switchyard_translation::{
-    normalize_anthropic_tool_use_ids, TranslationEngine, TranslationPolicy, WireFormat,
+    TranslationEngine, TranslationPolicy, WireFormat, normalize_anthropic_tool_use_ids,
 };
 
-use super::common::{
-    build_reqwest_client, decode_sse_frame, drain_next_sse_frame, has_non_whitespace_bytes,
-    parse_json_sse_frame, request_wire_format, set_json_model, shared_translation_engine,
-    ParsedSseFrame,
-};
 use super::BackendSelection;
-use crate::telemetry::{telemetry_header_value, SWITCHYARD_VERSION_HEADER};
+use super::common::{
+    ParsedSseFrame, build_reqwest_client, decode_sse_frame, drain_next_sse_frame,
+    has_non_whitespace_bytes, parse_json_sse_frame, request_wire_format, set_json_model,
+    shared_translation_engine,
+};
+use crate::telemetry::{SWITCHYARD_VERSION_HEADER, telemetry_header_value};
 
 const DEFAULT_ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";

--- a/crates/switchyard-components/src/backends/common.rs
+++ b/crates/switchyard-components/src/backends/common.rs
@@ -44,13 +44,12 @@ pub(crate) fn build_reqwest_client(
 
 /// Validates timeout values before they reach reqwest.
 pub(crate) fn validate_timeout_secs(backend_name: &str, timeout_secs: Option<f64>) -> Result<()> {
-    if let Some(timeout_secs) = timeout_secs {
-        if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
+    if let Some(timeout_secs) = timeout_secs
+        && (!timeout_secs.is_finite() || timeout_secs <= 0.0) {
             return Err(SwitchyardError::InvalidConfig(format!(
                 "{backend_name} target timeout_secs must be finite and positive, got {timeout_secs:?}"
             )));
         }
-    }
     Ok(())
 }
 

--- a/crates/switchyard-components/src/backends/common.rs
+++ b/crates/switchyard-components/src/backends/common.rs
@@ -45,11 +45,12 @@ pub(crate) fn build_reqwest_client(
 /// Validates timeout values before they reach reqwest.
 pub(crate) fn validate_timeout_secs(backend_name: &str, timeout_secs: Option<f64>) -> Result<()> {
     if let Some(timeout_secs) = timeout_secs
-        && (!timeout_secs.is_finite() || timeout_secs <= 0.0) {
-            return Err(SwitchyardError::InvalidConfig(format!(
-                "{backend_name} target timeout_secs must be finite and positive, got {timeout_secs:?}"
-            )));
-        }
+        && (!timeout_secs.is_finite() || timeout_secs <= 0.0)
+    {
+        return Err(SwitchyardError::InvalidConfig(format!(
+            "{backend_name} target timeout_secs must be finite and positive, got {timeout_secs:?}"
+        )));
+    }
     Ok(())
 }
 

--- a/crates/switchyard-components/src/backends/context_overflow.rs
+++ b/crates/switchyard-components/src/backends/context_overflow.rs
@@ -27,11 +27,9 @@ where
             .get("error")
             .and_then(|err| err.get("message"))
             .and_then(Value::as_str)
-        {
-            if contains_any(message, phrases) {
+            && contains_any(message, phrases) {
                 return true;
             }
-        }
     }
     // Some upstream proxies return plain-text bodies; fall through to a
     // string match on the raw body.

--- a/crates/switchyard-components/src/backends/context_overflow.rs
+++ b/crates/switchyard-components/src/backends/context_overflow.rs
@@ -27,9 +27,10 @@ where
             .get("error")
             .and_then(|err| err.get("message"))
             .and_then(Value::as_str)
-            && contains_any(message, phrases) {
-                return true;
-            }
+            && contains_any(message, phrases)
+        {
+            return true;
+        }
     }
     // Some upstream proxies return plain-text bodies; fall through to a
     // string match on the raw body.

--- a/crates/switchyard-components/src/backends/multi.rs
+++ b/crates/switchyard-components/src/backends/multi.rs
@@ -195,7 +195,7 @@ impl MultiLlmBackend {
             .map(|model| format!(" and request model {model:?} did not match a configured target"))
             .unwrap_or_default();
         SwitchyardError::InvalidConfig(format!(
-                "MultiLlmBackend has multiple targets but no selected target{request_model}; known targets: {}",
+            "MultiLlmBackend has multiple targets but no selected target{request_model}; known targets: {}",
             self.known_target_ids()
         ))
     }

--- a/crates/switchyard-components/src/backends/openai.rs
+++ b/crates/switchyard-components/src/backends/openai.rs
@@ -9,9 +9,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::{
-    merge_target_extra_body, BackendFormat, BoxResponseStream, ChatRequest, ChatRequestType,
-    ChatResponse, EndpointConfig, LlmBackend, LlmTarget, LlmTargetId, ModelId, ProxyContext,
-    Result, StreamEvent, SwitchyardError,
+    BackendFormat, BoxResponseStream, ChatRequest, ChatRequestType, ChatResponse, EndpointConfig,
+    LlmBackend, LlmTarget, LlmTargetId, ModelId, ProxyContext, Result, StreamEvent,
+    SwitchyardError, merge_target_extra_body,
 };
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -20,12 +20,12 @@ use serde_json::{Map, Value};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
 
 use super::common::{
-    build_reqwest_client, decode_sse_frame, drain_next_sse_frame, has_non_whitespace_bytes,
-    parse_json_sse_frame, request_wire_format, set_json_model, shared_translation_engine,
-    ParsedSseFrame,
+    ParsedSseFrame, build_reqwest_client, decode_sse_frame, drain_next_sse_frame,
+    has_non_whitespace_bytes, parse_json_sse_frame, request_wire_format, set_json_model,
+    shared_translation_engine,
 };
 use super::{BackendSelection, BackendSelectionReason};
-use crate::telemetry::{telemetry_header_value, SWITCHYARD_VERSION_HEADER};
+use crate::telemetry::{SWITCHYARD_VERSION_HEADER, telemetry_header_value};
 
 const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";

--- a/crates/switchyard-components/src/backends/stats.rs
+++ b/crates/switchyard-components/src/backends/stats.rs
@@ -11,7 +11,7 @@ use crate::{ChatRequest, ChatRequestType, ChatResponse, LlmBackend, ProxyContext
 use async_trait::async_trait;
 
 use crate::stats::{
-    selected_stats_model, selected_stats_tier, StatsAccumulator, StatsBackendLatency,
+    StatsAccumulator, StatsBackendLatency, selected_stats_model, selected_stats_tier,
 };
 
 /// Transparent backend wrapper that records call success/error and backend latency.

--- a/crates/switchyard-components/src/contracts/types.rs
+++ b/crates/switchyard-components/src/contracts/types.rs
@@ -90,15 +90,13 @@ impl ChatRequest {
     /// and is exempt.
     pub fn validate(&self) -> Result<()> {
         let checks_messages = matches!(self, Self::OpenAiChat(_) | Self::Anthropic(_));
-        if checks_messages {
-            if let Some(messages) = self.body().get("messages").and_then(Value::as_array) {
-                if messages.is_empty() {
+        if checks_messages
+            && let Some(messages) = self.body().get("messages").and_then(Value::as_array)
+                && messages.is_empty() {
                     return Err(SwitchyardError::InvalidRequest(
                         "messages must be a non-empty array".to_string(),
                     ));
                 }
-            }
-        }
         Ok(())
     }
 

--- a/crates/switchyard-components/src/contracts/types.rs
+++ b/crates/switchyard-components/src/contracts/types.rs
@@ -92,11 +92,12 @@ impl ChatRequest {
         let checks_messages = matches!(self, Self::OpenAiChat(_) | Self::Anthropic(_));
         if checks_messages
             && let Some(messages) = self.body().get("messages").and_then(Value::as_array)
-                && messages.is_empty() {
-                    return Err(SwitchyardError::InvalidRequest(
-                        "messages must be a non-empty array".to_string(),
-                    ));
-                }
+            && messages.is_empty()
+        {
+            return Err(SwitchyardError::InvalidRequest(
+                "messages must be a non-empty array".to_string(),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/switchyard-components/src/dimension_collector/mod.rs
+++ b/crates/switchyard-components/src/dimension_collector/mod.rs
@@ -12,7 +12,7 @@
 pub mod response;
 pub mod tool_signals;
 
-pub use response::{extract_response_signals, ResponseFlag, ResponseSignals};
+pub use response::{ResponseFlag, ResponseSignals, extract_response_signals};
 pub use tool_signals::{
-    extract_tool_signals, extract_tool_signals_with_window, ToolResultSignal, DEFAULT_RECENT_WINDOW,
+    DEFAULT_RECENT_WINDOW, ToolResultSignal, extract_tool_signals, extract_tool_signals_with_window,
 };

--- a/crates/switchyard-components/src/dimension_collector/tool_signals.rs
+++ b/crates/switchyard-components/src/dimension_collector/tool_signals.rs
@@ -13,7 +13,7 @@ use switchyard_protocol::{Metadata, Request, WireFormat};
 
 /// The tool-signal output type. Re-exported from libsy so downstream consumers
 /// (the `ToolResultSignal` stamped on `ProxyContext`) see a single type.
-pub use switchyard_libsy::{ToolSignals as ToolResultSignal, DEFAULT_RECENT_WINDOW};
+pub use switchyard_libsy::{DEFAULT_RECENT_WINDOW, ToolSignals as ToolResultSignal};
 
 /// Adapt a format-tagged [`ChatRequest`] to a [`switchyard_protocol::Request`]
 /// carrying the raw body and its wire format, which is all libsy's extractor reads.

--- a/crates/switchyard-components/src/intake.rs
+++ b/crates/switchyard-components/src/intake.rs
@@ -11,12 +11,12 @@ pub mod payload;
 pub use client::{HttpIntakeSink, IntakeSink};
 pub use config::{IntakeFormat, IntakeQueueFullPolicy, IntakeSinkConfig, IntakeTarget};
 pub use context::{
-    IntakeRequestMetadata, IntakeRequestState, RequestMetadata, SubModelCall, SubModelCalls,
-    INTAKE_APP_HEADER, INTAKE_ENABLED_HEADER, INTAKE_TASK_HEADER, PROXY_SESSION_ID_HEADER,
+    INTAKE_APP_HEADER, INTAKE_ENABLED_HEADER, INTAKE_TASK_HEADER, IntakeRequestMetadata,
+    IntakeRequestState, PROXY_SESSION_ID_HEADER, RequestMetadata, SubModelCall, SubModelCalls,
 };
 pub use payload::{
-    anthropic_response_from_stream, now_millis, openai_chat_response_from_stream,
-    request_type_value, responses_response_from_stream, to_flat_document, IntakePayloadBuilder,
-    IntakePayloadContext, IntakeStreamCapture, IntakeStreamFormat, SYNTHETIC_STREAM_RESPONSE_IDS,
-    UNKNOWN_MODEL,
+    IntakePayloadBuilder, IntakePayloadContext, IntakeStreamCapture, IntakeStreamFormat,
+    SYNTHETIC_STREAM_RESPONSE_IDS, UNKNOWN_MODEL, anthropic_response_from_stream, now_millis,
+    openai_chat_response_from_stream, request_type_value, responses_response_from_stream,
+    to_flat_document,
 };

--- a/crates/switchyard-components/src/intake/client.rs
+++ b/crates/switchyard-components/src/intake/client.rs
@@ -4,8 +4,8 @@
 //! Intake payload sinks.
 
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use crate::{Result, SwitchyardError};
@@ -238,10 +238,9 @@ async fn post_once(
         None => (chat_completions_ingest_url(config), true),
     };
     let mut request = client.post(url).json(payload);
-    if authenticated
-        && let Some(api_key) = config.api_key.as_deref() {
-            request = request.bearer_auth(api_key);
-        }
+    if authenticated && let Some(api_key) = config.api_key.as_deref() {
+        request = request.bearer_auth(api_key);
+    }
     let response = request.send().await.map_err(|error| {
         SwitchyardError::Upstream(format!("intake payload POST failed: {error}"))
     })?;

--- a/crates/switchyard-components/src/intake/client.rs
+++ b/crates/switchyard-components/src/intake/client.rs
@@ -238,11 +238,10 @@ async fn post_once(
         None => (chat_completions_ingest_url(config), true),
     };
     let mut request = client.post(url).json(payload);
-    if authenticated {
-        if let Some(api_key) = config.api_key.as_deref() {
+    if authenticated
+        && let Some(api_key) = config.api_key.as_deref() {
             request = request.bearer_auth(api_key);
         }
-    }
     let response = request.send().await.map_err(|error| {
         SwitchyardError::Upstream(format!("intake payload POST failed: {error}"))
     })?;

--- a/crates/switchyard-components/src/intake/payload.rs
+++ b/crates/switchyard-components/src/intake/payload.rs
@@ -1264,16 +1264,15 @@ impl OpenAiChatStreamCapture {
             "role": "assistant",
             "content": content,
         });
-        if !self.reasoning_content.is_empty() {
-            if let Value::Object(object) = &mut message {
+        if !self.reasoning_content.is_empty()
+            && let Value::Object(object) = &mut message {
                 object.insert(
                     "reasoning_content".to_string(),
                     Value::String(self.reasoning_content),
                 );
             }
-        }
-        if has_tool_calls {
-            if let Value::Object(object) = &mut message {
+        if has_tool_calls
+            && let Value::Object(object) = &mut message {
                 object.insert(
                     "tool_calls".to_string(),
                     Value::Array(
@@ -1285,7 +1284,6 @@ impl OpenAiChatStreamCapture {
                     ),
                 );
             }
-        }
         let mut response = json!({
             "id": self.id.unwrap_or_else(|| "chatcmpl-switchyard-stream".to_string()),
             "object": "chat.completion",
@@ -1302,11 +1300,10 @@ impl OpenAiChatStreamCapture {
                     .unwrap_or_else(|| default_openai_finish_reason(has_tool_calls)),
             }],
         });
-        if let Some(usage) = self.usage {
-            if let Value::Object(object) = &mut response {
+        if let Some(usage) = self.usage
+            && let Value::Object(object) = &mut response {
                 object.insert("usage".to_string(), usage);
             }
-        }
         response
     }
 }
@@ -1531,11 +1528,10 @@ impl AnthropicStreamCapture {
             "role": "assistant",
             "content": if content.is_empty() { Value::Null } else { Value::String(content) },
         });
-        if has_tool_calls {
-            if let Value::Object(object) = &mut message {
+        if has_tool_calls
+            && let Value::Object(object) = &mut message {
                 object.insert("tool_calls".to_string(), Value::Array(tool_calls));
             }
-        }
         let mut response = json!({
             "id": self.id.unwrap_or_else(|| "msg_switchyard_stream".to_string()),
             "object": "chat.completion",

--- a/crates/switchyard-components/src/intake/payload.rs
+++ b/crates/switchyard-components/src/intake/payload.rs
@@ -11,14 +11,14 @@ use crate::{
     ChatRequest, ChatRequestType, ChatResponse, ChatResponseType, ProxyContext, Result,
     StreamEvent, SwitchyardError,
 };
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
 
 use crate::backends::BackendSelection;
 use crate::intake::config::{IntakeFormat, IntakeSinkConfig};
 use crate::intake::context::{IntakeRequestState, RequestMetadata, SubModelCall};
 use crate::request_processors::RandomRoutingDecision;
-use crate::stats::{estimate_model_cost, usage_from_body, StatsRouteLabel};
+use crate::stats::{StatsRouteLabel, estimate_model_cost, usage_from_body};
 use crate::telemetry::switchyard_version;
 
 /// Placeholder model label used when no backend selected model is available.
@@ -1265,25 +1265,25 @@ impl OpenAiChatStreamCapture {
             "content": content,
         });
         if !self.reasoning_content.is_empty()
-            && let Value::Object(object) = &mut message {
-                object.insert(
-                    "reasoning_content".to_string(),
-                    Value::String(self.reasoning_content),
-                );
-            }
-        if has_tool_calls
-            && let Value::Object(object) = &mut message {
-                object.insert(
-                    "tool_calls".to_string(),
-                    Value::Array(
-                        self.tool_calls
-                            .into_iter()
-                            .enumerate()
-                            .filter_map(|(index, tool_call)| tool_call.into_openai(index))
-                            .collect(),
-                    ),
-                );
-            }
+            && let Value::Object(object) = &mut message
+        {
+            object.insert(
+                "reasoning_content".to_string(),
+                Value::String(self.reasoning_content),
+            );
+        }
+        if has_tool_calls && let Value::Object(object) = &mut message {
+            object.insert(
+                "tool_calls".to_string(),
+                Value::Array(
+                    self.tool_calls
+                        .into_iter()
+                        .enumerate()
+                        .filter_map(|(index, tool_call)| tool_call.into_openai(index))
+                        .collect(),
+                ),
+            );
+        }
         let mut response = json!({
             "id": self.id.unwrap_or_else(|| "chatcmpl-switchyard-stream".to_string()),
             "object": "chat.completion",
@@ -1301,9 +1301,10 @@ impl OpenAiChatStreamCapture {
             }],
         });
         if let Some(usage) = self.usage
-            && let Value::Object(object) = &mut response {
-                object.insert("usage".to_string(), usage);
-            }
+            && let Value::Object(object) = &mut response
+        {
+            object.insert("usage".to_string(), usage);
+        }
         response
     }
 }
@@ -1528,10 +1529,9 @@ impl AnthropicStreamCapture {
             "role": "assistant",
             "content": if content.is_empty() { Value::Null } else { Value::String(content) },
         });
-        if has_tool_calls
-            && let Value::Object(object) = &mut message {
-                object.insert("tool_calls".to_string(), Value::Array(tool_calls));
-            }
+        if has_tool_calls && let Value::Object(object) = &mut message {
+            object.insert("tool_calls".to_string(), Value::Array(tool_calls));
+        }
         let mut response = json!({
             "id": self.id.unwrap_or_else(|| "msg_switchyard_stream".to_string()),
             "object": "chat.completion",

--- a/crates/switchyard-components/src/lib.rs
+++ b/crates/switchyard-components/src/lib.rs
@@ -22,7 +22,7 @@ pub use backends::{
 };
 pub use contracts::*;
 pub use dimension_collector::{
-    extract_tool_signals, ResponseFlag, ResponseSignals, ToolResultSignal,
+    ResponseFlag, ResponseSignals, ToolResultSignal, extract_tool_signals,
 };
 pub use intake::{
     HttpIntakeSink, IntakeFormat, IntakePayloadBuilder, IntakeQueueFullPolicy,
@@ -37,8 +37,8 @@ pub use response_processors::{
     IntakeResponseProcessor, ResponseSignalCollector, StatsResponseProcessor,
 };
 pub use stats::{
-    prefix_probe, tracking_enabled_from_env, ClassifierStatsSnapshot, CostBreakdown, CostEstimate,
-    LatencyHistogramSnapshot, ModelStatsSnapshot, PrefixProbe, StatsAccumulator,
-    StatsBackendLatency, StatsRequestStart, StatsRouteLabel, StatsSnapshot, TierStatsSnapshot,
-    TokenTotals, TokenUsage,
+    ClassifierStatsSnapshot, CostBreakdown, CostEstimate, LatencyHistogramSnapshot,
+    ModelStatsSnapshot, PrefixProbe, StatsAccumulator, StatsBackendLatency, StatsRequestStart,
+    StatsRouteLabel, StatsSnapshot, TierStatsSnapshot, TokenTotals, TokenUsage, prefix_probe,
+    tracking_enabled_from_env,
 };

--- a/crates/switchyard-components/src/request_processors/dimension_collector.rs
+++ b/crates/switchyard-components/src/request_processors/dimension_collector.rs
@@ -10,7 +10,7 @@
 use crate::{ChatRequest, ProxyContext, Result};
 
 use crate::dimension_collector::{
-    extract_tool_signals_with_window, ToolResultSignal, DEFAULT_RECENT_WINDOW,
+    DEFAULT_RECENT_WINDOW, ToolResultSignal, extract_tool_signals_with_window,
 };
 
 /// Populates `ProxyContext` with a [`ToolResultSignal`] read from the request's

--- a/crates/switchyard-components/src/request_processors/random_routing.rs
+++ b/crates/switchyard-components/src/request_processors/random_routing.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use crate::{LlmTarget, LlmTargetId, ModelId, Result, SwitchyardError};
 use parking_lot::Mutex;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_STRONG_PROBABILITY: f64 = 0.5;
@@ -115,7 +115,7 @@ impl RandomRoutingEngine {
         config.validate()?;
         let rng = match config.rng_seed {
             Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
+            None => rand::make_rng(),
         };
         Ok(Self {
             config,
@@ -157,7 +157,7 @@ impl RandomRoutingEngine {
 
     // Draws the next probability sample.
     fn next_draw(&self) -> f64 {
-        self.rng.lock().gen()
+        (*self.rng.lock()).random()
     }
 }
 

--- a/crates/switchyard-components/src/request_processors/stats.rs
+++ b/crates/switchyard-components/src/request_processors/stats.rs
@@ -5,7 +5,7 @@
 
 use crate::{ChatRequest, ProxyContext, Result};
 
-use crate::stats::{prefix_probe, StatsRequestStart};
+use crate::stats::{StatsRequestStart, prefix_probe};
 
 /// Records request start time, and optionally the prefix fingerprints used for
 /// switch-aware theoretical cache eligibility (gated, since fingerprinting hashes

--- a/crates/switchyard-components/src/response_processors/intake.rs
+++ b/crates/switchyard-components/src/response_processors/intake.rs
@@ -10,8 +10,8 @@ use async_stream::try_stream;
 use futures_util::StreamExt;
 
 use crate::intake::{
-    now_millis, HttpIntakeSink, IntakePayloadBuilder, IntakePayloadContext, IntakeRequestState,
-    IntakeSink, IntakeSinkConfig, IntakeStreamCapture, IntakeStreamFormat, SubModelCalls,
+    HttpIntakeSink, IntakePayloadBuilder, IntakePayloadContext, IntakeRequestState, IntakeSink,
+    IntakeSinkConfig, IntakeStreamCapture, IntakeStreamFormat, SubModelCalls, now_millis,
 };
 
 /// Response processor that converts completed responses into intake payloads.

--- a/crates/switchyard-components/src/response_processors/response_signals.rs
+++ b/crates/switchyard-components/src/response_processors/response_signals.rs
@@ -11,7 +11,7 @@
 
 use crate::{ChatResponse, ProxyContext, Result};
 
-use crate::dimension_collector::response::{extract_response_signals, ResponseSignals};
+use crate::dimension_collector::response::{ResponseSignals, extract_response_signals};
 
 /// Populates `ProxyContext` with [`ResponseSignals`] derived from the
 /// buffered response body.

--- a/crates/switchyard-components/src/response_processors/stats.rs
+++ b/crates/switchyard-components/src/response_processors/stats.rs
@@ -133,8 +133,8 @@ fn wrap_openai_chat_stream(
         let mut committed = false;
         while let Some(event) = stream.next().await {
             let event = event?;
-            if !committed {
-                if let Some(usage) = openai_chat_usage_from_stream_event(&event) {
+            if !committed
+                && let Some(usage) = openai_chat_usage_from_stream_event(&event) {
                     log_stream_record_result(record_usage(
                         &accumulator,
                         &model,
@@ -146,7 +146,6 @@ fn wrap_openai_chat_stream(
                     ), &model);
                     committed = true;
                 }
-            }
             yield event;
         }
     })
@@ -165,8 +164,8 @@ fn wrap_openai_responses_stream(
         let mut committed = false;
         while let Some(event) = stream.next().await {
             let event = event?;
-            if !committed {
-                if let Some(usage) = openai_responses_usage_from_stream_event(&event) {
+            if !committed
+                && let Some(usage) = openai_responses_usage_from_stream_event(&event) {
                     log_stream_record_result(record_usage(
                         &accumulator,
                         &model,
@@ -178,7 +177,6 @@ fn wrap_openai_responses_stream(
                     ), &model);
                     committed = true;
                 }
-            }
             yield event;
         }
     })

--- a/crates/switchyard-components/src/response_processors/stats.rs
+++ b/crates/switchyard-components/src/response_processors/stats.rs
@@ -8,9 +8,9 @@ use async_stream::try_stream;
 use futures_util::StreamExt;
 
 use crate::stats::{
-    openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event,
-    selected_stats_model, selected_stats_tier, usage_from_body, AnthropicStreamUsage, PrefixProbe,
-    StatsAccumulator, StatsBackendLatency, StatsRequestStart, TokenUsage,
+    AnthropicStreamUsage, PrefixProbe, StatsAccumulator, StatsBackendLatency, StatsRequestStart,
+    TokenUsage, openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event,
+    selected_stats_model, selected_stats_tier, usage_from_body,
 };
 
 /// Records token usage, total latency, and routing overhead.

--- a/crates/switchyard-components/src/stage_router.rs
+++ b/crates/switchyard-components/src/stage_router.rs
@@ -10,6 +10,6 @@
 //! through the same implementation the libsy profile uses.
 
 pub use switchyard_libsy::{
-    dimensions_from_signal, pick_tier, score_signal, CodingAgentDimensions, DecisionSource,
-    PickOutcome, PickerMode, ScoreResult, StageClassifier, Tier,
+    CodingAgentDimensions, DecisionSource, PickOutcome, PickerMode, ScoreResult, StageClassifier,
+    Tier, dimensions_from_signal, pick_tier, score_signal,
 };

--- a/crates/switchyard-components/src/stats/accumulator.rs
+++ b/crates/switchyard-components/src/stats/accumulator.rs
@@ -585,13 +585,11 @@ impl LatencyHistogram {
         let sample = Reverse(LatencySample(latency_ms));
         if self.samples.len() < MAX_LATENCY_SAMPLES {
             self.samples.push(sample);
-        } else if let Some(smallest_sample) = self.samples.peek() {
-            if latency_ms > smallest_sample.0.value() {
-                if let Some(mut smallest_sample) = self.samples.peek_mut() {
+        } else if let Some(smallest_sample) = self.samples.peek()
+            && latency_ms > smallest_sample.0.value()
+                && let Some(mut smallest_sample) = self.samples.peek_mut() {
                     *smallest_sample = sample;
                 }
-            }
-        }
     }
 
     fn snapshot(&self) -> LatencyHistogramSnapshot {

--- a/crates/switchyard-components/src/stats/accumulator.rs
+++ b/crates/switchyard-components/src/stats/accumulator.rs
@@ -4,14 +4,14 @@
 //! Thread-safe stats accumulator and serializable snapshot schema.
 
 use std::cmp::{Ordering, Reverse};
-use std::collections::{btree_map::Entry, BTreeMap, BinaryHeap, HashSet};
+use std::collections::{BTreeMap, BinaryHeap, HashSet, btree_map::Entry};
 use std::sync::Arc;
 
 use crate::Result;
 use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 
-use super::cost::{estimate_cost, CostEstimate};
+use super::cost::{CostEstimate, estimate_cost};
 use super::{PrefixProbe, TokenUsage};
 
 const MAX_LATENCY_SAMPLES: usize = 10_000;
@@ -587,9 +587,10 @@ impl LatencyHistogram {
             self.samples.push(sample);
         } else if let Some(smallest_sample) = self.samples.peek()
             && latency_ms > smallest_sample.0.value()
-                && let Some(mut smallest_sample) = self.samples.peek_mut() {
-                    *smallest_sample = sample;
-                }
+            && let Some(mut smallest_sample) = self.samples.peek_mut()
+        {
+            *smallest_sample = sample;
+        }
     }
 
     fn snapshot(&self) -> LatencyHistogramSnapshot {

--- a/crates/switchyard-components/src/stats/cache_eligibility.rs
+++ b/crates/switchyard-components/src/stats/cache_eligibility.rs
@@ -3,8 +3,8 @@
 
 //! Switch-aware cache eligibility: how much of a prompt a model has already been sent.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use serde_json::Value;

--- a/crates/switchyard-components/src/stats/mod.rs
+++ b/crates/switchyard-components/src/stats/mod.rs
@@ -13,13 +13,13 @@ pub use accumulator::{
     ClassifierStatsSnapshot, LatencyHistogramSnapshot, ModelStatsSnapshot, StatsAccumulator,
     StatsSnapshot, TierStatsSnapshot, TokenTotals,
 };
-pub use cache_eligibility::{prefix_probe, tracking_enabled_from_env, PrefixProbe};
+pub use cache_eligibility::{PrefixProbe, prefix_probe, tracking_enabled_from_env};
 pub use context::{
-    selected_stats_model, selected_stats_tier, StatsBackendLatency, StatsRequestStart,
-    StatsRouteLabel,
+    StatsBackendLatency, StatsRequestStart, StatsRouteLabel, selected_stats_model,
+    selected_stats_tier,
 };
-pub use cost::{estimate_model_cost, has_model_price, CostBreakdown, CostEstimate};
+pub use cost::{CostBreakdown, CostEstimate, estimate_model_cost, has_model_price};
 pub use usage::{
-    openai_chat_usage_from_stream_event, openai_responses_usage_from_stream_event, usage_from_body,
-    AnthropicStreamUsage, TokenUsage,
+    AnthropicStreamUsage, TokenUsage, openai_chat_usage_from_stream_event,
+    openai_responses_usage_from_stream_event, usage_from_body,
 };

--- a/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
+++ b/crates/switchyard-components/tests/adversarial_multi_llm_backend.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_components::{
     BackendFormat, ChatRequest, ChatRequestType, ChatResponse, LlmBackend, LlmTarget, LlmTargetId,
     ModelId, ProxyContext, Result, SwitchyardError,
@@ -414,8 +414,8 @@ async fn single_target_fallback_routes_without_selector() -> Result<()> {
 
 // Non-object request bodies should be repaired only in the delegated clone.
 #[tokio::test]
-async fn single_target_fallback_recovers_non_object_request_body_without_mutating_original(
-) -> Result<()> {
+async fn single_target_fallback_recovers_non_object_request_body_without_mutating_original()
+-> Result<()> {
     let calls = Shared::default();
     let events = Shared::default();
     let backend = MultiLlmBackend::new([target_backend(
@@ -492,8 +492,8 @@ async fn routing_preserves_responses_payload_shape_while_rewriting_model() -> Re
 
 // Multi-LLM dispatch should not reject a selected child based on its native format list.
 #[tokio::test]
-async fn selected_child_backend_receives_request_even_when_its_direct_formats_do_not_match(
-) -> Result<()> {
+async fn selected_child_backend_receives_request_even_when_its_direct_formats_do_not_match()
+-> Result<()> {
     let calls = Shared::default();
     let events = Shared::default();
     let backend = MultiLlmBackend::new([target_backend(
@@ -746,8 +746,8 @@ async fn duplicate_models_route_successfully_when_target_is_explicit() -> Result
 
 // Successful explicit routing should replace stale context selection before delegation.
 #[tokio::test]
-async fn explicit_target_overwrites_stale_selected_model_and_selection_before_delegation(
-) -> Result<()> {
+async fn explicit_target_overwrites_stale_selected_model_and_selection_before_delegation()
+-> Result<()> {
     let calls = Shared::default();
     let events = Shared::default();
     let backend = MultiLlmBackend::new([target_backend(
@@ -1198,9 +1198,11 @@ fn public_accessors_return_targets_and_backends_without_leaking_storage_shape() 
             .model,
         ModelId::from_static("second-model")
     );
-    assert!(backend
-        .target(&LlmTargetId::from_static("missing-target"))
-        .is_none());
+    assert!(
+        backend
+            .target(&LlmTargetId::from_static("missing-target"))
+            .is_none()
+    );
     assert_eq!(
         backend.targets()[0].backend().supported_request_types(),
         &ALL_REQUEST_TYPES

--- a/crates/switchyard-components/tests/adversarial_native_backends.rs
+++ b/crates/switchyard-components/tests/adversarial_native_backends.rs
@@ -6,7 +6,7 @@
 mod support;
 
 use futures_util::StreamExt;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_components::{
     AnthropicNativeBackend, BackendSelection, OpenAiNativeBackend, OpenAiPassthroughBackend,
 };

--- a/crates/switchyard-components/tests/contracts.rs
+++ b/crates/switchyard-components/tests/contracts.rs
@@ -135,21 +135,23 @@ fn backend_format_stays_wire_compatible_with_python_configs() -> TestResult {
 // Verifies Rust LLM targets reject stale provider tuning fields instead of dropping typos.
 #[test]
 fn llm_target_rejects_provider_tuning_fields() -> TestResult {
-    assert!(serde_json::from_value::<LlmTarget>(json!({
-        "id": "primary",
-        "model": "gpt-5",
-        "format": "openai",
-        "endpoint": {
-            "base_url": "https://example.test/v1",
-            "api_key": null,
-            "timeout_secs": 30
-        },
-        "tuning": {
-            "max_output_tokens": 4096,
-            "reasoning_effort": "xhigh"
-        }
-    }))
-    .is_err());
+    assert!(
+        serde_json::from_value::<LlmTarget>(json!({
+            "id": "primary",
+            "model": "gpt-5",
+            "format": "openai",
+            "endpoint": {
+                "base_url": "https://example.test/v1",
+                "api_key": null,
+                "timeout_secs": 30
+            },
+            "tuning": {
+                "max_output_tokens": 4096,
+                "reasoning_effort": "xhigh"
+            }
+        }))
+        .is_err()
+    );
 
     let target = serde_json::from_value::<LlmTarget>(json!({
         "id": "primary",

--- a/crates/switchyard-components/tests/flat_target_live.rs
+++ b/crates/switchyard-components/tests/flat_target_live.rs
@@ -12,9 +12,9 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::{json, Value};
-use switchyard_components::intake::to_flat_document;
+use serde_json::{Value, json};
 use switchyard_components::Result;
+use switchyard_components::intake::to_flat_document;
 use switchyard_components::{
     HttpIntakeSink, IntakeFormat, IntakeSink, IntakeSinkConfig, IntakeTarget,
 };

--- a/crates/switchyard-components/tests/intake_payload.rs
+++ b/crates/switchyard-components/tests/intake_payload.rs
@@ -5,7 +5,7 @@
 
 mod support;
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_components::{
     ChatRequest, ChatRequestType, LlmTargetId, ModelId, ProxyContext, Result,
 };
@@ -337,9 +337,11 @@ fn payload_usage_uses_null_model_when_served_model_is_missing() -> Result<()> {
         false,
     )?;
 
-    assert!(payload["request"]["switchyard"]
-        .get("served_model")
-        .is_none());
+    assert!(
+        payload["request"]["switchyard"]
+            .get("served_model")
+            .is_none()
+    );
     Ok(())
 }
 

--- a/crates/switchyard-components/tests/intake_response_processor.rs
+++ b/crates/switchyard-components/tests/intake_response_processor.rs
@@ -16,7 +16,7 @@ use switchyard_components::{
 };
 
 use support::intake::{
-    completion, drain_stream, opted_in_context, record_backend_selection, RecordingSink,
+    RecordingSink, completion, drain_stream, opted_in_context, record_backend_selection,
 };
 
 // Skip metadata should preserve the response and avoid sink writes.
@@ -521,8 +521,8 @@ async fn response_processor_wraps_responses_stream_completed_response() -> Resul
 
 // Responses streams without a completed event should synthesize the final response.
 #[tokio::test]
-async fn response_processor_wraps_responses_stream_function_call_without_completed_event(
-) -> Result<()> {
+async fn response_processor_wraps_responses_stream_function_call_without_completed_event()
+-> Result<()> {
     let sink = Arc::new(RecordingSink::default());
     let processor = IntakeResponseProcessor::new(
         IntakeSinkConfig {

--- a/crates/switchyard-components/tests/stats_accumulator.rs
+++ b/crates/switchyard-components/tests/stats_accumulator.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use serde_json::json;
 use switchyard_components::{
-    prefix_probe, ModelStatsSnapshot, StatsAccumulator, StatsSnapshot, TokenUsage,
+    ModelStatsSnapshot, StatsAccumulator, StatsSnapshot, TokenUsage, prefix_probe,
 };
 use switchyard_components::{Result, SwitchyardError};
 

--- a/crates/switchyard-components/tests/stats_processors.rs
+++ b/crates/switchyard-components/tests/stats_processors.rs
@@ -3,8 +3,8 @@
 
 //! Stats processor tests covering request stamps, backend wrappers, and stream usage.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -277,8 +277,8 @@ async fn backend_wrapper_records_success_using_served_model_and_delegates_lifecy
 
 // If a backend does not stamp a served model, request model is the fallback.
 #[tokio::test]
-async fn backend_wrapper_falls_back_to_request_model_when_backend_does_not_stamp_model(
-) -> Result<()> {
+async fn backend_wrapper_falls_back_to_request_model_when_backend_does_not_stamp_model()
+-> Result<()> {
     let accumulator = StatsAccumulator::new();
     let backend = StatsLlmBackend::new(
         Arc::new(FakeBackend::success(ChatResponse::openai_completion(

--- a/crates/switchyard-components/tests/stats_usage_shapes.rs
+++ b/crates/switchyard-components/tests/stats_usage_shapes.rs
@@ -19,8 +19,8 @@
 //! eliminated.
 
 use serde_json::json;
-use switchyard_components::stats::usage_from_body;
 use switchyard_components::TokenUsage;
+use switchyard_components::stats::usage_from_body;
 
 #[test]
 fn openai_inclusive_shape_extracts_prompt_as_inclusive_total() {

--- a/crates/switchyard-components/tests/support/intake.rs
+++ b/crates/switchyard-components/tests/support/intake.rs
@@ -8,7 +8,7 @@
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use parking_lot::Mutex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_components::{
     BackendSelection, BackendSelectionReason, IntakeRequestMetadata, IntakeRequestState,
     IntakeSink, RequestMetadata,

--- a/crates/switchyard-components/tests/support/mod.rs
+++ b/crates/switchyard-components/tests/support/mod.rs
@@ -82,9 +82,10 @@ impl OneShotServer {
         match &request {
             Ok(_) | Err(RecvTimeoutError::Disconnected) => {
                 if let Some(handle) = self.handle.take()
-                    && handle.join().is_err() {
-                        return Err(SwitchyardError::Other("server thread panicked".to_string()));
-                    }
+                    && handle.join().is_err()
+                {
+                    return Err(SwitchyardError::Other("server thread panicked".to_string()));
+                }
             }
             Err(RecvTimeoutError::Timeout) => {}
         }
@@ -148,9 +149,10 @@ impl SequenceServer {
         match &requests {
             Ok(_) | Err(RecvTimeoutError::Disconnected) => {
                 if let Some(handle) = self.handle.take()
-                    && handle.join().is_err() {
-                        return Err(SwitchyardError::Other("server thread panicked".to_string()));
-                    }
+                    && handle.join().is_err()
+                {
+                    return Err(SwitchyardError::Other("server thread panicked".to_string()));
+                }
             }
             Err(RecvTimeoutError::Timeout) => {}
         }

--- a/crates/switchyard-components/tests/support/mod.rs
+++ b/crates/switchyard-components/tests/support/mod.rs
@@ -81,11 +81,10 @@ impl OneShotServer {
         let request = self.receiver.recv_timeout(Duration::from_secs(5));
         match &request {
             Ok(_) | Err(RecvTimeoutError::Disconnected) => {
-                if let Some(handle) = self.handle.take() {
-                    if handle.join().is_err() {
+                if let Some(handle) = self.handle.take()
+                    && handle.join().is_err() {
                         return Err(SwitchyardError::Other("server thread panicked".to_string()));
                     }
-                }
             }
             Err(RecvTimeoutError::Timeout) => {}
         }
@@ -148,11 +147,10 @@ impl SequenceServer {
         let requests = self.receiver.recv_timeout(Duration::from_secs(5));
         match &requests {
             Ok(_) | Err(RecvTimeoutError::Disconnected) => {
-                if let Some(handle) = self.handle.take() {
-                    if handle.join().is_err() {
+                if let Some(handle) = self.handle.take()
+                    && handle.join().is_err() {
                         return Err(SwitchyardError::Other("server thread panicked".to_string()));
                     }
-                }
             }
             Err(RecvTimeoutError::Timeout) => {}
         }

--- a/crates/switchyard-py/src/component_bindings/backends.rs
+++ b/crates/switchyard-py/src/component_bindings/backends.rs
@@ -14,7 +14,7 @@ use switchyard_components::{
 };
 use switchyard_components::{ChatRequestType, EndpointConfig, LlmBackend, LlmTargetId};
 
-use super::config::{endpoint_config_from_python, PyEndpointConfig, PyLlmTarget};
+use super::config::{PyEndpointConfig, PyLlmTarget, endpoint_config_from_python};
 use super::stats::PyStatsAccumulator;
 use crate::errors::py_core_error;
 use crate::interop::request::request_type_from_python;

--- a/crates/switchyard-py/src/component_bindings/dimension_collector.rs
+++ b/crates/switchyard-py/src/component_bindings/dimension_collector.rs
@@ -19,11 +19,11 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 use switchyard_components::ChatResponse;
 use switchyard_components::{
-    dimension_collector::{
-        extract_response_signals as core_extract_response_signals, ResponseFlag, ResponseSignals,
-        ToolResultSignal, DEFAULT_RECENT_WINDOW,
-    },
     DimensionCollector, ResponseSignalCollector,
+    dimension_collector::{
+        DEFAULT_RECENT_WINDOW, ResponseFlag, ResponseSignals, ToolResultSignal,
+        extract_response_signals as core_extract_response_signals,
+    },
 };
 
 use crate::py_serde::value_from_python;

--- a/crates/switchyard-py/src/component_bindings/request_processors.rs
+++ b/crates/switchyard-py/src/component_bindings/request_processors.rs
@@ -5,7 +5,7 @@
 
 use pyo3::prelude::*;
 use switchyard_components::{
-    tracking_enabled_from_env, IntakeRequestProcessor, StatsRequestProcessor,
+    IntakeRequestProcessor, StatsRequestProcessor, tracking_enabled_from_env,
 };
 
 use crate::errors::py_core_error;

--- a/crates/switchyard-py/src/component_bindings/stage_router.rs
+++ b/crates/switchyard-py/src/component_bindings/stage_router.rs
@@ -12,7 +12,7 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use switchyard_components::stage_router::{pick_tier, score_signal, PickOutcome, PickerMode, Tier};
+use switchyard_components::stage_router::{PickOutcome, PickerMode, Tier, pick_tier, score_signal};
 
 use super::dimension_collector::PyToolResultSignal;
 

--- a/crates/switchyard-py/src/interop/context.rs
+++ b/crates/switchyard-py/src/interop/context.rs
@@ -3,8 +3,8 @@
 
 //! Private adapter for Rust-owned request context values.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use parking_lot::{Mutex, MutexGuard};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -422,10 +422,7 @@ impl PyProxyContext {
             .map(|target| target.as_str().to_string());
         Ok(format!(
             "ProxyContext(request_id={:?}, inbound_format={:?}, selected_model={:?}, selected_target={:?})",
-            inner.request_id,
-            inner.inbound_format,
-            selected_model,
-            selected_target,
+            inner.request_id, inner.inbound_format, selected_model, selected_target,
         ))
     }
 }

--- a/crates/switchyard-py/src/interop/response.rs
+++ b/crates/switchyard-py/src/interop/response.rs
@@ -4,11 +4,11 @@
 //! Private adapter for Rust-owned chat response values.
 
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
-use futures_util::{stream, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, stream};
 use parking_lot::Mutex;
 use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration, PyValueError};
 use pyo3::prelude::*;

--- a/crates/switchyard-py/src/interop/roles.rs
+++ b/crates/switchyard-py/src/interop/roles.rs
@@ -5,10 +5,10 @@
 
 use std::sync::Arc;
 
+use pyo3::PyTypeInfo;
 use pyo3::exceptions::{PyNotImplementedError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple, PyType};
-use pyo3::PyTypeInfo;
 use switchyard_components::LlmBackend;
 
 use super::context::lease_from_python;

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_libsy::{
     Algorithm, HandoffNoteConfig, LibsyError as RustLibsyError, LlmFallback, LlmTarget,
     LlmTargetSet, LlmTaskClassifier, Noop, PickerMode, Random, StageRouter, StageRouterConfig,

--- a/crates/switchyard-py/src/py_serde.rs
+++ b/crates/switchyard-py/src/py_serde.rs
@@ -7,7 +7,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pythonize::{depythonize, pythonize};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
 /// Converts a Python mapping-like object into a Serde-owned Rust value.
@@ -36,15 +36,17 @@ pub(crate) fn value_to_python(py: Python<'_>, value: &Value) -> PyResult<Py<PyAn
 
 fn jsonable_python(value: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
     if let Ok(model_dump) = value.getattr("model_dump")
-        && model_dump.is_callable() {
-            let kwargs = PyDict::new(value.py());
-            kwargs.set_item("mode", "json")?;
-            kwargs.set_item("exclude_none", true)?;
-            return model_dump.call((), Some(&kwargs)).map(Bound::unbind);
-        }
+        && model_dump.is_callable()
+    {
+        let kwargs = PyDict::new(value.py());
+        kwargs.set_item("mode", "json")?;
+        kwargs.set_item("exclude_none", true)?;
+        return model_dump.call((), Some(&kwargs)).map(Bound::unbind);
+    }
     if let Ok(to_dict) = value.getattr("to_dict")
-        && to_dict.is_callable() {
-            return to_dict.call0().map(Bound::unbind);
-        }
+        && to_dict.is_callable()
+    {
+        return to_dict.call0().map(Bound::unbind);
+    }
     Ok(value.clone().unbind())
 }

--- a/crates/switchyard-py/src/py_serde.rs
+++ b/crates/switchyard-py/src/py_serde.rs
@@ -35,18 +35,16 @@ pub(crate) fn value_to_python(py: Python<'_>, value: &Value) -> PyResult<Py<PyAn
 }
 
 fn jsonable_python(value: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
-    if let Ok(model_dump) = value.getattr("model_dump") {
-        if model_dump.is_callable() {
+    if let Ok(model_dump) = value.getattr("model_dump")
+        && model_dump.is_callable() {
             let kwargs = PyDict::new(value.py());
             kwargs.set_item("mode", "json")?;
             kwargs.set_item("exclude_none", true)?;
             return model_dump.call((), Some(&kwargs)).map(Bound::unbind);
         }
-    }
-    if let Ok(to_dict) = value.getattr("to_dict") {
-        if to_dict.is_callable() {
+    if let Ok(to_dict) = value.getattr("to_dict")
+        && to_dict.is_callable() {
             return to_dict.call0().map(Bound::unbind);
         }
-    }
     Ok(value.clone().unbind())
 }

--- a/crates/switchyard-py/src/server_bindings.rs
+++ b/crates/switchyard-py/src/server_bindings.rs
@@ -122,11 +122,10 @@ impl PyServer {
         let task = self.task.take();
         let result = py.detach(move || {
             let result = completion.recv_timeout(timeout);
-            if matches!(result, Err(RecvTimeoutError::Timeout)) {
-                if let Some(task) = task {
+            if matches!(result, Err(RecvTimeoutError::Timeout))
+                && let Some(task) = task {
                     task.abort();
                 }
-            }
             flush_observability();
             result
         });

--- a/crates/switchyard-py/src/server_bindings.rs
+++ b/crates/switchyard-py/src/server_bindings.rs
@@ -5,15 +5,15 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
-use std::sync::mpsc::{sync_channel, Receiver, RecvTimeoutError};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, sync_channel};
 use std::time::Duration;
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use switchyard_server::config::load_server_state;
 use switchyard_server::{
-    flush_observability, initialize_observability, BoundServer, ServerResult, ServerRunOptions,
-    DEFAULT_LISTEN_BACKLOG,
+    BoundServer, DEFAULT_LISTEN_BACKLOG, ServerResult, ServerRunOptions, flush_observability,
+    initialize_observability,
 };
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -123,9 +123,10 @@ impl PyServer {
         let result = py.detach(move || {
             let result = completion.recv_timeout(timeout);
             if matches!(result, Err(RecvTimeoutError::Timeout))
-                && let Some(task) = task {
-                    task.abort();
-                }
+                && let Some(task) = task
+            {
+                task.abort();
+            }
             flush_observability();
             result
         });

--- a/crates/switchyard-py/src/translation.rs
+++ b/crates/switchyard-py/src/translation.rs
@@ -6,7 +6,7 @@
 use pyo3::prelude::*;
 use serde_json::Value;
 use switchyard_translation::{
-    normalize_anthropic_tool_use_ids, StreamTranslationState, TranslationEngine, TranslationPolicy,
+    StreamTranslationState, TranslationEngine, TranslationPolicy, normalize_anthropic_tool_use_ids,
 };
 
 use crate::errors::py_translation_error;

--- a/crates/switchyard-server/src/cli.rs
+++ b/crates/switchyard-server/src/cli.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 use clap::Parser;
 use switchyard_server::config::load_server_state;
 use switchyard_server::{
-    run_server, ServerError, ServerResult, ServerRunOptions, ServerState, TlsOptions,
-    DEFAULT_LISTEN_BACKLOG,
+    DEFAULT_LISTEN_BACKLOG, ServerError, ServerResult, ServerRunOptions, ServerState, TlsOptions,
+    run_server,
 };
 
 const DEFAULT_HOST: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -16,7 +16,7 @@ use libsy::{
 use serde::Deserialize;
 use serde_json::Value;
 use switchyard_llm_client::{
-    Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient, DEFAULT_MAX_RETRIES,
+    Backend, DEFAULT_MAX_RETRIES, HttpBackendConfig, ModelConfig, TranslatingLlmClient,
 };
 use switchyard_protocol::RoutedLlmClient;
 
@@ -733,14 +733,19 @@ target = "weak"
         assert!(error_message(&missing).contains("SWITCHYARD_CONFIG_TEST_KEY_THAT_IS_NOT_SET"));
 
         const EMPTY_KEY_ENV: &str = "SWITCHYARD_CONFIG_TEST_EMPTY_KEY";
-        std::env::set_var(EMPTY_KEY_ENV, "");
+        unsafe {
+            // "unsafe" is for concurrent reads and writes, very rare
+            std::env::set_var(EMPTY_KEY_ENV, "");
+        }
         let empty = VALID_CONFIG.replacen(
             "base_url = \"https://example.test/v1\"",
             &format!("base_url = \"https://example.test/v1\"\napi_key_env = \"{EMPTY_KEY_ENV}\""),
             1,
         );
         let message = error_message(&empty);
-        std::env::remove_var(EMPTY_KEY_ENV);
+        unsafe {
+            std::env::remove_var(EMPTY_KEY_ENV);
+        }
         assert!(message.contains("is empty"));
     }
 }

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -34,16 +34,16 @@ use axum_server::tls_rustls::RustlsConfig;
 use libsy::{Algorithm, LibsyError, RunObservation, RunObserver};
 use parking_lot::Mutex;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_protocol::{Context, Decision, LlmClientError, Metadata, Request, Usage};
 use tokio::net::{TcpListener, TcpSocket};
 use tokio::task;
 use tracing::{Instrument, Level};
 
-use switchyard_translation::{decode_request, WireFormat};
+use switchyard_translation::{WireFormat, decode_request};
 
 use crate::response::into_http_response;
-use crate::stats::{prefix_probe, tracking_enabled_from_env, StatsAccumulator, StatsSnapshot};
+use crate::stats::{StatsAccumulator, StatsSnapshot, prefix_probe, tracking_enabled_from_env};
 
 pub use observability::{flush_observability, initialize_observability};
 
@@ -871,7 +871,7 @@ async fn get_session_stats(
                 error.to_string(),
                 "invalid_request_error",
                 "invalid_query",
-            )
+            );
         }
     };
     let Some(routing_log) = state.routing_log else {

--- a/crates/switchyard-server/src/metrics.rs
+++ b/crates/switchyard-server/src/metrics.rs
@@ -63,11 +63,10 @@ fn initialize() -> Result<Metrics, String> {
 }
 
 pub(crate) fn flush() {
-    if let Some(Ok(metrics)) = METRICS.get() {
-        if let Err(error) = metrics.provider.force_flush() {
+    if let Some(Ok(metrics)) = METRICS.get()
+        && let Err(error) = metrics.provider.force_flush() {
             tracing::warn!(error = %error, "failed to flush OpenTelemetry metrics");
         }
-    }
 }
 
 fn routing_overhead_buckets(instrument: &Instrument) -> Option<Stream> {

--- a/crates/switchyard-server/src/metrics.rs
+++ b/crates/switchyard-server/src/metrics.rs
@@ -5,7 +5,7 @@
 
 use std::sync::OnceLock;
 
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream};
 use prometheus::{Encoder, Registry, TextEncoder};
 use switchyard_llm_client::metrics::{http_outcome_label, http_status_code_label};
@@ -64,9 +64,10 @@ fn initialize() -> Result<Metrics, String> {
 
 pub(crate) fn flush() {
     if let Some(Ok(metrics)) = METRICS.get()
-        && let Err(error) = metrics.provider.force_flush() {
-            tracing::warn!(error = %error, "failed to flush OpenTelemetry metrics");
-        }
+        && let Err(error) = metrics.provider.force_flush()
+    {
+        tracing::warn!(error = %error, "failed to flush OpenTelemetry metrics");
+    }
 }
 
 fn routing_overhead_buckets(instrument: &Instrument) -> Option<Stream> {

--- a/crates/switchyard-server/src/observability.rs
+++ b/crates/switchyard-server/src/observability.rs
@@ -9,15 +9,15 @@ use std::sync::OnceLock;
 use axum::http::HeaderMap;
 use opentelemetry::propagation::{Extractor, TextMapPropagator};
 use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use opentelemetry_sdk::Resource;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer as _};
 
-use crate::{metrics, ServerError, ServerResult};
+use crate::{ServerError, ServerResult, metrics};
 
 const DEFAULT_LOG_FILTER: &str = "switchyard_server=info,libsy=info,opentelemetry=warn";
 const DEFAULT_SERVICE_NAME: &str = "switchyard-server";
@@ -40,9 +40,10 @@ pub fn initialize_observability() -> ServerResult<()> {
 pub fn flush_observability() {
     if let Some(Ok(observability)) = OBSERVABILITY.get()
         && let Some(provider) = &observability.tracer_provider
-            && let Err(error) = provider.force_flush() {
-                tracing::warn!(error = %error, "failed to flush OpenTelemetry traces");
-            }
+        && let Err(error) = provider.force_flush()
+    {
+        tracing::warn!(error = %error, "failed to flush OpenTelemetry traces");
+    }
     metrics::flush();
 }
 

--- a/crates/switchyard-server/src/observability.rs
+++ b/crates/switchyard-server/src/observability.rs
@@ -38,13 +38,11 @@ pub fn initialize_observability() -> ServerResult<()> {
 
 /// Flushes pending OTLP telemetry without shutting down process-wide providers.
 pub fn flush_observability() {
-    if let Some(Ok(observability)) = OBSERVABILITY.get() {
-        if let Some(provider) = &observability.tracer_provider {
-            if let Err(error) = provider.force_flush() {
+    if let Some(Ok(observability)) = OBSERVABILITY.get()
+        && let Some(provider) = &observability.tracer_provider
+            && let Err(error) = provider.force_flush() {
                 tracing::warn!(error = %error, "failed to flush OpenTelemetry traces");
             }
-        }
-    }
     metrics::flush();
 }
 

--- a/crates/switchyard-server/src/response.rs
+++ b/crates/switchyard-server/src/response.rs
@@ -5,10 +5,10 @@
 
 use std::error::Error;
 
-use axum::response::{IntoResponse, Response as HttpResponse};
 use axum::Json;
+use axum::response::{IntoResponse, Response as HttpResponse};
 use switchyard_protocol::{LlmResponse, Response as AlgorithmResponse};
-use switchyard_translation::{encode_aggregated_response, encode_stream, WireFormat};
+use switchyard_translation::{WireFormat, encode_aggregated_response, encode_stream};
 
 use crate::sse::frame_stream;
 

--- a/crates/switchyard-server/src/sse.rs
+++ b/crates/switchyard-server/src/sse.rs
@@ -7,7 +7,7 @@ use std::convert::Infallible;
 
 use axum::response::sse::{Event, Sse};
 use futures_util::Stream;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_translation::{RawEventStream, WireFormat};
 
 /// Boxed stream type accepted by Axum's SSE response wrapper.

--- a/crates/switchyard-server/src/stats/cache_eligibility.rs
+++ b/crates/switchyard-server/src/stats/cache_eligibility.rs
@@ -3,8 +3,8 @@
 
 //! Switch-aware cache eligibility for the Rust server.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use serde_json::Value;

--- a/crates/switchyard-server/src/usage_metrics.rs
+++ b/crates/switchyard-server/src/usage_metrics.rs
@@ -6,12 +6,12 @@
 use std::time::{Duration, Instant};
 
 use futures_util::StreamExt;
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 use switchyard_protocol::{LlmResponse, LlmResponseChunk, Response, Usage};
 
+use crate::SharedRoutingLog;
 use crate::routing_log::RoutingLogContext;
 use crate::stats::{StatsAccumulator, TokenUsage};
-use crate::SharedRoutingLog;
 
 /// Observes a routed response without changing its aggregate or streaming contents.
 pub(crate) fn observe(

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -18,11 +18,11 @@ use axum::routing::post;
 use axum::{Json, Router};
 use http_body_util::BodyExt;
 use libsy::{Algorithm, LlmTarget, LlmTargetSet, Random};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_llm_client::{Backend, HttpBackendConfig, ModelConfig, TranslatingLlmClient};
 use switchyard_protocol::RoutedLlmClient;
 use switchyard_server::config::load_server_state;
-use switchyard_server::{build_switchyard_router, ServerState};
+use switchyard_server::{ServerState, build_switchyard_router};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -417,24 +417,30 @@ async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
         );
     }
     // A sub-millisecond boundary exists only because of the server's bucket view.
-    assert!(metric_line(
-        metrics,
-        "switchyard_routing_overhead_ms_bucket",
-        &[("algorithm", "random"), ("le", "0.1")]
-    )
-    .is_some());
-    assert!(metric_line(
-        metrics,
-        "switchyard_cache_creation_tokens_total",
-        &[("model", MODEL)]
-    )
-    .is_none());
-    assert!(metric_line(
-        metrics,
-        "switchyard_reasoning_tokens_total",
-        &[("model", MODEL)]
-    )
-    .is_none());
+    assert!(
+        metric_line(
+            metrics,
+            "switchyard_routing_overhead_ms_bucket",
+            &[("algorithm", "random"), ("le", "0.1")]
+        )
+        .is_some()
+    );
+    assert!(
+        metric_line(
+            metrics,
+            "switchyard_cache_creation_tokens_total",
+            &[("model", MODEL)]
+        )
+        .is_none()
+    );
+    assert!(
+        metric_line(
+            metrics,
+            "switchyard_reasoning_tokens_total",
+            &[("model", MODEL)]
+        )
+        .is_none()
+    );
     for metric in [
         "switchyard_prompt_tokens_total",
         "switchyard_completion_tokens_total",
@@ -892,9 +898,11 @@ async fn all_inbound_formats_run_libsy_and_return_the_caller_format() -> TestRes
         responses.push(send(&app, "POST", path, Some(body)).await?);
     }
 
-    assert!(responses
-        .iter()
-        .all(|response| response.status == StatusCode::OK));
+    assert!(
+        responses
+            .iter()
+            .all(|response| response.status == StatusCode::OK)
+    );
     assert_eq!(
         responses[0].json()?["choices"][0]["message"]["content"],
         "ok"
@@ -972,9 +980,11 @@ async fn routing_log_exposes_session_stats() -> TestResult {
     let records = std::fs::read_to_string(log_path)?;
     let first: Value =
         serde_json::from_str(records.lines().next().ok_or("routing log was empty")?)?;
-    assert!(first["ts"]
-        .as_str()
-        .is_some_and(|value| value.ends_with('Z')));
+    assert!(
+        first["ts"]
+            .as_str()
+            .is_some_and(|value| value.ends_with('Z'))
+    );
     Ok(())
 }
 

--- a/crates/switchyard-skill-distillation/src/lib.rs
+++ b/crates/switchyard-skill-distillation/src/lib.rs
@@ -23,8 +23,8 @@ pub use error::{Result, SkillDistillationError};
 pub use ids::{SkillEvidenceId, SkillNamespace, SkillVersionId};
 pub use model::{
     ActivationOperation, ActivationRecord, DistillationRequest, ExecutionMetadata, Metadata,
-    SkillCandidate, SkillProvenance, TaskDescriptor, Trajectory, TrajectoryEvent,
+    SCHEMA_VERSION, SkillCandidate, SkillProvenance, TaskDescriptor, Trajectory, TrajectoryEvent,
     TrajectoryEventKind, TrajectoryOutcome, TrajectorySourceInfo, ValidationCheck,
-    ValidationReport, ValidationStatus, SCHEMA_VERSION,
+    ValidationReport, ValidationStatus,
 };
 pub use ports::{SkillDistiller, SkillStore, SkillValidator, TrajectorySource};

--- a/crates/switchyard-skill-distillation/tests/contracts.rs
+++ b/crates/switchyard-skill-distillation/tests/contracts.rs
@@ -10,10 +10,10 @@ use async_trait::async_trait;
 use serde_json::json;
 use switchyard_skill_distillation::{
     ActivationOperation, ActivationRecord, DistillationRequest, ExecutionMetadata, Metadata,
-    Result, SkillCandidate, SkillDistillationError, SkillDistiller, SkillEvidenceId,
-    SkillNamespace, SkillProvenance, SkillStore, SkillValidator, SkillVersionId, TaskDescriptor,
-    Trajectory, TrajectoryEvent, TrajectoryEventKind, TrajectoryOutcome, TrajectorySource,
-    TrajectorySourceInfo, ValidationCheck, ValidationReport, ValidationStatus, SCHEMA_VERSION,
+    Result, SCHEMA_VERSION, SkillCandidate, SkillDistillationError, SkillDistiller,
+    SkillEvidenceId, SkillNamespace, SkillProvenance, SkillStore, SkillValidator, SkillVersionId,
+    TaskDescriptor, Trajectory, TrajectoryEvent, TrajectoryEventKind, TrajectoryOutcome,
+    TrajectorySource, TrajectorySourceInfo, ValidationCheck, ValidationReport, ValidationStatus,
 };
 use tokio::sync::Mutex;
 

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -71,14 +71,13 @@ impl FormatCodec for AnthropicMessagesCodec {
             ),
             ..LlmRequest::default()
         };
-        if let Some(system) = body.get("system") {
-            if let Some(content) = decode_anthropic_system(system, &mut diagnostics, policy)? {
+        if let Some(system) = body.get("system")
+            && let Some(content) = decode_anthropic_system(system, &mut diagnostics, policy)? {
                 request.instructions.push(InstructionBlock {
                     role: Role::System,
                     content,
                 });
             }
-        }
         if let Some(messages) = body.get("messages").and_then(Value::as_array) {
             let mut generated_id = 0;
             for (index, message) in messages.iter().enumerate() {
@@ -348,8 +347,8 @@ fn decode_anthropic_system(
         Value::Array(blocks) => {
             let mut content = Vec::new();
             for block in blocks {
-                if let Some(block) = block.as_object() {
-                    if block.get("type").and_then(Value::as_str) == Some("text") {
+                if let Some(block) = block.as_object()
+                    && block.get("type").and_then(Value::as_str) == Some("text") {
                         let text = block
                             .get("text")
                             .and_then(Value::as_str)
@@ -357,7 +356,6 @@ fn decode_anthropic_system(
                             .to_string();
                         content.push(ContentBlock::Text { text });
                     }
-                }
             }
             Ok((!content.is_empty()).then_some(content))
         }

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -3,7 +3,7 @@
 
 //! Buffered codec for Anthropic Messages request and response JSON.
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::codecs::common::{is_known_role_name, provider_extensions, text_from_blocks};
 use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
@@ -72,12 +72,13 @@ impl FormatCodec for AnthropicMessagesCodec {
             ..LlmRequest::default()
         };
         if let Some(system) = body.get("system")
-            && let Some(content) = decode_anthropic_system(system, &mut diagnostics, policy)? {
-                request.instructions.push(InstructionBlock {
-                    role: Role::System,
-                    content,
-                });
-            }
+            && let Some(content) = decode_anthropic_system(system, &mut diagnostics, policy)?
+        {
+            request.instructions.push(InstructionBlock {
+                role: Role::System,
+                content,
+            });
+        }
         if let Some(messages) = body.get("messages").and_then(Value::as_array) {
             let mut generated_id = 0;
             for (index, message) in messages.iter().enumerate() {
@@ -348,14 +349,15 @@ fn decode_anthropic_system(
             let mut content = Vec::new();
             for block in blocks {
                 if let Some(block) = block.as_object()
-                    && block.get("type").and_then(Value::as_str) == Some("text") {
-                        let text = block
-                            .get("text")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string();
-                        content.push(ContentBlock::Text { text });
-                    }
+                    && block.get("type").and_then(Value::as_str) == Some("text")
+                {
+                    let text = block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    content.push(ContentBlock::Text { text });
+                }
             }
             Ok((!content.is_empty()).then_some(content))
         }

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -3,15 +3,15 @@
 
 //! Streaming codec for Anthropic Messages events.
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
+use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    record_source_identity, target_message_id_or_source_message_id, target_model_or_source_model,
-    StreamCodec, StreamTranslationState,
+    StreamCodec, StreamTranslationState, record_source_identity,
+    target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
 use crate::util::sanitize_anthropic_tool_use_id;
-use crate::LlmResponseChunk;
 
 /// Stream codec for Anthropic Messages events.
 pub struct AnthropicMessagesStreamCodec;
@@ -69,9 +69,10 @@ fn decode_anthropic_stream(
                 state.message_id = Some(id.to_string());
             }
             if let Some(message) = message
-                && let Some(usage) = message.get("usage") {
-                    capture_anthropic_usage(state, usage);
-                }
+                && let Some(usage) = message.get("usage")
+            {
+                capture_anthropic_usage(state, usage);
+            }
             vec![LlmResponseChunk::MessageStart {
                 id: state.message_id.clone(),
                 model: state.model.clone(),
@@ -459,17 +460,18 @@ fn encode_anthropic_tool_delta(
     }
 
     if let Some(content_index) = tool.content_index
-        && !tool.pending_arguments.is_empty() {
-            out.push(json!({
-                "type": "content_block_delta",
-                "index": content_index,
-                "delta": {
-                    "type": "input_json_delta",
-                    "partial_json": tool.pending_arguments,
-                },
-            }));
-            tool.pending_arguments.clear();
-        }
+        && !tool.pending_arguments.is_empty()
+    {
+        out.push(json!({
+            "type": "content_block_delta",
+            "index": content_index,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": tool.pending_arguments,
+            },
+        }));
+        tool.pending_arguments.clear();
+    }
     out
 }
 

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -68,11 +68,10 @@ fn decode_anthropic_stream(
             {
                 state.message_id = Some(id.to_string());
             }
-            if let Some(message) = message {
-                if let Some(usage) = message.get("usage") {
+            if let Some(message) = message
+                && let Some(usage) = message.get("usage") {
                     capture_anthropic_usage(state, usage);
                 }
-            }
             vec![LlmResponseChunk::MessageStart {
                 id: state.message_id.clone(),
                 model: state.model.clone(),
@@ -459,8 +458,8 @@ fn encode_anthropic_tool_delta(
         return out;
     }
 
-    if let Some(content_index) = tool.content_index {
-        if !tool.pending_arguments.is_empty() {
+    if let Some(content_index) = tool.content_index
+        && !tool.pending_arguments.is_empty() {
             out.push(json!({
                 "type": "content_block_delta",
                 "index": content_index,
@@ -471,7 +470,6 @@ fn encode_anthropic_tool_delta(
             }));
             tool.pending_arguments.clear();
         }
-    }
     out
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -3,7 +3,7 @@
 
 //! Buffered codec for OpenAI Chat Completions request and response JSON.
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::codecs::common::{
     is_known_role_name, provider_extensions, reasoning_text_from_blocks, text_from_blocks,
@@ -95,19 +95,20 @@ impl FormatCodec for OpenAiChatCodec {
                 )?;
                 prepend_openai_reasoning_blocks(&mut content, message);
                 if role == Role::Assistant
-                    && let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
-                        if is_empty_text_only(&content) {
-                            content.clear();
-                        }
-                        for tool_call in tool_calls {
-                            generated_id += 1;
-                            if let Some(call) =
-                                decode_openai_tool_call(tool_call, generated_id, policy)?
-                            {
-                                content.push(ContentBlock::ToolCall(call));
-                            }
+                    && let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array)
+                {
+                    if is_empty_text_only(&content) {
+                        content.clear();
+                    }
+                    for tool_call in tool_calls {
+                        generated_id += 1;
+                        if let Some(call) =
+                            decode_openai_tool_call(tool_call, generated_id, policy)?
+                        {
+                            content.push(ContentBlock::ToolCall(call));
                         }
                     }
+                }
                 if role == Role::Tool {
                     let text = content
                         .iter()

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -94,8 +94,8 @@ impl FormatCodec for OpenAiChatCodec {
                     format!("$.messages[{index}].content"),
                 )?;
                 prepend_openai_reasoning_blocks(&mut content, message);
-                if role == Role::Assistant {
-                    if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
+                if role == Role::Assistant
+                    && let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
                         if is_empty_text_only(&content) {
                             content.clear();
                         }
@@ -108,7 +108,6 @@ impl FormatCodec for OpenAiChatCodec {
                             }
                         }
                     }
-                }
                 if role == Role::Tool {
                     let text = content
                         .iter()

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -3,15 +3,15 @@
 
 //! Streaming codec for OpenAI Chat Completions chunks.
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
+use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    record_source_identity, state_source_is, string_field, target_model_or_source_model,
-    StreamCodec, StreamTranslationState,
+    StreamCodec, StreamTranslationState, record_source_identity, state_source_is, string_field,
+    target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
 use crate::llm::Usage;
-use crate::LlmResponseChunk;
 
 /// Stream codec for OpenAI Chat Completions chunks.
 pub struct OpenAiChatStreamCodec;
@@ -98,20 +98,22 @@ fn decode_openai_chat_stream(
         };
         if let Some(delta) = choice.get("delta").and_then(Value::as_object) {
             if let Some(text) = delta.get("content").and_then(Value::as_str)
-                && !text.is_empty() {
-                    out.push(LlmResponseChunk::TextDelta {
+                && !text.is_empty()
+            {
+                out.push(LlmResponseChunk::TextDelta {
+                    index: 0,
+                    text: text.to_string(),
+                });
+            }
+            for reasoning_key in ["reasoning_content", "reasoning"] {
+                if let Some(text) = delta.get(reasoning_key).and_then(Value::as_str)
+                    && !text.is_empty()
+                {
+                    out.push(LlmResponseChunk::ReasoningDelta {
                         index: 0,
                         text: text.to_string(),
                     });
                 }
-            for reasoning_key in ["reasoning_content", "reasoning"] {
-                if let Some(text) = delta.get(reasoning_key).and_then(Value::as_str)
-                    && !text.is_empty() {
-                        out.push(LlmResponseChunk::ReasoningDelta {
-                            index: 0,
-                            text: text.to_string(),
-                        });
-                    }
             }
             if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
                 for tool_call in tool_calls {

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -97,23 +97,21 @@ fn decode_openai_chat_stream(
             continue;
         };
         if let Some(delta) = choice.get("delta").and_then(Value::as_object) {
-            if let Some(text) = delta.get("content").and_then(Value::as_str) {
-                if !text.is_empty() {
+            if let Some(text) = delta.get("content").and_then(Value::as_str)
+                && !text.is_empty() {
                     out.push(LlmResponseChunk::TextDelta {
                         index: 0,
                         text: text.to_string(),
                     });
                 }
-            }
             for reasoning_key in ["reasoning_content", "reasoning"] {
-                if let Some(text) = delta.get(reasoning_key).and_then(Value::as_str) {
-                    if !text.is_empty() {
+                if let Some(text) = delta.get(reasoning_key).and_then(Value::as_str)
+                    && !text.is_empty() {
                         out.push(LlmResponseChunk::ReasoningDelta {
                             index: 0,
                             text: text.to_string(),
                         });
                     }
-                }
             }
             if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
                 for tool_call in tool_calls {

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -73,14 +73,15 @@ impl FormatCodec for OpenAiResponsesCodec {
             ..LlmRequest::default()
         };
         if let Some(instructions) = body.get("instructions").and_then(Value::as_str)
-            && !instructions.is_empty() {
-                request.instructions.push(crate::llm::InstructionBlock {
-                    role: Role::System,
-                    content: vec![ContentBlock::Text {
-                        text: instructions.to_string(),
-                    }],
-                });
-            }
+            && !instructions.is_empty()
+        {
+            request.instructions.push(crate::llm::InstructionBlock {
+                role: Role::System,
+                content: vec![ContentBlock::Text {
+                    text: instructions.to_string(),
+                }],
+            });
+        }
         request.messages = decode_responses_input(
             body.get("input").unwrap_or(&Value::String(String::new())),
             &mut diagnostics,
@@ -152,9 +153,10 @@ impl FormatCodec for OpenAiResponsesCodec {
             body.insert("tools".to_string(), encode_responses_tools(&request.tools));
         }
         if let Some(choice) = &request.tool_choice
-            && let Some(choice) = encode_responses_tool_choice(choice) {
-                body.insert("tool_choice".to_string(), choice);
-            }
+            && let Some(choice) = encode_responses_tool_choice(choice)
+        {
+            body.insert("tool_choice".to_string(), choice);
+        }
         if let Some(max_output_tokens) = request.output.max_output_tokens {
             body.insert("max_output_tokens".to_string(), json!(max_output_tokens));
         }
@@ -558,11 +560,11 @@ fn collect_responses_reasoning_text(value: Option<&Value>, out: &mut Vec<String>
                         if matches!(
                             object.get("type").and_then(Value::as_str),
                             Some("reasoning_text" | "summary_text" | "text")
-                        )
-                            && let Some(text) = object.get("text").and_then(Value::as_str)
-                                && !text.is_empty() {
-                                    out.push(text.to_string());
-                                }
+                        ) && let Some(text) = object.get("text").and_then(Value::as_str)
+                            && !text.is_empty()
+                        {
+                            out.push(text.to_string());
+                        }
                     }
                     _ => {}
                 }
@@ -682,20 +684,21 @@ fn decode_responses_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
         if tool.get("type").and_then(Value::as_str) == Some("function") {
             if let Some(function) = tool.get("function").and_then(Value::as_object) {
                 if let Some(name) = function.get("name").and_then(Value::as_str)
-                    && !name.is_empty() {
-                        out.push(ToolDefinition {
-                            name: name.to_string(),
-                            description: function
-                                .get("description")
-                                .and_then(Value::as_str)
-                                .map(ToOwned::to_owned),
-                            parameters: function
-                                .get("parameters")
-                                .cloned()
-                                .unwrap_or_else(|| json!({})),
-                            strict: function.get("strict").and_then(Value::as_bool),
-                        });
-                    }
+                    && !name.is_empty()
+                {
+                    out.push(ToolDefinition {
+                        name: name.to_string(),
+                        description: function
+                            .get("description")
+                            .and_then(Value::as_str)
+                            .map(ToOwned::to_owned),
+                        parameters: function
+                            .get("parameters")
+                            .cloned()
+                            .unwrap_or_else(|| json!({})),
+                        strict: function.get("strict").and_then(Value::as_bool),
+                    });
+                }
             } else {
                 if !push_responses_function_tool(&mut out, tool) {
                     push_responses_id_tool(&mut out, tool);

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::codecs::common::{
     is_known_role_name, provider_extensions, reasoning_text_from_blocks, text_from_blocks,
@@ -72,8 +72,8 @@ impl FormatCodec for OpenAiResponsesCodec {
             ),
             ..LlmRequest::default()
         };
-        if let Some(instructions) = body.get("instructions").and_then(Value::as_str) {
-            if !instructions.is_empty() {
+        if let Some(instructions) = body.get("instructions").and_then(Value::as_str)
+            && !instructions.is_empty() {
                 request.instructions.push(crate::llm::InstructionBlock {
                     role: Role::System,
                     content: vec![ContentBlock::Text {
@@ -81,7 +81,6 @@ impl FormatCodec for OpenAiResponsesCodec {
                     }],
                 });
             }
-        }
         request.messages = decode_responses_input(
             body.get("input").unwrap_or(&Value::String(String::new())),
             &mut diagnostics,
@@ -152,11 +151,10 @@ impl FormatCodec for OpenAiResponsesCodec {
         if !request.tools.is_empty() {
             body.insert("tools".to_string(), encode_responses_tools(&request.tools));
         }
-        if let Some(choice) = &request.tool_choice {
-            if let Some(choice) = encode_responses_tool_choice(choice) {
+        if let Some(choice) = &request.tool_choice
+            && let Some(choice) = encode_responses_tool_choice(choice) {
                 body.insert("tool_choice".to_string(), choice);
             }
-        }
         if let Some(max_output_tokens) = request.output.max_output_tokens {
             body.insert("max_output_tokens".to_string(), json!(max_output_tokens));
         }
@@ -560,13 +558,11 @@ fn collect_responses_reasoning_text(value: Option<&Value>, out: &mut Vec<String>
                         if matches!(
                             object.get("type").and_then(Value::as_str),
                             Some("reasoning_text" | "summary_text" | "text")
-                        ) {
-                            if let Some(text) = object.get("text").and_then(Value::as_str) {
-                                if !text.is_empty() {
+                        )
+                            && let Some(text) = object.get("text").and_then(Value::as_str)
+                                && !text.is_empty() {
                                     out.push(text.to_string());
                                 }
-                            }
-                        }
                     }
                     _ => {}
                 }
@@ -685,8 +681,8 @@ fn decode_responses_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
         };
         if tool.get("type").and_then(Value::as_str) == Some("function") {
             if let Some(function) = tool.get("function").and_then(Value::as_object) {
-                if let Some(name) = function.get("name").and_then(Value::as_str) {
-                    if !name.is_empty() {
+                if let Some(name) = function.get("name").and_then(Value::as_str)
+                    && !name.is_empty() {
                         out.push(ToolDefinition {
                             name: name.to_string(),
                             description: function
@@ -700,7 +696,6 @@ fn decode_responses_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
                             strict: function.get("strict").and_then(Value::as_bool),
                         });
                     }
-                }
             } else {
                 if !push_responses_function_tool(&mut out, tool) {
                     push_responses_id_tool(&mut out, tool);
@@ -830,10 +825,9 @@ fn encode_responses_input(
         && matches!(messages[0].role, Role::User)
         && messages[0].content.len() == 1
         && matches!(messages[0].content[0], ContentBlock::Text { .. })
+        && let ContentBlock::Text { text } = &messages[0].content[0]
     {
-        if let ContentBlock::Text { text } = &messages[0].content[0] {
-            return Ok(Value::String(text.clone()));
-        }
+        return Ok(Value::String(text.clone()));
     }
     let mut encoded = Vec::new();
     for message in messages {

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -3,15 +3,15 @@
 
 //! Streaming codec for OpenAI Responses API events.
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
+use crate::LlmResponseChunk;
 use crate::codecs::stream::{
-    record_source_identity, target_message_id_or_source_message_id, target_model_or_source_model,
-    StreamCodec, StreamTranslationState,
+    StreamCodec, StreamTranslationState, record_source_identity,
+    target_message_id_or_source_message_id, target_model_or_source_model,
 };
 use crate::format::{FormatId, WireFormat};
 use crate::llm::Usage;
-use crate::LlmResponseChunk;
 
 /// Stream codec for OpenAI Responses API events.
 pub struct OpenAiResponsesStreamCodec;
@@ -186,66 +186,66 @@ fn encode_responses_stream(
 // Emits final OpenAI Responses completion events from accumulated state.
 fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
     let mut out = ensure_responses_created(state);
-    if state.response_text_started {
-        if let Some(output_index) = state.response_text_output_index {
-            out.push(json!({
-                "type": "response.content_part.done",
-                "output_index": output_index,
-                "content_index": 0,
-                "part": {"type": "output_text", "text": state.response_text},
-            }));
-            out.push(json!({
-                "type": "response.output_item.done",
-                "output_index": output_index,
-                "item": {
-                    "type": "message",
-                    "role": "assistant",
-                    "status": "completed",
-                    "content": [{"type": "output_text", "text": state.response_text}],
-                },
-            }));
-        }
+    if state.response_text_started
+        && let Some(output_index) = state.response_text_output_index
+    {
+        out.push(json!({
+            "type": "response.content_part.done",
+            "output_index": output_index,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": state.response_text},
+        }));
+        out.push(json!({
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": state.response_text}],
+            },
+        }));
     }
 
     let mut final_items: Vec<(usize, Value)> = Vec::new();
-    if state.response_reasoning_started {
-        if let Some(output_index) = state.response_reasoning_output_index {
-            out.push(json!({
-                "type": "response.reasoning_text.done",
-                "output_index": output_index,
-                "content_index": 0,
+    if state.response_reasoning_started
+        && let Some(output_index) = state.response_reasoning_output_index
+    {
+        out.push(json!({
+            "type": "response.reasoning_text.done",
+            "output_index": output_index,
+            "content_index": 0,
+            "text": state.response_reasoning_text,
+        }));
+        let item = json!({
+            "type": "reasoning",
+            "id": format!("rs_{output_index}"),
+            "status": "completed",
+            "content": [{
+                "type": "reasoning_text",
                 "text": state.response_reasoning_text,
-            }));
-            let item = json!({
-                "type": "reasoning",
-                "id": format!("rs_{output_index}"),
-                "status": "completed",
-                "content": [{
-                    "type": "reasoning_text",
-                    "text": state.response_reasoning_text,
-                }],
-                "summary": [],
-            });
-            out.push(json!({
-                "type": "response.output_item.done",
-                "output_index": output_index,
-                "item": item,
-            }));
-            final_items.push((output_index, item));
-        }
+            }],
+            "summary": [],
+        });
+        out.push(json!({
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": item,
+        }));
+        final_items.push((output_index, item));
     }
-    if state.response_text_started {
-        if let Some(output_index) = state.response_text_output_index {
-            final_items.push((
-                output_index,
-                json!({
-                    "type": "message",
-                    "role": "assistant",
-                    "status": "completed",
-                    "content": [{"type": "output_text", "text": state.response_text}],
-                }),
-            ));
-        }
+    if state.response_text_started
+        && let Some(output_index) = state.response_text_output_index
+    {
+        final_items.push((
+            output_index,
+            json!({
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": state.response_text}],
+            }),
+        ));
     }
 
     for tool in state.tool_states.values() {
@@ -507,15 +507,15 @@ fn encode_responses_tool_delta(
         return out;
     }
 
-    if let Some(output_index) = tool.response_output_index {
-        if !tool.pending_arguments.is_empty() {
-            out.push(json!({
-                "type": "response.function_call_arguments.delta",
-                "output_index": output_index,
-                "delta": tool.pending_arguments,
-            }));
-            tool.pending_arguments.clear();
-        }
+    if let Some(output_index) = tool.response_output_index
+        && !tool.pending_arguments.is_empty()
+    {
+        out.push(json!({
+            "type": "response.function_call_arguments.delta",
+            "output_index": output_index,
+            "delta": tool.pending_arguments,
+        }));
+        tool.pending_arguments.clear();
     }
     out
 }

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -7,8 +7,9 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
+use crate::LlmResponseChunk;
 use crate::codecs::anthropic::AnthropicMessagesStreamCodec;
 use crate::codecs::openai_chat::OpenAiChatStreamCodec;
 use crate::codecs::responses::OpenAiResponsesStreamCodec;
@@ -16,7 +17,6 @@ use crate::engine::{FormatRegistry, TranslationEngine};
 use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::llm::Usage;
-use crate::LlmResponseChunk;
 
 /// Mutable state accumulated while translating one streaming response.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/crates/switchyard-translation/src/engine.rs
+++ b/crates/switchyard-translation/src/engine.rs
@@ -8,11 +8,11 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use crate::codecs::FormatCodec;
 use crate::codecs::anthropic::AnthropicMessagesCodec;
 use crate::codecs::openai_chat::OpenAiChatCodec;
 use crate::codecs::responses::OpenAiResponsesCodec;
 use crate::codecs::stream::{StreamCodecRegistry, StreamTranslationState};
-use crate::codecs::FormatCodec;
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::FormatId;

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -169,6 +169,7 @@ where
 
         // A non-standard upstream might omit the final blank line; parse a trailing
         // complete frame instead of losing its last chunk.
+        #[allow(clippy::collapsible_if)]
         if !frame.trim_end().is_empty() {
             if let Some(value) = sse::parse_json_sse_frame(&frame, marker)
                 .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?
@@ -201,9 +202,9 @@ fn llm_client_error_from_io(error: std::io::Error) -> LlmClientError {
 #[cfg(test)]
 mod tests {
     use futures::executor::block_on;
-    use futures::{stream, Stream, StreamExt};
-    use serde_json::{json, Value};
-    use switchyard_protocol::{completion_text, LlmClientError, LlmResponseChunk};
+    use futures::{Stream, StreamExt, stream};
+    use serde_json::{Value, json};
+    use switchyard_protocol::{LlmClientError, LlmResponseChunk, completion_text};
 
     use super::{
         decode_aggregated_response, decode_request, decode_stream, encode_aggregated_response,
@@ -300,9 +301,11 @@ mod tests {
             .collect();
         assert_eq!(content, "Hello world");
         // The terminal chunk carries the stop reason through to the wire events.
-        assert!(events
-            .iter()
-            .any(|event| event["choices"][0]["finish_reason"] == "stop"));
+        assert!(
+            events
+                .iter()
+                .any(|event| event["choices"][0]["finish_reason"] == "stop")
+        );
         Ok(())
     }
 

--- a/crates/switchyard-translation/src/lib.rs
+++ b/crates/switchyard-translation/src/lib.rs
@@ -30,5 +30,5 @@ pub use llm::*;
 pub use policy::*;
 pub use stream::*;
 pub use util::{
-    normalize_anthropic_tool_use_ids, sanitize_anthropic_tool_use_id, PRESERVATION_METADATA_KEY,
+    PRESERVATION_METADATA_KEY, normalize_anthropic_tool_use_ids, sanitize_anthropic_tool_use_id,
 };

--- a/crates/switchyard-translation/src/util.rs
+++ b/crates/switchyard-translation/src/util.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
@@ -422,10 +422,10 @@ fn mapped_tool_id(
         return existing.clone();
     }
     let mut candidate = sanitize_anthropic_tool_use_id(raw);
-    if let Some(owner) = used_ids.get(&candidate) {
-        if owner != raw {
-            candidate = format!("{}_{}", candidate, stable_suffix(raw));
-        }
+    if let Some(owner) = used_ids.get(&candidate)
+        && owner != raw
+    {
+        candidate = format!("{}_{}", candidate, stable_suffix(raw));
     }
     id_map.insert(raw.to_string(), candidate.clone());
     used_ids.insert(candidate.clone(), raw.to_string());

--- a/crates/switchyard-translation/tests/extension_points.rs
+++ b/crates/switchyard-translation/tests/extension_points.rs
@@ -4,7 +4,7 @@
 //! Tests for custom translation and stream codec extension points.
 
 use pretty_assertions::assert_eq;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_translation::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
 };
@@ -114,9 +114,11 @@ fn capability_profile_can_fail_fast_when_target_cannot_accept_request_features()
         Err(error) => error,
     };
 
-    assert!(error
-        .to_string()
-        .contains("target format/profile does not support tools"));
+    assert!(
+        error
+            .to_string()
+            .contains("target format/profile does not support tools")
+    );
 }
 
 // Minimal custom buffered codec used to exercise the registry extension point.

--- a/crates/switchyard-translation/tests/lossless_roundtrip.rs
+++ b/crates/switchyard-translation/tests/lossless_roundtrip.rs
@@ -4,9 +4,9 @@
 //! Lossless round-trip tests for preservation metadata across all wire formats.
 
 use pretty_assertions::assert_eq;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_translation::{
-    PreservationPolicy, TranslationEngine, TranslationPolicy, WireFormat, PRESERVATION_METADATA_KEY,
+    PRESERVATION_METADATA_KEY, PreservationPolicy, TranslationEngine, TranslationPolicy, WireFormat,
 };
 
 const FORMATS: [WireFormat; 3] = [

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -4,7 +4,7 @@
 //! Tests for buffered request translation between provider formats.
 
 use pretty_assertions::assert_eq;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -78,10 +78,12 @@ fn anthropic_request_translates_to_openai_chat_without_anthropic_only_fields() -
     );
     assert_eq!(output["messages"][3]["role"], "tool");
     assert_eq!(output["messages"][3]["tool_call_id"], "toolu_1");
-    assert!(output["messages"][3]["content"]
-        .as_str()
-        .unwrap()
-        .contains("72F"));
+    assert!(
+        output["messages"][3]["content"]
+            .as_str()
+            .unwrap()
+            .contains("72F")
+    );
     assert_eq!(output["tools"][0]["function"]["name"], "lookup");
     assert_eq!(
         output["tool_choice"],
@@ -1332,8 +1334,10 @@ fn anthropic_thinking_is_dropped_from_responses_input() -> TestResult {
     assert!(!json_contains_content_type(&output, "reasoning_text"));
     assert!(!output.to_string().contains("private chain of thought"));
     assert!(input.iter().any(|item| item["type"] == "function_call"));
-    assert!(input
-        .iter()
-        .any(|item| item["type"] == "function_call_output"));
+    assert!(
+        input
+            .iter()
+            .any(|item| item["type"] == "function_call_output")
+    );
     Ok(())
 }

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -7,7 +7,7 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 use switchyard_protocol::{ResponseAccumulator, StopReason};
 use switchyard_translation::{
-    decode_stream_event, LlmResponseChunk, StreamTranslationState, TranslationEngine, WireFormat,
+    LlmResponseChunk, StreamTranslationState, TranslationEngine, WireFormat, decode_stream_event,
 };
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
@@ -543,9 +543,11 @@ fn anthropic_thinking_stream_deltas_do_not_become_openai_chat_content() -> TestR
     assert!(events.iter().any(|event| {
         event["choices"][0]["delta"]["reasoning_content"] == "private chain of thought"
     }));
-    assert!(!events
-        .iter()
-        .any(|event| { event["choices"][0]["delta"]["content"] == "private chain of thought" }));
+    assert!(
+        !events
+            .iter()
+            .any(|event| { event["choices"][0]["delta"]["content"] == "private chain of thought" })
+    );
     Ok(())
 }
 


### PR DESCRIPTION
This gives us if-let chains.

Also upgrade `rand` so we have a single version of that dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal conditional logic across request validation, routing, streaming, translation, metrics, and error handling.
  - Preserved existing runtime behavior, validation results, response formats, and shutdown handling.

- **Chores**
  - Updated the project to newer Rust language and build conventions.
  - Updated random-number generation compatibility and improved compiler/linter compliance.
  - Reformatted imports and tests for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->