### PR TITLE
feat(libsy): record task_kind and agent_role on the run span

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -455,6 +455,8 @@ fn request_with_metadata(session_id: &str, correlation_id: &str) -> Request {
         metadata: Some(Metadata {
             session_id: Some(session_id.to_string()),
             correlation_id: Some(correlation_id.to_string()),
+            task_kind: Some("code_review".to_string()),
+            agent_role: Some("reviewer".to_string()),
             extra_metadata: Some(BTreeMap::from([(
                 "tenant".to_string(),
                 "obs-tenant-1".to_string(),
@@ -722,6 +724,15 @@ async fn successful_run_records_metrics_spans_and_decision_log() -> switchyard_l
     assert_eq!(
         run_span.fields.get("outcome").map(String::as_str),
         Some("ok")
+    );
+    // Semantic harness labels: bounded classes, distinct from the high-cardinality ids above.
+    assert_eq!(
+        run_span.fields.get("task_kind").map(String::as_str),
+        Some("code_review")
+    );
+    assert_eq!(
+        run_span.fields.get("agent_role").map(String::as_str),
+        Some("reviewer")
     );
     // Host-defined labels ride in generically via Metadata.extra_metadata.
     assert!(

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -109,6 +109,8 @@ pub(crate) fn run_span(algorithm: &str, request: &Request) -> Span {
         session.id = tracing::field::Empty,
         agent_id = tracing::field::Empty,
         task_id = tracing::field::Empty,
+        task_kind = tracing::field::Empty,
+        agent_role = tracing::field::Empty,
         correlation_id = tracing::field::Empty,
         extra_metadata = tracing::field::Empty,
         outcome = tracing::field::Empty,
@@ -122,6 +124,8 @@ pub(crate) fn run_span(algorithm: &str, request: &Request) -> Span {
             ("session_id", &metadata.session_id),
             ("agent_id", &metadata.agent_id),
             ("task_id", &metadata.task_id),
+            ("task_kind", &metadata.task_kind),
+            ("agent_role", &metadata.agent_role),
             ("correlation_id", &metadata.correlation_id),
         ] {
             if let Some(value) = value {


### PR DESCRIPTION
## What

`run_span` records `session_id`, `agent_id`, `task_id`, and `correlation_id` from the request `Metadata`, but not `task_kind` or `agent_role`. This adds them.

## Why

`Metadata::from_headers` already parses both on every request, and they are the only fields describing *what kind of work* a request is; everything else is an opaque id. Today they are parsed and then dropped before reaching telemetry, so routing behaviour cannot be segmented by work type. #145 noted the same gap on live traffic and left it as a follow-up.

Both have real producers: Codex emits them inside `x-codex-turn-metadata`, and `HEADER_CONFIG` already normalizes them.

Span fields only. No metric gains a label, so the bounded-label invariant in `docs/internal/metrics_reference.md` is unaffected.

Related: #145

## How tested

Rust-only change, so the Python gates do not apply.

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p switchyard-libsy --all-targets -- -D warnings` clean
- [x] `cargo test -p switchyard-libsy --test observability` green (6 passed)

Extends the existing span assertions in `successful_run_records_metrics_spans_and_decision_log`. Stashing only the `src` change while keeping the test fails with `left: None, right: Some("code_review")`, so the coverage is load-bearing rather than incidentally green.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. — N/A
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. — N/A
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. — N/A
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

- Naming follows the bare-name siblings in the same array rather than the namespaced forms also present on this span. Happy to use an OpenTelemetry semantic-convention name instead.
- `agent_kind` left out to keep this to one concern.
- Touches the same file as #224 and is meant to complement it; happy to rebase or defer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run telemetry now records task type and agent role when available.
  * These fields are included in run spans, improving observability and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->