### PR TITLE
chore: Symlink .claude/skills to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
That way Claude will read all our skills.

```
❯ What skills do you have available?                                                                                                                                                                                                                          

● Here are the available skills:

  Project-specific (Switchyard)
  - publish-python-release — build/publish Python wheels, PyPI releases, release workflow
  - switchyard-coding-agent-launchers — Claude Code, Codex, OpenClaw launcher changes
  - switchyard-docs — MkDocs site, strict builds, docs CI
  - switchyard-rust-review — review Rust, PyO3, async, streaming, crate boundaries
  - switchyard-stage-router-scorer — replay benchmark trajectories through stage-router scorer
  - switchyard-testing-ci — select/debug validation and CI failures
```

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a symbolic link for shared assistant skills configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->