### PR TITLE
fix(switchyard-server): Remove redundant HTTP header name lower-case

### DIFF
--- a/crates/protocol/src/metadata.rs
+++ b/crates/protocol/src/metadata.rs
@@ -205,8 +205,6 @@ impl Metadata {
     /// from an explicit `x-switchyard-is-subagent` header when present, and otherwise
     /// inferred from Claude Code lineage or Codex harness signals.
     pub fn from_headers(headers: &BTreeMap<String, String>) -> Self {
-        let headers = &normalize_headers(headers);
-
         let (parent_agent_id, is_subagent, is_delegated_work) = parse_sub_agent(headers);
 
         Metadata {
@@ -304,20 +302,6 @@ fn parse_bool(value: &str) -> Option<bool> {
         "0" | "false" | "no" | "off" => Some(false),
         _ => None,
     }
-}
-
-/// Lowercases header names and keeps the first non-empty, trimmed value per name.
-fn normalize_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
-    let mut normalized = BTreeMap::new();
-    for (key, value) in headers {
-        let lower_key = key.to_ascii_lowercase();
-        let trimmed_value = value.trim();
-        if !normalized.contains_key(&lower_key) && !trimmed_value.is_empty() {
-            normalized.insert(lower_key, trimmed_value.to_string());
-        }
-    }
-
-    normalized
 }
 
 /// Resolves the logical field `key` against `headers` using [`HEADER_CONFIG`]'s paths.
@@ -651,15 +635,6 @@ mod tests {
             None
         );
         assert_eq!(sy_header(&headers, "x-not-a-field"), None);
-    }
-
-    #[test]
-    fn codex_session_header_is_case_insensitive() {
-        let metadata = Metadata::from_headers(&BTreeMap::from([(
-            "Session-ID".to_string(),
-            "codex-run".to_string(),
-        )]));
-        assert_eq!(metadata.session_id.as_deref(), Some("codex-run"));
     }
 
     #[test]

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -431,7 +431,7 @@ async fn anthropic_count_tokens(
     };
     let (algorithm, request) = match resolve_route(
         &state,
-        metadata_from_headers(&headers),
+        metadata_from_headers(headers),
         body,
         WireFormat::AnthropicMessages,
     ) {
@@ -477,15 +477,15 @@ async fn handle_endpoint(
 async fn handle_endpoint_inner(
     state: ServerState,
     started: RequestStart,
-    headers: HeaderMap,
+    http_headers: HeaderMap,
     body: std::result::Result<Json<Value>, JsonRejection>,
     wire_format: WireFormat,
 ) -> Response {
     let routing_log_context = state
         .routing_log
         .as_ref()
-        .map(|_| routing_log::RoutingLogContext::from_headers(&normalized_headers(&headers)));
-    let metadata = metadata_from_headers(&headers);
+        .map(|_| routing_log::RoutingLogContext::from_headers(&http_headers));
+    let metadata = metadata_from_headers(http_headers);
     let request_log = RequestLogContext {
         started: started.0,
         wire_format,
@@ -701,23 +701,21 @@ fn request_log_level(status: StatusCode) -> Level {
     }
 }
 
-fn metadata_from_headers(headers: &HeaderMap) -> Metadata {
-    let headers = normalized_headers(headers);
+fn metadata_from_headers(http_headers: HeaderMap) -> Metadata {
+    // Converting `http::HeaderMap` to `BTreeMap<String, String>` avoids `protocol` crate taking a
+    // dependency on `http`. Probably we should take that dependency.
+    let mut headers = BTreeMap::new();
+    for (k, v) in http_headers {
+        let Some(k) = k else {
+            continue;
+        };
+        if let Ok(v) = v.to_str() {
+            headers.insert(k.as_str().to_string(), v.to_string());
+        }
+    }
     let mut metadata = Metadata::from_headers(&headers);
     metadata.http_headers = Some(headers);
     metadata
-}
-
-fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-        })
-        .collect()
 }
 
 fn attach_routing_headers(response: &mut Response, decision: &dyn Decision) {

--- a/crates/switchyard-server/src/routing_log.rs
+++ b/crates/switchyard-server/src/routing_log.rs
@@ -10,6 +10,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use axum::http::HeaderMap;
 use humantime::format_rfc3339_millis;
 use serde::{Deserialize, Serialize};
 use switchyard_protocol::Usage;
@@ -103,11 +104,11 @@ pub(crate) struct RoutingLogContext {
 }
 
 impl RoutingLogContext {
-    pub(crate) fn from_headers(headers: &BTreeMap<String, String>) -> Self {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Self {
         Self {
-            task: nonempty_header(headers, TASK_HEADER),
-            trial_id: nonempty_header(headers, TRIAL_ID_HEADER),
-            session_id: nonempty_header(headers, SESSION_ID_HEADER),
+            task: nonempty_header(headers, TASK_HEADER).map(|s| s.to_string()),
+            trial_id: nonempty_header(headers, TRIAL_ID_HEADER).map(|s| s.to_string()),
+            session_id: nonempty_header(headers, SESSION_ID_HEADER).map(|s| s.to_string()),
         }
     }
 }
@@ -206,8 +207,11 @@ impl SessionStatsSnapshot {
     }
 }
 
-fn nonempty_header(headers: &BTreeMap<String, String>, name: &str) -> Option<String> {
-    headers.get(name).filter(|value| !value.is_empty()).cloned()
+fn nonempty_header<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .filter(|value| !value.is_empty())
+        .and_then(|v| v.to_str().ok())
 }
 
 fn routing_log_error(path: &Path, error: std::io::Error) -> ServerError {


### PR DESCRIPTION
`http::HeaderMap` already does that.

See:
https://docs.rs/http/latest/http/header/struct.HeaderName.html#method.as_str

AFAICT the only way we get HTTP headers is via axum / http crates, so we
don't need to re-do the normalization. This avoids an extra allocate and
copy of the headers.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header handling for routing logs and metadata processing.
  * Preserved original header-name casing during request processing.
  * Ignored empty or invalid header values when extracting routing context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->