### PR TITLE
feat(stage-router): recognize hermes tool names in signal extraction

### DIFF
--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -1018,6 +1018,10 @@ mod tests {
             classify_tool_call("terminal", Some("grep foo /app")),
             ToolCategory::Read,
         );
+        assert_eq!(
+            classify_tool_call("terminal", Some("./run_tests.sh")),
+            ToolCategory::Other,
+        );
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -103,9 +103,10 @@ static EDIT_TOOL_NAMES: &[&str] = &[
     "str_replace",
     "str_replace_based_edit_tool",
     "text_editor",
+    "patch", // hermes's str_replace-style edit tool
 ];
 
-static WRITE_TOOL_NAMES: &[&str] = &["write", "create_file", "new_file"];
+static WRITE_TOOL_NAMES: &[&str] = &["write", "create_file", "new_file", "write_file"];
 
 // Bash subcommand patterns. Lowercased; callers must lowercase the command
 // before matching. Bucketed into write_count / edit_count alongside the
@@ -145,7 +146,7 @@ static BASH_READ_PATTERNS: &[&str] = &[
     "diff ", "which ", "ps ", "df ", "du ", "stat ", "file ", "less ", "more ",
 ];
 
-static READ_TOOL_NAMES: &[&str] = &["read", "view"];
+static READ_TOOL_NAMES: &[&str] = &["read", "view", "read_file", "search_files"];
 
 // Planning / scratchpad tool calls — investigative (non-producing) activity.
 // `update_plan` is codex's equivalent of `todowrite`.
@@ -153,8 +154,15 @@ static PLAN_TOOL_NAMES: &[&str] = &["todowrite", "todo_write", "todo", "update_p
 
 // Tool names that route through Bash-command pattern matching. `bash` is
 // claude-code's name; `shell_command` is codex's; `shell` / `local_shell_call`
-// are seen on some OpenAI-derived harnesses.
-static BASH_TOOL_NAMES: &[&str] = &["bash", "shell_command", "shell", "local_shell_call"];
+// are seen on some OpenAI-derived harnesses; `terminal` is hermes's (it carries
+// a `command` arg like the others, so its intent comes from the pattern match).
+static BASH_TOOL_NAMES: &[&str] = &[
+    "bash",
+    "shell_command",
+    "shell",
+    "local_shell_call",
+    "terminal",
+];
 
 // Prefer false negatives: tests_passed routes the picker to EFFICIENT, so a false
 // positive would drop tier on an unfinished task.
@@ -991,6 +999,25 @@ mod tests {
     fn read_tool_classifies_as_read() {
         assert_eq!(classify_tool_call("Read", None), ToolCategory::Read);
         assert_eq!(classify_tool_call("View", None), ToolCategory::Read);
+    }
+
+    #[test]
+    fn hermes_tool_names_classify() {
+        // Hermes (NousResearch) file tools route by name.
+        assert_eq!(classify_tool_call("write_file", None), ToolCategory::Write);
+        assert_eq!(classify_tool_call("patch", None), ToolCategory::Edit);
+        assert_eq!(classify_tool_call("read_file", None), ToolCategory::Read);
+        assert_eq!(classify_tool_call("search_files", None), ToolCategory::Read);
+        // Hermes runs shell through `terminal`, which carries a `command` arg,
+        // so its intent comes from the Bash-pattern match like codex's shell_command.
+        assert_eq!(
+            classify_tool_call("terminal", Some("sed -i 's/a/b/' /app/x.py")),
+            ToolCategory::Edit,
+        );
+        assert_eq!(
+            classify_tool_call("terminal", Some("grep foo /app")),
+            ToolCategory::Read,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

- recognize Hermes `write_file`, `patch`, `read_file`, and `search_files` calls in the existing write/edit/read categories
- route Hermes `terminal` calls through the existing shell-command intent matcher
- add regression coverage for direct Hermes tools and terminal read/edit commands

## Why

I ran into this while trying to run Hermes with stage routing. Its native tool names were classified as `Other`, so the stage-router picker was missing the read, write, and edit activity it uses to understand the agent's current stage.

Closes #266

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` — 1324 passed, 12 skipped, 24 deselected
- [ ] Manual Hermes smoke not rerun for this PR; the reported tool mappings are covered directly by the regression test

Additional Rust validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p switchyard-libsy hermes_tool_names_classify`

## Checklist

- [x] No new classes or files.
- [x] No new public symbols.
- [x] Unit tests added for the bug fix.
- [x] No customer-facing configuration or help surface changed.
- [x] Commit signed off per the DCO.

## Notes for reviewers

`terminal` is intentionally only categorized when one of the existing shell patterns matches. Unmatched terminal commands remain `Other`, preserving the extractor's false-negative bias.

No live provider calls were made during validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Hermes tools, including editing, writing, reading, searching, and terminal commands.
  * Improved classification of terminal commands based on their behavior.

* **Tests**
  * Added coverage for Hermes tool mappings and terminal command classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->