### PR TITLE
feat(llm-client): harden HTTP provider transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Switchyard HTTP transport limits** — provider redirects are rejected,
+  connection and read-inactivity timeouts are enforced, buffered success and
+  error bodies are bounded, and oversized SSE events fail before unbounded line
+  buffering. Provider error bodies remain available in typed errors but are no
+  longer included in their default display text.
+
 ### Removed
 
 - **Latency-aware router** — the `latency_service` route type and its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,11 @@ name = "switchyard-llm-client"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "futures",
  "futures-util",
  "http",
+ "http-body",
  "httpdate",
  "opentelemetry",
  "reqwest",

--- a/crates/libsy-llm-client/Cargo.toml
+++ b/crates/libsy-llm-client/Cargo.toml
@@ -25,5 +25,8 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+bytes = "1"
 futures.workspace = true
+http = "1"
+http-body = "1"
 wiremock = "0.6"

--- a/crates/libsy-llm-client/README.md
+++ b/crates/libsy-llm-client/README.md
@@ -173,6 +173,7 @@ fn build_multi_format_client(
   `authorization` / `x-api-key` / `anthropic-version` / `content-type`. So a
   caller's placeholder credential never overrides the backend's real key.
 - Per-backend static headers go in `HttpBackendConfig::extra_headers`.
+  Its `Debug` output includes header names but redacts all values.
 - Per-target top-level request defaults go in `HttpBackendConfig::extra_body`.
   The merge is shallow and fields already present in the request take precedence.
 - `HttpBackendConfig::max_retries` controls additional attempts after retryable
@@ -183,6 +184,9 @@ fn build_multi_format_client(
 Retries replay the same upstream request. A transport failure can therefore
 duplicate a request that the provider processed but did not finish returning,
 and the retry budget plus capped `Retry-After` delays determines total latency.
+Configured provider requests do not follow redirects. Connections time out
+after 10 seconds, and a 120-second read timeout resets after every successful
+read so active streams may continue while stalled providers are released.
 
 ## Errors
 
@@ -201,6 +205,12 @@ and the retry budget plus capped `Retry-After` delays determines total latency.
 | `UpstreamHttp { status, body }` | any other non-2xx upstream response |
 | `InvalidResponse { source }` | the upstream response could not be decoded |
 | `Other(source)` | a client-specific failure outside the shared categories |
+
+Buffered success bodies are capped at 64 MiB and HTTP error bodies at 64 KiB.
+Typed HTTP errors retain the bounded body for explicit handling, but their
+default display text includes only the status so provider content is not copied
+into ordinary logs or spans. The shared stream decoder rejects an SSE frame
+larger than 8 MiB before its line buffer can grow without bound.
 
 [`switchyard_protocol::Request`]: ../libsy-protocol
 [`switchyard_protocol::Response`]: ../libsy-protocol

--- a/crates/libsy-llm-client/README.md
+++ b/crates/libsy-llm-client/README.md
@@ -186,7 +186,10 @@ duplicate a request that the provider processed but did not finish returning,
 and the retry budget plus capped `Retry-After` delays determines total latency.
 Configured provider requests do not follow redirects. Connections time out
 after 10 seconds, and a 120-second read timeout resets after every successful
-read so active streams may continue while stalled providers are released.
+read so active streams may continue while stalled providers are released. Use
+`TranslatingLlmClient::new_with_transport_config` with an
+`HttpTransportConfig` to change either timeout; setting `read_timeout` to `None`
+disables the idle-read timeout for providers that may remain silent for longer.
 
 ## Errors
 

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -52,14 +52,24 @@ pub struct HttpBackendConfig {
 impl fmt::Debug for HttpBackendConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let extra_header_names = self.extra_headers.keys().collect::<Vec<_>>();
+        let base_url = redacted_base_url(&self.base_url);
         f.debug_struct("HttpBackendConfig")
-            .field("base_url", &self.base_url)
+            .field("base_url", &base_url)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("extra_header_names", &extra_header_names)
             .field("extra_body_keys", &self.extra_body.keys())
             .field("max_retries", &self.max_retries)
             .finish()
     }
+}
+
+fn redacted_base_url(base_url: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(base_url) else {
+        return "[INVALID URL]".into();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.into()
 }
 
 /// A configured upstream backend, one variant per built-in wire format.
@@ -216,6 +226,21 @@ mod tests {
     fn openai_chat_url_joins_bare_v1() {
         let backend = Backend::OpenAiChat(config("https://api.openai.com/v1"));
         assert_eq!(backend.url(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn debug_redacts_base_url_userinfo() {
+        let debug = format!("{:?}", config("https://user:pass@provider.example/v1"));
+        assert!(debug.contains("provider.example/v1"));
+        assert!(!debug.contains("user"));
+        assert!(!debug.contains("pass"));
+    }
+
+    #[test]
+    fn debug_does_not_emit_an_invalid_base_url() {
+        let debug = format!("{:?}", config("not a valid url with a secret"));
+        assert!(debug.contains("[INVALID URL]"));
+        assert!(!debug.contains("secret"));
     }
 
     #[test]

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -51,10 +51,11 @@ pub struct HttpBackendConfig {
 
 impl fmt::Debug for HttpBackendConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let extra_header_names = self.extra_headers.keys().collect::<Vec<_>>();
         f.debug_struct("HttpBackendConfig")
             .field("base_url", &self.base_url)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
-            .field("extra_headers", &self.extra_headers)
+            .field("extra_header_names", &extra_header_names)
             .field("extra_body_keys", &self.extra_body.keys())
             .field("max_retries", &self.max_retries)
             .finish()
@@ -279,6 +280,18 @@ mod tests {
         assert!(Backend::Anthropic(config("x")).is_anthropic());
         assert!(!Backend::OpenAiChat(config("x")).is_anthropic());
         assert!(!Backend::OpenAiResponses(config("x")).is_anthropic());
+    }
+
+    #[test]
+    fn debug_redacts_static_header_values() {
+        let mut config = config("https://provider.example/v1");
+        config
+            .extra_headers
+            .insert("authorization".into(), "Bearer provider-secret".into());
+
+        let debug = format!("{config:?}");
+        assert!(debug.contains("authorization"));
+        assert!(!debug.contains("provider-secret"));
     }
 
     #[test]

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -527,13 +527,10 @@ async fn collect_response_body(
     response: reqwest::Response,
     limit: usize,
 ) -> std::result::Result<CollectedBody, reqwest::Error> {
-    let mut bytes = Vec::with_capacity(
-        response
-            .content_length()
-            .and_then(|length| usize::try_from(length).ok())
-            .unwrap_or_default()
-            .min(limit),
-    );
+    // Content-Length is provider-controlled and may be much larger than the
+    // bytes actually received. Grow from received chunks instead of reserving
+    // the advertised size up front.
+    let mut bytes = Vec::new();
     let mut chunks = response.bytes_stream();
     while let Some(chunk) = chunks.next().await {
         let chunk = chunk?;
@@ -1199,6 +1196,60 @@ mod tests {
             body.len(),
             MAX_ERROR_BODY_BYTES + TRUNCATED_BODY_SUFFIX.len()
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn response_body_does_not_preallocate_advertised_content_length()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        struct InflatedContentLengthBody {
+            data: Option<bytes::Bytes>,
+            advertised_length: u64,
+        }
+
+        impl http_body::Body for InflatedContentLengthBody {
+            type Data = bytes::Bytes;
+            type Error = std::convert::Infallible;
+
+            fn poll_frame(
+                self: std::pin::Pin<&mut Self>,
+                _context: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<
+                Option<std::result::Result<http_body::Frame<Self::Data>, Self::Error>>,
+            > {
+                std::task::Poll::Ready(
+                    self.get_mut()
+                        .data
+                        .take()
+                        .map(http_body::Frame::data)
+                        .map(Ok),
+                )
+            }
+
+            fn size_hint(&self) -> http_body::SizeHint {
+                let mut hint = http_body::SizeHint::new();
+                hint.set_exact(self.advertised_length);
+                hint
+            }
+        }
+
+        let advertised_length = MAX_BUFFERED_RESPONSE_BYTES as u64;
+        let response_body = reqwest::Body::wrap(InflatedContentLengthBody {
+            data: Some(bytes::Bytes::from_static(b"{}")),
+            advertised_length,
+        });
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .header(reqwest::header::CONTENT_LENGTH, advertised_length)
+                .body(response_body)?,
+        );
+        assert_eq!(response.content_length(), Some(advertised_length));
+
+        let body = collect_response_body(response, MAX_BUFFERED_RESPONSE_BYTES).await?;
+
+        assert_eq!(body.bytes, b"{}");
+        assert!(body.bytes.capacity() < MAX_BUFFERED_RESPONSE_BYTES);
+        assert!(!body.truncated);
         Ok(())
     }
 

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -51,6 +51,11 @@ const RESERVED_HEADERS: &[&str] = &[
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
 const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(2);
 const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_BUFFERED_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
+const TRUNCATED_BODY_SUFFIX: &str = "...[truncated]";
 
 /// How one model is served: the `default_backend` used when the request does not
 /// pin a wire format, plus any `other_backends` reachable over additional formats.
@@ -94,12 +99,18 @@ impl TranslatingLlmClient {
     /// Builds a client over the given [`ModelConfig`]s, with a fresh shared HTTP
     /// client and the built-in translation codecs.
     pub fn new(model_configs: &[ModelConfig]) -> Result<Self> {
-        let client =
-            reqwest::Client::builder()
-                .build()
-                .map_err(|error| LlmClientError::Transport {
-                    source: Box::new(error),
-                })?;
+        let client = reqwest::Client::builder()
+            // A configured target is an authority boundary. Do not let a
+            // provider redirect credentials or request bodies elsewhere.
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+            // Read timeout resets after each successful read, so active LLM
+            // streams may run indefinitely while stalled providers cannot.
+            .read_timeout(DEFAULT_READ_TIMEOUT)
+            .build()
+            .map_err(|error| LlmClientError::Transport {
+                source: Box::new(error),
+            })?;
         let model_to_config = model_configs
             .iter()
             .map(|config| (config.model_name.clone(), config.clone()))
@@ -274,8 +285,28 @@ impl TranslatingLlmClient {
                 record_upstream_attempt(Some(status.as_u16()));
                 return Ok(EncodedResponse::Streaming(response));
             }
-            let body = match response.bytes().await {
-                Ok(body) => body,
+            let body = match collect_response_body(response, MAX_BUFFERED_RESPONSE_BYTES).await {
+                Ok(CollectedBody {
+                    bytes,
+                    truncated: false,
+                }) => bytes,
+                Ok(CollectedBody {
+                    truncated: true, ..
+                }) => {
+                    record_upstream_attempt(Some(status.as_u16()));
+                    return Err(AttemptFailure {
+                        error: LlmClientError::InvalidResponse {
+                            source: Box::new(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                format!(
+                                    "upstream response exceeded {MAX_BUFFERED_RESPONSE_BYTES} bytes"
+                                ),
+                            )),
+                        },
+                        status: Some(status.as_u16()),
+                        retry_after: None,
+                    });
+                }
                 Err(error) => {
                     record_upstream_attempt(None);
                     return Err(AttemptFailure {
@@ -288,13 +319,13 @@ impl TranslatingLlmClient {
             record_upstream_attempt(Some(status.as_u16()));
             return Ok(EncodedResponse::Buffered {
                 status: status.as_u16(),
-                body: body.to_vec(),
+                body,
             });
         }
 
         let retry_after = retry_after_delay(response.headers());
-        let body = match response.text().await {
-            Ok(body) => body,
+        let body = match collect_response_body(response, MAX_ERROR_BODY_BYTES).await {
+            Ok(body) => body.into_text(),
             Err(error) => {
                 record_upstream_attempt(None);
                 return Err(AttemptFailure {
@@ -475,6 +506,51 @@ impl TranslatingLlmClient {
             }
         }
     }
+}
+
+struct CollectedBody {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+impl CollectedBody {
+    fn into_text(self) -> String {
+        let mut text = String::from_utf8_lossy(&self.bytes).into_owned();
+        if self.truncated {
+            text.push_str(TRUNCATED_BODY_SUFFIX);
+        }
+        text
+    }
+}
+
+async fn collect_response_body(
+    response: reqwest::Response,
+    limit: usize,
+) -> std::result::Result<CollectedBody, reqwest::Error> {
+    let mut bytes = Vec::with_capacity(
+        response
+            .content_length()
+            .and_then(|length| usize::try_from(length).ok())
+            .unwrap_or_default()
+            .min(limit),
+    );
+    let mut chunks = response.bytes_stream();
+    while let Some(chunk) = chunks.next().await {
+        let chunk = chunk?;
+        let remaining = limit.saturating_sub(bytes.len());
+        if chunk.len() > remaining {
+            bytes.extend_from_slice(&chunk[..remaining]);
+            return Ok(CollectedBody {
+                bytes,
+                truncated: true,
+            });
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(CollectedBody {
+        bytes,
+        truncated: false,
+    })
 }
 
 #[async_trait]
@@ -1050,6 +1126,79 @@ mod tests {
         let agg = response.llm_response.into_agg().await?;
         assert_eq!(completion_text(&agg), "Hi there");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn configured_provider_requests_do_not_follow_redirects()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let redirected = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(chat_success_response())
+            .mount(&redirected)
+            .await;
+
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(307).insert_header(
+                "location",
+                format!("{}/v1/chat/completions", redirected.uri()),
+            ))
+            .mount(&provider)
+            .await;
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", provider.uri())))?;
+        let Err(error) = client
+            .call_rewrite_model(Context::default(), request_for(Some("gpt"), false), None)
+            .await
+        else {
+            panic!("redirect must be returned instead of followed");
+        };
+
+        assert!(matches!(
+            error,
+            LlmClientError::UpstreamHttp { status: 307, .. }
+        ));
+        let redirected_requests = redirected
+            .received_requests()
+            .await
+            .ok_or("request recording should be enabled")?;
+        assert!(redirected_requests.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn upstream_error_body_is_bounded_and_redacted_from_display()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        let secret = "provider-reflected-secret";
+        let oversized = format!("{secret}{}", "x".repeat(MAX_ERROR_BODY_BYTES));
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500).set_body_string(oversized))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
+        let Err(error) = client
+            .call_rewrite_model(Context::default(), request_for(Some("gpt"), false), None)
+            .await
+        else {
+            panic!("expected an upstream error");
+        };
+
+        assert!(!error.to_string().contains(secret));
+        let LlmClientError::UpstreamHttp { body, .. } = error else {
+            panic!("expected a typed HTTP error");
+        };
+        assert!(body.starts_with(secret));
+        assert!(body.ends_with(TRUNCATED_BODY_SUFFIX));
+        assert_eq!(
+            body.len(),
+            MAX_ERROR_BODY_BYTES + TRUNCATED_BODY_SUFFIX.len()
+        );
         Ok(())
     }
 

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -57,6 +57,24 @@ const MAX_BUFFERED_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
 const TRUNCATED_BODY_SUFFIX: &str = "...[truncated]";
 
+/// Connection and idle-read timeouts for a [`TranslatingLlmClient`]'s shared HTTP client.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HttpTransportConfig {
+    /// Maximum time allowed to establish an upstream connection.
+    pub connect_timeout: Duration,
+    /// Maximum idle time between response reads. `None` disables the idle-read timeout.
+    pub read_timeout: Option<Duration>,
+}
+
+impl Default for HttpTransportConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+            read_timeout: Some(DEFAULT_READ_TIMEOUT),
+        }
+    }
+}
+
 /// How one model is served: the `default_backend` used when the request does not
 /// pin a wire format, plus any `other_backends` reachable over additional formats.
 #[derive(Clone, Debug)]
@@ -97,16 +115,27 @@ pub struct TranslatingLlmClient {
 
 impl TranslatingLlmClient {
     /// Builds a client over the given [`ModelConfig`]s, with a fresh shared HTTP
-    /// client and the built-in translation codecs.
+    /// client, the default transport timeouts, and the built-in translation codecs.
     pub fn new(model_configs: &[ModelConfig]) -> Result<Self> {
-        let client = reqwest::Client::builder()
+        Self::new_with_transport_config(model_configs, HttpTransportConfig::default())
+    }
+
+    /// Builds a client with explicit connection and idle-read timeouts.
+    pub fn new_with_transport_config(
+        model_configs: &[ModelConfig],
+        transport: HttpTransportConfig,
+    ) -> Result<Self> {
+        let mut client_builder = reqwest::Client::builder()
             // A configured target is an authority boundary. Do not let a
             // provider redirect credentials or request bodies elsewhere.
             .redirect(reqwest::redirect::Policy::none())
-            .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+            .connect_timeout(transport.connect_timeout);
+        if let Some(read_timeout) = transport.read_timeout {
             // Read timeout resets after each successful read, so active LLM
             // streams may run indefinitely while stalled providers cannot.
-            .read_timeout(DEFAULT_READ_TIMEOUT)
+            client_builder = client_builder.read_timeout(read_timeout);
+        }
+        let client = client_builder
             .build()
             .map_err(|error| LlmClientError::Transport {
                 source: Box::new(error),
@@ -1803,10 +1832,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let mut client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
-        client.client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(10))
-            .build()?;
+        let client = TranslatingLlmClient::new_with_transport_config(
+            &chat_map(&format!("{}/v1", server.uri())),
+            HttpTransportConfig {
+                connect_timeout: Duration::from_secs(1),
+                read_timeout: Some(Duration::from_millis(10)),
+            },
+        )?;
         let decision: std::sync::Arc<dyn Decision> = std::sync::Arc::new(FixedDecision("gpt"));
 
         let Err(error) = client

--- a/crates/libsy-llm-client/src/lib.rs
+++ b/crates/libsy-llm-client/src/lib.rs
@@ -18,7 +18,7 @@ pub mod metrics;
 pub mod raw;
 
 pub use backend::{Backend, DEFAULT_MAX_RETRIES, HttpBackendConfig};
-pub use client::{ModelConfig, TranslatingLlmClient};
+pub use client::{HttpTransportConfig, ModelConfig, TranslatingLlmClient};
 pub use error::{LlmClientError, Result};
 pub use raw::RawResponse;
 pub use switchyard_translation::RawEventStream;

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -1050,10 +1050,6 @@ mod tests {
             Err(LlmClientError::UpstreamHttp { status, body }) => {
                 assert_eq!(status, 502);
                 assert_eq!(body, "upstream exploded");
-                assert_eq!(
-                    LlmClientError::UpstreamHttp { status, body }.to_string(),
-                    "upstream returned HTTP 502"
-                );
                 Ok(())
             }
             Err(error) => panic!("expected an upstream HTTP error, got {error:?}"),

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -1047,10 +1047,16 @@ mod tests {
         let (_, response) = orch.run(Context::default(), request()).await?;
         match response.llm_response.into_agg().await {
             Ok(_) => panic!("expected a mid-stream error, got an aggregate"),
-            Err(err) => {
-                assert!(err.to_string().contains("upstream exploded"));
+            Err(LlmClientError::UpstreamHttp { status, body }) => {
+                assert_eq!(status, 502);
+                assert_eq!(body, "upstream exploded");
+                assert_eq!(
+                    LlmClientError::UpstreamHttp { status, body }.to_string(),
+                    "upstream returned HTTP 502"
+                );
                 Ok(())
             }
+            Err(error) => panic!("expected an upstream HTTP error, got {error:?}"),
         }
     }
 

--- a/crates/protocol/src/client.rs
+++ b/crates/protocol/src/client.rs
@@ -71,7 +71,7 @@ pub enum LlmClientError {
     },
 
     /// The upstream rejected the request because it exceeds the model's context window.
-    #[error("context window exceeded for model {model}: {message}")]
+    #[error("context window exceeded for model {model}")]
     ContextWindowExceeded {
         /// Model whose context window was exceeded.
         model: String,
@@ -80,7 +80,7 @@ pub enum LlmClientError {
     },
 
     /// The upstream returned a non-success HTTP response.
-    #[error("upstream returned HTTP {status}: {body}")]
+    #[error("upstream returned HTTP {status}")]
     UpstreamHttp {
         /// Upstream HTTP status code.
         status: u16,

--- a/crates/protocol/src/client.rs
+++ b/crates/protocol/src/client.rs
@@ -10,7 +10,7 @@
 //! in libsy's orchestration crate — so a client crate that depends only on the
 //! protocol can serve routed calls without pulling in the orchestrator.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -26,7 +26,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// while boxed sources preserve implementation-specific detail. `General` is the
 /// escape hatch for failures that do not fit a shared category.
 #[non_exhaustive]
-#[derive(Debug, Error)]
+#[derive(Error)]
 pub enum LlmClientError {
     /// The request cannot be served as supplied.
     #[error("invalid request: {message}")]
@@ -108,6 +108,60 @@ pub enum LlmClientError {
     /// A string message. Useful in testing, but prefer adding variants over using this.
     #[error("{0}")]
     General(String),
+}
+
+impl fmt::Debug for LlmClientError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { message } => formatter
+                .debug_struct("InvalidRequest")
+                .field("message", message)
+                .finish(),
+            Self::RequestTranslation(message) => formatter
+                .debug_tuple("RequestTranslation")
+                .field(message)
+                .finish(),
+            Self::RequestEncoding(message) => formatter
+                .debug_tuple("RequestEncoding")
+                .field(message)
+                .finish(),
+            Self::ResponseTranslation(message) => formatter
+                .debug_tuple("ResponseTranslation")
+                .field(message)
+                .finish(),
+            Self::Configuration { message } => formatter
+                .debug_struct("Configuration")
+                .field("message", message)
+                .finish(),
+            Self::Transport { source } => formatter
+                .debug_struct("Transport")
+                .field("source", source)
+                .finish(),
+            Self::Timeout { source } => formatter
+                .debug_struct("Timeout")
+                .field("source", source)
+                .finish(),
+            Self::ContextWindowExceeded { model, .. } => formatter
+                .debug_struct("ContextWindowExceeded")
+                .field("model", model)
+                .field("message", &"[REDACTED]")
+                .finish(),
+            Self::UpstreamHttp { status, .. } => formatter
+                .debug_struct("UpstreamHttp")
+                .field("status", status)
+                .field("body", &"[REDACTED]")
+                .finish(),
+            Self::InvalidResponse { source } => formatter
+                .debug_struct("InvalidResponse")
+                .field("source", source)
+                .finish(),
+            Self::Ffi { source } => formatter
+                .debug_struct("Ffi")
+                .field("source", source)
+                .finish(),
+            Self::General(message) => formatter.debug_tuple("General").field(message).finish(),
+        }
+    }
 }
 
 /// A decision/trace object produced by an algorithm.
@@ -199,5 +253,41 @@ pub trait RoutedLlmClient: Send + Sync {
         Err(LlmClientError::Configuration {
             message: "count_tokens is not supported by this client".to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LlmClientError;
+
+    #[test]
+    fn context_window_message_is_redacted_from_display_and_debug() {
+        let secret = "provider context-window details";
+        let error = LlmClientError::ContextWindowExceeded {
+            model: "provider/model".to_string(),
+            message: secret.to_string(),
+        };
+
+        assert!(!error.to_string().contains(secret));
+        let debug = format!("{error:?}");
+        assert!(!debug.contains(secret));
+        assert_eq!(
+            debug,
+            "ContextWindowExceeded { model: \"provider/model\", message: \"[REDACTED]\" }"
+        );
+    }
+
+    #[test]
+    fn upstream_http_body_is_redacted_from_display_and_debug() {
+        let secret = "provider error body";
+        let error = LlmClientError::UpstreamHttp {
+            status: 500,
+            body: secret.to_string(),
+        };
+
+        assert!(!error.to_string().contains(secret));
+        let debug = format!("{error:?}");
+        assert!(!debug.contains(secret));
+        assert_eq!(debug, "UpstreamHttp { status: 500, body: \"[REDACTED]\" }");
     }
 }

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -649,6 +649,16 @@ mod tests {
     }
 
     #[test]
+    fn decode_stream_accepts_data_fields_without_the_optional_space() -> Result<(), BoxError> {
+        let sse = b"data:{\"choices\":[{\"delta\":{\"content\":\"compact\"}}]}\n\ndata:[DONE]\n\n"
+            .to_vec();
+        let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
+        let chunks = decode_all(bytes, WireFormat::OpenAiChat)?;
+        assert_eq!(text_of(&chunks), "compact");
+        Ok(())
+    }
+
+    #[test]
     fn decode_stream_propagates_source_errors() -> Result<(), BoxError> {
         // A transport error mid-stream surfaces as an error item, not a panic.
         let bytes = stream::iter(vec![

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -26,6 +26,7 @@ static DEFAULT_TRANSLATION_POLICY: LazyLock<TranslationPolicy> =
     LazyLock::new(TranslationPolicy::default);
 static DEFAULT_TRANSLATION_ENGINE: LazyLock<TranslationEngine> =
     LazyLock::new(TranslationEngine::default);
+const MAX_SSE_FRAME_BYTES: usize = 8 * 1024 * 1024;
 
 /// Decodes a `wire_format` request body into the neutral IR.
 pub fn decode_request(wire_format: WireFormat, body: &Value) -> Result<LlmRequest> {
@@ -188,8 +189,21 @@ where
     // an `io::Error` item so `into_async_read`'s error bound resolves cleanly. The
     // source error is boxed intact rather than stringified, so
     // `llm_client_error_from_io` can recover its original variant on the way out.
+    // Validate frame growth before the line reader allocates an unbounded
+    // `String` for a provider event without a delimiter.
+    let bounded_bytes: Pin<
+        Box<dyn Stream<Item = std::result::Result<Vec<u8>, LlmClientError>> + Send>,
+    > = Box::pin(try_stream! {
+        let mut bytes = Box::pin(bytes);
+        let mut tracker = SseFrameSizeTracker::default();
+        while let Some(chunk) = bytes.next().await {
+            let chunk = chunk?;
+            tracker.observe(&chunk, MAX_SSE_FRAME_BYTES)?;
+            yield chunk;
+        }
+    });
     let io_bytes: Pin<Box<dyn Stream<Item = std::io::Result<Vec<u8>>> + Send>> =
-        Box::pin(bytes.map(|item| item.map_err(std::io::Error::other)));
+        Box::pin(bounded_bytes.map(|item| item.map_err(std::io::Error::other)));
     let lines = futures::io::BufReader::new(io_bytes.into_async_read()).lines();
 
     let mut state = StreamTranslationState {
@@ -239,6 +253,36 @@ where
     Ok(stream)
 }
 
+#[derive(Default)]
+struct SseFrameSizeTracker {
+    frame_bytes: usize,
+    current_line_has_content: bool,
+}
+
+impl SseFrameSizeTracker {
+    // Tracks blank-line frame boundaries across arbitrary transport chunks.
+    fn observe(&mut self, bytes: &[u8], limit: usize) -> std::result::Result<(), LlmClientError> {
+        for byte in bytes {
+            self.frame_bytes = self.frame_bytes.saturating_add(1);
+            match byte {
+                b'\n' if !self.current_line_has_content => self.frame_bytes = 0,
+                b'\n' => self.current_line_has_content = false,
+                b'\r' => {}
+                _ => self.current_line_has_content = true,
+            }
+            if self.frame_bytes > limit {
+                return Err(LlmClientError::InvalidResponse {
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("provider SSE frame exceeded {limit} bytes"),
+                    )),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
 // Recover transport errors wrapped for `AsyncRead`; other reader failures are
 // invalid upstream responses.
 fn llm_client_error_from_io(error: std::io::Error) -> LlmClientError {
@@ -265,8 +309,8 @@ mod tests {
     };
 
     use super::{
-        decode_aggregated_response, decode_request, decode_stream, encode_aggregated_response,
-        encode_request, encode_stream, stamp_streamed_response_model,
+        SseFrameSizeTracker, decode_aggregated_response, decode_request, decode_stream,
+        encode_aggregated_response, encode_request, encode_stream, stamp_streamed_response_model,
     };
     use crate::{LlmResponseStream, WireFormat};
 
@@ -612,5 +656,17 @@ mod tests {
         };
         assert!(matches!(error, LlmClientError::ResponseTranslation(_)));
         Ok(())
+    }
+
+    #[test]
+    fn sse_frame_limit_spans_transport_chunks_and_resets_at_boundaries() {
+        let mut tracker = SseFrameSizeTracker::default();
+        tracker.observe(b"data: 1\n", 16).unwrap();
+        tracker.observe(b"\ndata: 2\n\n", 16).unwrap();
+
+        let mut oversized = SseFrameSizeTracker::default();
+        oversized.observe(b"data: ", 8).unwrap();
+        let error = oversized.observe(b"123", 8).unwrap_err();
+        assert!(matches!(error, LlmClientError::InvalidResponse { .. }));
     }
 }

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -204,9 +204,10 @@ where
     // `String` for a provider event without a delimiter.
     let bounded_bytes = try_stream! {
         let mut bytes = Box::pin(bytes);
+        let mut line_endings = SseLineEndingNormalizer::default();
         let mut tracker = SseFrameSizeTracker::default();
         while let Some(chunk) = bytes.next().await {
-            let chunk = chunk?;
+            let chunk = line_endings.normalize(chunk?);
             tracker.observe(&chunk, max_frame_bytes)?;
             yield chunk;
         }
@@ -274,6 +275,31 @@ fn is_sse_frame_boundary(line: &str) -> bool {
 }
 
 #[derive(Default)]
+struct SseLineEndingNormalizer {
+    previous_byte_was_cr: bool,
+}
+
+impl SseLineEndingNormalizer {
+    // SSE accepts CR, LF, and CRLF. Normalize all three to one LF while
+    // retaining enough state to collapse a CRLF pair split across chunks.
+    fn normalize(&mut self, mut bytes: Vec<u8>) -> Vec<u8> {
+        let mut write = 0;
+        for read in 0..bytes.len() {
+            let byte = bytes[read];
+            if self.previous_byte_was_cr && byte == b'\n' {
+                self.previous_byte_was_cr = false;
+                continue;
+            }
+            self.previous_byte_was_cr = byte == b'\r';
+            bytes[write] = if byte == b'\r' { b'\n' } else { byte };
+            write += 1;
+        }
+        bytes.truncate(write);
+        bytes
+    }
+}
+
+#[derive(Default)]
 struct SseFrameSizeTracker {
     frame_bytes: usize,
     current_line_has_non_whitespace: bool,
@@ -329,9 +355,9 @@ mod tests {
     };
 
     use super::{
-        SseFrameSizeTracker, decode_aggregated_response, decode_request, decode_stream,
-        decode_stream_with_limit, encode_aggregated_response, encode_request, encode_stream,
-        stamp_streamed_response_model,
+        SseFrameSizeTracker, SseLineEndingNormalizer, decode_aggregated_response, decode_request,
+        decode_stream, decode_stream_with_limit, encode_aggregated_response, encode_request,
+        encode_stream, stamp_streamed_response_model,
     };
     use crate::{LlmResponseStream, WireFormat};
 
@@ -649,6 +675,16 @@ mod tests {
     }
 
     #[test]
+    fn decode_stream_decodes_bare_cr_delimited_frames() -> Result<(), BoxError> {
+        let sse =
+            b"data:{\"choices\":[{\"delta\":{\"content\":\"cr\"}}]}\r\rdata:[DONE]\r\r".to_vec();
+        let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
+        let chunks = decode_all(bytes, WireFormat::OpenAiChat)?;
+        assert_eq!(text_of(&chunks), "cr");
+        Ok(())
+    }
+
+    #[test]
     fn decode_stream_accepts_data_fields_without_the_optional_space() -> Result<(), BoxError> {
         let sse = b"data:{\"choices\":[{\"delta\":{\"content\":\"compact\"}}]}\n\ndata:[DONE]\n\n"
             .to_vec();
@@ -702,10 +738,35 @@ mod tests {
     }
 
     #[test]
+    fn sse_line_endings_collapse_crlf_split_across_chunks() {
+        let mut normalizer = SseLineEndingNormalizer::default();
+        assert_eq!(normalizer.normalize(b"data: {}\r".to_vec()), b"data: {}\n");
+        assert_eq!(normalizer.normalize(b"\n\r".to_vec()), b"\n");
+        assert!(normalizer.normalize(b"\n".to_vec()).is_empty());
+    }
+
+    #[test]
     fn decode_stream_resets_frame_limit_at_whitespace_boundaries() -> Result<(), LlmClientError> {
         let bytes = stream::iter(vec![
             Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n \n".to_vec()),
             Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n".to_vec()),
+        ]);
+
+        let events = block_on(
+            decode_stream_with_limit(bytes, WireFormat::OpenAiChat, 50)?.collect::<Vec<_>>(),
+        )
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(text_of(&events), "ab");
+        Ok(())
+    }
+
+    #[test]
+    fn decode_stream_resets_frame_limit_at_bare_cr_boundaries() -> Result<(), LlmClientError> {
+        let bytes = stream::iter(vec![
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\r\r".to_vec()),
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\r\r".to_vec()),
         ]);
 
         let events = block_on(

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -256,7 +256,7 @@ where
 #[derive(Default)]
 struct SseFrameSizeTracker {
     frame_bytes: usize,
-    current_line_has_content: bool,
+    current_line_has_non_whitespace: bool,
 }
 
 impl SseFrameSizeTracker {
@@ -265,10 +265,10 @@ impl SseFrameSizeTracker {
         for byte in bytes {
             self.frame_bytes = self.frame_bytes.saturating_add(1);
             match byte {
-                b'\n' if !self.current_line_has_content => self.frame_bytes = 0,
-                b'\n' => self.current_line_has_content = false,
-                b'\r' => {}
-                _ => self.current_line_has_content = true,
+                b'\n' if !self.current_line_has_non_whitespace => self.frame_bytes = 0,
+                b'\n' => self.current_line_has_non_whitespace = false,
+                byte if byte.is_ascii_whitespace() => {}
+                _ => self.current_line_has_non_whitespace = true,
             }
             if self.frame_bytes > limit {
                 return Err(LlmClientError::InvalidResponse {
@@ -661,8 +661,8 @@ mod tests {
     #[test]
     fn sse_frame_limit_spans_transport_chunks_and_resets_at_boundaries() {
         let mut tracker = SseFrameSizeTracker::default();
-        tracker.observe(b"data: 1\n", 16).unwrap();
-        tracker.observe(b"\ndata: 2\n\n", 16).unwrap();
+        tracker.observe(b"data: 1\n", 10).unwrap();
+        tracker.observe(b" \ndata: 2\n\n", 10).unwrap();
 
         let mut oversized = SseFrameSizeTracker::default();
         oversized.observe(b"data: ", 8).unwrap();

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -202,9 +202,7 @@ where
     // `llm_client_error_from_io` can recover its original variant on the way out.
     // Validate frame growth before the line reader allocates an unbounded
     // `String` for a provider event without a delimiter.
-    let bounded_bytes: Pin<
-        Box<dyn Stream<Item = std::result::Result<Vec<u8>, LlmClientError>> + Send>,
-    > = Box::pin(try_stream! {
+    let bounded_bytes = try_stream! {
         let mut bytes = Box::pin(bytes);
         let mut tracker = SseFrameSizeTracker::default();
         while let Some(chunk) = bytes.next().await {
@@ -212,9 +210,12 @@ where
             tracker.observe(&chunk, max_frame_bytes)?;
             yield chunk;
         }
-    });
-    let io_bytes: Pin<Box<dyn Stream<Item = std::io::Result<Vec<u8>>> + Send>> =
-        Box::pin(bounded_bytes.map(|item| item.map_err(std::io::Error::other)));
+    };
+    let io_bytes: Pin<Box<dyn Stream<Item = std::io::Result<Vec<u8>>> + Send>> = Box::pin(
+        bounded_bytes.map(|item: std::result::Result<Vec<u8>, LlmClientError>| {
+            item.map_err(std::io::Error::other)
+        }),
+    );
     let lines = futures::io::BufReader::new(io_bytes.into_async_read()).lines();
 
     let mut state = StreamTranslationState {

--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -176,6 +176,17 @@ pub fn decode_stream<S>(
 where
     S: Stream<Item = std::result::Result<Vec<u8>, LlmClientError>> + Send + 'static,
 {
+    decode_stream_with_limit(bytes, source, MAX_SSE_FRAME_BYTES)
+}
+
+fn decode_stream_with_limit<S>(
+    bytes: S,
+    source: WireFormat,
+    max_frame_bytes: usize,
+) -> std::result::Result<LlmResponseStream, LlmClientError>
+where
+    S: Stream<Item = std::result::Result<Vec<u8>, LlmClientError>> + Send + 'static,
+{
     let marker = sse::done_marker(source);
     let source_format: FormatId = source.into();
     // The source is always a built-in wire format, so this lookup cannot fail; a
@@ -198,7 +209,7 @@ where
         let mut tracker = SseFrameSizeTracker::default();
         while let Some(chunk) = bytes.next().await {
             let chunk = chunk?;
-            tracker.observe(&chunk, MAX_SSE_FRAME_BYTES)?;
+            tracker.observe(&chunk, max_frame_bytes)?;
             yield chunk;
         }
     });
@@ -215,8 +226,8 @@ where
         futures::pin_mut!(lines);
         while let Some(line) = lines.next().await {
             let line = line.map_err(llm_client_error_from_io)?;
-            // A blank line (allowing a bare CR for CRLF streams) ends the frame.
-            if line.trim_end().is_empty() {
+            // An ASCII-whitespace-only line ends the frame.
+            if is_sse_frame_boundary(&line) {
                 let parsed = sse::parse_json_sse_frame(&frame, marker)
                     .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?;
                 frame.clear();
@@ -241,7 +252,7 @@ where
         // A non-standard upstream might omit the final blank line; parse a trailing
         // complete frame instead of losing its last chunk.
         #[allow(clippy::collapsible_if)]
-        if !frame.trim_end().is_empty() {
+        if !is_sse_frame_boundary(&frame) {
             let parsed = sse::parse_json_sse_frame(&frame, marker)
                 .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?;
             if let sse::SseFrame::Data(value) = parsed {
@@ -251,6 +262,14 @@ where
         }
     });
     Ok(stream)
+}
+
+fn is_sse_whitespace(byte: &u8) -> bool {
+    byte.is_ascii_whitespace()
+}
+
+fn is_sse_frame_boundary(line: &str) -> bool {
+    line.as_bytes().iter().all(is_sse_whitespace)
 }
 
 #[derive(Default)]
@@ -267,7 +286,7 @@ impl SseFrameSizeTracker {
             match byte {
                 b'\n' if !self.current_line_has_non_whitespace => self.frame_bytes = 0,
                 b'\n' => self.current_line_has_non_whitespace = false,
-                byte if byte.is_ascii_whitespace() => {}
+                byte if is_sse_whitespace(byte) => {}
                 _ => self.current_line_has_non_whitespace = true,
             }
             if self.frame_bytes > limit {
@@ -310,7 +329,8 @@ mod tests {
 
     use super::{
         SseFrameSizeTracker, decode_aggregated_response, decode_request, decode_stream,
-        encode_aggregated_response, encode_request, encode_stream, stamp_streamed_response_model,
+        decode_stream_with_limit, encode_aggregated_response, encode_request, encode_stream,
+        stamp_streamed_response_model,
     };
     use crate::{LlmResponseStream, WireFormat};
 
@@ -668,5 +688,22 @@ mod tests {
         oversized.observe(b"data: ", 8).unwrap();
         let error = oversized.observe(b"123", 8).unwrap_err();
         assert!(matches!(error, LlmClientError::InvalidResponse { .. }));
+    }
+
+    #[test]
+    fn decode_stream_resets_frame_limit_at_whitespace_boundaries() -> Result<(), LlmClientError> {
+        let bytes = stream::iter(vec![
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n \n".to_vec()),
+            Ok(b"data: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\n".to_vec()),
+        ]);
+
+        let events = block_on(
+            decode_stream_with_limit(bytes, WireFormat::OpenAiChat, 50)?.collect::<Vec<_>>(),
+        )
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+        assert_eq!(text_of(&events), "ab");
+        Ok(())
     }
 }

--- a/crates/switchyard-translation/src/sse.rs
+++ b/crates/switchyard-translation/src/sse.rs
@@ -36,7 +36,8 @@ pub(crate) fn parse_json_sse_frame(
     let data = frame
         .lines()
         .filter(|line| !line.is_empty() && !line.starts_with(':'))
-        .filter_map(|line| line.strip_prefix("data: ").map(|l| l.to_string()))
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(|value| value.strip_prefix(' ').unwrap_or(value).to_string())
         .fold(String::new(), |mut a, b| {
             a.reserve(b.len() + 1);
             a.push_str(&b);
@@ -66,6 +67,15 @@ mod tests {
     #[test]
     fn parses_a_data_line_as_json() -> Result<(), BoxError> {
         let SseFrame::Data(value) = parse_json_sse_frame("data: {\"text\":\"hi\"}\n", DONE)? else {
+            return Err("expected a payload".into());
+        };
+        assert_eq!(value, json!({"text": "hi"}));
+        Ok(())
+    }
+
+    #[test]
+    fn parses_a_data_line_without_the_optional_space() -> Result<(), BoxError> {
+        let SseFrame::Data(value) = parse_json_sse_frame("data:{\"text\":\"hi\"}\n", DONE)? else {
             return Err("expected a payload".into());
         };
         assert_eq!(value, json!({"text": "hi"}));


### PR DESCRIPTION
## What

Hardens the reusable `switchyard-llm-client` HTTP transport used for provider
dispatch. The PR establishes five generic safety guarantees:

* configured provider requests do not follow redirects;
* connections and inactive response reads have safe, configurable timeouts;
* buffered success and retained error bodies have explicit memory bounds;
* credentials and provider error bodies are redacted from ordinary diagnostics; and
* individual SSE frames are bounded before line-oriented decoding can allocate
  without limit.

This is intentionally independent of the NeMo Relay dynamic-plugin implementation.
It changes the shared client and translation behavior for every caller rather than
placing Relay-specific protections in NVIDIA-NeMo/Switchyard#270.

### Review guide

#### 1\. Redirect rejection at the provider authority boundary

**Motivation:** A configured provider request can contain credentials and a full
prompt. Following an upstream redirect would allow a provider—or a compromised
endpoint—to move that request to a different authority. Redirects are therefore
returned as ordinary non-success HTTP responses instead of being followed.

* Implementation: [`TranslatingLlmClient` constructs a no-redirect shared client](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L116-L142>).
* Contract test: [`configured_provider_requests_do_not_follow_redirects`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L1158-L1196>) verifies the redirect target receives no request.

#### 2\. Configurable connection and idle-read timeouts

**Motivation:** Without transport timeouts, an unreachable or silent provider can
retain request resources indefinitely. The defaults are a 10-second connection
timeout and a 120-second idle-read timeout. The read timeout resets after every
successful read, so an active long-running stream is not limited to 120 seconds.
Callers serving providers that may legitimately remain silent longer can override
the values or disable the idle-read timeout.

* Public configuration: [`HttpTransportConfig`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L54-L76>) and [`new_with_transport_config`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L116-L142>).
* Error mapping: [reqwest timeouts remain the typed `LlmClientError::Timeout` variant](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L733-L747>).
* Contract test: [`routed_llm_client_exposes_timeout_variant`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L1824-L1858>) exercises a short timeout through the public configuration path.

#### 3\. Bounded buffered and error response bodies

**Motivation:** A provider controls both its response body and advertised
`Content-Length`. Relying on that metadata can reserve large amounts of memory
before any bytes arrive, while collecting an unbounded body allows concurrent
responses to exhaust the process. The client now grows buffers only from received
chunks, rejects buffered success bodies above 64 MiB, and retains at most 64 KiB
of an HTTP error body with an explicit truncation marker.

* Enforcement: [buffered success and error handling](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L310-L380>) and the shared [`collect_response_body`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L540-L580>) collector.
* Error-body test: [`upstream_error_body_is_bounded_and_redacted_from_display`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L1198-L1229>).
* Allocation regression: [`response_body_does_not_preallocate_advertised_content_length`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/client.rs#L1231-L1283>) advertises 64 MiB while yielding only two bytes.

#### 4\. Diagnostic redaction without weakening typed errors

**Motivation:** Provider credentials can be stored in static target headers, and
provider error bodies can echo prompts or secrets. Redacting only `Display` is
insufficient because structured tracing commonly records errors with `?error`,
which uses `Debug`. Header values and sensitive provider fields are now redacted
from both ordinary formatting paths. The bounded body/message fields remain
available to code that explicitly matches the typed error.

* Static headers: [`HttpBackendConfig::Debug` emits names but not values](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/backend.rs#L52-L62>), covered by [`debug_redacts_static_header_values`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/src/backend.rs#L285-L295>).
* Provider bodies: [`LlmClientError` display and debug formatting](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/protocol/src/client.rs#L73-L165>), covered by the [protocol redaction tests](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/protocol/src/client.rs#L259-L293>).

#### 5\. Bounded SSE frames before line buffering

**Motivation:** `AsyncBufReadExt::lines()` must accumulate a complete line before
returning it. A provider that never emits an SSE frame boundary could otherwise
grow that allocation without limit. The translation layer now checks raw transport
chunks before the line reader and rejects a frame above 8 MiB. The byte limiter and
parser share the same ASCII-whitespace boundary semantics so valid small frames do
not accumulate into a false oversized-frame failure.

* Enforcement: [`decode_stream_with_limit` and `SseFrameSizeTracker`](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/switchyard-translation/src/helpers.rs#L166-L304>).
* Tests: [chunk-spanning limit, oversized-frame, and whitespace-boundary coverage](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/switchyard-translation/src/helpers.rs#L682-L709>).

#### 6\. Public documentation

* [`switchyard-llm-client` README](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/crates/libsy-llm-client/README.md#L167-L216>) documents credentials, retries, timeout overrides, body limits, redaction, and the SSE limit.
* The [`Unreleased` changelog entry](<https://github.com/NVIDIA-NeMo/Switchyard/blob/889ce9553ceba1474c1569e6b25568b8513d2442/CHANGELOG.md#L7-L15>) records the behavior change for all client consumers.

## Why

`switchyard-llm-client` is the reusable provider-dispatch boundary for the
Switchyard server, libsy examples, and the external Relay plugin. It handles
credentials and untrusted network responses, so its defaults must protect:

* **authority integrity:** credentials and request bodies stay with the configured provider;
* **availability:** stalled connections and reads cannot retain resources indefinitely;
* **memory safety:** provider metadata, buffered responses, and SSE frames cannot cause unbounded allocation; and
* **credential/content privacy:** routine logs and spans do not copy target headers or provider-returned content.

These are generic client guarantees, not routing-algorithm behavior. PR NVIDIA-NeMo/Switchyard#270 can
build and function independently, while consuming these safer defaults once this
PR lands.

Relates to: NVIDIA-NeMo/Switchyard#270

## How tested

- [ ] `uv run ruff check .` clean (N/A: Rust-only change)
- [ ] `uv run mypy switchyard` clean (N/A: Rust-only change)
- [ ] `uv run pytest tests/` green (N/A: Rust-only change)
- [X] `cargo test -p switchyard-llm-client`
- [X] `cargo test -p switchyard-translation`
- [X] `cargo test -p switchyard-protocol -p switchyard-libsy`
- [X] `cargo clippy --workspace --all-targets -- -D warnings`
- [X] `cargo fmt --all -- --check`
- [ ] Manual smoke (not needed: behavior is covered with local HTTP fixtures)

## Checklist

- [X] One class per file; filename = `snake_case` of the primary class. (N/A: Rust-only change.)
- [X] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: no Python symbols.)
- [X] Unit tests added for new components / bug fixes.
- [X] README / `--help` updated if customer-facing surface changed.
- [X] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

* `TranslatingLlmClient::new` remains source-compatible and applies the safe defaults. The only new public surface is `HttpTransportConfig` plus `new_with_transport_config` for callers that need different timeout behavior.
* The read timeout is an **idle timeout**, not a total request deadline; every successful read resets it.
* Redirects are not followed. A provider 3xx is returned through the existing typed HTTP-error path.
* Oversized successful buffered responses fail. Oversized HTTP error bodies are truncated because callers still need bounded provider context for typed classification and diagnostics.
* Raw provider bodies remain available through explicit typed-error field access. Only implicit `Display` and `Debug` rendering is redacted.
* The 8 MiB SSE limit is enforced in `switchyard-translation`, before its line reader. This is the allocation boundary and protects every caller of the shared decoder.
* This PR adds no Relay plugin, manifest, Relay SDK dependency, routing behavior, or Relay-specific configuration.
* This PR is non-blocking for the Relay plugin integration. It captures hardening that could be made before production, but it should not prevent the integration from working.

## Summary by CodeRabbit

* **Security**
  * Sensitive header values are no longer exposed in diagnostic output.
  * HTTP error messages are sanitized to avoid displaying upstream response contents.
* **Reliability**
  * Added connection and read timeouts, redirect blocking, and response-size limits.
  * Oversized responses and streaming frames now fail safely with clear errors.
  * Large error responses are capped and marked as truncated.
* **Documentation**
  * Documented HTTP safety, timeout, redaction, and streaming limits.