### PR TITLE
fix: resolve routing tier for fallback and affinity-reuse decisions

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -1436,3 +1436,39 @@ async fn classifier_fail_open_records_each_failure_stage() -> switchyard_libsy::
     }
     Ok(())
 }
+
+/// A decision made by the cascade fallback still names its routing tier.
+///
+/// The judge call fails, so `TaskClassifier` fails open and `DefaultTarget`
+/// decides. That decider defines no tier of its own, so without the cascade
+/// lookup the selection logs `tier: None` while a judged decision to the same
+/// target logs its tier. `AffinityRouter` reuse takes the same path.
+#[tokio::test]
+async fn fallback_decision_logs_the_routing_tier() -> switchyard_libsy::Result<()> {
+    let _guard = serialize_test().lock().await;
+    let (store, _, _, _, _) = telemetry();
+
+    let client = Arc::new(JudgeClient {
+        judge_model: "ft-judge".into(),
+        outcome: JudgeOutcome::CallFailure,
+    }) as Arc<dyn RoutedLlmClient>;
+    run(
+        classifier_router("ft-judge", "ft-weak", "ft-strong")?,
+        client,
+        classifier_request(),
+    )
+    .await?;
+
+    let events = store.events();
+    assert!(
+        events.iter().any(|event| {
+            event.fields.get("target").map(String::as_str) == Some("ft-strong")
+                && event
+                    .fields
+                    .get("tier")
+                    .is_some_and(|tier| tier.contains("strong"))
+        }),
+        "fallback selection logged without its routing tier: {events:?}"
+    );
+    Ok(())
+}

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -264,7 +264,13 @@ where
         // 3. Resolve the target and log the choice.
         algorithm::ensure_model_is_target(&self.targets, &score.target)?;
         let target = score.target.clone();
-        let tier = deciding.routing_tier(&target);
+        // A fallback or affinity-reuse decider carries no tier of its own, so
+        // resolve it across the cascade rather than logging it as None.
+        let tier = deciding.routing_tier(&target).or_else(|| {
+            self.classifiers
+                .iter()
+                .find_map(|c| c.routing_tier(&target))
+        });
         tracing::info!(algorithm=self.name, target=%score.target, confidence=score.confidence, tier = ?tier, "Model selected");
 
         // 4. Post-decision replay: every processor sees the selection so stateful ones


### PR DESCRIPTION
Closes #276.

## Why

A routing decision made by the cascade fallback, or served from an affinity pin, logs without its routing tier while a judged decision to the same target logs with one:

```
fall-through selected ok-strong (confidence 1.000); routing tier: strong
fall-through selected ft-strong (confidence 0.000)
```

#338 preserves routing-tier and fallback details in the decision reasoning and #413 moved that reasoning into the log, so a decision that omits the tier loses detail the log is meant to carry.

## What

`with_routing_tier` asks only the deciding classifier for the tier. Neither `DefaultTarget` nor `AffinityRouter` implements `Classifier::routing_tier`, so the trait default returns `None` and the tier is dropped. This resolves the tier across the cascade when the deciding classifier defines none.

## How

One lookup in `crates/libsy/src/algorithms/fall_through.rs`: fall back to the first classifier in the cascade that defines a tier for the selected target. `TaskClassifier` sits in the cascade in both cases, so the fallback and affinity paths resolve the same `weak`/`strong` labels a judged decision would produce.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p switchyard-protocol -p switchyard-libsy -p switchyard-llm-client -p switchyard-server`
- [x] `git diff --check`
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest tests/ -m "not integration"`

Two tests in `crates/libsy-llm-client/tests/observability.rs` cover the fallback and affinity-reuse paths. Both fail without the `fall_through.rs` change.

## Note on this branch

This was rebased at maintainer request and became a rewrite rather than a replay. The original commits patched `FallThroughDecision.tier` and asserted a `tier` attribute on `switchyard.requests`; #338 removed both, so there was nothing left for them to apply to. The defect they described survives in the decision log, and this branch addresses it there.
