### PR TITLE
fix(translation): reduce Anthropic token fallback

### DIFF
--- a/crates/switchyard-components/tests/adversarial_native_backends.rs
+++ b/crates/switchyard-components/tests/adversarial_native_backends.rs
@@ -892,7 +892,7 @@ async fn anthropic_translates_responses_requests_with_default_max_tokens() -> Re
 
     assert_eq!(ctx.inbound_format, Some(ChatRequestType::OpenAiResponses));
     assert_eq!(request.body["model"], "target-claude");
-    assert_eq!(request.body["max_tokens"], 128000);
+    assert_eq!(request.body["max_tokens"], 64000);
     assert_eq!(request.body["messages"][0]["role"], "user");
     assert_eq!(request.body["messages"][0]["content"], "translate me");
     Ok(())

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -204,7 +204,7 @@ impl FormatCodec for AnthropicMessagesCodec {
         if let Some(max_tokens) = request.output.max_output_tokens {
             body.insert("max_tokens".to_string(), json!(max_tokens));
         } else {
-            body.insert("max_tokens".to_string(), json!(128_000));
+            body.insert("max_tokens".to_string(), json!(64_000));
         }
         if let Some(value) = request.sampling.temperature {
             body.insert("temperature".to_string(), json!(value));

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -994,7 +994,7 @@ fn openai_request_to_anthropic_adds_required_default_max_tokens() -> TestResult 
         )?
         .body;
 
-    assert_eq!(output["max_tokens"], 128_000);
+    assert_eq!(output["max_tokens"], 64_000);
     Ok(())
 }
 

--- a/tests/test_translation_engine_chaos.py
+++ b/tests/test_translation_engine_chaos.py
@@ -979,11 +979,9 @@ class TestRequestEngineEdgeCases:
     def test_openai_to_anthropic_default_max_tokens(self, req_engine):
         """When ``max_tokens`` is omitted, Anthropic requires a default.
 
-        The translation layer injects ``128_000`` (generous on purpose —
-        see ``convert_openai_request_to_anthropic``'s docstring).  Anthropic
-        clamps this to the model's real output ceiling server-side, so
-        oversizing is harmless and a small default would silently
-        truncate long coding outputs.
+        The translation layer injects ``64_000`` to provide room for long
+        coding outputs without defaulting every request to the model's
+        absolute output ceiling.
         """
         body = {
             "model": "gpt-4o",
@@ -991,7 +989,7 @@ class TestRequestEngineEdgeCases:
         }
         req = ChatRequest.openai_chat(body)
         result = req_engine.request_to(ChatRequestType.ANTHROPIC, req)
-        assert result.body["max_tokens"] == 128_000
+        assert result.body["max_tokens"] == 64_000
 
     def test_openai_to_anthropic_system_extraction(self, req_engine):
         """System messages should be extracted into the Anthropic system param."""


### PR DESCRIPTION
## What

Reduce the implicit Anthropic `max_tokens` fallback from 128,000 to 64,000 when an OpenAI-format request omits both `max_tokens` and `max_completion_tokens`.

## Why

Omitting an output limit is valid for OpenAI clients, while Anthropic Messages requires `max_tokens`. Switchyard therefore needs to supply a fallback during cross-format translation.

The existing fallback used 128,000, which is the model's absolute output ceiling rather than a conservative default. Anthropic counts both adaptive reasoning and visible response tokens against this limit. Combined with `reasoning_effort=max`, the implicit 128K budget can allow requests to run beyond the 600-second upstream deadline and return HTTP 500.

64K matches Claude Code's default for recognized modern Opus models and still leaves substantial room for agentic and coding output without automatically granting every uncapped request the maximum possible budget.

Tracks [SWITCH-1194](https://linear.app/nvidia/issue/SWITCH-1194/oss-020translation-anthropic-128k-fallback-causes-max-reasoning).

## How

- Change only the Anthropic fallback from 128K to 64K.
- Preserve explicit caller-provided token limits unchanged.
- Align the existing fallback assertions and remove the stale claim that oversizing is harmless.

## What to review

- Whether 64K is the appropriate provider-neutral fallback.
- That explicitly supplied output limits still bypass the fallback.

## Validation

```text
cargo test -p switchyard-translation openai_request_to_anthropic_adds_required_default_max_tokens
cargo test -p switchyard-components anthropic_translates_responses_requests_with_default_max_tokens
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Anthropic requests now default to a maximum of 64,000 output tokens when no limit is specified.
  * Updated OpenAI-to-Anthropic translation behavior and expectations to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->