### PR TITLE
fix(translation): reject incomplete anthropic streams

### DIFF
--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -196,6 +196,7 @@ where
         source: Some(source_format.clone()),
         ..StreamTranslationState::default()
     };
+    let mut saw_anthropic_message_stop = false;
     let mut frame = String::new();
     let stream = Box::pin(try_stream! {
         futures::pin_mut!(lines);
@@ -210,6 +211,8 @@ where
                     sse::SseFrame::Empty => {}
                     sse::SseFrame::Done => break,
                     sse::SseFrame::Data(value) => {
+                        saw_anthropic_message_stop |= source == WireFormat::AnthropicMessages
+                            && value.get("type").and_then(Value::as_str) == Some("message_stop");
                         let normalized = codec.decode_event(&mut state, &value);
                         yield LlmResponseStreamEvent::preserved(
                             source_format.clone(),
@@ -231,9 +234,17 @@ where
             let parsed = sse::parse_json_sse_frame(&frame, marker)
                 .map_err(|error| LlmClientError::ResponseTranslation(error.to_string()))?;
             if let sse::SseFrame::Data(value) = parsed {
+                saw_anthropic_message_stop |= source == WireFormat::AnthropicMessages
+                    && value.get("type").and_then(Value::as_str) == Some("message_stop");
                 let normalized = codec.decode_event(&mut state, &value);
                 yield LlmResponseStreamEvent::preserved(source_format, value, normalized);
             }
+        }
+
+        if source == WireFormat::AnthropicMessages && !saw_anthropic_message_stop {
+            Err(LlmClientError::ResponseTranslation(
+                "anthropic stream ended before message_stop".to_string(),
+            ))?;
         }
     });
     Ok(stream)
@@ -567,6 +578,31 @@ mod tests {
         let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
         let chunks = decode_all(bytes, WireFormat::OpenAiChat)?;
         assert_eq!(text_of(&chunks), "tail");
+        Ok(())
+    }
+
+    #[test]
+    fn anthropic_stream_without_message_stop_is_an_error() -> Result<(), BoxError> {
+        let sse = b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude\"}}\n\n".to_vec();
+        let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
+        let decoded = decode_stream(bytes, WireFormat::AnthropicMessages)?;
+        let results = block_on(
+            encode_stream(decoded, WireFormat::AnthropicMessages, None)?.collect::<Vec<_>>(),
+        );
+
+        let Some(Err(error)) = results.last() else {
+            panic!("expected incomplete Anthropic stream to fail");
+        };
+        assert_eq!(
+            error.to_string(),
+            "response translation failed: anthropic stream ended before message_stop"
+        );
+        assert!(
+            results
+                .iter()
+                .filter_map(|result| result.as_ref().ok())
+                .all(|event| event.get("type").and_then(Value::as_str) != Some("message_stop"))
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## What

Explicitly throws and SSE error in case the upstream Anthropic stream ends prematurely without a `message_stop` event.

## Why

The motivation — what problem does this solve, or which ticket does it close?

Closes #

## How tested

- [ ] `uv run ruff check .` clean
- [ ] `uv run mypy switchyard` clean
- [ ] `uv run pytest tests/` green
- [ ] Manual smoke (describe what was run)

## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class.
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use.
- [ ] Unit tests added for new components / bug fixes.
- [ ] README / `--help` updated if customer-facing surface changed.
- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

Anything reviewers should pay extra attention to — risky paths, follow-up tickets, intentional trade-offs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic stream handling to detect incomplete responses.
  * Added an error when a stream ends without the expected completion event.
  * Prevented incomplete streams from being treated as successfully completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->