### PR TITLE
fix(translation): preserve final answers in buffered Responses

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -182,24 +182,38 @@ impl FormatCodec for OpenAiResponsesCodec {
     fn decode_response(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedResponse> {
         let body = crate::util::object(body, "$")?;
         let mut diagnostics = Vec::new();
-        let mut outputs = Vec::new();
+        let mut content = Vec::new();
+        let mut role = Role::Assistant;
+        let mut stop_reason = None;
+        let mut has_output = false;
         if let Some(items) = body.get("output").and_then(Value::as_array) {
             for item in items {
                 if let Some(output) = decode_responses_output_item(item, &mut diagnostics, policy)?
                 {
-                    outputs.push(output);
+                    has_output = true;
+                    role = output.role;
+                    content.extend(output.content);
+                    if output.stop_reason.is_some() {
+                        stop_reason = output.stop_reason;
+                    }
                 }
             }
         }
-        if outputs.is_empty() {
-            outputs.push(ResponseOutput {
+        let outputs = vec![if has_output {
+            ResponseOutput {
+                role,
+                content,
+                stop_reason,
+            }
+        } else {
+            ResponseOutput {
                 role: Role::Assistant,
                 content: vec![ContentBlock::Text {
                     text: String::new(),
                 }],
                 stop_reason: Some(StopReason::EndTurn),
-            });
-        }
+            }
+        }];
         let response = AggLlmResponse {
             id: body
                 .get("id")

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -122,6 +122,60 @@ fn responses_reasoning_usage_translates_to_openai_chat_usage_details() -> TestRe
     Ok(())
 }
 
+// Verifies Responses reasoning and its following message remain one semantic assistant output.
+#[test]
+fn responses_reasoning_and_message_preserve_the_final_answer() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "resp_test",
+        "object": "response",
+        "model": "gpt-reasoning",
+        "status": "completed",
+        "output": [
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "private reasoning"}]
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Visible answer"}]
+            }
+        ]
+    });
+
+    let anthropic = engine
+        .translate_response(
+            WireFormat::OpenAiResponses,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(
+        anthropic["content"],
+        json!([
+            {"type": "thinking", "thinking": "private reasoning", "signature": ""},
+            {"type": "text", "text": "Visible answer"}
+        ])
+    );
+
+    let chat = engine
+        .translate_response(
+            WireFormat::OpenAiResponses,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(chat["choices"][0]["message"]["content"], "Visible answer");
+    assert_eq!(
+        chat["choices"][0]["message"]["reasoning_content"],
+        "private reasoning"
+    );
+    Ok(())
+}
+
 // Verifies OpenAI cache usage survives the Chat-to-Responses translation used by Codex.
 #[test]
 fn openai_chat_cache_usage_translates_to_responses_usage_details() -> TestResult {

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -837,6 +837,64 @@ fn anthropic_message_stop_does_not_overwrite_max_tokens_stop_reason() -> TestRes
     Ok(())
 }
 
+// Equivalent buffered and streamed Responses results must normalize to the same output.
+#[test]
+fn responses_buffered_and_streamed_outputs_match() -> TestResult {
+    let engine = TranslationEngine::default();
+    let buffered = engine
+        .decode_response(
+            WireFormat::OpenAiResponses,
+            &json!({
+                "id": "resp_1",
+                "object": "response",
+                "model": "gpt-reasoning",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "summary": [{"type": "summary_text", "text": "private reasoning"}]
+                    },
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Visible answer"}]
+                    }
+                ]
+            }),
+            &Default::default(),
+        )?
+        .response;
+
+    let events = [
+        json!({
+            "type": "response.created",
+            "response": {"id": "resp_1", "model": "gpt-reasoning"}
+        }),
+        json!({
+            "type": "response.reasoning_summary_text.delta",
+            "output_index": 0,
+            "delta": "private reasoning"
+        }),
+        json!({
+            "type": "response.output_text.delta",
+            "output_index": 1,
+            "delta": "Visible answer"
+        }),
+        json!({"type": "response.completed", "response": {}}),
+    ];
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiResponses, WireFormat::OpenAiResponses);
+    let mut accumulator = ResponseAccumulator::new();
+    for event in &events {
+        for chunk in decode_stream_event(&mut state, WireFormat::OpenAiResponses, event) {
+            accumulator.push(chunk);
+        }
+    }
+
+    assert_eq!(buffered.outputs, accumulator.finish().outputs);
+    Ok(())
+}
+
 // An OpenAI-shaped error frame carries no `choices`, so it must decode to a stream error
 // instead of a bare message start that silently drops the upstream message.
 #[test]


### PR DESCRIPTION
## What

Normalize buffered OpenAI Responses output items into one semantic assistant output.

## Why

`first_output()` means the first semantic `ResponseOutput`, not the first content block or modality. One `ResponseOutput` can contain ordered reasoning, text, tool calls, images, and other normalized content blocks. Chat, Anthropic, and accumulated streams already represent one completed assistant response this way.

The Responses wire format can instead split one logical completion across multiple top-level `output[]` items, such as a reasoning item followed by a message containing the visible final answer. The buffered decoder incorrectly mapped each wire item to a separate `ResponseOutput`. Anthropic and Chat then encoded the first semantic output, preserving its reasoning but never reaching the separately stored final message. Requests therefore returned HTTP 200 while silently dropping the visible answer.

This change normalizes the supported Responses output item types: reasoning, message, and function call. It does not broaden multimodal output support; audio, video, and unknown top-level Responses output items remain separate translation coverage gaps.

This fixes [SWITCH-1187](https://linear.app/nvidia/issue/SWITCH-1187/oss-020translation-responses-final-answers-are-dropped-for-anthropic).

## How

- Fold decoded Responses reasoning, message, and function-call items into ordered content blocks in one `ResponseOutput`.
- Retain the last meaningful role and stop reason.
- Preserve the existing empty-response fallback.
- Keep the Anthropic, Chat, and streaming production codecs unchanged.
- Verify buffered normalization matches the equivalent accumulated stream.

## What to review

- Responses output-item ordering during normalization.
- Stop-reason selection across reasoning, message, and tool-call items.
- Buffered/stream semantic parity.

## Live validation

Built the release server from this branch and ran the issue reproducer with live credentials:

- Direct Responses control: HTTP 200, `reasoning,message`, exact final-answer marker present.
- Chat through Switchyard: HTTP 200, reasoning non-empty, exact final-answer marker present.
- Anthropic through Switchyard: three consecutive HTTP 200 responses containing `thinking,text`, exact final-answer marker present.

One earlier Anthropic-format generation returned reasoning only. Since each call is a separate stochastic generation, it did not establish translation loss; every retry that produced final text preserved it.

## Validation

- `cargo fmt --all --check`
- `cargo test -p switchyard-translation`
- `cargo clippy -p switchyard-translation --all-targets -- -D warnings`