### PR TITLE
docs: llm classifier reasoning note

### DIFF
--- a/crates/switchyard-server/CONFIGURATION.md
+++ b/crates/switchyard-server/CONFIGURATION.md
@@ -20,6 +20,11 @@ extra_body = { chat_template_kwargs = { enable_thinking = false } }
 `extra_body` is target-specific. It shallow-merges top-level provider options into
 the outbound request, while explicit request fields win on conflicts.
 
+The `chat_template_kwargs.enable_thinking` example is a provider/model-specific
+vLLM option. It is not a portable Switchyard reasoning switch. Use it on a judge
+target only when the upstream supports it and would otherwise return the verdict
+outside normal assistant `content`.
+
 To support another wire format, add its `ClientFormat` variant and explicit construction match in
 `src/config.rs`. Add a client type only when a second implementation exists.
 

--- a/docs/routing_algorithms/escalation_router_routing.md
+++ b/docs/routing_algorithms/escalation_router_routing.md
@@ -88,6 +88,32 @@ A judge that times out, errors, or returns an unparseable verdict fails open: th
 turn serves the buffered weak reply and the existing streak is held rather than
 cleared. A judge failure never creates a strong-tier latch.
 
+## Judge model compatibility
+
+The trajectory judge has the same response contract as capability routing: it
+must return complete, schema-valid JSON in normal assistant `content`.
+Switchyard does not parse provider-specific reasoning fields such as
+`reasoning_content`. If `content` is empty or unparseable, the client request can
+still succeed, but the weak reply is served and the turn cannot confirm an
+escalation.
+
+When a vLLM-compatible provider supports `enable_thinking`, configure it on the
+judge target through `extra_body`:
+
+```toml
+[targets.judge]
+extra_body = { chat_template_kwargs = { enable_thinking = false } }
+```
+
+`enable_thinking` is a provider-specific vLLM option, not a general requirement
+for reasoning models. Other model/provider pairs may work with reasoning enabled
+or use a different control. Verify the judge response shape before deployment.
+If reasoning remains enabled, set the route-level `max_output_tokens` high enough
+for both the reasoning and final JSON. A truncated verdict has the same fail-open
+result. See the
+[target-level `extra_body` reference](../../crates/switchyard-server/CONFIGURATION.md#add-an-llm-client-and-target)
+for the server merge behavior.
+
 ## Tuning options
 
 The judge exposes three settings. Their defaults are the benchmarked

--- a/docs/routing_algorithms/escalation_router_routing.md
+++ b/docs/routing_algorithms/escalation_router_routing.md
@@ -90,29 +90,9 @@ cleared. A judge failure never creates a strong-tier latch.
 
 ## Judge model compatibility
 
-The trajectory judge has the same response contract as capability routing: it
-must return complete, schema-valid JSON in normal assistant `content`.
-Switchyard does not parse provider-specific reasoning fields such as
-`reasoning_content`. If `content` is empty or unparseable, the client request can
-still succeed, but the weak reply is served and the turn cannot confirm an
-escalation.
-
-When a vLLM-compatible provider supports `enable_thinking`, configure it on the
-judge target through `extra_body`:
-
-```toml
-[targets.judge]
-extra_body = { chat_template_kwargs = { enable_thinking = false } }
-```
-
-`enable_thinking` is a provider-specific vLLM option, not a general requirement
-for reasoning models. Other model/provider pairs may work with reasoning enabled
-or use a different control. Verify the judge response shape before deployment.
-If reasoning remains enabled, set the route-level `max_output_tokens` high enough
-for both the reasoning and final JSON. A truncated verdict has the same fail-open
-result. See the
-[target-level `extra_body` reference](../../crates/switchyard-server/CONFIGURATION.md#add-an-llm-client-and-target)
-for the server merge behavior.
+The trajectory judge uses the same response contract and provider/model
+compatibility guidance as the LLM classifier judge. See
+[Judge model compatibility](llm_classifier_routing.md#judge-model-compatibility).
 
 ## Tuning options
 

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -69,6 +69,16 @@ An abstention, an invalid or unparseable verdict, a judge failure, or confidence
 below `min_confidence` routes to `strong_target`. Raising either threshold sends
 more traffic to the strong model.
 
+!!! note "Reasoning-model compatibility"
+
+    The verdict must be returned in normal assistant `content`. Some
+    model/provider pairs put it only in `reasoning_content`, which causes
+    fail-open routing. Where supported, a provider-specific override such as
+    `extra_body = { chat_template_kwargs = { enable_thinking = false } }` can
+    disable reasoning for the classifier target. Only use this override when
+    the provider supports it and the judge would otherwise return the verdict
+    outside normal `content`.
+
 ## Tuning options
 
 | Key | Default | Meaning |

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -69,15 +69,29 @@ An abstention, an invalid or unparseable verdict, a judge failure, or confidence
 below `min_confidence` routes to `strong_target`. Raising either threshold sends
 more traffic to the strong model.
 
-!!! note "Reasoning-model compatibility"
+## Judge model compatibility
 
-    The verdict must be returned in normal assistant `content`. Some
-    model/provider pairs put it only in `reasoning_content`, which causes
-    fail-open routing. Where supported, a provider-specific override such as
-    `extra_body = { chat_template_kwargs = { enable_thinking = false } }` can
-    disable reasoning for the classifier target. Only use this override when
-    the provider supports it and the judge would otherwise return the verdict
-    outside normal `content`.
+The judge must return complete, schema-valid JSON in normal assistant `content`.
+Switchyard does not parse provider-specific reasoning fields such as
+`reasoning_content`. If `content` is empty or unparseable, the route falls back
+to `strong_target` even when the judge request returned HTTP 200. With session
+affinity, that fallback can be reused without another judge call.
+
+When a vLLM-compatible provider supports `enable_thinking`, configure it on the
+judge target through `extra_body`:
+
+```toml
+[targets.classifier]
+extra_body = { chat_template_kwargs = { enable_thinking = false } }
+```
+
+`enable_thinking` is a provider-specific vLLM option, not a general requirement
+for reasoning models. Other model/provider pairs may work with reasoning enabled
+or use a different control. Verify the judge response shape before deployment.
+If reasoning remains enabled, set `max_output_tokens` high enough for both the
+reasoning and final JSON. A truncated verdict has the same fail-open result. See
+the [target-level `extra_body` reference](../../crates/switchyard-server/CONFIGURATION.md#add-an-llm-client-and-target)
+for the server merge behavior.
 
 ## Tuning options
 


### PR DESCRIPTION
## Why

Judge-based routes can receive an HTTP 200 response while the structured verdict is unavailable because the provider returned it outside normal assistant content. This documents the compatibility contract and fail-open behavior tracked in [SWITCH-1186](https://linear.app/nvidia/issue/SWITCH-1186/oss-020docs-document-judge-model-reasoning-compatibility-and-silent).

## What

- Document the normal `content` contract for capability and trajectory judges.
- Explain fail-open behavior for both routes and the output-budget implications.
- Clarify that `enable_thinking` is a provider-specific `extra_body` option, not a portable Switchyard reasoning switch.

## How

Keep provider-specific reasoning controls on the configured judge target. The public guides use a generic vLLM-compatible example and avoid internal endpoint or model names.

## Where to Start Review

Start with `docs/routing_algorithms/llm_classifier_routing.md`, then compare the escalation behavior in `docs/routing_algorithms/escalation_router_routing.md`. `crates/switchyard-server/CONFIGURATION.md` documents the target-level configuration.

## Test Plan

- `cd docs && make publish`
- `git diff --check`