### PR TITLE
fix(translation): reject malformed request fields

### DIFF
--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -39,6 +39,15 @@ impl FormatCodec for AnthropicMessagesCodec {
     fn decode_request(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedRequest> {
         let body = crate::util::object(body, "$")?;
         let mut diagnostics = Vec::new();
+        let max_output_tokens = match body.get("max_tokens") {
+            Some(value) => Some(value.as_u64().filter(|tokens| *tokens > 0).ok_or_else(|| {
+                TranslationError::InvalidValue {
+                    path: "$.max_tokens".to_string(),
+                    message: "expected a positive integer".to_string(),
+                }
+            })?),
+            None => None,
+        };
         let mut request = LlmRequest {
             model: body
                 .get("model")
@@ -46,7 +55,7 @@ impl FormatCodec for AnthropicMessagesCodec {
                 .filter(|model| !model.is_empty())
                 .map(ToOwned::to_owned),
             output: OutputParams {
-                max_output_tokens: body.get("max_tokens").and_then(Value::as_u64),
+                max_output_tokens,
                 response_format: None,
             },
             sampling: SamplingParams {
@@ -72,7 +81,7 @@ impl FormatCodec for AnthropicMessagesCodec {
             ..LlmRequest::default()
         };
         if let Some(system) = body.get("system")
-            && let Some(content) = decode_anthropic_system(system, &mut diagnostics, policy)?
+            && let Some(content) = decode_anthropic_system(system)?
         {
             request.instructions.push(InstructionBlock {
                 role: Role::System,
@@ -335,16 +344,12 @@ impl FormatCodec for AnthropicMessagesCodec {
 }
 
 // Decodes Anthropic's `system` field into instruction blocks.
-fn decode_anthropic_system(
-    value: &Value,
-    diagnostics: &mut Vec<TranslationDiagnostic>,
-    policy: &TranslationPolicy,
-) -> Result<Option<Vec<ContentBlock>>> {
+fn decode_anthropic_system(value: &Value) -> Result<Option<Vec<ContentBlock>>> {
     match value {
         Value::String(text) if !text.is_empty() => {
             Ok(Some(vec![ContentBlock::Text { text: text.clone() }]))
         }
-        Value::String(_) | Value::Null => Ok(None),
+        Value::String(_) => Ok(None),
         Value::Array(blocks) => {
             let mut content = Vec::new();
             for block in blocks {
@@ -361,12 +366,10 @@ fn decode_anthropic_system(
             }
             Ok((!content.is_empty()).then_some(content))
         }
-        other => {
-            push_lossy(diagnostics, policy, "Anthropic system field was not text")?;
-            Ok(Some(vec![ContentBlock::Text {
-                text: string_value(other).unwrap_or_default(),
-            }]))
-        }
+        _ => Err(TranslationError::InvalidType {
+            path: "$.system".to_string(),
+            expected: "string or array of text blocks",
+        }),
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -39,15 +39,17 @@ impl FormatCodec for AnthropicMessagesCodec {
     fn decode_request(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedRequest> {
         let body = crate::util::object(body, "$")?;
         let mut diagnostics = Vec::new();
-        let max_output_tokens = match body.get("max_tokens") {
-            Some(value) => Some(value.as_u64().filter(|tokens| *tokens > 0).ok_or_else(|| {
-                TranslationError::InvalidValue {
-                    path: "$.max_tokens".to_string(),
-                    message: "expected a positive integer".to_string(),
-                }
-            })?),
-            None => None,
-        };
+        let max_output_tokens = body
+            .get("max_tokens")
+            .map(|value| {
+                value
+                    .as_u64()
+                    .ok_or_else(|| TranslationError::InvalidValue {
+                        path: "$.max_tokens".to_string(),
+                        message: "expected a non-negative integer".to_string(),
+                    })
+            })
+            .transpose()?;
         let mut request = LlmRequest {
             model: body
                 .get("model")
@@ -349,7 +351,7 @@ fn decode_anthropic_system(value: &Value) -> Result<Option<Vec<ContentBlock>>> {
         Value::String(text) if !text.is_empty() => {
             Ok(Some(vec![ContentBlock::Text { text: text.clone() }]))
         }
-        Value::String(_) => Ok(None),
+        Value::String(_) | Value::Null => Ok(None),
         Value::Array(blocks) => {
             let mut content = Vec::new();
             for block in blocks {

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -442,10 +442,10 @@ fn decode_responses_input(
             }
             Ok(messages)
         }
-        other => Ok(vec![Message::text(
-            Role::User,
-            string_value(other).unwrap_or_default(),
-        )]),
+        _ => Err(TranslationError::InvalidType {
+            path: "$.input".to_string(),
+            expected: "string or array",
+        }),
     }
 }
 

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1091,6 +1091,57 @@ fn json_contains_content_type(value: &Value, expected: &str) -> bool {
     }
 }
 
+// Malformed provider fields must fail before normalization can change their meaning.
+#[test]
+fn malformed_request_fields_are_rejected() {
+    let engine = TranslationEngine::default();
+    let cases = [
+        (
+            "Anthropic object system",
+            WireFormat::AnthropicMessages,
+            json!({"model": "claude", "max_tokens": 8, "system": {}, "messages": []}),
+            "expected string or array of text blocks at $.system",
+        ),
+        (
+            "Anthropic boolean system",
+            WireFormat::AnthropicMessages,
+            json!({"model": "claude", "max_tokens": 8, "system": true, "messages": []}),
+            "expected string or array of text blocks at $.system",
+        ),
+        (
+            "Anthropic negative max_tokens",
+            WireFormat::AnthropicMessages,
+            json!({"model": "claude", "max_tokens": -1, "messages": []}),
+            "invalid value at $.max_tokens: expected a positive integer",
+        ),
+        (
+            "Anthropic string max_tokens",
+            WireFormat::AnthropicMessages,
+            json!({"model": "claude", "max_tokens": "8", "messages": []}),
+            "invalid value at $.max_tokens: expected a positive integer",
+        ),
+        (
+            "Responses boolean input",
+            WireFormat::OpenAiResponses,
+            json!({"model": "gpt", "input": true}),
+            "expected string or array at $.input",
+        ),
+        (
+            "Responses null input",
+            WireFormat::OpenAiResponses,
+            json!({"model": "gpt", "input": null}),
+            "expected string or array at $.input",
+        ),
+    ];
+
+    for (case, format, body, expected) in cases {
+        match engine.decode_request(format, &body, &TranslationPolicy::default()) {
+            Ok(_) => panic!("{case} should be rejected"),
+            Err(error) => assert_eq!(error.to_string(), expected, "{case}"),
+        }
+    }
+}
+
 // --- Invalid-role rejection ----------------------------------
 // A transparent router must reject the same payloads the upstream provider
 // would, rather than silently coercing an unknown role (e.g. "api") to `user`

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1112,13 +1112,13 @@ fn malformed_request_fields_are_rejected() {
             "Anthropic negative max_tokens",
             WireFormat::AnthropicMessages,
             json!({"model": "claude", "max_tokens": -1, "messages": []}),
-            "invalid value at $.max_tokens: expected a positive integer",
+            "invalid value at $.max_tokens: expected a non-negative integer",
         ),
         (
             "Anthropic string max_tokens",
             WireFormat::AnthropicMessages,
             json!({"model": "claude", "max_tokens": "8", "messages": []}),
-            "invalid value at $.max_tokens: expected a positive integer",
+            "invalid value at $.max_tokens: expected a non-negative integer",
         ),
         (
             "Responses boolean input",
@@ -1139,6 +1139,20 @@ fn malformed_request_fields_are_rejected() {
             Ok(_) => panic!("{case} should be rejected"),
             Err(error) => assert_eq!(error.to_string(), expected, "{case}"),
         }
+    }
+
+    let valid_empty_output = json!({
+        "model": "claude",
+        "max_tokens": 0,
+        "system": null,
+        "messages": []
+    });
+    if let Err(error) = engine.decode_request(
+        WireFormat::AnthropicMessages,
+        &valid_empty_output,
+        &TranslationPolicy::default(),
+    ) {
+        panic!("Anthropic null system and zero max_tokens should be accepted: {error}");
     }
 }
 


### PR DESCRIPTION
## What

Reject malformed Anthropic `system` and `max_tokens` fields and malformed OpenAI Responses `input` fields during request decoding.

## Why

These explicitly invalid values were previously coerced into text or treated as absent. That changed request semantics, allowed malformed requests to reach an upstream model, and could create unintended usage.

Fixes [SWITCH-1188](https://linear.app/nvidia/issue/SWITCH-1188/oss-020-rc1anthropic-invalid-system-values-are-serialized-into).
Fixes [SWITCH-1189](https://linear.app/nvidia/issue/SWITCH-1189/oss-020-rc1anthropic-invalid-max-tokens-values-are-silently-omitted).
Fixes [SWITCH-1190](https://linear.app/nvidia/issue/SWITCH-1190/oss-020-rc1responses-boolean-or-null-input-is-coerced-and-executed-as).

## How

- Treat an omitted or null Anthropic `system` as no system instruction; otherwise require a string or text-block array.
- Require an explicitly supplied Anthropic `max_tokens` to be a non-negative integer.
- Require Responses `input` to be a string or array.
- Return path-aware translation errors that the server already exposes as structured HTTP 400 responses.
- Preserve the existing behavior for omitted fields.

## What to review

- **Please review the public error messages specifically**, including whether the JSONPath-style field paths are clear and appropriate.
- The accepted wire types and non-negative-integer constraint.
- The single table-driven regression test covering all six reported variants across the three tickets.

## Live validation

Built the release server from this branch and ran every issue reproducer with live credentials:

| Malformed input | Direct control | Switchyard | Switchyard error message |
|---|---:|---:|---|
| Anthropic `system={}` or `system=true` | HTTP 400 | HTTP 400 | `expected string or array of text blocks at $.system` |
| Anthropic `max_tokens=-1` or `max_tokens="8"` | HTTP 400 | HTTP 400 | `invalid value at $.max_tokens: expected a non-negative integer` |
| Responses `input=true` or `input=null` | HTTP 500 | HTTP 400 | `expected string or array at $.input` |

After all six rejected Switchyard requests, `/v1/stats` reported `total_requests: 0`, confirming that none reached routing or an upstream model. A valid routed control then returned HTTP 200 and incremented `total_requests` to 1.

## Validation

- `cargo test -p switchyard-translation`
- `cargo clippy -p switchyard-translation --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation for Anthropic and OpenAI Responses integrations.
  * Invalid or missing token limits now return clear validation errors.
  * Unsupported system and input field formats are rejected instead of being silently converted to text.
  * Added coverage for malformed request fields to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


