### PR TITLE
fix(translation): preserve valid provider request semantics

### DIFF
--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -5,7 +5,7 @@
 
 use serde_json::{Map, Value, json};
 
-use crate::codecs::common::{is_known_role_name, provider_extensions, text_from_blocks};
+use crate::codecs::common::{is_known_role_name, provider_extensions};
 use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
@@ -425,7 +425,7 @@ fn decode_anthropic_content_block(
     block: &Map<String, Value>,
     _role: Role,
     generated_counter: usize,
-    _diagnostics: &mut Vec<TranslationDiagnostic>,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
     policy: &TranslationPolicy,
 ) -> Result<Vec<ContentBlock>> {
     Ok(match block.get("type").and_then(Value::as_str) {
@@ -473,21 +473,21 @@ fn decode_anthropic_content_block(
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string(),
-            content: decode_tool_result_content(block.get("content").unwrap_or(&Value::Null)),
+            content: decode_tool_result_content(
+                block.get("content").unwrap_or(&Value::Null),
+                generated_counter,
+                diagnostics,
+                policy,
+            )?,
             is_error: block.get("is_error").and_then(Value::as_bool),
         })],
-        Some("image") => {
-            let source = block
-                .get("source")
-                .cloned()
-                .map(ImageSource::Raw)
-                .unwrap_or_else(|| ImageSource::Raw(Value::Object(block.clone())));
-            vec![ContentBlock::Image { source }]
-        }
+        Some("image") => vec![ContentBlock::Image {
+            source: decode_anthropic_image_source(block),
+        }],
         Some("input_image") | Some("image_url") => decode_image_source(block)
             .map(|source| vec![ContentBlock::Image { source }])
             .unwrap_or_default(),
-        Some("input_file") | Some("file") => vec![ContentBlock::File {
+        Some("input_file") | Some("file") | Some("document") => vec![ContentBlock::File {
             source: decode_file_source(block),
         }],
         _ => vec![ContentBlock::Unknown {
@@ -497,37 +497,76 @@ fn decode_anthropic_content_block(
     })
 }
 
-// Converts Anthropic tool-result content into text-like IR blocks.
-fn decode_tool_result_content(value: &Value) -> Vec<ContentBlock> {
+// Normalizes Anthropic image sources while retaining unfamiliar block shapes.
+fn decode_anthropic_image_source(block: &Map<String, Value>) -> ImageSource {
+    let Some(source) = block.get("source").and_then(Value::as_object) else {
+        return ImageSource::Raw(Value::Object(block.clone()));
+    };
+    match source.get("type").and_then(Value::as_str) {
+        Some("base64") => source
+            .get("data")
+            .and_then(Value::as_str)
+            .map(|data| ImageSource::Base64 {
+                media_type: source
+                    .get("media_type")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                data: data.to_string(),
+            })
+            .unwrap_or_else(|| ImageSource::Raw(Value::Object(block.clone()))),
+        Some("url") => source
+            .get("url")
+            .and_then(Value::as_str)
+            .map(|url| ImageSource::Url {
+                url: url.to_string(),
+                detail: None,
+            })
+            .unwrap_or_else(|| ImageSource::Raw(Value::Object(block.clone()))),
+        _ => ImageSource::Raw(Value::Object(block.clone())),
+    }
+}
+
+// Decodes Anthropic tool-result content without flattening rich blocks.
+fn decode_tool_result_content(
+    value: &Value,
+    generated_counter: usize,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<ContentBlock>> {
     match value {
-        Value::String(text) => vec![ContentBlock::Text { text: text.clone() }],
+        Value::String(text) => Ok(vec![ContentBlock::Text { text: text.clone() }]),
         Value::Array(blocks) => {
-            let mut text = Vec::new();
-            for block in blocks {
-                if let Some(block) = block.as_object() {
-                    if block.get("type").and_then(Value::as_str) == Some("text") {
-                        text.push(
-                            block
-                                .get("text")
-                                .and_then(Value::as_str)
-                                .unwrap_or_default()
-                                .to_string(),
-                        );
-                    } else {
-                        text.push(json_string(&Value::Object(block.clone())));
-                    }
-                }
+            let mut content = Vec::new();
+            for (index, block) in blocks.iter().enumerate() {
+                let Some(block) = block.as_object() else {
+                    push_lossy(
+                        diagnostics,
+                        policy,
+                        format!("Anthropic tool-result content block {index} is not an object"),
+                    )?;
+                    continue;
+                };
+                content.extend(decode_anthropic_content_block(
+                    block,
+                    Role::User,
+                    generated_counter + index,
+                    diagnostics,
+                    policy,
+                )?);
             }
-            vec![ContentBlock::Text {
-                text: text.join(" "),
-            }]
+            if content.is_empty() {
+                content.push(ContentBlock::Text {
+                    text: String::new(),
+                });
+            }
+            Ok(content)
         }
-        Value::Null => vec![ContentBlock::Text {
+        Value::Null => Ok(vec![ContentBlock::Text {
             text: String::new(),
-        }],
-        other => vec![ContentBlock::Text {
+        }]),
+        other => Ok(vec![ContentBlock::Text {
             text: json_string(other),
-        }],
+        }]),
     }
 }
 
@@ -740,7 +779,7 @@ fn encode_one_anthropic_block(block: &ContentBlock) -> Vec<Value> {
         ContentBlock::ToolResult(result) => vec![json!({
             "type": "tool_result",
             "tool_use_id": sanitize_anthropic_tool_use_id(&result.tool_call_id),
-            "content": text_from_blocks(&result.content, " "),
+            "content": encode_anthropic_tool_result_content(&result.content),
         })],
         ContentBlock::Image { source } => vec![match source {
             ImageSource::Url { url, .. } => {
@@ -799,6 +838,25 @@ fn encode_one_anthropic_block(block: &ContentBlock) -> Vec<Value> {
             MediaSource::Raw(raw) => raw.clone(),
         }],
         ContentBlock::Unknown { raw, .. } => vec![raw.clone()],
+    }
+}
+
+// Preserves ordered rich blocks inside Anthropic tool results.
+fn encode_anthropic_tool_result_content(content: &[ContentBlock]) -> Value {
+    let blocks = content
+        .iter()
+        .flat_map(encode_one_anthropic_block)
+        .collect::<Vec<_>>();
+    if content.len() == 1
+        && let Some(text) = blocks
+            .first()
+            .and_then(Value::as_object)
+            .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+            .and_then(|block| block.get("text"))
+    {
+        text.clone()
+    } else {
+        Value::Array(blocks)
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -95,7 +95,10 @@ impl FormatCodec for OpenAiChatCodec {
                 )?;
                 prepend_openai_reasoning_blocks(&mut content, message);
                 if role == Role::Assistant
-                    && let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array)
+                    && let Some(tool_calls) = message
+                        .get("tool_calls")
+                        .and_then(Value::as_array)
+                        .filter(|tool_calls| !tool_calls.is_empty())
                 {
                     if is_empty_text_only(&content) {
                         content.clear();
@@ -107,6 +110,18 @@ impl FormatCodec for OpenAiChatCodec {
                         {
                             content.push(ContentBlock::ToolCall(call));
                         }
+                    }
+                } else if role == Role::Assistant
+                    && let Some(function_call) =
+                        message.get("function_call").and_then(Value::as_object)
+                {
+                    if is_empty_text_only(&content) {
+                        content.clear();
+                    }
+                    generated_id += 1;
+                    let tool_call = json!({"function": function_call});
+                    if let Some(call) = decode_openai_tool_call(&tool_call, generated_id, policy)? {
+                        content.push(ContentBlock::ToolCall(call));
                     }
                 }
                 if role == Role::Tool {
@@ -707,10 +722,11 @@ fn encode_message_with_tool_results_to_openai(
                 diagnostics,
                 policy,
             )?;
+            let content = encode_openai_tool_result_content(result, diagnostics, policy)?;
             out.push(json!({
                 "role": "tool",
                 "tool_call_id": result.tool_call_id,
-                "content": text_from_blocks(&result.content, " "),
+                "content": content,
             }));
         } else {
             pending_content.push(block.clone());
@@ -725,6 +741,27 @@ fn encode_message_with_tool_results_to_openai(
         policy,
     )?;
     Ok(out)
+}
+
+// Converts tool-result content to Chat's text-only tool message shape.
+fn encode_openai_tool_result_content(
+    result: &ToolResult,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<String> {
+    if result.content.iter().any(|block| {
+        !matches!(
+            block,
+            ContentBlock::Text { .. } | ContentBlock::Refusal { .. }
+        )
+    }) {
+        push_lossy(
+            diagnostics,
+            policy,
+            "OpenAI Chat tool-result messages only support text content",
+        )?;
+    }
+    Ok(text_from_blocks(&result.content, " "))
 }
 
 // Flushes accumulated non-tool-result content as a normal OpenAI message.

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -301,7 +301,16 @@ fn decode_responses_input(
                     )?;
                     continue;
                 };
-                match item.get("type").and_then(Value::as_str) {
+                let item_type = item.get("type").and_then(Value::as_str);
+                let item_type = if item_type.is_none()
+                    && item.contains_key("role")
+                    && item.contains_key("content")
+                {
+                    Some("message")
+                } else {
+                    item_type
+                };
+                match item_type {
                     Some("message") => {
                         let role = request_role_from_responses(
                             item.get("role").and_then(Value::as_str),
@@ -794,7 +803,7 @@ fn decode_responses_tool_choice(value: &Value) -> Option<ToolChoice> {
                     name: name.to_string(),
                 })
         }
-        Value::Object(_) => None,
+        Value::Object(_) => Some(ToolChoice::Raw(value.clone())),
         _ => Some(ToolChoice::Raw(value.clone())),
     }
 }

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -5,7 +5,10 @@
 
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
-use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
+use switchyard_translation::{
+    ContentBlock, LossyConversionPolicy, PreservationPolicy, ToolChoice, TranslationEngine,
+    TranslationError, TranslationPolicy, WireFormat,
+};
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -1404,5 +1407,188 @@ fn anthropic_thinking_is_dropped_from_responses_input() -> TestResult {
             .iter()
             .any(|item| item["type"] == "function_call_output")
     );
+    Ok(())
+}
+
+// Valid provider-specific request forms retain their semantics in the IR.
+#[test]
+fn valid_provider_request_fidelity_is_preserved() -> TestResult {
+    let engine = TranslationEngine::default();
+
+    let responses = json!({
+        "model": "gpt-5",
+        "input": [{
+            "role": "user",
+            "content": [{"type": "input_text", "text": "easy input"}]
+        }],
+        "tool_choice": {"type": "web_search_preview"}
+    });
+    let decoded_responses = engine.decode_request(
+        WireFormat::OpenAiResponses,
+        &responses,
+        &TranslationPolicy::default(),
+    )?;
+    assert_eq!(decoded_responses.request.messages.len(), 1);
+    assert_eq!(
+        decoded_responses.request.messages[0].text_content(""),
+        Some("easy input".to_string())
+    );
+    assert_eq!(
+        decoded_responses.request.tool_choice,
+        Some(ToolChoice::Raw(json!({"type": "web_search_preview"})))
+    );
+
+    let anthropic = json!({
+        "model": "claude-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [
+                    {"type": "text", "text": "found"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U="
+                        }
+                    },
+                    {
+                        "type": "document",
+                        "source": {"type": "file", "file_id": "file_1"}
+                    },
+                    {"type": "vendor_result", "data": {"kept": true}}
+                ]
+            }]
+        }]
+    });
+    let decoded_anthropic = engine.decode_request(
+        WireFormat::AnthropicMessages,
+        &anthropic,
+        &TranslationPolicy::default(),
+    )?;
+    let tool_result = decoded_anthropic.request.messages[0]
+        .content
+        .iter()
+        .find_map(|block| match block {
+            ContentBlock::ToolResult(result) => Some(result),
+            _ => None,
+        })
+        .ok_or("expected an Anthropic tool result")?;
+    assert!(matches!(tool_result.content[0], ContentBlock::Text { .. }));
+    assert!(matches!(tool_result.content[1], ContentBlock::Image { .. }));
+    assert!(matches!(tool_result.content[2], ContentBlock::File { .. }));
+    assert!(matches!(
+        tool_result.content[3],
+        ContentBlock::Unknown { .. }
+    ));
+
+    let no_preservation = TranslationPolicy {
+        preservation: PreservationPolicy::Disabled,
+        ..TranslationPolicy::default()
+    };
+    let replayed_anthropic = engine.encode_request(
+        WireFormat::AnthropicMessages,
+        &decoded_anthropic.request,
+        &no_preservation,
+    )?;
+    let replayed_blocks = replayed_anthropic.body["messages"][0]["content"][0]["content"]
+        .as_array()
+        .ok_or("rich tool-result content should remain an array")?;
+    assert_eq!(
+        replayed_blocks
+            .iter()
+            .map(|block| block["type"].as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("text"),
+            Some("image"),
+            Some("document"),
+            Some("vendor_result")
+        ]
+    );
+
+    let openai_chat = json!({
+        "model": "gpt-4",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": null,
+                "function_call": {"name": "lookup", "arguments": "{\"q\":\"rust\"}"}
+            },
+            {
+                "role": "assistant",
+                "content": null,
+                "function_call": {"name": "legacy", "arguments": "{}"},
+                "tool_calls": [{
+                    "id": "call_modern",
+                    "type": "function",
+                    "function": {"name": "modern", "arguments": "{}"}
+                }]
+            }
+        ]
+    });
+    let decoded_chat = engine.decode_request(
+        WireFormat::OpenAiChat,
+        &openai_chat,
+        &TranslationPolicy::default(),
+    )?;
+    let legacy_call = decoded_chat.request.messages[0]
+        .content
+        .iter()
+        .find_map(|block| match block {
+            ContentBlock::ToolCall(call) => Some(call),
+            _ => None,
+        })
+        .ok_or("expected a legacy function call")?;
+    assert_eq!(legacy_call.id, "sw_00000001");
+    assert_eq!(legacy_call.name, "lookup");
+    assert_eq!(legacy_call.arguments, json!({"q": "rust"}));
+    assert!(
+        decoded_chat.request.messages[1]
+            .content
+            .iter()
+            .any(|block| {
+                matches!(block, ContentBlock::ToolCall(call) if call.name == "modern")
+            })
+    );
+    assert!(
+        !decoded_chat.request.messages[1]
+            .content
+            .iter()
+            .any(|block| {
+                matches!(block, ContentBlock::ToolCall(call) if call.name == "legacy")
+            })
+    );
+
+    let translated = engine.translate_request(
+        WireFormat::AnthropicMessages,
+        WireFormat::OpenAiChat,
+        &anthropic,
+        &TranslationPolicy::default(),
+    )?;
+    assert!(
+        translated
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "lossy_conversion")
+    );
+    let strict = TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        ..TranslationPolicy::default()
+    };
+    assert!(matches!(
+        engine.translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &anthropic,
+            &strict,
+        ),
+        Err(TranslationError::LossyConversion(_))
+    ));
+
     Ok(())
 }


### PR DESCRIPTION
## What
- decode Responses easy input messages without a `type`
- preserve provider-specific Responses `tool_choice` objects as `ToolChoice::Raw`
- retain ordered rich Anthropic tool-result blocks
- normalize legacy Chat Completions assistant `function_call` values

## Why
These are valid provider request forms. Dropping or flattening them changes request semantics before routing and cross-format translation.

## How
The codecs reuse existing IR variants and deterministic tool-call IDs. Rich Anthropic tool results remain structured; text-only Chat targets emit the existing lossy-conversion diagnostic and honor strict rejection. No protocol types or unknown-field behavior change.

## What to review
- Responses easy-message detection remains limited to objects with both `role` and `content`
- modern `tool_calls` take precedence over deprecated `function_call`
- Anthropic tool-result block order survives preservation-disabled encoding
- Chat conversion diagnoses non-text tool-result loss

## Validation
- `cargo fmt --all --check`
- `cargo test -p switchyard-translation --test request_translation valid_provider_request_fidelity_is_preserved -- --exact` (1 passed)
- commit hooks: cargo fmt, workspace clippy, commitlint passed

## Known limitation
Legacy `role: "function"` result messages still lack a reliable call ID for correlation and are unchanged.