### PR TITLE
fix(translation): preserve provider tools and enforce field policy

### DIFF
--- a/crates/libsy/examples/ensemble.rs
+++ b/crates/libsy/examples/ensemble.rs
@@ -1035,7 +1035,7 @@ mod tests {
                 Message::text(Role::System, "be terse"),
                 Message::text(Role::User, "add 2 and 2"),
             ],
-            tools: vec![ToolDefinition {
+            tools: vec![ToolDefinition::Function {
                 name: "calc".to_string(),
                 description: Some("do math".to_string()),
                 parameters: serde_json::json!({"type": "object"}),

--- a/crates/protocol/src/llm.rs
+++ b/crates/protocol/src/llm.rs
@@ -209,17 +209,28 @@ pub struct ToolResult {
     pub is_error: Option<bool>,
 }
 
-/// Normalized tool definition.
+/// Tool definition available to a model.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ToolDefinition {
-    /// Tool name exposed to the model.
-    pub name: String,
-    /// Human-readable tool description.
-    pub description: Option<String>,
-    /// JSON Schema describing accepted arguments.
-    pub parameters: Value,
-    /// Whether the provider should enforce the schema strictly.
-    pub strict: Option<bool>,
+#[serde(untagged)]
+pub enum ToolDefinition {
+    /// Portable function tool normalized across provider APIs.
+    Function {
+        /// Tool name exposed to the model.
+        name: String,
+        /// Human-readable tool description.
+        description: Option<String>,
+        /// JSON Schema describing accepted arguments.
+        parameters: Value,
+        /// Whether the provider should enforce the schema strictly.
+        strict: Option<bool>,
+    },
+    /// Exact provider tool with no normalized representation.
+    Raw {
+        /// Wire format that owns the raw definition.
+        provider: FormatId,
+        /// Original provider tool definition.
+        raw: Value,
+    },
 }
 
 /// Normalized tool choice policy.

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -5,7 +5,9 @@
 
 use serde_json::{Map, Value, json};
 
-use crate::codecs::common::{is_known_role_name, provider_extensions, text_from_blocks};
+use crate::codecs::common::{
+    is_known_role_name, provider_extensions, raw_tool_for_target, text_from_blocks,
+};
 use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
@@ -148,7 +150,9 @@ impl FormatCodec for AnthropicMessagesCodec {
                 "output_config",
                 "stream",
             ],
-        );
+            &mut diagnostics,
+            policy,
+        )?;
 
         Ok(DecodedRequest {
             request,
@@ -199,7 +203,10 @@ impl FormatCodec for AnthropicMessagesCodec {
         );
 
         if !request.tools.is_empty() {
-            body.insert("tools".to_string(), encode_anthropic_tools(&request.tools));
+            let tools = encode_anthropic_tools(&request.tools, &mut diagnostics, policy)?;
+            if !tools.is_empty() {
+                body.insert("tools".to_string(), Value::Array(tools));
+            }
         }
         if let Some(choice) = &request.tool_choice {
             body.insert(
@@ -238,12 +245,9 @@ impl FormatCodec for AnthropicMessagesCodec {
         Ok(EncodedRequest { body, diagnostics })
     }
 
-    fn decode_response(
-        &self,
-        body: &Value,
-        _policy: &TranslationPolicy,
-    ) -> Result<DecodedResponse> {
+    fn decode_response(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedResponse> {
         let body = crate::util::object(body, "$")?;
+        let mut diagnostics = Vec::new();
         let mut content = Vec::new();
         if let Some(blocks) = body.get("content").and_then(Value::as_array) {
             for (index, block) in blocks.iter().enumerate() {
@@ -292,17 +296,19 @@ impl FormatCodec for AnthropicMessagesCodec {
                         "stop_reason",
                         "usage",
                     ],
-                ),
+                    &mut diagnostics,
+                    policy,
+                )?,
             },
             preservation: capture_response_preservation(
                 WireFormat::AnthropicMessages,
                 &Value::Object(body.clone()),
-                _policy,
+                policy,
             ),
         };
         Ok(DecodedResponse {
             response,
-            diagnostics: Vec::new(),
+            diagnostics,
         })
     }
 
@@ -540,7 +546,7 @@ fn decode_anthropic_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
         .filter_map(Value::as_object)
         .filter_map(|tool| {
             let name = tool.get("name").and_then(Value::as_str)?.to_string();
-            (!name.is_empty()).then(|| ToolDefinition {
+            (!name.is_empty()).then(|| ToolDefinition::Function {
                 name,
                 description: tool
                     .get("description")
@@ -825,19 +831,39 @@ fn ensure_anthropic_tool_input_object(arguments: Value) -> Value {
 }
 
 // Encodes normalized tool definitions into Anthropic tool JSON.
-fn encode_anthropic_tools(tools: &[ToolDefinition]) -> Value {
-    Value::Array(
-        tools
-            .iter()
-            .map(|tool| {
-                json!({
-                    "name": tool.name,
-                    "description": tool.description.clone().unwrap_or_default(),
-                    "input_schema": tool.parameters,
-                })
-            })
-            .collect(),
-    )
+fn encode_anthropic_tools(
+    tools: &[ToolDefinition],
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<Value>> {
+    let mut encoded = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        match tool {
+            ToolDefinition::Function {
+                name,
+                description,
+                parameters,
+                ..
+            } => encoded.push(json!({
+                "name": name,
+                "description": description.clone().unwrap_or_default(),
+                "input_schema": parameters,
+            })),
+            ToolDefinition::Raw { provider, raw } => {
+                if let Some(raw) = raw_tool_for_target(
+                    provider,
+                    raw,
+                    index,
+                    WireFormat::AnthropicMessages,
+                    diagnostics,
+                    policy,
+                )? {
+                    encoded.push(raw);
+                }
+            }
+        }
+    }
+    Ok(encoded)
 }
 
 // Encodes normalized tool choice into Anthropic tool-choice JSON.

--- a/crates/switchyard-translation/src/codecs/common.rs
+++ b/crates/switchyard-translation/src/codecs/common.rs
@@ -5,7 +5,12 @@
 
 use serde_json::{Map, Value};
 
+use crate::diagnostic::TranslationDiagnostic;
+use crate::error::Result;
+use crate::format::{FormatId, WireFormat};
 use crate::llm::ContentBlock;
+use crate::policy::{TranslationPolicy, UnknownFieldPolicy};
+use crate::util::{push_lossy_at, push_unknown_field};
 
 /// Returns whether a role name is recognized by a supported provider API.
 pub(crate) fn is_known_role_name(name: &str) -> bool {
@@ -41,16 +46,45 @@ pub(crate) fn reasoning_text_from_blocks(content: &[ContentBlock], separator: &s
         .join(separator)
 }
 
-/// Copies unknown provider fields into the IR extension map.
+/// Applies policy to unknown top-level provider fields and preserves them when configured.
 pub(crate) fn provider_extensions(
     object: &Map<String, Value>,
     known: &[&str],
-) -> Map<String, Value> {
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Map<String, Value>> {
     let mut extensions = Map::new();
     for (key, value) in object {
         if !known.contains(&key.as_str()) {
-            extensions.insert(key.clone(), value.clone());
+            push_unknown_field(diagnostics, policy, format!("$.{key}"))?;
+            if policy.unknown_field_policy == UnknownFieldPolicy::Preserve {
+                extensions.insert(key.clone(), value.clone());
+            }
         }
     }
-    extensions
+    Ok(extensions)
+}
+
+/// Returns a raw tool for its owning format or applies cross-format loss policy.
+pub(crate) fn raw_tool_for_target(
+    provider: &FormatId,
+    raw: &Value,
+    index: usize,
+    target: WireFormat,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Option<Value>> {
+    if provider.as_str() == target.as_str() {
+        return Ok(Some(raw.clone()));
+    }
+    let path = format!("$.tools[{index}]");
+    push_lossy_at(
+        diagnostics,
+        policy,
+        format!("provider tool at {path} for {provider} cannot be represented in {target}"),
+        path,
+        provider.as_str(),
+        target,
+    )?;
+    Ok(None)
 }

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -6,7 +6,8 @@
 use serde_json::{Map, Value, json};
 
 use crate::codecs::common::{
-    is_known_role_name, provider_extensions, reasoning_text_from_blocks, text_from_blocks,
+    is_known_role_name, provider_extensions, raw_tool_for_target, reasoning_text_from_blocks,
+    text_from_blocks,
 };
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
@@ -163,7 +164,9 @@ impl FormatCodec for OpenAiChatCodec {
                 "tools",
                 "tool_choice",
             ],
-        );
+            &mut diagnostics,
+            policy,
+        )?;
 
         Ok(DecodedRequest {
             request,
@@ -208,9 +211,12 @@ impl FormatCodec for OpenAiChatCodec {
         body.insert("messages".to_string(), Value::Array(messages));
 
         if !request.tools.is_empty() {
-            body.insert("tools".to_string(), encode_openai_tools(&request.tools));
-            if let Some(choice) = &request.tool_choice {
-                body.insert("tool_choice".to_string(), encode_openai_tool_choice(choice));
+            let tools = encode_openai_tools(&request.tools, &mut diagnostics, policy)?;
+            if !tools.is_empty() {
+                body.insert("tools".to_string(), Value::Array(tools));
+                if let Some(choice) = &request.tool_choice {
+                    body.insert("tool_choice".to_string(), encode_openai_tool_choice(choice));
+                }
             }
         }
         if let Some(value) = request.output.max_output_tokens {
@@ -240,12 +246,9 @@ impl FormatCodec for OpenAiChatCodec {
         Ok(EncodedRequest { body, diagnostics })
     }
 
-    fn decode_response(
-        &self,
-        body: &Value,
-        _policy: &TranslationPolicy,
-    ) -> Result<DecodedResponse> {
+    fn decode_response(&self, body: &Value, policy: &TranslationPolicy) -> Result<DecodedResponse> {
         let object = object(body, "$")?;
+        let mut diagnostics = Vec::new();
         let mut response = AggLlmResponse {
             id: object
                 .get("id")
@@ -258,12 +261,17 @@ impl FormatCodec for OpenAiChatCodec {
             outputs: Vec::new(),
             usage: decode_openai_usage(object.get("usage")),
             extensions: ProviderExtensions {
-                fields: provider_extensions(object, &["id", "model", "choices", "usage"]),
+                fields: provider_extensions(
+                    object,
+                    &["id", "model", "choices", "usage"],
+                    &mut diagnostics,
+                    policy,
+                )?,
             },
             preservation: capture_response_preservation(
                 WireFormat::OpenAiChat,
                 &Value::Object(object.clone()),
-                _policy,
+                policy,
             ),
         };
         if let Some(choice) = object
@@ -307,7 +315,7 @@ impl FormatCodec for OpenAiChatCodec {
 
         Ok(DecodedResponse {
             response,
-            diagnostics: Vec::new(),
+            diagnostics,
         })
     }
 
@@ -637,7 +645,7 @@ pub(crate) fn decode_openai_tools(
         if name.is_empty() {
             continue;
         }
-        definitions.push(ToolDefinition {
+        definitions.push(ToolDefinition::Function {
             name,
             description: function
                 .get("description")
@@ -1031,23 +1039,45 @@ fn media_source_text(source: &MediaSource) -> String {
 }
 
 /// Encodes normalized tool definitions into OpenAI tool JSON.
-pub(crate) fn encode_openai_tools(tools: &[ToolDefinition]) -> Value {
-    Value::Array(
-        tools
-            .iter()
-            .map(|tool| {
+pub(crate) fn encode_openai_tools(
+    tools: &[ToolDefinition],
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<Value>> {
+    let mut encoded = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        match tool {
+            ToolDefinition::Function {
+                name,
+                description,
+                parameters,
+                strict,
+            } => {
                 let mut function = json!({
-                    "name": tool.name,
-                    "description": tool.description.clone().unwrap_or_default(),
-                    "parameters": tool.parameters,
+                    "name": name,
+                    "description": description.clone().unwrap_or_default(),
+                    "parameters": parameters,
                 });
-                if let Some(strict) = tool.strict {
-                    function["strict"] = Value::Bool(strict);
+                if let Some(strict) = strict {
+                    function["strict"] = Value::Bool(*strict);
                 }
-                json!({"type": "function", "function": function})
-            })
-            .collect(),
-    )
+                encoded.push(json!({"type": "function", "function": function}));
+            }
+            ToolDefinition::Raw { provider, raw } => {
+                if let Some(raw) = raw_tool_for_target(
+                    provider,
+                    raw,
+                    index,
+                    WireFormat::OpenAiChat,
+                    diagnostics,
+                    policy,
+                )? {
+                    encoded.push(raw);
+                }
+            }
+        }
+    }
+    Ok(encoded)
 }
 
 /// Encodes normalized tool choice into OpenAI Chat JSON.

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -8,7 +8,8 @@ use std::collections::HashSet;
 use serde_json::{Map, Value, json};
 
 use crate::codecs::common::{
-    is_known_role_name, provider_extensions, reasoning_text_from_blocks, text_from_blocks,
+    is_known_role_name, provider_extensions, raw_tool_for_target, reasoning_text_from_blocks,
+    text_from_blocks,
 };
 use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
 use crate::codecs::{
@@ -106,7 +107,9 @@ impl FormatCodec for OpenAiResponsesCodec {
                 "top_p",
                 "stream",
             ],
-        );
+            &mut diagnostics,
+            policy,
+        )?;
         Ok(DecodedRequest {
             request,
             diagnostics,
@@ -150,7 +153,10 @@ impl FormatCodec for OpenAiResponsesCodec {
             encode_responses_input(&request.messages, &mut diagnostics, _policy)?,
         );
         if !request.tools.is_empty() {
-            body.insert("tools".to_string(), encode_responses_tools(&request.tools));
+            let tools = encode_responses_tools(&request.tools, &mut diagnostics, _policy)?;
+            if !tools.is_empty() {
+                body.insert("tools".to_string(), Value::Array(tools));
+            }
         }
         if let Some(choice) = &request.tool_choice
             && let Some(choice) = encode_responses_tool_choice(choice)
@@ -229,7 +235,9 @@ impl FormatCodec for OpenAiResponsesCodec {
                 fields: provider_extensions(
                     body,
                     &["id", "model", "object", "output", "usage", "status"],
-                ),
+                    &mut diagnostics,
+                    policy,
+                )?,
             },
             preservation: capture_response_preservation(
                 WireFormat::OpenAiResponses,
@@ -700,7 +708,7 @@ fn decode_responses_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
                 if let Some(name) = function.get("name").and_then(Value::as_str)
                     && !name.is_empty()
                 {
-                    out.push(ToolDefinition {
+                    out.push(ToolDefinition::Function {
                         name: name.to_string(),
                         description: function
                             .get("description")
@@ -720,8 +728,18 @@ fn decode_responses_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
             }
         } else if tool.get("type").is_none() && tool.contains_key("name") {
             push_responses_function_tool(&mut out, tool);
+        } else if tool.get("type").is_some() {
+            out.push(ToolDefinition::Raw {
+                provider: WireFormat::OpenAiResponses.into(),
+                raw: Value::Object(tool.clone()),
+            });
         } else {
-            push_responses_id_tool(&mut out, tool);
+            if !push_responses_id_tool(&mut out, tool) {
+                out.push(ToolDefinition::Raw {
+                    provider: WireFormat::OpenAiResponses.into(),
+                    raw: Value::Object(tool.clone()),
+                });
+            }
         }
     }
     out
@@ -739,7 +757,7 @@ fn push_responses_function_tool(
         return false;
     }
 
-    out.push(ToolDefinition {
+    out.push(ToolDefinition::Function {
         name: name.to_string(),
         description: tool
             .get("description")
@@ -763,7 +781,7 @@ fn push_responses_id_tool(
         return false;
     }
 
-    out.push(ToolDefinition {
+    out.push(ToolDefinition::Function {
         name: id.to_string(),
         description: tool
             .get("description")
@@ -1004,24 +1022,46 @@ fn encode_responses_content(
 }
 
 // Encodes normalized tool definitions into Responses tool JSON.
-fn encode_responses_tools(tools: &[ToolDefinition]) -> Value {
-    Value::Array(
-        tools
-            .iter()
-            .map(|tool| {
+fn encode_responses_tools(
+    tools: &[ToolDefinition],
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Vec<Value>> {
+    let mut encoded = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        match tool {
+            ToolDefinition::Function {
+                name,
+                description,
+                parameters,
+                strict,
+            } => {
                 let mut item = json!({
                     "type": "function",
-                    "name": tool.name,
-                    "description": tool.description.clone().unwrap_or_default(),
-                    "parameters": tool.parameters,
+                    "name": name,
+                    "description": description.clone().unwrap_or_default(),
+                    "parameters": parameters,
                 });
-                if let Some(strict) = tool.strict {
-                    item["strict"] = Value::Bool(strict);
+                if let Some(strict) = strict {
+                    item["strict"] = Value::Bool(*strict);
                 }
-                item
-            })
-            .collect(),
-    )
+                encoded.push(item);
+            }
+            ToolDefinition::Raw { provider, raw } => {
+                if let Some(raw) = raw_tool_for_target(
+                    provider,
+                    raw,
+                    index,
+                    WireFormat::OpenAiResponses,
+                    diagnostics,
+                    policy,
+                )? {
+                    encoded.push(raw);
+                }
+            }
+        }
+    }
+    Ok(encoded)
 }
 
 // Encodes normalized tool choice into Responses JSON.

--- a/crates/switchyard-translation/src/util.rs
+++ b/crates/switchyard-translation/src/util.rs
@@ -95,6 +95,29 @@ pub fn push_lossy(
     }
 }
 
+/// Applies lossy-conversion policy with structured location and format metadata.
+pub(crate) fn push_lossy_at(
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+    message: impl Into<String>,
+    path: impl Into<String>,
+    source: impl Into<FormatId>,
+    target: impl Into<FormatId>,
+) -> Result<()> {
+    let message = message.into();
+    match policy.lossy_conversion_policy {
+        LossyConversionPolicy::AllowWithDiagnostics => {
+            diagnostics.push(
+                TranslationDiagnostic::warning("lossy_conversion", message)
+                    .with_formats(source, target)
+                    .at_path(path),
+            );
+            Ok(())
+        }
+        LossyConversionPolicy::Reject => Err(TranslationError::LossyConversion(message)),
+    }
+}
+
 /// Generates a stable, human-readable ID from a prefix and counter.
 pub fn stable_id(prefix: &str, counter: usize) -> String {
     format!("{prefix}_{counter:08}")

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -5,7 +5,10 @@
 
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
-use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
+use switchyard_translation::{
+    LossyConversionPolicy, PreservationPolicy, ToolDefinition, TranslationEngine,
+    TranslationPolicy, UnknownFieldPolicy, WireFormat,
+};
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -1089,6 +1092,166 @@ fn json_contains_content_type(value: &Value, expected: &str) -> bool {
             .any(|child| json_contains_content_type(child, expected)),
         _ => false,
     }
+}
+
+// Provider-specific tools and unknown extensions must follow explicit translation policy.
+#[test]
+fn provider_tools_and_unknown_fields_follow_translation_policy() -> TestResult {
+    let engine = TranslationEngine::default();
+    let preserve = TranslationPolicy {
+        preservation: PreservationPolicy::Disabled,
+        ..TranslationPolicy::default()
+    };
+    let raw_tool = json!({"type": "web_search_preview", "search_context_size": "medium"});
+    let responses_request = json!({
+        "model": "gpt-5",
+        "input": "search",
+        "tools": [raw_tool.clone()],
+        "vendor_extension": true
+    });
+
+    let decoded =
+        engine.decode_request(WireFormat::OpenAiResponses, &responses_request, &preserve)?;
+    assert!(matches!(
+        decoded.request.tools.as_slice(),
+        [ToolDefinition::Raw { provider, raw }]
+            if provider.as_str() == WireFormat::OpenAiResponses.as_str() && raw == &raw_tool
+    ));
+    let replayed =
+        engine.encode_request(WireFormat::OpenAiResponses, &decoded.request, &preserve)?;
+    assert_eq!(replayed.body["tools"], json!([raw_tool]));
+
+    let translated = engine.encode_request(WireFormat::OpenAiChat, &decoded.request, &preserve)?;
+    assert!(translated.body.get("tools").is_none());
+    assert_eq!(translated.diagnostics.len(), 1);
+    let diagnostic = &translated.diagnostics[0];
+    assert_eq!(diagnostic.code, "lossy_conversion");
+    assert_eq!(diagnostic.path.as_deref(), Some("$.tools[0]"));
+    assert_eq!(
+        diagnostic.source.as_ref().map(|format| format.as_str()),
+        Some(WireFormat::OpenAiResponses.as_str())
+    );
+    assert_eq!(
+        diagnostic.target.as_ref().map(|format| format.as_str()),
+        Some(WireFormat::OpenAiChat.as_str())
+    );
+
+    let reject_lossy = TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        preservation: PreservationPolicy::Disabled,
+        ..TranslationPolicy::default()
+    };
+    let error = engine
+        .encode_request(WireFormat::OpenAiChat, &decoded.request, &reject_lossy)
+        .expect_err("strict policy must reject a provider-specific tool");
+    assert_eq!(error.kind(), "LossyConversion");
+
+    let request_cases = [
+        (
+            WireFormat::OpenAiChat,
+            json!({"model": "gpt", "messages": [], "vendor_extension": true}),
+        ),
+        (
+            WireFormat::AnthropicMessages,
+            json!({
+                "model": "claude",
+                "messages": [],
+                "max_tokens": 8,
+                "vendor_extension": true
+            }),
+        ),
+        (
+            WireFormat::OpenAiResponses,
+            json!({"model": "gpt", "input": "hi", "vendor_extension": true}),
+        ),
+    ];
+    let response_cases = [
+        (
+            WireFormat::OpenAiChat,
+            json!({"id": "chat", "choices": [], "vendor_extension": true}),
+        ),
+        (
+            WireFormat::AnthropicMessages,
+            json!({"id": "message", "content": [], "vendor_extension": true}),
+        ),
+        (
+            WireFormat::OpenAiResponses,
+            json!({"id": "response", "output": [], "vendor_extension": true}),
+        ),
+    ];
+
+    for (format, body) in &request_cases {
+        let output = engine.decode_request(*format, body, &preserve)?;
+        assert_eq!(output.request.extensions.fields["vendor_extension"], true);
+    }
+    for (format, body) in &response_cases {
+        let output = engine.decode_response(*format, body, &preserve)?;
+        assert_eq!(output.response.extensions.fields["vendor_extension"], true);
+    }
+
+    let drop_unknown = TranslationPolicy {
+        unknown_field_policy: UnknownFieldPolicy::DropWithWarning,
+        preservation: PreservationPolicy::Disabled,
+        ..TranslationPolicy::default()
+    };
+    for (format, body) in &request_cases {
+        let output = engine.decode_request(*format, body, &drop_unknown)?;
+        assert!(
+            !output
+                .request
+                .extensions
+                .fields
+                .contains_key("vendor_extension")
+        );
+        assert_eq!(output.diagnostics.len(), 1);
+        assert_eq!(output.diagnostics[0].code, "unknown_field_dropped");
+        assert_eq!(
+            output.diagnostics[0].path.as_deref(),
+            Some("$.vendor_extension")
+        );
+    }
+    for (format, body) in &response_cases {
+        let output = engine.decode_response(*format, body, &drop_unknown)?;
+        assert!(
+            !output
+                .response
+                .extensions
+                .fields
+                .contains_key("vendor_extension")
+        );
+        assert_eq!(output.diagnostics.len(), 1);
+        assert_eq!(output.diagnostics[0].code, "unknown_field_dropped");
+        assert_eq!(
+            output.diagnostics[0].path.as_deref(),
+            Some("$.vendor_extension")
+        );
+    }
+
+    let reject_unknown = TranslationPolicy {
+        unknown_field_policy: UnknownFieldPolicy::Reject,
+        preservation: PreservationPolicy::Disabled,
+        ..TranslationPolicy::default()
+    };
+    for (format, body) in &request_cases {
+        let error = engine
+            .decode_request(*format, body, &reject_unknown)
+            .expect_err("reject policy must reject request extensions");
+        assert_eq!(
+            error.to_string(),
+            "unknown field rejected at $.vendor_extension"
+        );
+    }
+    for (format, body) in &response_cases {
+        let error = engine
+            .decode_response(*format, body, &reject_unknown)
+            .expect_err("reject policy must reject response extensions");
+        assert_eq!(
+            error.to_string(),
+            "unknown field rejected at $.vendor_extension"
+        );
+    }
+
+    Ok(())
 }
 
 // Malformed provider fields must fail before normalization can change their meaning.


### PR DESCRIPTION
## What

- represent normalized function tools and exact provider-specific tools in `ToolDefinition`
- preserve OpenAI Responses built-in tools through decode and same-format encode
- enforce `UnknownFieldPolicy` for buffered request and response extensions in all three codecs

## Why

Valid provider tools were dropped when they had no normalized function shape, and the public unknown-field policy did not affect collected provider extensions. This is follow-up translation fidelity and policy work.

## How

- changes the public `ToolDefinition` struct into an untagged `Function`/`Raw` enum; normalized function serde remains unchanged
- passes raw tools only to their owning format and emits a structured diagnostic or strict error for cross-format loss
- routes top-level extension collection through the existing unknown-field policy helper

## What to review

- **Public API:** Rust callers now construct and match `ToolDefinition::Function`
- raw tool ownership and cross-format diagnostic path/source/target
- Preserve, DropWithWarning, and Reject behavior for request and response extensions

## Validation

- `cargo fmt --all --check`
- `cargo check -p switchyard-protocol -p switchyard-translation`
- `cargo clippy -p switchyard-protocol -p switchyard-translation --all-targets -- -D warnings`
- `cargo check -p switchyard-libsy --examples`
- `cargo test -p switchyard-translation --test request_translation provider_tools_and_unknown_fields_follow_translation_policy -- --exact`