### PR TITLE
docs: close RC1 reference gaps for [targets] and switchyard-server options

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -69,7 +69,9 @@ When built from the repository, invoke it as
 | `--host HOST` | `0.0.0.0` | Address on which the server listens. |
 | `-p, --port PORT` | `4000` | Port on which the server listens. |
 | `--backlog BACKLOG` | `65535` | TCP listen backlog configured before accepting traffic. |
+| `--shutdown-timeout SHUTDOWN_TIMEOUT` | `30s` | Maximum time active requests may drain during shutdown. |
 | `--dry-run` | Off | Validate the deployment without binding a socket. |
+| `--routing-log-file PATH` | None | Append durable per-request routing records to this JSONL file. |
 | `--tls-cert PATH` | None | PEM certificate path; requires `--tls-key`. |
 | `--tls-key PATH` | None | PEM private-key path; requires `--tls-cert`. |
 | `-h, --help` | — | Print command help. |

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -33,6 +33,11 @@ target = "strong"
 `schema_version` must be `1`. Table names under `llm_clients`, `targets`, and
 `routes` are local references; clients send the route's `id` as the model name.
 
+`schema_version`, `[targets]`, and `[routes]` must all be present, even when a
+route reaches no upstream. A file without a `[targets]` table is rejected with
+`missing field targets`; an empty `[targets]` table satisfies it.
+`[llm_clients]` defaults to empty and may be omitted.
+
 ## `[llm_clients.<name>]`
 
 | Key | Required | Default | Meaning |
@@ -69,6 +74,19 @@ Every route takes the common keys below, plus the keys for its type.
 
 Returns a buffered assistant response containing `OK` without calling an
 upstream model. Use it for local smoke tests.
+
+A noop-only deployment reaches no upstream but still needs the `[targets]`
+table, which can be empty:
+
+```toml
+schema_version = 1
+
+[targets]
+
+[routes.smoke]
+id = "noop-route"
+type = "noop"
+```
 
 ### `passthrough`
 


### PR DESCRIPTION
## Summary

Two gaps in the published reference docs, found by a step-by-step first-time-user pass over the `v0.2.0-rc.1` documentation.

**`docs/reference/toml_schema.md`** — the page describes `noop` as a zero-upstream local smoke test, but a noop-only config is rejected with ``missing field `targets` ``. The page now states that `schema_version`, `[targets]`, and `[routes]` must all be present even when a route reaches no upstream, that an empty `[targets]` table satisfies the requirement, and that `[llm_clients]` defaults to empty and may be omitted. A minimal noop-only example was added to the `noop` section.

This matches `ServerConfig` (`crates/switchyard-server/src/config.rs`), where `llm_clients` carries `#[serde(default)]` and `targets` does not.

**`docs/cli_reference.md`** — the `switchyard-server` options table was missing two shipped options: `--routing-log-file PATH` and `--shutdown-timeout` (default `30s`). Both are added in `--help` order, so the table now matches the binary.
