### PR TITLE
fix(docs): explain removed setup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Catalog auto-discovery via a bare `type: passthrough` route is gone; there is
   no `type: model` equivalent, so list the model ids you want as explicit
   `type: model` routes.
+- **`switchyard configure` and `switchyard verify` CLI commands** — removed when
+  the CLI was narrowed to `serve` and `launch`. Switchyard no longer saves
+  provider credentials or deployment paths. Name the credential environment
+  variable with `api_key_env` in a native TOML deployment, export it, and pass
+  the deployment to each `switchyard launch`. Validate a deployment with
+  `./target/release/switchyard-server --config <deployment.toml> --dry-run`.
 
 ### Fixed
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -100,10 +100,10 @@ switchyard launch claude --model my-route --config routes.toml
 ```
 
 The CLI does not save provider credentials or deployment paths.
-Use `switchyard-server --config routes.toml --dry-run` to validate a native
-deployment before starting the standalone server.
+Use `./target/release/switchyard-server --config routes.toml --dry-run` to
+validate a native deployment before starting the standalone server.
 
 ## Related Documentation
 
-- [Getting Started](getting_started.md): installation, configuration, and verification for both paths
+- [Getting Started](getting_started.md): installation, configuration, and validation for both paths
 - [`switchyard-server`](../crates/switchyard-server/README.md): complete TOML schema, TLS, and metrics

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -83,6 +83,26 @@ Validate a deployment, then start the proxy:
   --host 127.0.0.1 --port 4000
 ```
 
+## Removed Setup Commands
+
+`switchyard configure` and `switchyard verify` are not available. Export the
+environment variable named by `api_key_env` in the native TOML deployment,
+then pass that deployment on each run. For example:
+
+```toml
+[llm_clients.provider]
+api_key_env = "PROVIDER_API_KEY"
+```
+
+```bash
+export PROVIDER_API_KEY="your-provider-key"  # pragma: allowlist secret
+switchyard launch claude --model my-route --config routes.toml
+```
+
+The CLI does not save provider credentials or deployment paths.
+Use `switchyard-server --config routes.toml --dry-run` to validate a native
+deployment before starting the standalone server.
+
 ## Related Documentation
 
 - [Getting Started](getting_started.md): installation, configuration, and verification for both paths

--- a/tests/test_cli_reference_docs.py
+++ b/tests/test_cli_reference_docs.py
@@ -43,7 +43,9 @@ def test_reference_documents_launcher_before_server() -> None:
 
 def test_reference_marks_removed_setup_commands() -> None:
     text = CLI_REFERENCE.read_text()
-    removed = text[text.index("## Removed Setup Commands") :]
+    removed_start = text.index("## Removed Setup Commands")
+    related_start = text.index("## Related Documentation", removed_start)
+    removed = text[removed_start:related_start]
     commands = _subparsers(_build_parser())
 
     assert "`switchyard configure` and `switchyard verify` are not available" in removed

--- a/tests/test_cli_reference_docs.py
+++ b/tests/test_cli_reference_docs.py
@@ -34,12 +34,22 @@ def test_reference_documents_launcher_before_server() -> None:
     text = CLI_REFERENCE.read_text()
     launcher = text.index("## Launcher Path: `switchyard launch`")
     server = text.index("## Server Path: `switchyard-server`")
+    removed = text.index("## Removed Setup Commands")
     related = text.index("## Related Documentation")
 
-    assert launcher < server < related
+    assert launcher < server < removed < related
     assert "switchyard serve" not in text
-    assert "switchyard configure" not in text
-    assert "switchyard verify" not in text
+
+
+def test_reference_marks_removed_setup_commands() -> None:
+    text = CLI_REFERENCE.read_text()
+    removed = text[text.index("## Removed Setup Commands") :]
+    commands = _subparsers(_build_parser())
+
+    assert "`switchyard configure` and `switchyard verify` are not available" in removed
+    assert "api_key_env" in removed
+    assert "The CLI does not save provider credentials or deployment paths" in removed
+    assert {"configure", "verify"}.isdisjoint(commands)
 
 
 def test_reference_lists_launcher_contract() -> None:


### PR DESCRIPTION
```text
switchyard configure --provider nvidia --target provider --no-tui
```

The current CLI prints:

```text
usage: switchyard [-h] [--version] {serve,launch} ...
switchyard: error: argument command: invalid choice: 'configure' (choose from serve, launch)
```

`configure` and `verify` were deliberately removed when the CLI was narrowed to `serve` and `launch`, but the CLI reference only omits them. A reader cannot tell whether the commands moved or were removed.

This PR records the removal and the supported replacement: name the credential environment variable with `api_key_env`, export it, pass the TOML deployment to each `launch`, and use `switchyard-server --dry-run` to validate a native deployment. It does not restore saved credentials, saved deployment paths, or either removed command.

The documented replacement is:

```toml
[llm_clients.provider]
api_key_env = "PROVIDER_API_KEY"
```

```bash
export PROVIDER_API_KEY="your-provider-key"
switchyard launch claude --model my-route --config routes.toml
switchyard-server --config routes.toml --dry-run
```

## How tested

- `make publish` from `docs/` builds the site in strict mode.
- `uv run pytest tests/test_cli_reference_docs.py -v -o addopts=` passes all four tests. `test_reference_marks_removed_setup_commands` fails against `main` because the migration note is absent, and it also checks that the parser still excludes both removed commands.

This documentation change does not alter CLI behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that `switchyard configure` and `switchyard verify` are no longer available.
  * Added guidance for providing API credentials and deployment configuration on each run.
  * Documented validation through `switchyard-server --dry-run`.
  * Clarified that credentials and deployment paths are not persisted.

* **Tests**
  * Added checks to keep CLI documentation aligned with supported commands and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->