### PR TITLE
docs(routing): the judge never sees client instructions

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -71,8 +71,11 @@ impl TaskClassifierVerdict {
     }
 }
 
-/// Keeps client instructions, the opening task, and the last `recent_turn_window`
-/// turns after it. A window of `0` keeps the instructions and the task alone.
+/// Keeps the opening task and the last `recent_turn_window` turns after it. A
+/// window of `0` keeps the task alone.
+///
+/// Inbound decoders normalize client system and developer content into
+/// `LlmRequest::instructions`, so it never reaches this list.
 ///
 /// Selects by reference and clones only what survives — a coding-agent
 /// conversation carries every tool result, so cloning it whole to keep a window

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -100,7 +100,7 @@ for the server merge behavior.
 |---|---|---|
 | `base_threshold` | required | Lowest `p_solve` that routes a supported task to `weak_target`. Must be between `0` and `1`. |
 | `threshold_step` | `0.0` | Amount added for each boundary step. Must be finite and non-negative, and `base_threshold + 2 * threshold_step` must not exceed `1`. |
-| `recent_turn_window` | unset | When unset, the judge sees the opening user task and the latest user message when they differ. When set to `N`, it sees client system/developer instructions, the opening user task, and the last `N` conversation messages after that task. `0` keeps only the instructions and opening task. |
+| `recent_turn_window` | unset | When unset, the judge sees the opening user task and the latest user message when they differ. When set to `N`, it sees the opening user task and the last `N` conversation messages after that task. `0` keeps only the opening task. Client system and developer instructions are not shown to the judge. |
 | `session_affinity` | `false` | Retains the first selected target for a session and reuses it on later requests. |
 | `message_hash_fallback` | `false` | When session metadata is absent, keys affinity from the first user-message text. Requires `session_affinity = true`. |
 | `prompt` | packaged capability prompt | Replaces the classifier's system prompt. The packaged verdict schema and routing policy remain active. |


### PR DESCRIPTION
The `recent_turn_window` docs claim the judge sees client system/developer instructions. It does not, and it never has — inbound decoders normalize that content into `LlmRequest::instructions`, which the judge request never reads.

The packaged classifier prompt agrees with the code, not the docs: it tells the judge it receives the task's opening instruction and latest user follow-up. Correcting the docs and the matching `trim_messages` comment.