### PR TITLE
fix(libsy): put judge system prompt in instructions, not messages

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -916,7 +916,8 @@ mod tests {
 
     use super::*;
     use switchyard_protocol::{
-        LlmClientError, LlmRequest, Metadata, completion_text, text_request, text_response,
+        ContentBlock, InstructionBlock, LlmClientError, LlmRequest, Metadata, completion_text,
+        text_request, text_response,
     };
 
     use crate::algorithms::util::llm_judge::Judge;
@@ -1000,9 +1001,17 @@ mod tests {
                 self.judge_system_prompts.lock().extend(
                     request
                         .llm_request
-                        .messages
+                        .instructions
                         .first()
-                        .and_then(|message| message.text_content("\n")),
+                        .and_then(|instruction| {
+                            instruction.content.iter().find_map(|b| {
+                                if let ContentBlock::Text { text } = b {
+                                    Some(text.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                        }),
                 );
                 r#"{"crux":"bounded task","primary_rule":"SUP-1","capability_boundary":"supported","p_solve":0.9}"#.to_string()
             } else {
@@ -1470,7 +1479,17 @@ mod tests {
         let judge_request = judge.build_request(&State::default(), &request);
 
         assert_eq!(judge_request.llm_request.model, request.llm_request.model);
-        assert_eq!(judge_request.llm_request.messages.len(), 3);
+        assert_eq!(judge_request.llm_request.instructions.len(), 1);
+        assert_eq!(judge_request.llm_request.instructions[0].role, Role::System);
+        assert_eq!(
+            judge_request.llm_request.instructions[0].content,
+            InstructionBlock {
+                role: Role::System,
+                content: Message::text(Role::System, judge.contract().system_prompt()).content,
+            }
+            .content,
+        );
+        assert_eq!(judge_request.llm_request.messages.len(), 2);
         let contents = judge_request
             .llm_request
             .messages

--- a/crates/libsy/src/algorithms/util/escalation.rs
+++ b/crates/libsy/src/algorithms/util/escalation.rs
@@ -375,12 +375,13 @@ mod tests {
             .push(Message::text(Role::Assistant, "this turn's reply"));
         let built = judge.build_request(&State::default(), &judged);
 
-        // Two messages: the rubric as system, the condensed trajectory as user.
-        assert_eq!(built.llm_request.messages.len(), 2);
-        assert_eq!(built.llm_request.messages[0].role, Role::System);
-        assert_eq!(built.llm_request.messages[1].role, Role::User);
+        // Rubric in instructions, condensed trajectory as the sole user message.
+        assert_eq!(built.llm_request.instructions.len(), 1);
+        assert_eq!(built.llm_request.instructions[0].role, Role::System);
+        assert_eq!(built.llm_request.messages.len(), 1);
+        assert_eq!(built.llm_request.messages[0].role, Role::User);
         assert!(
-            built.llm_request.messages[1]
+            built.llm_request.messages[0]
                 .text_content("")
                 .is_some_and(|text| text.contains("Conversation turn 4"))
         );

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use switchyard_protocol::{
-    AggLlmResponse, LlmRequest, Message, OutputParams, Role, completion_text,
+    AggLlmResponse, InstructionBlock, LlmRequest, Message, OutputParams, Role, completion_text,
 };
 
 use super::classifier_contract::ClassifierContract;
@@ -144,14 +144,15 @@ where
     type Verdict = D::Verdict;
 
     fn build_request(&self, state: &State, request: &Request) -> Request {
-        let mut messages = self.input.build_messages(state, request);
-        messages.insert(
-            0,
-            Message::text(Role::System, self.contract.system_prompt().to_string()),
-        );
+        let messages = self.input.build_messages(state, request);
         Request {
             llm_request: LlmRequest {
                 model: request.llm_request.model.clone(),
+                instructions: vec![InstructionBlock {
+                    role: Role::System,
+                    content: Message::text(Role::System, self.contract.system_prompt().to_string())
+                        .content,
+                }],
                 messages,
                 output: OutputParams {
                     max_output_tokens: Some(self.runtime.max_output_tokens),

--- a/tests/test_libsy_minimal_bindings.py
+++ b/tests/test_libsy_minimal_bindings.py
@@ -100,7 +100,7 @@ async def test_classifier_config_accepts_a_prompt_override() -> None:
 
     _, response = await algorithm.run(request_body())
 
-    prompt = judge.calls[0]["messages"][0]["content"][0]["text"]
+    prompt = judge.calls[0]["instructions"][0]["content"][0]["text"]
     assert prompt == "Custom capability rubric."
     assert judge.calls[0]["output"]["response_format"]["json_schema"]["schema"][
         "properties"


### PR DESCRIPTION
PR #204 refactored `CapabilityJudge` to a `StructuredJudge` type alias, but `StructuredJudge::build_request` inserts the system prompt into `messages` as a `Role::System` entry instead of `LlmRequest.instructions`. This silently reverted the fix from PR #195 and removed its test.

For OpenAI-compatible backends the wire output happens to be identical, but for Anthropic backends a `Role::System` message in `messages` serializes as a user turn — the `system` field ends up empty. Fix `StructuredJudge::build_request` to use `instructions` (as `InstructionBlock`), and update the tests in `llm_class.rs` and `escalation.rs` that were asserting the old messages-based shape.