### PR TITLE
fix(overflow): add hub GLM phrase to context-overflow detector

### DIFF
--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -24,6 +24,7 @@ const OPENAI_OVERFLOW_PHRASES: &[&str] = &[
     "context window",
     "context length is only",
     "please reduce the length of the input",
+    "exceeds the maximum allowed input length",
 ];
 
 // Anthropic has no structured `error.code`, so detection is phrase-based only.
@@ -310,6 +311,10 @@ mod tests {
             r#"{"error":{"message":"the model's context length is only 131072 tokens"}}"#
         ));
         assert!(!backend.is_context_overflow(r#"{"error":{"code":"invalid_api_key"}}"#));
+        // Hub GLM (LiteLLM-wrapped): code is "400", detection relies on phrase match.
+        assert!(backend.is_context_overflow(
+            r#"{"error":{"message":"Input length 877338 exceeds the maximum allowed input length of 639968 tokens","code":"400"}}"#
+        ));
     }
 
     #[test]

--- a/crates/switchyard-components/src/backends/openai.rs
+++ b/crates/switchyard-components/src/backends/openai.rs
@@ -528,6 +528,7 @@ const OPENAI_OVERFLOW_PHRASES: &[&str] = &[
     "context window",
     "context length is only",
     "please reduce the length of the input",
+    "exceeds the maximum allowed input length",
 ];
 
 fn is_context_overflow(body: &str) -> bool {
@@ -757,6 +758,14 @@ mod tests {
     fn context_overflow_unrelated_400_does_not_match() {
         let body = r#"{"error":{"code":"invalid_api_key","message":"bad key"}}"#;
         assert!(!is_context_overflow(body));
+    }
+
+    #[test]
+    fn context_overflow_hub_glm_matches() {
+        // Hub GLM error via LiteLLM: code is "400" (not context_length_exceeded),
+        // so detection relies on phrase matching.
+        let body = r#"{"error":{"message":"Input length 877338 exceeds the maximum allowed input length of 639968 tokens","code":"400"}}"#;
+        assert!(is_context_overflow(body));
     }
 
     #[test]


### PR DESCRIPTION
The hub's GLM model returns "Input length N exceeds the maximum allowed input length of M tokens" with code "400" rather than "context_length_exceeded", so is_context_overflow returned false and the fallback in #302 was never consulted. Adds "exceeds the maximum allowed input length" to the OpenAI phrase list in both crates, with a test asserting the exact GLM error body shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of input-length limit errors from OpenAI-compatible providers.
  * Added support for recognizing overflow errors returned through Hub and LiteLLM-wrapped GLM responses, including non-standard error codes.
  * These errors are now handled consistently as context overflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->