### PR TITLE
fix(cost): align GLM 5.2 pricing with the benchmark catalog; record judge calls in session stats

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -382,9 +382,21 @@ async fn serve_until_shutdown(
 #[derive(Clone, Copy)]
 struct RequestStart(Instant);
 
+/// Tier recorded for classifier and judge calls in the routing log, distinguishing
+/// routing overhead from the routed tiers a session was served by.
+const CLASSIFIER_TIER: &str = "classifier";
+
 /// Maps routed call observations to backend stats, non-routed calls to classifier/judge
 /// stats, and records routing overhead once the algorithm run completes.
-fn stats_observer(stats: StatsAccumulator) -> RunObserver {
+///
+/// Successful classifier/judge calls are also appended to `classifier_log` when one is
+/// configured, so per-session routing snapshots account for judge token overhead. Routed
+/// calls stay off this path: the served call is logged with its terminal usage in
+/// [`usage_metrics::observe`], which would make a second append here a double count.
+fn stats_observer(
+    stats: StatsAccumulator,
+    classifier_log: Option<(SharedRoutingLog, routing_log::RoutingLogContext)>,
+) -> RunObserver {
     Arc::new(move |observation| match observation {
         RunObservation::LlmCall(call) => {
             let latency_ms = call.duration.as_secs_f64() * 1_000.0;
@@ -395,6 +407,16 @@ fn stats_observer(stats: StatsAccumulator) -> RunObserver {
                     stats.record_error(&call.selected_model, call.tier.as_deref());
                 }
             } else if call.is_success {
+                if let (Some((log, context)), Some(usage)) =
+                    (classifier_log.as_ref(), call.usage.as_ref())
+                {
+                    log.append(
+                        context.clone(),
+                        &call.selected_model,
+                        Some(CLASSIFIER_TIER),
+                        usage,
+                    );
+                }
                 stats.record_classifier_success(
                     call.selected_model,
                     call.usage.as_ref().map(usage_metrics::token_usage),
@@ -656,7 +678,10 @@ async fn handle_llm_request(
         Err(response) => return response,
     };
     let algorithm = Arc::clone(&route.algorithm);
-    let observer = stats_observer(state.stats.clone());
+    let observer = stats_observer(
+        state.stats.clone(),
+        state.routing_log.clone().zip(routing_log_context.clone()),
+    );
     let (trace, response) = match algorithm
         .run_observed(Context::default(), request, Some(observer))
         .await
@@ -1266,10 +1291,52 @@ fn endpoint_listing(has_routing_log: bool) -> String {
 
 #[cfg(test)]
 mod tests {
+    use libsy::LlmCallObservation;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::sync::{Notify, oneshot};
 
     use super::*;
+
+    /// A successful judge call lands in the per-session routing snapshot under its
+    /// model id with the classifier tier, while routed calls stay off the observer's
+    /// log path — they are logged with terminal usage when the served response is
+    /// observed, so an append here would double count them.
+    #[test]
+    fn stats_observer_logs_judge_calls_to_the_routing_log() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let log = SharedRoutingLog::new(dir.path().join("routing.jsonl")).expect("routing log");
+        let mut headers = HeaderMap::new();
+        headers.insert("proxy_x_session_id", "session-1".parse().expect("header"));
+        let context = routing_log::RoutingLogContext::from_headers(&headers);
+        let observer = stats_observer(StatsAccumulator::default(), Some((log.clone(), context)));
+
+        let call = |model: &str, is_routed: bool| {
+            RunObservation::LlmCall(LlmCallObservation {
+                selected_model: model.to_string(),
+                tier: None,
+                is_routed,
+                is_success: true,
+                duration: Duration::from_millis(3),
+                usage: Some(Usage {
+                    input_tokens: Some(100),
+                    output_tokens: Some(7),
+                    ..Usage::default()
+                }),
+            })
+        };
+        observer(call("judge-model", false));
+        observer(call("routed-model", true));
+
+        let snapshot = log
+            .snapshot_session("session-1")
+            .expect("read log")
+            .expect("session recorded");
+        let snapshot = serde_json::to_value(&snapshot).expect("serializable snapshot");
+        assert_eq!(snapshot["models"]["judge-model"]["calls"], 1);
+        assert_eq!(snapshot["models"]["judge-model"]["prompt_tokens"], 100);
+        assert_eq!(snapshot["models"]["judge-model"]["completion_tokens"], 7);
+        assert!(snapshot["models"].get("routed-model").is_none());
+    }
 
     #[derive(Clone)]
     struct ShutdownTestState {

--- a/crates/switchyard-server/src/routing_log.rs
+++ b/crates/switchyard-server/src/routing_log.rs
@@ -96,6 +96,7 @@ pub(crate) fn snapshot(
 }
 
 /// Request headers retained until terminal usage is available.
+#[derive(Clone)]
 pub(crate) struct RoutingLogContext {
     task: Option<String>,
     trial_id: Option<String>,

--- a/docs/routing_algorithms/escalation_router_routing.md
+++ b/docs/routing_algorithms/escalation_router_routing.md
@@ -153,6 +153,11 @@ The snapshot reports per-model calls, tokens, latency, and cost for the strong
 and weak tiers. Judge calls are recorded in the classifier stats bucket, so their
 token cost and latency remain visible as routing overhead.
 
+When the server runs with a routing log, successful judge calls also appear in
+per-session routing stats under the judge's model id, tagged with the
+`classifier` tier — so per-session token accounting includes judge overhead
+alongside the tiers the session was served by.
+
 ## When not to use escalation routing
 
 - **One-shot requests.** No trajectory to judge. Use

--- a/switchyard/lib/cost_estimator.py
+++ b/switchyard/lib/cost_estimator.py
@@ -124,27 +124,17 @@ MODEL_PRICING: dict[str, ModelPriceData] = {
         input=0.60, output=2.50, cached=0.15, cache_write=0.60,
     ),
     # Z.ai GLM-5.2 — REFERENCE pricing only. Switchyard reaches this model as
-    # ``glm-5.2-fp8`` on a self-hosted vLLM deployment (also as
-    # ``zai-org/glm-5.2`` on the NVIDIA hub), neither of which has per-token
-    # billing: the real cost is GPU-hours. These rates are the benchmark
-    # pricing catalog's ``zai-org/glm-5.2`` entry (verified 2026-08-05),
-    # carried so benchmark arms can be compared against commercial models on
-    # a common basis — "what this traffic would have cost at market rates",
-    # not what we are billed — and so cost numbers computed here agree with
-    # the benchmark dashboards. Provider list prices vary about 2x
-    # (SiliconFlow's serverless tier is $1.40/$4.40), so treat the absolute
-    # number as indicative, not exact. OpenAI wire format and no documented
-    # cache-write premium, so cache_write = input.
+    # ``glm-5.2-fp8`` on a self-hosted vLLM deployment, which has no per-token
+    # billing at all: the real cost is GPU-hours. These rates are the benchmark
+    # pricing catalog's GLM-5.2 entry (verified 2026-08-05), carried so
+    # benchmark arms can be compared against commercial models on a common
+    # basis — "what this traffic would have cost at market rates", not what we
+    # are billed — and so cost numbers computed here agree with the benchmark
+    # dashboards. Provider list prices vary about 2x (SiliconFlow's serverless
+    # tier is $1.40/$4.40), so treat the absolute number as indicative, not
+    # exact. OpenAI wire format and no documented cache-write premium, so
+    # cache_write = input.
     "glm-5.2-fp8": ModelPriceData(
-        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
-    ),
-    "zai-org/glm-5.2": ModelPriceData(
-        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
-    ),
-    "nvidia/zai-org/glm-5.2": ModelPriceData(
-        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
-    ),
-    "openai/nvidia/zai-org/glm-5.2": ModelPriceData(
         input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
     ),
     # DeepSeek V4 Flash — official api-docs.deepseek.com standard list

--- a/switchyard/lib/cost_estimator.py
+++ b/switchyard/lib/cost_estimator.py
@@ -125,15 +125,15 @@ MODEL_PRICING: dict[str, ModelPriceData] = {
     ),
     # Z.ai GLM-5.2 — REFERENCE pricing only. Switchyard reaches this model as
     # ``glm-5.2-fp8`` on a self-hosted vLLM deployment, which has no per-token
-    # billing at all: the real cost is GPU-hours. These rates are the benchmark
-    # pricing catalog's GLM-5.2 entry (verified 2026-08-05), carried so
-    # benchmark arms can be compared against commercial models on a common
-    # basis — "what this traffic would have cost at market rates", not what we
-    # are billed — and so cost numbers computed here agree with the benchmark
-    # dashboards. Provider list prices vary about 2x (SiliconFlow's serverless
-    # tier is $1.40/$4.40), so treat the absolute number as indicative, not
-    # exact. OpenAI wire format and no documented cache-write premium, so
-    # cache_write = input.
+    # billing at all: the real cost is GPU-hours. These rates are an average of
+    # OpenRouter provider rates captured in late July 2026, not a first-party
+    # Z.ai quote. Keeping the same snapshot across benchmark calculations makes
+    # estimates comparable; it represents "what this traffic would have cost at
+    # market rates", not what NVIDIA is billed. The snapshot provides input,
+    # output, and cache-read prices but no cache-creation price, and the Hub does
+    # not report a separate cache-write bucket for this deployment. Use the base
+    # input rate as the fallback so any reported cache-write tokens are not
+    # accidentally zero-rated.
     "glm-5.2-fp8": ModelPriceData(
         input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
     ),

--- a/switchyard/lib/cost_estimator.py
+++ b/switchyard/lib/cost_estimator.py
@@ -124,17 +124,28 @@ MODEL_PRICING: dict[str, ModelPriceData] = {
         input=0.60, output=2.50, cached=0.15, cache_write=0.60,
     ),
     # Z.ai GLM-5.2 — REFERENCE pricing only. Switchyard reaches this model as
-    # ``glm-5.2-fp8`` on a self-hosted vLLM deployment, which has no per-token
-    # billing at all: the real cost is GPU-hours. These rates are
-    # SiliconFlow's published GLM-5.2 serverless tier (verified 2026-07-27),
-    # carried so benchmark arms can be compared against commercial models on a
-    # common basis — "what this traffic would have cost at market rates", not
-    # what we are billed. Provider rates vary about 2x (OpenRouter lists
-    # $0.76/$2.42), so treat the absolute number as indicative, not exact.
-    # OpenAI wire format and no documented cache-write premium, so
-    # cache_write = input.
+    # ``glm-5.2-fp8`` on a self-hosted vLLM deployment (also as
+    # ``zai-org/glm-5.2`` on the NVIDIA hub), neither of which has per-token
+    # billing: the real cost is GPU-hours. These rates are the benchmark
+    # pricing catalog's ``zai-org/glm-5.2`` entry (verified 2026-08-05),
+    # carried so benchmark arms can be compared against commercial models on
+    # a common basis — "what this traffic would have cost at market rates",
+    # not what we are billed — and so cost numbers computed here agree with
+    # the benchmark dashboards. Provider list prices vary about 2x
+    # (SiliconFlow's serverless tier is $1.40/$4.40), so treat the absolute
+    # number as indicative, not exact. OpenAI wire format and no documented
+    # cache-write premium, so cache_write = input.
     "glm-5.2-fp8": ModelPriceData(
-        input=1.40, output=4.40, cached=0.26, cache_write=1.40,
+        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
+    ),
+    "zai-org/glm-5.2": ModelPriceData(
+        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
+    ),
+    "nvidia/zai-org/glm-5.2": ModelPriceData(
+        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
+    ),
+    "openai/nvidia/zai-org/glm-5.2": ModelPriceData(
+        input=0.805, output=2.53, cached=0.1495, cache_write=0.805,
     ),
     # DeepSeek V4 Flash — official api-docs.deepseek.com standard list
     # price (post-promo). 284B total / 13B active, 1M-token context


### PR DESCRIPTION
The glm-5.2-fp8 reference entry carried SiliconFlow's serverless list price, while the team's benchmark pricing catalog prices GLM 5.2 from a different reference tier. Cost figures computed from this table therefore disagreed with the benchmark dashboards for identical traffic, which caused confusion when comparing runs. This change adopts the catalog rates so the checked-in table and the dashboards produce the same numbers. The comment block keeps the reference-pricing framing: the deployment is self-hosted, so these rates describe what the traffic would cost at market rates, not what is billed.

The second commit closes a related accounting gap on the server side. Judge and classifier calls were recorded only in the server-wide classifier stats bucket, so per-session routing snapshots reported the routed tiers but silently omitted judge token overhead, and that overhead became unrecoverable once the server shut down. The stats observer now also appends successful non-routed calls to the routing log under the judge's model id with a classifier tier tag, while routed calls stay off this path because the served response is already logged with terminal usage.