### PR TITLE
ci(release): publish Rust crates from release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,13 +59,24 @@ jobs:
 
           with open("pyproject.toml", "rb") as file:
               pyproject = tomllib.load(file)
+          with open("Cargo.toml", "rb") as file:
+              cargo = tomllib.load(file)
+
           package_version = pyproject["project"]["version"]
+          workspace_version = cargo["workspace"]["package"]["version"]
+          if workspace_version != package_version:
+              raise SystemExit(
+                  "Python package version "
+                  f"{package_version!r} does not match Rust workspace version "
+                  f"{workspace_version!r}"
+              )
+
           expected = f"v{package_version}"
           if tag != expected:
               raise SystemExit(
                   f"release tag {tag!r} does not match pyproject version {package_version!r}"
               )
-          print(f"release tag {tag} matches pyproject version {package_version}")
+          print(f"release tag {tag} matches Python and Rust version {package_version}")
           PY
 
   python-release-checks:
@@ -417,7 +428,7 @@ jobs:
   publish:
     name: Publish distributions
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [source-dist, wheels]
+    needs: [source-dist, wheels, publish-rust-server]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -438,3 +449,100 @@ jobs:
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
+
+  publish-rust-protocol:
+    name: Publish switchyard-protocol
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [source-dist, wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --package switchyard-protocol
+
+  publish-rust-foundations:
+    name: Publish ${{ matrix.crate }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [publish-rust-protocol]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [switchyard-libsy, switchyard-translation]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for registry dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in {1..30}; do
+            cargo info --registry crates-io "switchyard-protocol@${version}" >/dev/null 2>&1 \
+              && exit 0
+            echo "Waiting for switchyard-protocol ${version} (${attempt}/30)"
+            sleep 10
+          done
+          echo "switchyard-protocol ${version} did not reach the crates.io index" >&2
+          exit 1
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --package "${{ matrix.crate }}"
+
+  publish-rust-client:
+    name: Publish switchyard-llm-client
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [publish-rust-foundations]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for registry dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in {1..30}; do
+            ready=true
+            for crate in switchyard-libsy switchyard-translation; do
+              cargo info --registry crates-io "${crate}@${version}" >/dev/null 2>&1 \
+                || ready=false
+            done
+            if [[ "${ready}" == true ]]; then
+              exit 0
+            fi
+            echo "Waiting for Rust foundation crates ${version} (${attempt}/30)"
+            sleep 10
+          done
+          echo "Rust foundation crates ${version} did not reach the crates.io index" >&2
+          exit 1
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --package switchyard-llm-client
+
+  publish-rust-server:
+    name: Publish switchyard-server
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: [publish-rust-client]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for registry dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          for attempt in {1..30}; do
+            cargo info --registry crates-io "switchyard-llm-client@${version}" >/dev/null 2>&1 \
+              && exit 0
+            echo "Waiting for switchyard-llm-client ${version} (${attempt}/30)"
+            sleep 10
+          done
+          echo "switchyard-llm-client ${version} did not reach the crates.io index" >&2
+          exit 1
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --package switchyard-server

--- a/README.md
+++ b/README.md
@@ -59,19 +59,16 @@ switchyard launch claude --model my-route --config routes.toml
 
 ### Server Path
 
-Use this path to build and run the standalone Rust proxy. Install
-[Rust with Cargo](https://rust-lang.org/tools/install/), then build the release
-binary from source:
+Use this path to install and run the standalone Rust proxy. Install
+[Rust with Cargo](https://rust-lang.org/tools/install/), then install the
+published binary:
 
 ```bash
-git clone https://github.com/NVIDIA-NeMo/Switchyard.git
-cd Switchyard
-cargo build --locked --release -p switchyard-server
-./target/release/switchyard-server --help
+cargo install --locked switchyard-server
+switchyard-server --help
 ```
 
-Prebuilt binaries are not published yet. `rustup` installs the pinned toolchain
-automatically when you run Cargo from the repository.
+Cargo builds the release binary and installs it into `~/.cargo/bin` by default.
 
 Create `routes.toml` using the
 [Getting Started guide](docs/getting_started.md#server-path), then validate it
@@ -79,8 +76,8 @@ and start the server:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml --host 127.0.0.1 --port 4000
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml --host 127.0.0.1 --port 4000
 ```
 
 Verify the proxy in another terminal:

--- a/crates/libsy-llm-client/Cargo.toml
+++ b/crates/libsy-llm-client/Cargo.toml
@@ -7,9 +7,14 @@ version.workspace = true
 description = "HTTP LLM client speaking Switchyard's neutral IR directly"
 authors.workspace = true
 edition.workspace = true
+homepage = "https://github.com/NVIDIA-NeMo/Switchyard"
 license.workspace = true
+readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
+documentation = "https://docs.rs/switchyard-llm-client"
+keywords = ["llm", "client", "openai", "anthropic"]
+publish = ["crates-io"]
 
 [dependencies]
 switchyard-libsy.workspace = true

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -7,9 +7,14 @@ version.workspace = true
 description = "Rust HTTP server surface for libsy algorithms"
 authors.workspace = true
 edition.workspace = true
+homepage = "https://github.com/NVIDIA-NeMo/Switchyard"
 license.workspace = true
+readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
+documentation = "https://docs.rs/switchyard-server"
+keywords = ["llm", "proxy", "routing", "openai", "anthropic"]
+publish = ["crates-io"]
 
 [dependencies]
 async-stream.workspace = true
@@ -20,7 +25,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", 
 clap = { version = "4", features = ["derive", "env"] }
 futures-util.workspace = true
 http.workspace = true
-libsy = { package = "switchyard-libsy", path = "../libsy" }
+libsy = { package = "switchyard-libsy", path = "../libsy", version = "0.2.0" }
 opentelemetry = { version = "0.32", default-features = false, features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "metrics", "reqwest-blocking-client", "reqwest-rustls", "trace"] }
 opentelemetry-prometheus = "0.32"

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -55,7 +55,8 @@ confidence_threshold = 0.5
 
 ```bash
 export API_KEY="..."
-cargo run -p switchyard-server -- --config routes.toml
+cargo install --locked switchyard-server
+switchyard-server --config routes.toml
 ```
 
 Ctrl+C and Unix `SIGTERM` stop new connections and allow active requests to drain for up to

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -50,18 +50,14 @@ This command does not install or run the standalone `switchyard-server` binary.
 
 ## Server Path: `switchyard-server`
 
-Build the standalone binary with
-`cargo build --locked --release -p switchyard-server`. It reads the same native
-TOML deployment schema accepted by the launcher.
+Install the standalone binary with `cargo install --locked switchyard-server`.
+It reads the same native TOML deployment schema accepted by the launcher.
 
 ### Usage
 
 ```bash
 switchyard-server --config <deployment.toml> [options]
 ```
-
-When built from the repository, invoke it as
-`./target/release/switchyard-server`.
 
 | Option | Default | Purpose |
 |---|---|---|
@@ -80,8 +76,8 @@ When built from the repository, invoke it as
 Validate a deployment, then start the proxy:
 
 ```bash
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 
@@ -102,7 +98,7 @@ switchyard launch claude --model my-route --config routes.toml
 ```
 
 The CLI does not save provider credentials or deployment paths.
-Use `./target/release/switchyard-server --config routes.toml --dry-run` to
+Use `switchyard-server --config routes.toml --dry-run` to
 validate a native deployment before starting the standalone server.
 
 ## Related Documentation

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -107,20 +107,16 @@ cargo --version
 uv --version
 ```
 
-### Build the server
+### Install the server
 
-Build the Rust server from source:
+Install the Rust server from crates.io:
 
 ```bash
-git clone https://github.com/NVIDIA-NeMo/Switchyard.git
-cd Switchyard
-cargo build --locked --release -p switchyard-server
-./target/release/switchyard-server --help
+cargo install --locked switchyard-server
+switchyard-server --help
 ```
 
-The repository pins Rust `1.96.1` in `rust-toolchain.toml`; `rustup` selects and
-installs it automatically when Cargo runs from the repository. Prebuilt Rust
-binaries are not published yet.
+Cargo builds the release binary and installs it into `~/.cargo/bin` by default.
 
 ### Configure
 
@@ -166,8 +162,8 @@ socket, then start the release binary:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 
@@ -211,7 +207,7 @@ the complete TOML schema, route options, TLS, and metrics.
 
 ```bash
 test -n "$OPENROUTER_API_KEY" && echo "key is set" || echo "key is missing"
-./target/release/switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml --dry-run
 ```
 
 Confirm that `api_key_env` in `routes.toml` names the environment variable you

--- a/docs/internal/release_workflow.md
+++ b/docs/internal/release_workflow.md
@@ -8,7 +8,8 @@ Switchyard currently follows the OSS-style NeMo path for GitHub builds:
 - manual dev builds create one Linux x86_64 wheel as a one-day GitHub Actions artifact;
 - manual dev matrix builds create the full sdist and wheel set as GitHub Actions artifacts;
 - root `vMAJOR.MINOR.PATCH` tags run the complete release validation and wheel matrix;
-- public PyPI/GitHub publishing happens only from approved `vMAJOR.MINOR.PATCH` tag releases.
+- public PyPI, crates.io, and GitHub publishing happens only from approved
+  `vMAJOR.MINOR.PATCH` tag releases.
 
 Wheel metadata uses the public distribution name `nemo-switchyard`, while the Python import and CLI
 stay `switchyard`.
@@ -69,7 +70,8 @@ Create a root `vMAJOR.MINOR.PATCH` tag only when a real release has been approve
 - native wheel smoke installs where the runner can execute the artifact.
 
 The workflow rejects release tags that do not exactly match `pyproject.toml`'s package version. For
-example, package version `0.0.1` must be released with the `v0.0.1` tag.
+example, package version `0.2.0` must be released with the `v0.2.0` tag. The Rust workspace and
+Python package versions must also match.
 
 The official `publish` job uses `uv publish --trusted-publishing always`, so PyPI project creation
 and uploads require a matching pending trusted publisher:
@@ -84,6 +86,19 @@ and uploads require a matching pending trusted publisher:
 
 Do not create a root release tag until the PyPI pending publisher and GitHub `pypi` environment are
 ready.
+
+The same tag publishes these crates to crates.io in dependency order:
+
+1. `switchyard-protocol`
+2. `switchyard-libsy`
+3. `switchyard-translation`
+4. `switchyard-llm-client`
+5. `switchyard-server`
+
+Add a repository Actions secret named `CARGO_REGISTRY_TOKEN` containing a crates.io API token that
+can publish all five crates and create new crates. The job waits for each version to reach the
+crates.io index before publishing its dependents. If publication stops partway through, use
+GitHub's **Re-run failed jobs** action so successful crate jobs are not repeated.
 
 ## Local Metadata Helper
 

--- a/docs/routing_algorithms/escalation_router_routing.md
+++ b/docs/routing_algorithms/escalation_router_routing.md
@@ -123,8 +123,8 @@ credential, validate the configuration, and start the binary:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 

--- a/docs/routing_algorithms/escalation_router_routing.md
+++ b/docs/routing_algorithms/escalation_router_routing.md
@@ -117,8 +117,8 @@ resets the streak to zero.
 
 ## Run the route
 
-After building the Rust server, as described in
-[Getting Started](../getting_started.md#build-the-server), export the provider
+After installing the Rust server, as described in
+[Getting Started](../getting_started.md#install-the-server), export the provider
 credential, validate the configuration, and start the binary:
 
 ```bash

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -215,8 +215,8 @@ binary:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 

--- a/docs/routing_algorithms/llm_classifier_routing.md
+++ b/docs/routing_algorithms/llm_classifier_routing.md
@@ -209,7 +209,7 @@ user-message text.
 
 ## Run the route
 
-After [building the Rust server](../getting_started.md#build-the-server), export
+After [installing the Rust server](../getting_started.md#install-the-server), export
 the provider credential, validate the configuration, and start the release
 binary:
 

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -117,8 +117,8 @@ credential, validate the configuration, and start the binary:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -111,8 +111,8 @@ the configured endpoint.
 
 ## Run a deployment
 
-After building the Rust server, as described in
-[Getting Started](../getting_started.md#build-the-server), export the provider
+After installing the Rust server, as described in
+[Getting Started](../getting_started.md#install-the-server), export the provider
 credential, validate the configuration, and start the binary:
 
 ```bash

--- a/docs/routing_algorithms/random_routing.md
+++ b/docs/routing_algorithms/random_routing.md
@@ -83,8 +83,8 @@ binary:
 
 ```bash
 export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
-./target/release/switchyard-server --config routes.toml --dry-run
-./target/release/switchyard-server --config routes.toml \
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml \
   --host 127.0.0.1 --port 4000
 ```
 

--- a/docs/routing_algorithms/random_routing.md
+++ b/docs/routing_algorithms/random_routing.md
@@ -77,7 +77,7 @@ therefore use different targets.
 
 ## Run the route
 
-After [building the Rust server](../getting_started.md#build-the-server), export
+After [installing the Rust server](../getting_started.md#install-the-server), export
 the provider credential, validate the configuration, and start the release
 binary:
 

--- a/tests/getting_started/test_getting_started.py
+++ b/tests/getting_started/test_getting_started.py
@@ -14,8 +14,8 @@ def test_getting_started_documents_current_paths() -> None:
     assert guide.index("## Launcher Path") < guide.index("## Server Path")
     assert 'uv tool install --python 3.12 "nemo-switchyard[cli,server]"' in guide
     assert "switchyard launch claude --model switchyard" in guide
-    assert "cargo build --locked --release -p switchyard-server" in guide
-    assert "./target/release/switchyard-server --config routes.toml --dry-run" in guide
+    assert "cargo install --locked switchyard-server" in guide
+    assert "switchyard-server --config routes.toml --dry-run" in guide
 
     for legacy_command in (
         "switchyard configure",

--- a/tests/readme/test_readme.py
+++ b/tests/readme/test_readme.py
@@ -12,8 +12,8 @@ def test_readme_documents_current_paths() -> None:
     assert readme.index("### Launcher Path") < readme.index("### Server Path")
     assert 'uv tool install --python 3.12 "nemo-switchyard[cli,server]"' in readme
     assert "switchyard launch claude --model switchyard" in readme
-    assert "cargo build --locked --release -p switchyard-server" in readme
-    assert "./target/release/switchyard-server --config routes.toml --dry-run" in readme
+    assert "cargo install --locked switchyard-server" in readme
+    assert "switchyard-server --config routes.toml --dry-run" in readme
 
     for legacy_command in (
         "switchyard configure",


### PR DESCRIPTION
## What

Publish the five public Rust packages from the same stable release tag used for `nemo-switchyard`:

- `switchyard-protocol`
- `switchyard-libsy`
- `switchyard-translation`
- `switchyard-llm-client`
- `switchyard-server`

Update the standalone server documentation to install the published binary with `cargo install --locked switchyard-server`.

## Why

The Rust libraries and server are versioned with the Python package but are not currently released by CI. Publishing from one `vMAJOR.MINOR.PATCH` tag keeps the Python and Rust artifacts aligned and makes the standalone server directly installable from crates.io.

## How

- Validate that the tag, Python package version, and Rust workspace version match.
- Wait for the complete Python/Rust release checks and distribution builds before uploading anything.
- Publish crates in dependency order, waiting for each registry dependency to become visible before continuing.
- Gate PyPI publication and GitHub Release creation on successful publication of `switchyard-server`.
- Mark the new LLM client and server packages as crates.io publications and add the missing registry version to the server's libsy path dependency.

## How tested

- [x] Parsed `.github/workflows/publish.yml` as YAML.
- [x] `cargo metadata --locked --no-deps --format-version 1`
- [x] `cargo publish --dry-run --locked --package switchyard-protocol`
- [x] `uv run pytest tests/readme/test_readme.py tests/getting_started/test_getting_started.py -v`
- [x] `make publish` from `docs/` (strict MkDocs build).
- [x] [Artifact-only release matrix](https://github.com/NVIDIA-NeMo/Switchyard/actions/runs/31202767992): release checks, source distribution, and all six wheel targets passed. Publishing jobs remained disabled for the manual run.
- [x] `git diff --check`
- [ ] Full publication from a stable release tag.

No crates or Python distributions were uploaded during validation.

## What to review

- Crate dependency ordering and crates.io index waits.
- The shared version/tag gate.
- The `CARGO_REGISTRY_TOKEN` boundary: it is exposed only to `cargo publish` steps.

## Release setup

The repository already has a `CARGO_REGISTRY_TOKEN` Actions secret. Its crates.io token must be authorized to update `switchyard-protocol` and `switchyard-translation` and to create the three new crate names.

A release tag must point to a commit containing this workflow; tagging an older commit will execute the older workflow and will not publish these crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added published Rust packages for the protocol, foundation libraries, LLM client, and server.
  * The server can now be installed and run directly with Cargo.

* **Documentation**
  * Updated setup, CLI, and routing guides to use the installed `switchyard-server` command.
  * Documented Rust package release validation, publishing order, and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
