### PR TITLE
fix(release): make package publishing resumable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -461,6 +461,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -468,6 +470,21 @@ jobs:
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
+          metadata="$(cargo metadata --locked --no-deps --format-version 1)"
+
+          for crate in \
+            switchyard-protocol \
+            switchyard-translation \
+            switchyard-libsy \
+            switchyard-llm-client \
+            switchyard-server; do
+            crate_version="$(jq -r --arg crate "${crate}" \
+              '.packages[] | select(.name == $crate) | .version' <<<"${metadata}")"
+            if [[ "${crate_version}" != "${version}" ]]; then
+              echo "Release tag ${version} does not match ${crate} ${crate_version}" >&2
+              exit 1
+            fi
+          done
 
           wait_for_crate() {
             local crate="$1"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -428,7 +428,7 @@ jobs:
   publish:
     name: Publish distributions
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [source-dist, wheels, publish-rust-server]
+    needs: [source-dist, wheels, publish-rust-crates]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -445,104 +445,55 @@ jobs:
         run: ls -l dist
 
       - name: Publish to PyPI
-        run: uv publish --trusted-publishing always dist/*
+        run: |
+          uv publish \
+            --trusted-publishing always \
+            --check-url https://pypi.org/simple/ \
+            dist/*
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
 
-  publish-rust-protocol:
-    name: Publish switchyard-protocol
+  publish-rust-crates:
+    name: Publish Rust crates
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [source-dist, wheels]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Publish crate
+      - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --package switchyard-protocol
-
-  publish-rust-foundations:
-    name: Publish ${{ matrix.crate }}
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [publish-rust-protocol]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        crate: [switchyard-libsy, switchyard-translation]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Wait for registry dependencies
         shell: bash
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
-          for attempt in {1..30}; do
-            cargo info --registry crates-io "switchyard-protocol@${version}" >/dev/null 2>&1 \
-              && exit 0
-            echo "Waiting for switchyard-protocol ${version} (${attempt}/30)"
-            sleep 10
-          done
-          echo "switchyard-protocol ${version} did not reach the crates.io index" >&2
-          exit 1
-      - name: Publish crate
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --package "${{ matrix.crate }}"
 
-  publish-rust-client:
-    name: Publish switchyard-llm-client
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [publish-rust-foundations]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Wait for registry dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          for attempt in {1..30}; do
-            ready=true
-            for crate in switchyard-libsy switchyard-translation; do
-              cargo info --registry crates-io "${crate}@${version}" >/dev/null 2>&1 \
-                || ready=false
+          wait_for_crate() {
+            local crate="$1"
+            for attempt in {1..30}; do
+              if cargo info --registry crates-io "${crate}@${version}" >/dev/null 2>&1; then
+                return 0
+              fi
+              echo "Waiting for ${crate} ${version} (${attempt}/30)"
+              sleep 10
             done
-            if [[ "${ready}" == true ]]; then
-              exit 0
-            fi
-            echo "Waiting for Rust foundation crates ${version} (${attempt}/30)"
-            sleep 10
-          done
-          echo "Rust foundation crates ${version} did not reach the crates.io index" >&2
-          exit 1
-      - name: Publish crate
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --package switchyard-llm-client
+            echo "${crate} ${version} did not reach the crates.io index" >&2
+            return 1
+          }
 
-  publish-rust-server:
-    name: Publish switchyard-server
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [publish-rust-client]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Wait for registry dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          for attempt in {1..30}; do
-            cargo info --registry crates-io "switchyard-llm-client@${version}" >/dev/null 2>&1 \
-              && exit 0
-            echo "Waiting for switchyard-llm-client ${version} (${attempt}/30)"
-            sleep 10
-          done
-          echo "switchyard-llm-client ${version} did not reach the crates.io index" >&2
-          exit 1
-      - name: Publish crate
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked --package switchyard-server
+          publish_crate() {
+            local crate="$1"
+            if cargo info --registry crates-io "${crate}@${version}" >/dev/null 2>&1; then
+              echo "${crate} ${version} already exists; skipping"
+              return 0
+            fi
+            cargo publish --locked --package "${crate}"
+            wait_for_crate "${crate}"
+          }
+
+          publish_crate switchyard-protocol
+          publish_crate switchyard-translation
+          publish_crate switchyard-libsy
+          publish_crate switchyard-llm-client
+          publish_crate switchyard-server


### PR DESCRIPTION
## What

- publish Rust crates sequentially in dependency order: protocol, translation, libsy, LLM client, then server
- skip an exact Rust crate version when it already exists on crates.io
- wait for each new crate to reach the registry before publishing its dependents
- use `uv publish --check-url` so existing PyPI distributions are skipped on retries

## Why

The `v0.2.0` release run published protocol and translation, then failed while packaging libsy because its registry dependency was not available. The split job graph also made the partial release difficult to resume safely.

Failed run: https://github.com/NVIDIA-NeMo/Switchyard/actions/runs/31226077491/job/93490742992

## How

A single Rust publication job owns the dependency order and checks crates.io before every publish. Re-running a partial release therefore resumes at the first missing crate instead of failing on immutable versions already uploaded.

## What to review

- crate publication order matches the current manifests
- exact-version checks correctly skip completed crate uploads
- `--check-url https://pypi.org/simple/` makes Python uploads resumable

## Validation

- workflow YAML parses
- embedded Bash passes `bash -n`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rust crate releases are now published in dependency order.
  * Releases automatically skip crates already available at the target version.
  * Publishing waits for each crate to appear in the public registry before continuing.
  * Python package publishing now verifies the trusted-publishing URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->