### PR TITLE
fix(libsy): harden the classifier judge path

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -33,6 +33,17 @@ const SCHEMA_TEMPLATE: &str = include_str!("../prompts/capability-classifier/sch
 /// Telemetry label for this algorithm's spans, metrics, and logs.
 const ALGORITHM_NAME: &str = "llm_task_classifier";
 
+/// Restates the task after the conversation the judge is asked to route.
+///
+/// The rubric leads the request, which works while the payload is a single short
+/// message. Once `recent_turn_window` includes real conversation, those instructions
+/// sit far from the generation point and the judge sometimes *answers* the
+/// conversation instead of classifying it — the reply then fails to parse, the
+/// verdict is unavailable, and the turn silently falls back. Repeating the task at
+/// the end is what reliably prevents that.
+const END_POSITION_REINFORCEMENT: &str =
+    "Route the conversation above. Output ONLY the routing JSON object, nothing else.";
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct TaskClassifierVerdict {
@@ -156,10 +167,20 @@ impl ClassifierInput for TaskInput {
     fn build_messages(&self, _state: &State, request: &Request) -> Vec<Message> {
         // The default preserves the whole-task anchor and latest user update. A
         // configured window widens that to the surrounding conversation.
-        match self.recent_turn_window {
+        let mut messages = match self.recent_turn_window {
             Some(window) => trim_messages(&request.llm_request.messages, window),
             None => task_messages(&request.llm_request.messages),
+        };
+        // Only the windowed path carries assistant turns and tool traffic for the judge
+        // to be distracted by. The default path is user task messages only — the anchor
+        // and the latest follow-up — so there is nothing there to outrank.
+        if self.recent_turn_window.is_some() {
+            messages.push(Message::text(
+                Role::User,
+                END_POSITION_REINFORCEMENT.to_string(),
+            ));
         }
+        messages
     }
 }
 
@@ -1613,6 +1634,50 @@ mod tests {
                 Message::text(Role::User, "recent 2"),
             ]
         );
+    }
+
+    #[test]
+    fn a_window_reinforces_the_task_after_the_conversation() -> Result<()> {
+        let contents = judged_contents(2)?;
+
+        // Last, not merely present: the reinforcement only works end-positioned,
+        // after the conversation content it is meant to outrank.
+        assert_eq!(
+            contents.last().map(String::as_str),
+            Some(END_POSITION_REINFORCEMENT)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn the_single_message_path_is_left_unreinforced() -> Result<()> {
+        // No window means no conversation to be distracted by, so the default
+        // request shape stays exactly as it was.
+        let judge = capability_judge(None)?;
+        let request = Request {
+            llm_request: LlmRequest {
+                messages: vec![Message::text(Role::User, "the task")],
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        };
+
+        let built = judge.build_request(&State::default(), &request);
+
+        // The task message alone; the rubric reaches the judge as an instruction block
+        // rather than a message, so nothing was dropped by it not being counted here.
+        assert_eq!(built.llm_request.messages.len(), 1);
+        assert!(!built.llm_request.instructions.is_empty());
+        assert!(
+            !built
+                .llm_request
+                .messages
+                .iter()
+                .filter_map(|message| message.text_content("\n"))
+                .any(|text| text.contains(END_POSITION_REINFORCEMENT))
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Deserializer};
@@ -244,6 +245,13 @@ pub struct TaskClassifierConfig {
     pub contract: ClassifierContractConfig,
     /// Maximum completion tokens available to the classifier verdict.
     pub max_output_tokens: u64,
+    /// Bounds one judge consultation, in milliseconds.
+    ///
+    /// The judge call sits in front of the routed call, so a stalled judge stalls the
+    /// turn. On expiry the judge counts as unavailable and routing falls back exactly
+    /// as it does for any other judge failure. `None` (the default) leaves it
+    /// unbounded, preserving existing behaviour.
+    pub judge_deadline_ms: Option<u64>,
 }
 
 /// Flat serialized shape that maps prompt settings into the runtime contract.
@@ -263,6 +271,8 @@ struct TaskClassifierConfigWire {
     prompt: Option<String>,
     #[serde(default = "default_judge_max_output_tokens")]
     max_output_tokens: u64,
+    #[serde(default)]
+    judge_deadline_ms: Option<u64>,
 }
 
 impl<'de> Deserialize<'de> for TaskClassifierConfig {
@@ -283,6 +293,7 @@ impl<'de> Deserialize<'de> for TaskClassifierConfig {
             recent_turn_window: wire.recent_turn_window,
             contract,
             max_output_tokens: wire.max_output_tokens,
+            judge_deadline_ms: wire.judge_deadline_ms,
         })
     }
 }
@@ -301,6 +312,7 @@ impl Default for TaskClassifierConfig {
             recent_turn_window: None,
             contract: ClassifierContractConfig::default(),
             max_output_tokens: DEFAULT_JUDGE_MAX_OUTPUT_TOKENS,
+            judge_deadline_ms: None,
         }
     }
 }
@@ -694,7 +706,8 @@ impl LlmTaskClassifier {
                     },
                     contract,
                     SerdeDecoder::new(),
-                    JudgeRuntimeConfig::new(config.max_output_tokens)?,
+                    JudgeRuntimeConfig::new(config.max_output_tokens)?
+                        .with_deadline(config.judge_deadline_ms.map(Duration::from_millis))?,
                 ),
                 judge_target.clone(),
                 TaskClassifierPolicy::new(

--- a/crates/libsy/src/algorithms/util.rs
+++ b/crates/libsy/src/algorithms/util.rs
@@ -6,6 +6,7 @@ pub(crate) mod classifier_contract;
 pub mod escalation;
 pub(crate) mod llm_judge;
 pub(crate) mod prompts;
+pub(crate) mod robustness;
 pub(crate) mod stage;
 pub mod subagent;
 pub(crate) mod target_selector;

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -16,6 +16,8 @@ use switchyard_protocol::{
     AggLlmResponse, InstructionBlock, LlmRequest, Message, OutputParams, Role, completion_text,
 };
 
+use super::robustness::{safe_client_error, safe_error_summary};
+
 use super::classifier_contract::ClassifierContract;
 use crate::core::algorithm::{Driver, LlmTarget};
 use crate::core::classifier::{Classification, Classifier};
@@ -235,23 +237,40 @@ where
                 ),
             )
             .await
-            .inspect_err(|error| report_fail_open(judge_model, error, libsy_error_reason(error)))
+            .inspect_err(|error| {
+                report_fail_open(
+                    judge_model,
+                    safe_error_summary(error),
+                    libsy_error_reason(error),
+                )
+            })
             .ok()?;
         let aggregate = response
             .llm_response
             .into_agg()
             .await
-            .inspect_err(|error| report_fail_open(judge_model, error, client_error_reason(error)))
+            .inspect_err(|error| {
+                report_fail_open(
+                    judge_model,
+                    safe_client_error(error),
+                    client_error_reason(error),
+                )
+            })
             .ok()?;
         self.judge
             .parse(&aggregate)
-            .inspect_err(|error| report_fail_open(judge_model, error, "parse_error"))
+            .inspect_err(|error| {
+                report_fail_open(judge_model, safe_error_summary(error), "parse_error")
+            })
             .ok()
     }
 }
 
 /// Logs and counts a judge failure with a bounded label that excludes message content.
-fn report_fail_open(judge_model: &str, error: &dyn std::fmt::Display, reason: &'static str) {
+/// `error` must already be redacted: `LlmClientError::UpstreamHttp`'s `Display` interpolates the
+/// raw upstream body, which can quote the conversation back. Callers pass a
+/// `robustness::safe_*` summary rather than the error itself.
+fn report_fail_open(judge_model: &str, error: String, reason: &'static str) {
     tracing::warn!(
         target: "libsy",
         judge_model,

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -8,6 +8,7 @@
 //! the route.
 
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -95,6 +96,8 @@ impl VerdictDecoder for JsonSchemaDecoder {
 /// Runtime limits shared by structured classifier judges.
 pub(crate) struct JudgeRuntimeConfig {
     max_output_tokens: u64,
+    /// Bounds one consultation. `None` leaves it unbounded.
+    deadline: Option<Duration>,
 }
 
 impl JudgeRuntimeConfig {
@@ -104,7 +107,26 @@ impl JudgeRuntimeConfig {
                 message: "max_output_tokens must be at least 1".to_string(),
             });
         }
-        Ok(Self { max_output_tokens })
+        Ok(Self {
+            max_output_tokens,
+            deadline: None,
+        })
+    }
+
+    /// Bounds how long one consultation may take before the judge counts as
+    /// unavailable.
+    ///
+    /// The judge call sits in front of the routed call, so a stalled judge stalls the
+    /// turn behind it with no bound of its own. Expiry folds into the same fail-open
+    /// path as any other judge failure, so the turn is still served.
+    pub(crate) fn with_deadline(mut self, deadline: Option<Duration>) -> Result<Self> {
+        if deadline.is_some_and(|d| d.is_zero()) {
+            return Err(LibsyError::AlgorithmError {
+                message: "judge_deadline_ms must be greater than 0".to_string(),
+            });
+        }
+        self.deadline = deadline;
+        Ok(self)
     }
 }
 
@@ -142,6 +164,10 @@ where
     I: ClassifierInput,
     D: VerdictDecoder,
 {
+    fn deadline(&self) -> Option<Duration> {
+        self.runtime.deadline
+    }
+
     type Verdict = D::Verdict;
 
     fn build_request(&self, state: &State, request: &Request) -> Request {
@@ -179,6 +205,13 @@ pub trait Judge: Send + Sync {
 
     fn parse(&self, response: &AggLlmResponse) -> Result<Self::Verdict> {
         parse_json_verdict(response)
+    }
+
+    /// Bounds one consultation, when the judge is configured with a deadline.
+    ///
+    /// Defaulted so a judge that does not care about liveness need not implement it.
+    fn deadline(&self) -> Option<Duration> {
+        None
     }
 }
 
@@ -227,36 +260,57 @@ where
     ) -> Option<J::Verdict> {
         let judge_model = self.target.semantic_name.as_str();
 
-        let response = driver
-            .call_model(
-                self.judge.build_request(state, request),
-                Decision::new(
-                    self.target.semantic_name.to_string(),
-                    Some("llm judge consultation".to_string()),
-                    false,
-                ),
-            )
-            .await
-            .inspect_err(|error| {
-                report_fail_open(
-                    judge_model,
-                    safe_error_summary(error),
-                    libsy_error_reason(error),
+        // The whole consultation is bounded, not just the HTTP call: a judge that
+        // returns its headers promptly and then stalls mid-stream would otherwise hold
+        // the turn open just as long.
+        let consult = async {
+            let response = driver
+                .call_model(
+                    self.judge.build_request(state, request),
+                    Decision::new(
+                        self.target.semantic_name.to_string(),
+                        Some("llm judge consultation".to_string()),
+                        false,
+                    ),
                 )
-            })
-            .ok()?;
-        let aggregate = response
-            .llm_response
-            .into_agg()
-            .await
-            .inspect_err(|error| {
-                report_fail_open(
-                    judge_model,
-                    safe_client_error(error),
-                    client_error_reason(error),
-                )
-            })
-            .ok()?;
+                .await
+                .inspect_err(|error| {
+                    report_fail_open(
+                        judge_model,
+                        safe_error_summary(error),
+                        libsy_error_reason(error),
+                    )
+                })
+                .ok()?;
+            response
+                .llm_response
+                .into_agg()
+                .await
+                .inspect_err(|error| {
+                    report_fail_open(
+                        judge_model,
+                        safe_client_error(error),
+                        client_error_reason(error),
+                    )
+                })
+                .ok()
+        };
+
+        let aggregate = match self.judge.deadline() {
+            Some(deadline) => match tokio::time::timeout(deadline, consult).await {
+                Ok(aggregate) => aggregate,
+                Err(_) => {
+                    // Libsy-authored text with a configured duration: no upstream content.
+                    report_fail_open(
+                        judge_model,
+                        format!("judge deadline of {} ms exceeded", deadline.as_millis()),
+                        "deadline_exceeded",
+                    );
+                    None
+                }
+            },
+            None => consult.await,
+        }?;
         self.judge
             .parse(&aggregate)
             .inspect_err(|error| {
@@ -354,6 +408,24 @@ fn strip_json_fence(text: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    #[test]
+    fn a_zero_judge_deadline_is_rejected() {
+        let runtime = JudgeRuntimeConfig::new(4096).expect("valid token budget");
+        assert!(runtime.with_deadline(Some(Duration::ZERO)).is_err());
+
+        // A positive deadline, and no deadline at all, both configure cleanly.
+        let runtime = JudgeRuntimeConfig::new(4096).expect("valid token budget");
+        assert!(
+            runtime
+                .with_deadline(Some(Duration::from_millis(50)))
+                .is_ok()
+        );
+        let runtime = JudgeRuntimeConfig::new(4096).expect("valid token budget");
+        assert!(runtime.with_deadline(None).is_ok());
+    }
+
     use super::*;
 
     use futures::StreamExt;

--- a/crates/libsy/src/algorithms/util/robustness.rs
+++ b/crates/libsy/src/algorithms/util/robustness.rs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hardening helpers shared by classifier-style inner-LLM callers.
+//!
+//! Consulting a model to make a routing decision fails in ways the routed call does
+//! not, and those failures are logged on a path that runs for every turn. The
+//! natural `Display` of an error is not safe there: an upstream error body is echoed
+//! verbatim, and both bodies and decode failures can embed the conversation or the
+//! model's reply. [`safe_error_summary`] is the redaction those log sites use.
+
+use switchyard_protocol::LlmClientError;
+
+use crate::LibsyError;
+
+/// A loggable description of `error` that carries no conversation or response content.
+///
+/// Each case contributes only vetted operational detail — the failure's class, the
+/// target or model it concerns, and a status code where one exists. Messages libsy
+/// builds itself from static strings are reported in full; anything sourced from
+/// outside the process is reduced to its class.
+///
+/// The match is deliberately exhaustive rather than defaulting to `to_string()`, so a
+/// new [`LibsyError`] variant cannot start leaking content by omission.
+pub(crate) fn safe_error_summary(error: &LibsyError) -> String {
+    match error {
+        LibsyError::ClientCall { target, source } => {
+            format!(
+                "client call to target {target:?} failed: {}",
+                safe_client_error(source)
+            )
+        }
+        // Built by libsy from static text plus a serde position, so safe verbatim.
+        LibsyError::AlgorithmError { message } => message.clone(),
+        // A task panic message is arbitrary text from wherever the panic was raised,
+        // so only the fact of the failure is reported.
+        LibsyError::AlgorithmTask { .. } => "algorithm task failed".to_string(),
+        LibsyError::Driver(_) => "algorithm driver failed".to_string(),
+        // The operation is a static label, but the boxed source comes from a user
+        // extension and is unvetted.
+        LibsyError::External { operation, .. } => format!("{operation} failed"),
+        // The remaining variants render only structural detail — configured target
+        // names and fixed strings — and carry nothing request-derived.
+        LibsyError::TargetNotFound { .. }
+        | LibsyError::NoTargets
+        | LibsyError::MissingFinalResponse
+        | LibsyError::AllTargetsExcluded => error.to_string(),
+    }
+}
+
+/// The client half of [`safe_error_summary`].
+///
+/// `UpstreamHttp` is the sharp edge: its `Display` interpolates the raw upstream
+/// body, which routinely quotes the request back. Boxed transport, decode, and FFI
+/// sources are reduced for the same reason.
+pub(crate) fn safe_client_error(error: &LlmClientError) -> String {
+    match error {
+        LlmClientError::UpstreamHttp { status, .. } => format!("upstream HTTP {status}"),
+        LlmClientError::ContextWindowExceeded { model, .. } => {
+            format!("context window exceeded for model {model}")
+        }
+        LlmClientError::Timeout { .. } => "upstream request timed out".to_string(),
+        LlmClientError::Transport { .. } => "upstream transport error".to_string(),
+        LlmClientError::InvalidResponse { .. } => "invalid upstream response".to_string(),
+        LlmClientError::Ffi { .. } => "foreign function interface error".to_string(),
+        LlmClientError::InvalidRequest { .. } => "invalid request".to_string(),
+        LlmClientError::RequestTranslation(_) => "request translation failed".to_string(),
+        LlmClientError::RequestEncoding(_) => "outbound request encoding failed".to_string(),
+        LlmClientError::ResponseTranslation(_) => "response translation failed".to_string(),
+        // Raised by the client from its own configuration, not from a request.
+        LlmClientError::Configuration { message } => {
+            format!("client configuration error: {message}")
+        }
+        // `General` and any future variant are unvetted by construction.
+        _ => "client call failed".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The conversation text a leaking log line would expose.
+    const SECRET: &str = "patient name is Jane Doe";
+
+    #[test]
+    fn an_upstream_body_never_reaches_the_summary() {
+        let error = LibsyError::ClientCall {
+            target: "weak".to_string(),
+            source: LlmClientError::UpstreamHttp {
+                status: 400,
+                body: format!(r#"{{"error":{{"message":"bad request: {SECRET}"}}}}"#),
+            },
+        };
+
+        let summary = safe_error_summary(&error);
+
+        // The status and target survive; the body does not.
+        assert!(summary.contains("upstream HTTP 400"), "{summary}");
+        assert!(summary.contains("weak"), "{summary}");
+        assert!(!summary.contains(SECRET), "{summary}");
+        // Guard against the redaction silently regressing to `Display`.
+        assert!(error.to_string().contains(SECRET));
+    }
+
+    #[test]
+    fn boxed_sources_are_reduced_to_their_class() {
+        for source in [
+            LlmClientError::Transport {
+                source: std::io::Error::other(SECRET).into(),
+            },
+            LlmClientError::InvalidResponse {
+                source: std::io::Error::other(SECRET).into(),
+            },
+            LlmClientError::Timeout {
+                source: std::io::Error::other(SECRET).into(),
+            },
+        ] {
+            let summary = safe_client_error(&source);
+            assert!(!summary.contains(SECRET), "{summary}");
+            assert!(!summary.is_empty());
+        }
+    }
+
+    #[test]
+    fn context_overflow_keeps_the_model_but_not_the_message() {
+        let summary = safe_client_error(&LlmClientError::ContextWindowExceeded {
+            model: "weak".to_string(),
+            message: SECRET.to_string(),
+        });
+        assert!(summary.contains("weak"), "{summary}");
+        assert!(!summary.contains(SECRET), "{summary}");
+    }
+
+    #[test]
+    fn libsy_authored_messages_are_reported_in_full() {
+        // The parse path builds this from static text plus a serde position; it is
+        // the one message operators need verbatim to diagnose a bad judge reply.
+        let message = "judge reply did not parse as Verdict: expected value at line 1 column 1";
+        let summary = safe_error_summary(&LibsyError::AlgorithmError {
+            message: message.to_string(),
+        });
+        assert_eq!(summary, message);
+    }
+
+    #[test]
+    fn an_extension_failure_keeps_its_label_but_not_its_source() {
+        let error = LibsyError::external("loading extension", std::io::Error::other(SECRET));
+
+        let summary = safe_error_summary(&error);
+
+        assert_eq!(summary, "loading extension failed");
+        assert!(error.to_string().contains(SECRET));
+    }
+
+    #[test]
+    fn structural_variants_keep_their_detail() {
+        let summary = safe_error_summary(&LibsyError::TargetNotFound {
+            target: "strong".to_string(),
+        });
+        assert!(summary.contains("strong"), "{summary}");
+    }
+}

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -136,7 +136,8 @@ impl PyTaskClassifierConfig {
         message_hash_fallback=false,
         recent_turn_window=None,
         max_output_tokens=4096,
-        prompt=None
+        prompt=None,
+        judge_deadline_ms=None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -147,6 +148,7 @@ impl PyTaskClassifierConfig {
         recent_turn_window: Option<usize>,
         max_output_tokens: u64,
         prompt: Option<String>,
+        judge_deadline_ms: Option<u64>,
     ) -> Self {
         let mut contract = ClassifierContractConfig::default();
         if let Some(prompt) = prompt {
@@ -161,6 +163,7 @@ impl PyTaskClassifierConfig {
                 recent_turn_window,
                 contract,
                 max_output_tokens,
+                judge_deadline_ms,
             },
         }
     }

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -305,6 +305,8 @@ struct CapabilityClassifierRouteConfig {
     recent_turn_window: Option<usize>,
     prompt: Option<String>,
     max_output_tokens: u64,
+    /// Bounds one judge consultation, in milliseconds. Omit to leave it unbounded.
+    judge_deadline_ms: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -392,6 +394,13 @@ enum RouteConfig {
         prompt: Option<String>,
         #[serde(default = "default_classifier_max_output_tokens")]
         max_output_tokens: u64,
+        /// Bounds one judge consultation, in milliseconds.
+        ///
+        /// The judge call sits in front of the routed call, so a stalled judge stalls
+        /// the turn. On expiry the judge counts as unavailable and the route falls back
+        /// as it does for any other judge failure. Omit to leave it unbounded.
+        #[serde(default)]
+        judge_deadline_ms: Option<u64>,
         #[serde(default)]
         escalation: Option<EscalationJudgeConfig>,
         #[serde(default)]
@@ -452,6 +461,9 @@ struct StageClassifierConfig {
     prompt: Option<String>,
     #[serde(default = "default_classifier_max_output_tokens")]
     max_output_tokens: u64,
+    /// Bounds one judge consultation, in milliseconds. Omit to leave it unbounded.
+    #[serde(default)]
+    judge_deadline_ms: Option<u64>,
 }
 
 impl StageClassifierConfig {
@@ -464,6 +476,7 @@ impl StageClassifierConfig {
             recent_turn_window: self.recent_turn_window,
             contract: classifier_contract(self.prompt.as_deref()),
             max_output_tokens: self.max_output_tokens,
+            judge_deadline_ms: self.judge_deadline_ms,
         }
     }
 }
@@ -589,6 +602,7 @@ impl RouteConfig {
             recent_turn_window,
             prompt,
             max_output_tokens,
+            judge_deadline_ms,
             escalation,
             targets,
             default_target,
@@ -646,6 +660,7 @@ impl RouteConfig {
                         recent_turn_window: *recent_turn_window,
                         prompt: prompt.clone(),
                         max_output_tokens: *max_output_tokens,
+                        judge_deadline_ms: *judge_deadline_ms,
                     },
                 ))
             }
@@ -858,6 +873,7 @@ fn build_algorithm(
                         recent_turn_window: config.recent_turn_window,
                         contract: classifier_contract(config.prompt.as_deref()),
                         max_output_tokens: config.max_output_tokens,
+                        judge_deadline_ms: config.judge_deadline_ms,
                     };
                     LlmTaskClassifier::new(LlmClassifierConfig::Capability {
                         judge_target: classifier,

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -118,6 +118,7 @@ Runs one of three judge-backed modes: `capability`, `escalation`, or `custom`.
 | `mode` | No | `capability` | Classifier behavior. Set it explicitly for new configurations. |
 | `classifier_target` | Yes | — | Target the judge is called through. Not a routing destination. |
 | `max_output_tokens` | No | `4096` | Maximum completion tokens for the judge verdict. Must be at least `1`. |
+| `judge_deadline_ms` | No | unset | Bounds one judge consultation, in milliseconds. On expiry the judge counts as unavailable and the route falls back as it does for any other judge failure. |
 
 Capability mode classifies before serving. See
 [LLM Classifier Routing](../routing_algorithms/llm_classifier_routing.md).


### PR DESCRIPTION
Closes #278, closes #346, closes #279.

Three related fixes to the `llm_classifier` judge path, kept in one PR because they touch the same two functions and would conflict as separate branches. Each is one reviewable commit.

## 1. Redact upstream error content from judge warning logs (#278)

`report_fail_open` logs `error = %error`, and `LlmClientError::UpstreamHttp`'s `Display` interpolates the raw upstream body — on a warning that fires on **every** turn whose judge is unavailable. Providers routinely echo the offending request back in a 400, and the judge's request is a condensed view of the user's conversation.

This keeps everything #205 built — `report_fail_open`, the bounded `reason` taxonomy, `record_classifier_fail_open` — and changes one parameter: it now takes an already-redacted summary produced by an exhaustive match over `LibsyError`/`LlmClientError`.

Two properties worth preserving in review:

- the match is **deliberately exhaustive** rather than defaulting to `to_string()`, so a new error variant cannot start leaking by omission. Resolving a future compile error there with a `_ =>` arm would discard the whole guarantee.
- the test asserts both that the summary omits the secret **and** that `error.to_string()` still contains it. The second assertion documents that the hazard is still live in `Display`.

Not covered by #271, which redacts `Debug` and caps body size; the `Display` path is untouched by it.

## 2. Bound judge consultations with a configurable deadline (#346)

`judge_deadline_ms` on the route. The judge call sits in front of the routed call, so a stalled judge stalls the turn with no bound of its own.

The **whole consultation** is bounded, not just the HTTP call — a judge that returns headers promptly then stalls mid-stream would otherwise hold the turn just as long. Expiry folds into the existing fail-open path with `reason = "deadline_exceeded"`, so it appears on `/metrics` alongside the other reasons rather than as an untracked silent path. Default `None` preserves current behaviour exactly.

## 3. Reinforce the routing task after windowed conversation content (#279)

With `recent_turn_window` set, the judge sees conversation content after the task, and tends to assess the content rather than the request. This appends a short reinforcement line **end-positioned**, which is the only position where it works — the test asserts `contents.last()`, not merely presence.

Only the windowed path is affected. The default path carries user task messages only (the anchor and latest follow-up, per #309), so there is nothing there to outrank.

## How tested

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`, and again with `--test-threads=1` (this path registers process-global OTel instruments)
- [x] `uv run pytest tests/ -m "not integration"` — 871 passed, 9 skipped
- [x] `uv run ruff check .`
- [x] `uv run --only-group docs mkdocs build --strict`
- [x] Commits signed off per the DCO

Rebased onto current `main`, which required re-siting all three against #309 (`build_messages` rewritten), #312 (judge system prompt moved to `instructions`), #332/#338/#340 (`verdict()` rewritten) and #337 (`LibsyError::MissingClient` removed).

One rebase detail worth flagging, since it is the kind of thing that passes review while being wrong: a test here asserted `messages.len() == 2`, which held only while the judge system prompt lived in `messages[0]`. After #312 it lives in `instructions`. The assertion is now `== 1` **plus** an assertion that `instructions` is non-empty — decrementing the number alone would have silently stopped checking that the rubric reaches the model at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional time limits for LLM judge consultations, with automatic fallback when a judge times out.
  * Added end-position reinforcement for windowed classifier prompts.
  * Exposed `judge_deadline_ms` configuration through Python and server configuration.

* **Bug Fixes**
  * Improved error handling with sanitized diagnostic summaries that omit sensitive response content.

* **Documentation**
  * Documented judge timeout configuration and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->