### PR TITLE
fix: simplify identical source/target loop in payload builder

### DIFF
--- a/examples/experimental/litellm/src/switchyard_litellm/client.py
+++ b/examples/experimental/litellm/src/switchyard_litellm/client.py
@@ -236,10 +236,10 @@ def _payload(request: Mapping[str, object], model: str) -> dict[str, Any]:
     tool_choice = _tool_choice(request)
     if tool_choice is not None:
         payload["tool_choice"] = tool_choice
-    for source, target in (("temperature", "temperature"), ("top_p", "top_p")):
-        value = sampling.get(source)
+    for key in ("temperature", "top_p"):
+        value = sampling.get(key)
         if value is not None:
-            payload[target] = value
+            payload[key] = value
     max_tokens = output.get("max_output_tokens")
     if max_tokens is not None:
         payload["max_completion_tokens"] = max_tokens

--- a/examples/experimental/litellm/tests/test_payload_sampling.py
+++ b/examples/experimental/litellm/tests/test_payload_sampling.py
@@ -1,0 +1,11 @@
+from switchyard_litellm.client import _payload
+
+
+def test_sampling_temperature_and_top_p_forwarded() -> None:
+    request = {
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "sampling": {"temperature": 0.5, "top_p": 0.9},
+    }
+    payload = _payload(request, "strong")
+    assert payload["temperature"] == 0.5
+    assert payload["top_p"] == 0.9


### PR DESCRIPTION
fix: simplify identical source/target loop in payload builder

### Root cause
The loop copied sampling values with a source-to-target mapping, but the keys (`temperature`, `top_p`) were identical on both sides, so the mapping added noise without adding flexibility.

### Fix
Iterate over the keys directly. Behavior is preserved: values are still copied only when present.

```diff
-    for source, target in (("temperature", "temperature"), ("top_p", "top_p")):
-        value = sampling.get(source)
-        if value is not None:
-            payload[target] = value
+    for key in ("temperature", "top_p"):
+        value = sampling.get(key)
+        if value is not None:
+            payload[key] = value
```

### Testing
- `pytest tests/test_client.py tests/test_payload_sampling.py -v`: 34 passed
- Full `pytest` has one pre-existing failure unrelated to this change: `test_stage_router_drives_both_litellm_targets`.
- `mypy` reports one pre-existing `no-redef` error on line 127 (also present on unmodified `main`).

### Why existing tests missed it
No functional change; the new regression test explicitly verifies `temperature`/`top_p` are forwarded through the payload builder.

### Contributor guidelines
- DCO sign-off: included.
- Squash: one commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured temperature and top-p sampling settings are correctly forwarded in generated requests.

* **Tests**
  * Added coverage verifying that both sampling values are preserved in request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->