### PR TITLE
fix: remove dead callable() check in parametrize test

### DIFF
--- a/examples/experimental/litellm/tests/test_client.py
+++ b/examples/experimental/litellm/tests/test_client.py
@@ -436,7 +436,6 @@ async def test_call_rejects_unsupported_normalized_fields(
     match: str,
 ) -> None:
     request = request_body()
-    assert callable(mutate)
     mutate(request)
     with respx.mock(assert_all_called=False) as router:
         router.post(f"{BASE_URL}/chat/completions").mock(


### PR DESCRIPTION
fix: remove dead callable() check in parametrize test

### Root cause
The test asserted `assert callable(mutate)` even though every parametrized case supplies a lambda. The assertion added no value and was flagged as dead code.

### Fix
Drop the assert and call `mutate(request)` directly. All 18 parametrized cases still pass.

```diff
-    assert callable(mutate)
     mutate(request)
```

### Testing
- `pytest tests/test_client.py::test_call_rejects_unsupported_normalized_fields -v`: 18 passed
- `ruff check .`: All checks passed

### Contributor guidelines
- DCO sign-off: included.
- Squash: one commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a redundant test assertion from the unsupported-fields test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->