### PR TITLE
fix: normalize empty content-filter responses instead of raising

### DIFF
--- a/examples/experimental/litellm/src/switchyard_litellm/client.py
+++ b/examples/experimental/litellm/src/switchyard_litellm/client.py
@@ -300,7 +300,7 @@ def _response(response: ModelResponse) -> dict[str, object]:
             "name": tool_call.function.name,
             "arguments": arguments,
         })
-    if not content:
+    if not content and choice.finish_reason != "content_filter":
         raise ValueError("LiteLLM returned no text content")
     return {
         "id": response.id,

--- a/examples/experimental/litellm/tests/test_client.py
+++ b/examples/experimental/litellm/tests/test_client.py
@@ -15,6 +15,7 @@ from litellm import (
 from litellm.exceptions import (
     ContextWindowExceededError as LiteLLMContextWindowExceededError,
 )
+from litellm.types.utils import Choices, Message, Usage
 from switchyard_litellm import LiteLLMSyClient
 
 from switchyard.libsy import ContextWindowExceededError
@@ -586,21 +587,42 @@ async def test_cached_token_count_preserves_explicit_zero() -> None:
 
 def test_response_content_filter_empty_content() -> None:
     """Empty content with a content_filter finish reason must be normalized."""
-    from types import SimpleNamespace
-
     from switchyard_litellm.client import _response
 
-    response = SimpleNamespace(
+    response = ModelResponse(
         id="chatcmpl-test",
         model="openai/strong",
         choices=[
-            SimpleNamespace(
-                message=SimpleNamespace(content=None, tool_calls=None),
+            Choices(
+                message=Message(content=None, tool_calls=None),
                 finish_reason="content_filter",
             )
         ],
-        usage=None,
+        usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
     )
     result = _response(response)
-    assert result["outputs"][0]["content"] == []
-    assert result["outputs"][0]["stop_reason"] == "content_filter"
+    outputs = result["outputs"]
+    assert isinstance(outputs, list)
+    output = outputs[0]
+    assert isinstance(output, dict)
+    assert output["content"] == []
+    assert output["stop_reason"] == "content_filter"
+
+
+def test_response_empty_content_without_content_filter_raises() -> None:
+    """Empty content with any other finish reason must still raise."""
+    from switchyard_litellm.client import _response
+
+    response = ModelResponse(
+        id="chatcmpl-test",
+        model="openai/strong",
+        choices=[
+            Choices(
+                message=Message(content=None, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+    with pytest.raises(ValueError, match="LiteLLM returned no text content"):
+        _response(response)

--- a/examples/experimental/litellm/tests/test_client.py
+++ b/examples/experimental/litellm/tests/test_client.py
@@ -582,3 +582,25 @@ async def test_cached_token_count_preserves_explicit_zero() -> None:
         await client.aclose()
 
     assert response["usage"]["cached_input_tokens"] == 0
+
+
+def test_response_content_filter_empty_content() -> None:
+    """Empty content with a content_filter finish reason must be normalized."""
+    from types import SimpleNamespace
+
+    from switchyard_litellm.client import _response
+
+    response = SimpleNamespace(
+        id="chatcmpl-test",
+        model="openai/strong",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=None),
+                finish_reason="content_filter",
+            )
+        ],
+        usage=None,
+    )
+    result = _response(response)
+    assert result["outputs"][0]["content"] == []
+    assert result["outputs"][0]["stop_reason"] == "content_filter"


### PR DESCRIPTION
fix: content-filter responses raise instead of normalizing

## Summary
`_response()` raised `ValueError("LiteLLM returned no text content")` for any
response with empty `content`, including content-filter responses where empty
output is expected. This caused legitimate content-filter results to fail
instead of being normalized.

## Root cause
The guard at the end of `_response()` did not distinguish between a truly
empty/invalid response and a `content_filter` finish reason, which by design
returns no content.

## Fix
Allow empty `content` when the finish reason is `content_filter`; keep the
existing raise for all other empty-content cases so unexpected responses still
fail fast.

```diff
-    if not content:
-        raise ValueError("LiteLLM returned no text content")
+    if not content and choice.finish_reason != "content_filter":
+        raise ValueError("LiteLLM returned no text content")
```

## Testing
Added `test_response_content_filter_empty_content` to
`examples/experimental/litellm/tests/test_client.py` and verified the full
non-e2e suite passes:

```
uv run --project examples/experimental/litellm --python 3.12 \
  pytest examples/experimental/litellm/tests/test_client.py -m "not e2e" -v
# 34 passed
```

## Contributor guidelines
- DCO sign-off included.
- One focused commit per PR.

Signed-off-by: andrewwhitecdw <andrewwhitecdw@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses blocked by content filtering are now handled correctly when they contain no text.
  * Other unexpected empty responses continue to be reported as errors.

* **Tests**
  * Added coverage to verify content-filtered responses preserve their stop reason and return an empty output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->