### PR TITLE
docs: add a self-hosted (local vLLM) deployment example

### DIFF
--- a/examples/local-vllm/README.md
+++ b/examples/local-vllm/README.md
@@ -1,0 +1,49 @@
+# Routing to a self-hosted model
+
+Every deployment example in this repository points at a hosted provider. This one
+puts the **weak tier on a local OpenAI-compatible server** — vLLM, NIM, Ollama or
+llama.cpp — and keeps a hosted model for the hard turns, so routine steps never
+leave the machine.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `routes.toml` | Hybrid deployment: local weak + local classifier, hosted strong. |
+
+## Run it
+
+Start the local server, giving it a stable name to route to:
+
+```bash
+vllm serve <checkpoint> --served-model-name my-local-model --port 8000
+```
+
+Point the deployment at it and check the wiring without sending traffic:
+
+```bash
+export OPENROUTER_API_KEY=...
+switchyard-server --config routes.toml --dry-run
+switchyard-server --config routes.toml --host 127.0.0.1 --port 4000
+```
+
+Then send the route id as the model name:
+
+```bash
+curl -s http://127.0.0.1:4000/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"local-first","messages":[{"role":"user","content":"hello"}]}'
+```
+
+## Notes
+
+- **`id` must match `/v1/models` on the local server**, not the checkpoint path.
+  With vLLM that is whatever `--served-model-name` was set to; unset, it defaults
+  to the full path you passed to `vllm serve`, which is rarely what you want in a
+  config file.
+- **`api_key_env` is omitted for the local client.** Omitting it sends no
+  authentication, which is what a server started without `--api-key` expects. Add
+  it back if yours requires a key — the value never belongs in the TOML.
+- **The classifier runs locally** so the per-turn routing decision costs nothing
+  on the metered path. Point `classifier_target` at the hosted client if you would
+  rather trade that cost for a stronger classifier.

--- a/examples/local-vllm/routes.toml
+++ b/examples/local-vllm/routes.toml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version = 1
+
+# A self-hosted OpenAI-compatible server. vLLM, NIM, Ollama and llama.cpp all
+# expose this shape, so only `base_url` changes between them. `api_key_env` is
+# omitted deliberately: with no key configured, no authentication is sent, which
+# is what a local server started without `--api-key` expects. Add it back if
+# yours requires one.
+[llm_clients.local]
+format = "openai_chat"
+base_url = "http://127.0.0.1:8000/v1"
+
+[llm_clients.openrouter]
+format = "openai_chat"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+
+# `id` must match what the local server reports at /v1/models. For vLLM that is
+# `--served-model-name`, which defaults to the checkpoint path when unset.
+[targets.weak]
+id = "my-local-model"
+llm_client = "local"
+
+# Classifying locally keeps the per-turn routing decision off the metered path.
+# Point this at the hosted client instead if you want a stronger classifier.
+[targets.classifier]
+id = "my-local-model"
+llm_client = "local"
+
+[targets.strong]
+id = "anthropic/claude-opus-4.7"
+llm_client = "openrouter"
+
+[routes.local_first]
+id = "local-first"
+type = "llm_classifier"
+classifier_target = "classifier"
+strong_target = "strong"
+weak_target = "weak"
+base_threshold = 0.5
+threshold_step = 0.0
+session_affinity = true
+message_hash_fallback = true


### PR DESCRIPTION
Every deployment example in the repo points at a hosted provider (`docs/reference/toml_schema.md`, `docs/getting_started.md`, `switchyard/cli/defaults/openrouter.toml` all use OpenRouter). There is no reference for pointing a client at a local OpenAI-compatible server, which is the case the local-model story depends on. `docs/vllm-serve-hidden-state.md` covers hidden-state extraction, not using vLLM as a routing backend.

This adds `examples/local-vllm/` with a hybrid deployment — local weak tier and local classifier, hosted strong tier — plus a short README.

Two things that cost me time and are now written down:

- **`id` must match `/v1/models` on the local server**, not the checkpoint path. With vLLM that is `--served-model-name`; unset, it defaults to the full path passed to `vllm serve`.
- **`api_key_env` is omitted for the local client.** Per `toml_schema.md` omitting it sends no authentication, which is what a server started without `--api-key` expects. Worth demonstrating, since every existing example sets a key.

Docs only, no code changes.

## Verification

- `switchyard-server` accepts the config; the launcher starts a proxy against it and an agent runs through it.
- Confirmed the env-var check fires as documented when `OPENROUTER_API_KEY` is unset:
  `invalid server config ...: llm client openrouter could not read api_key_env OPENROUTER_API_KEY: environment variable not found`

I did not run `pre-commit` (it needs the full dev env sync); happy to fix anything CI flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an example configuration for routing requests through a self-hosted, OpenAI-compatible model.
  - Supports local-first classification with hosted handling for more complex requests.
  - Includes session affinity, threshold-based routing, and message-hash fallback options.

- **Documentation**
  - Added setup and usage instructions for starting the local model, deploying routes, running dry runs, and testing requests.
  - Documented model IDs, authentication, and local-versus-hosted classification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->