### PR TITLE
fix(translation): report content filter stops as Anthropic refusal

### DIFF
--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -433,7 +433,7 @@ fn stop_reason_from_str(reason: Option<&str>) -> StopReason {
     match reason {
         Some("length" | "max_tokens") => StopReason::MaxTokens,
         Some("tool_calls" | "function_call" | "tool_use") => StopReason::ToolUse,
-        Some("content_filter" | "refusal") => StopReason::ContentFilter,
+        Some("content_filter") => StopReason::ContentFilter,
         Some("stop" | "end_turn" | "stop_sequence") | None => StopReason::EndTurn,
         Some(_) => StopReason::Unknown,
     }
@@ -488,15 +488,6 @@ mod tests {
                 text: "Hello".to_string()
             }]
         );
-    }
-
-    #[test]
-    fn folds_anthropic_refusal_as_content_filter() {
-        let agg = fold(vec![LlmResponseChunk::MessageStop {
-            reason: Some("refusal".to_string()),
-        }]);
-
-        assert_eq!(agg.outputs[0].stop_reason, Some(StopReason::ContentFilter));
     }
 
     #[test]

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -433,7 +433,7 @@ fn stop_reason_from_str(reason: Option<&str>) -> StopReason {
     match reason {
         Some("length" | "max_tokens") => StopReason::MaxTokens,
         Some("tool_calls" | "function_call" | "tool_use") => StopReason::ToolUse,
-        Some("content_filter") => StopReason::ContentFilter,
+        Some("content_filter" | "refusal") => StopReason::ContentFilter,
         Some("stop" | "end_turn" | "stop_sequence") | None => StopReason::EndTurn,
         Some(_) => StopReason::Unknown,
     }
@@ -488,6 +488,15 @@ mod tests {
                 text: "Hello".to_string()
             }]
         );
+    }
+
+    #[test]
+    fn folds_anthropic_refusal_as_content_filter() {
+        let agg = fold(vec![LlmResponseChunk::MessageStop {
+            reason: Some("refusal".to_string()),
+        }]);
+
+        assert_eq!(agg.outputs[0].stop_reason, Some(StopReason::ContentFilter));
     }
 
     #[test]

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -352,7 +352,9 @@ impl FormatCodec for AnthropicMessagesCodec {
                 .unwrap_or("end_turn"),
             "stop_sequence": Value::Null,
             "stop_details": normalized_stop_reason
-                .map(anthropic_stop_details)
+                .map(|reason| {
+                    anthropic_stop_details(reason, response.extensions.fields.get("stop_details"))
+                })
                 .unwrap_or(Value::Null),
             "usage": encode_anthropic_usage(&response.usage),
         });
@@ -996,14 +998,25 @@ fn anthropic_stop_reason(reason: StopReason) -> &'static str {
     }
 }
 
-// Emits the metadata object required by Anthropic refusal responses.
-fn anthropic_stop_details(reason: StopReason) -> Value {
+// Emits the metadata object Anthropic pairs with a `refusal` stop reason.
+//
+// An Anthropic source keeps its `stop_details` in provider extensions, so replay that
+// object and preserve the named policy category and its explanation. Only a refusal
+// synthesized from a provider that reports no category falls back to the null form,
+// which Anthropic documents as the normal value for a refusal that maps to no named
+// category.
+fn anthropic_stop_details(reason: StopReason, source: Option<&Value>) -> Value {
     match reason {
-        StopReason::ContentFilter => json!({
-            "type": "refusal",
-            "category": Value::Null,
-            "explanation": Value::Null,
-        }),
+        StopReason::ContentFilter => source
+            .filter(|details| !details.is_null())
+            .cloned()
+            .unwrap_or_else(|| {
+                json!({
+                    "type": "refusal",
+                    "category": Value::Null,
+                    "explanation": Value::Null,
+                })
+            }),
         _ => Value::Null,
     }
 }

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -340,17 +340,20 @@ impl FormatCodec for AnthropicMessagesCodec {
         let content = output
             .map(|output| encode_anthropic_content(&output.content))
             .unwrap_or_else(|| vec![json!({"type": "text", "text": ""})]);
+        let normalized_stop_reason = output.and_then(|output| output.stop_reason);
         let body = json!({
             "id": response.id.clone().unwrap_or_else(|| "msg_switchyard".to_string()),
             "type": "message",
             "role": "assistant",
             "model": response.model.clone().unwrap_or_else(|| "unknown".to_string()),
             "content": content,
-            "stop_reason": output
-                .and_then(|output| output.stop_reason)
+            "stop_reason": normalized_stop_reason
                 .map(anthropic_stop_reason)
                 .unwrap_or("end_turn"),
             "stop_sequence": Value::Null,
+            "stop_details": normalized_stop_reason
+                .map(anthropic_stop_details)
+                .unwrap_or(Value::Null),
             "usage": encode_anthropic_usage(&response.usage),
         });
         Ok(EncodedResponse {
@@ -990,5 +993,17 @@ fn anthropic_stop_reason(reason: StopReason) -> &'static str {
         StopReason::ToolUse => "tool_use",
         StopReason::ContentFilter => "refusal",
         StopReason::EndTurn | StopReason::Error | StopReason::Unknown => "end_turn",
+    }
+}
+
+// Emits the metadata object required by Anthropic refusal responses.
+fn anthropic_stop_details(reason: StopReason) -> Value {
+    match reason {
+        StopReason::ContentFilter => json!({
+            "type": "refusal",
+            "category": Value::Null,
+            "explanation": Value::Null,
+        }),
+        _ => Value::Null,
     }
 }

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -977,6 +977,7 @@ fn map_anthropic_stop_reason(reason: Option<&str>) -> StopReason {
     match reason {
         Some("max_tokens") => StopReason::MaxTokens,
         Some("tool_use") => StopReason::ToolUse,
+        Some("refusal") => StopReason::ContentFilter,
         Some("end_turn") | None => StopReason::EndTurn,
         _ => StopReason::Unknown,
     }
@@ -987,9 +988,7 @@ fn anthropic_stop_reason(reason: StopReason) -> &'static str {
     match reason {
         StopReason::MaxTokens => "max_tokens",
         StopReason::ToolUse => "tool_use",
-        StopReason::EndTurn
-        | StopReason::ContentFilter
-        | StopReason::Error
-        | StopReason::Unknown => "end_turn",
+        StopReason::ContentFilter => "refusal",
+        StopReason::EndTurn | StopReason::Error | StopReason::Unknown => "end_turn",
     }
 }

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -572,9 +572,12 @@ fn anthropic_stop_reason(reason: Option<&str>) -> String {
     match reason {
         Some("length") => "max_tokens".to_string(),
         Some("tool_calls") | Some("function_call") => "tool_use".to_string(),
-        Some("end_turn") | Some("max_tokens") | Some("tool_use") | Some("stop_sequence") => {
-            reason.unwrap_or("end_turn").to_string()
-        }
+        Some("content_filter") => "refusal".to_string(),
+        Some("end_turn")
+        | Some("max_tokens")
+        | Some("tool_use")
+        | Some("stop_sequence")
+        | Some("refusal") => reason.unwrap_or("end_turn").to_string(),
         _ => "end_turn".to_string(),
     }
 }

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -117,6 +117,12 @@ fn decode_anthropic_stream(
                 // Remember the provider stop reason: Anthropic delivers it here, on
                 // `message_delta`, while the terminal `message_stop` carries none of its own.
                 state.stop_reason = Some(stop_reason.to_string());
+                state.stop_details = object
+                    .get("delta")
+                    .and_then(Value::as_object)
+                    .and_then(|delta| delta.get("stop_details"))
+                    .filter(|details| !details.is_null())
+                    .cloned();
                 out.push(LlmResponseChunk::MessageStop {
                     reason: Some(stop_reason.to_string()),
                 });
@@ -265,7 +271,10 @@ fn finish_anthropic_stream(state: &mut StreamTranslationState) -> Vec<Value> {
             "delta": {
                 "stop_reason": anthropic_stop_reason(state.stop_reason.as_deref()),
                 "stop_sequence": Value::Null,
-                "stop_details": anthropic_stop_details(state.stop_reason.as_deref()),
+                "stop_details": anthropic_stop_details(
+                    state.stop_reason.as_deref(),
+                    state.stop_details.as_ref(),
+                ),
             },
             "usage": anthropic_stream_usage(state),
         }));
@@ -573,23 +582,28 @@ fn anthropic_stop_reason(reason: Option<&str>) -> String {
     match reason {
         Some("length") => "max_tokens".to_string(),
         Some("tool_calls") | Some("function_call") => "tool_use".to_string(),
-        Some("content_filter") => "refusal".to_string(),
-        Some("end_turn")
-        | Some("max_tokens")
-        | Some("tool_use")
-        | Some("stop_sequence")
-        | Some("refusal") => reason.unwrap_or("end_turn").to_string(),
+        Some("content_filter" | "refusal") => "refusal".to_string(),
+        Some(reason @ ("end_turn" | "max_tokens" | "tool_use" | "stop_sequence")) => {
+            reason.to_string()
+        }
         _ => "end_turn".to_string(),
     }
 }
 
-// Emits the metadata object required by Anthropic refusal events.
-fn anthropic_stop_details(reason: Option<&str>) -> Value {
+// Emits the metadata object Anthropic pairs with a `refusal` stop reason.
+//
+// A source that already reported `stop_details` carries the named policy category and
+// its explanation, so replay that object verbatim. Only a refusal synthesized from a
+// provider that reports no category falls back to the null form, which Anthropic
+// documents as the normal value for a refusal that maps to no named category.
+fn anthropic_stop_details(reason: Option<&str>, source: Option<&Value>) -> Value {
     match reason {
-        Some("content_filter" | "refusal") => json!({
-            "type": "refusal",
-            "category": Value::Null,
-            "explanation": Value::Null,
+        Some("content_filter" | "refusal") => source.cloned().unwrap_or_else(|| {
+            json!({
+                "type": "refusal",
+                "category": Value::Null,
+                "explanation": Value::Null,
+            })
         }),
         _ => Value::Null,
     }

--- a/crates/switchyard-translation/src/codecs/anthropic/stream.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/stream.rs
@@ -265,6 +265,7 @@ fn finish_anthropic_stream(state: &mut StreamTranslationState) -> Vec<Value> {
             "delta": {
                 "stop_reason": anthropic_stop_reason(state.stop_reason.as_deref()),
                 "stop_sequence": Value::Null,
+                "stop_details": anthropic_stop_details(state.stop_reason.as_deref()),
             },
             "usage": anthropic_stream_usage(state),
         }));
@@ -579,6 +580,18 @@ fn anthropic_stop_reason(reason: Option<&str>) -> String {
         | Some("stop_sequence")
         | Some("refusal") => reason.unwrap_or("end_turn").to_string(),
         _ => "end_turn".to_string(),
+    }
+}
+
+// Emits the metadata object required by Anthropic refusal events.
+fn anthropic_stop_details(reason: Option<&str>) -> Value {
+    match reason {
+        Some("content_filter" | "refusal") => json!({
+            "type": "refusal",
+            "category": Value::Null,
+            "explanation": Value::Null,
+        }),
+        _ => Value::Null,
     }
 }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -397,6 +397,7 @@ fn openai_finish_reason(reason: Option<&str>) -> String {
         Some("end_turn") | Some("stop_sequence") | None => "stop".to_string(),
         Some("max_tokens") => "length".to_string(),
         Some("tool_use") => "tool_calls".to_string(),
+        Some("refusal") => "content_filter".to_string(),
         Some(other) => other.to_string(),
     }
 }

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -42,6 +42,9 @@ pub struct StreamTranslationState {
     pub(crate) output_tokens_seen: u64,
     pub(crate) saw_backend_usage: bool,
     pub(crate) stop_reason: Option<String>,
+    /// Refusal metadata carried by the source, replayed instead of a synthesized
+    /// object so a named policy category and its explanation are not flattened away.
+    pub(crate) stop_details: Option<Value>,
     pub(crate) emitted_message_delta: bool,
 
     pub(crate) next_content_index: usize,

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -627,6 +627,10 @@ fn openai_content_filter_translates_to_anthropic_refusal() -> TestResult {
         .body;
 
     assert_eq!(output["stop_reason"], "refusal");
+    assert_eq!(
+        output["stop_details"],
+        json!({"type": "refusal", "category": null, "explanation": null})
+    );
     Ok(())
 }
 

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -600,3 +600,60 @@ fn incomplete_responses_source_survives_translation() -> TestResult {
     assert_eq!(output["choices"][0]["finish_reason"], "length");
     Ok(())
 }
+
+// Verifies a moderation stop reaches Anthropic clients as `refusal` rather than
+// being reported as a normal `end_turn`.
+#[test]
+fn openai_content_filter_translates_to_anthropic_refusal() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "chatcmpl-test",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Partial answer"},
+            "finish_reason": "content_filter"
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::OpenAiChat,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["stop_reason"], "refusal");
+    Ok(())
+}
+
+// Verifies the same distinction survives the other direction, so an Anthropic
+// `refusal` is not flattened when re-encoded for an OpenAI client.
+#[test]
+fn anthropic_refusal_translates_to_openai_content_filter() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "Partial answer"}],
+        "stop_reason": "refusal",
+        "usage": {"input_tokens": 10, "output_tokens": 5}
+    });
+
+    let output = engine
+        .translate_response(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["choices"][0]["finish_reason"], "content_filter");
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -601,12 +601,16 @@ fn incomplete_responses_source_survives_translation() -> TestResult {
     Ok(())
 }
 
-// Verifies a moderation stop reaches Anthropic clients as `refusal` rather than
-// being reported as a normal `end_turn`.
+// Verifies a moderation stop stays distinguishable from a normal turn in both
+// directions, and that a named refusal category survives re-encoding.
 #[test]
-fn openai_content_filter_translates_to_anthropic_refusal() -> TestResult {
+fn content_filter_and_refusal_translate_across_formats() -> TestResult {
     let engine = TranslationEngine::default();
-    let body = json!({
+
+    // An OpenAI moderation stop reaches Anthropic clients as `refusal`, not `end_turn`.
+    // OpenAI reports no policy category, so the refusal carries the null form that
+    // Anthropic documents for a refusal mapping to no named category.
+    let openai = json!({
         "id": "chatcmpl-test",
         "model": "gpt-4o",
         "choices": [{
@@ -616,48 +620,59 @@ fn openai_content_filter_translates_to_anthropic_refusal() -> TestResult {
         }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
     });
-
     let output = engine
         .translate_response(
             WireFormat::OpenAiChat,
             WireFormat::AnthropicMessages,
-            &body,
+            &openai,
             &TranslationPolicy::default(),
         )?
         .body;
-
     assert_eq!(output["stop_reason"], "refusal");
     assert_eq!(
         output["stop_details"],
         json!({"type": "refusal", "category": null, "explanation": null})
     );
-    Ok(())
-}
 
-// Verifies the same distinction survives the other direction, so an Anthropic
-// `refusal` is not flattened when re-encoded for an OpenAI client.
-#[test]
-fn anthropic_refusal_translates_to_openai_content_filter() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = json!({
+    // The distinction survives the other direction rather than being flattened.
+    let anthropic = json!({
         "id": "msg_test",
         "type": "message",
         "role": "assistant",
         "model": "claude-sonnet-4-5",
         "content": [{"type": "text", "text": "Partial answer"}],
         "stop_reason": "refusal",
+        "stop_details": {
+            "type": "refusal",
+            "category": "cyber",
+            "explanation": "This request was declined because it could enable cyber harm."
+        },
         "usage": {"input_tokens": 10, "output_tokens": 5}
     });
-
     let output = engine
         .translate_response(
             WireFormat::AnthropicMessages,
             WireFormat::OpenAiChat,
-            &body,
+            &anthropic,
             &TranslationPolicy::default(),
         )?
         .body;
-
     assert_eq!(output["choices"][0]["finish_reason"], "content_filter");
+
+    // Re-encoding a refusal keeps the category the source named instead of
+    // replacing it with the null form used for an unnamed refusal.
+    let output = engine
+        .translate_response(
+            WireFormat::AnthropicMessages,
+            WireFormat::AnthropicMessages,
+            &anthropic,
+            &TranslationPolicy {
+                preservation: switchyard_translation::PreservationPolicy::Disabled,
+                ..TranslationPolicy::default()
+            },
+        )?
+        .body;
+    assert_eq!(output["stop_reason"], "refusal");
+    assert_eq!(output["stop_details"]["category"], "cyber");
     Ok(())
 }

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -303,43 +303,6 @@ fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResu
     Ok(())
 }
 
-// Verifies streamed moderation stops are not reported to Anthropic clients as normal turns.
-#[test]
-fn openai_content_filter_stream_translates_to_anthropic_refusal() -> TestResult {
-    let engine = TranslationEngine::default();
-    let mut state =
-        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
-    let chunk = json!({
-        "id": "chatcmpl-test",
-        "object": "chat.completion.chunk",
-        "model": "gpt-4o",
-        "choices": [{
-            "index": 0,
-            "delta": {},
-            "finish_reason": "content_filter"
-        }]
-    });
-
-    let mut events = engine.translate_event(
-        &mut state,
-        WireFormat::OpenAiChat,
-        WireFormat::AnthropicMessages,
-        &chunk,
-    )?;
-    events.extend(engine.finish_stream(&mut state, WireFormat::AnthropicMessages)?);
-
-    let terminal = events
-        .iter()
-        .find(|event| event["type"] == "message_delta")
-        .ok_or("missing Anthropic terminal delta")?;
-    assert_eq!(terminal["delta"]["stop_reason"], "refusal");
-    assert_eq!(
-        terminal["delta"]["stop_details"],
-        json!({"type": "refusal", "category": null, "explanation": null})
-    );
-    Ok(())
-}
-
 // Verifies Anthropic usage and stop events become terminal OpenAI chunks.
 #[test]
 fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {
@@ -374,26 +337,78 @@ fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {
     Ok(())
 }
 
-// Verifies streamed Anthropic refusals remain distinguishable for OpenAI clients.
+// Verifies streamed moderation stops stay distinguishable from normal turns in both
+// directions, and that a named refusal category survives re-encoding.
 #[test]
-fn anthropic_refusal_stream_translates_to_openai_content_filter() -> TestResult {
+fn content_filter_and_refusal_streams_translate_across_formats() -> TestResult {
     let engine = TranslationEngine::default();
+
+    // An OpenAI moderation stop reaches Anthropic clients as `refusal`, carrying the
+    // null form Anthropic documents for a refusal mapping to no named category.
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let chunk = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "content_filter"}]
+    });
+    let mut events = engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &chunk,
+    )?;
+    events.extend(engine.finish_stream(&mut state, WireFormat::AnthropicMessages)?);
+    let terminal = events
+        .iter()
+        .find(|event| event["type"] == "message_delta")
+        .ok_or("missing Anthropic terminal delta")?;
+    assert_eq!(terminal["delta"]["stop_reason"], "refusal");
+    assert_eq!(
+        terminal["delta"]["stop_details"],
+        json!({"type": "refusal", "category": null, "explanation": null})
+    );
+
+    // The distinction survives the other direction rather than being flattened.
     let mut state =
         StreamTranslationState::new(WireFormat::AnthropicMessages, WireFormat::OpenAiChat);
     let delta = json!({
         "type": "message_delta",
-        "delta": {"stop_reason": "refusal"},
+        "delta": {
+            "stop_reason": "refusal",
+            "stop_details": {
+                "type": "refusal",
+                "category": "cyber",
+                "explanation": "This request was declined because it could enable cyber harm."
+            }
+        },
         "usage": {"output_tokens": 1}
     });
-
     let events = engine.translate_event(
         &mut state,
         WireFormat::AnthropicMessages,
         WireFormat::OpenAiChat,
         &delta,
     )?;
-
     assert_eq!(events[0]["choices"][0]["finish_reason"], "content_filter");
+
+    // Re-encoding a streamed refusal keeps the category the source named.
+    let mut state =
+        StreamTranslationState::new(WireFormat::AnthropicMessages, WireFormat::AnthropicMessages);
+    let mut events = engine.translate_event(
+        &mut state,
+        WireFormat::AnthropicMessages,
+        WireFormat::AnthropicMessages,
+        &delta,
+    )?;
+    events.extend(engine.finish_stream(&mut state, WireFormat::AnthropicMessages)?);
+    let terminal = events
+        .iter()
+        .find(|event| event["type"] == "message_delta")
+        .ok_or("missing Anthropic terminal delta")?;
+    assert_eq!(terminal["delta"]["stop_reason"], "refusal");
+    assert_eq!(terminal["delta"]["stop_details"]["category"], "cyber");
     Ok(())
 }
 

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -303,6 +303,39 @@ fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResu
     Ok(())
 }
 
+// Verifies streamed moderation stops are not reported to Anthropic clients as normal turns.
+#[test]
+fn openai_content_filter_stream_translates_to_anthropic_refusal() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let chunk = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": "content_filter"
+        }]
+    });
+
+    let mut events = engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &chunk,
+    )?;
+    events.extend(engine.finish_stream(&mut state, WireFormat::AnthropicMessages)?);
+
+    let terminal = events
+        .iter()
+        .find(|event| event["type"] == "message_delta")
+        .ok_or("missing Anthropic terminal delta")?;
+    assert_eq!(terminal["delta"]["stop_reason"], "refusal");
+    Ok(())
+}
+
 // Verifies Anthropic usage and stop events become terminal OpenAI chunks.
 #[test]
 fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {
@@ -334,6 +367,29 @@ fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {
 
     assert_eq!(events[0]["usage"]["completion_tokens"], 42);
     assert_eq!(events[0]["choices"][0]["finish_reason"], "stop");
+    Ok(())
+}
+
+// Verifies streamed Anthropic refusals remain distinguishable for OpenAI clients.
+#[test]
+fn anthropic_refusal_stream_translates_to_openai_content_filter() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::AnthropicMessages, WireFormat::OpenAiChat);
+    let delta = json!({
+        "type": "message_delta",
+        "delta": {"stop_reason": "refusal"},
+        "usage": {"output_tokens": 1}
+    });
+
+    let events = engine.translate_event(
+        &mut state,
+        WireFormat::AnthropicMessages,
+        WireFormat::OpenAiChat,
+        &delta,
+    )?;
+
+    assert_eq!(events[0]["choices"][0]["finish_reason"], "content_filter");
     Ok(())
 }
 

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -333,6 +333,10 @@ fn openai_content_filter_stream_translates_to_anthropic_refusal() -> TestResult 
         .find(|event| event["type"] == "message_delta")
         .ok_or("missing Anthropic terminal delta")?;
     assert_eq!(terminal["delta"]["stop_reason"], "refusal");
+    assert_eq!(
+        terminal["delta"]["stop_details"],
+        json!({"type": "refusal", "category": null, "explanation": null})
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## What

- Translate OpenAI `content_filter` stops to Anthropic `refusal` in buffered and streaming responses.
- Emit the required Anthropic `stop_details` object for synthesized refusals.
- Decode Anthropic `refusal` back to the normalized content-filter reason.
- Normalize streamed Anthropic refusals as `StopReason::ContentFilter` when responses are accumulated.
- Translate streamed Anthropic refusals to OpenAI `content_filter`.
- Add buffered, streaming, and accumulator regression coverage.

## Why

An OpenAI-compatible backend could stop generation because of content filtering, but Anthropic clients received `end_turn`. That made a filtered or truncated response indistinguishable from a normal completion.

The normalized response already preserves this condition as `StopReason::ContentFilter`. The loss occurred when the Anthropic codecs encoded the stop reason. Anthropic documents `refusal` for safety refusals and requires a `stop_details` object, so the translated response now preserves the relevant meaning with a valid Anthropic shape.

`Error` and `Unknown` remain mapped to `end_turn` and are outside this change.

Closes #369

## Validation

- `cargo fmt --all --check`
- `cargo clippy --ignore-rust-version -p switchyard-protocol -p switchyard-translation --all-targets -- -D warnings`
- `cargo test --ignore-rust-version -p switchyard-protocol`: 18 unit tests and 2 documentation tests passed
- `cargo test --ignore-rust-version -p switchyard-translation`: 119 tests passed
- Commitlint across all three PR commits: 0 problems and 0 warnings

The full workspace test run is blocked locally while linking the existing `switchyard-py` PyO3 cdylib because of a macOS deployment-target mismatch in `aws-lc-sys`. The same linker failure reproduces on a clean tree. CI runs the workspace suite on Linux.

The local Rust commands use `--ignore-rust-version` because the available Homebrew compiler is Rust 1.96.0 while the repository declares Rust 1.96.1.