### PR TITLE
fix(translation): flatten Responses JSON schema format

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -161,7 +161,10 @@ impl FormatCodec for OpenAiResponsesCodec {
             body.insert("max_output_tokens".to_string(), json!(max_output_tokens));
         }
         if let Some(response_format) = &request.output.response_format {
-            body.insert("text".to_string(), json!({"format": response_format}));
+            body.insert(
+                "text".to_string(),
+                json!({"format": encode_responses_text_format(response_format)}),
+            );
         }
         if let Some(effort) = &request.reasoning.effort {
             body.insert("reasoning".to_string(), json!({"effort": effort}));
@@ -853,6 +856,23 @@ fn decode_responses_text_format(value: Option<&Value>) -> Option<Value> {
         Some("text") => Some(json!({"type": "text"})),
         _ => None,
     }
+}
+
+// Flattens Chat-compatible JSON schema fields into the Responses text format shape.
+fn encode_responses_text_format(response_format: &Value) -> Value {
+    let Some(format) = response_format.as_object() else {
+        return response_format.clone();
+    };
+    if format.get("type").and_then(Value::as_str) != Some("json_schema") {
+        return response_format.clone();
+    }
+
+    let mut output = format.clone();
+    let Some(Value::Object(json_schema)) = output.remove("json_schema") else {
+        return response_format.clone();
+    };
+    output.extend(json_schema);
+    Value::Object(output)
 }
 
 // Encodes normalized messages into the Responses `input` shape.

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -863,15 +863,35 @@ fn encode_responses_text_format(response_format: &Value) -> Value {
     let Some(format) = response_format.as_object() else {
         return response_format.clone();
     };
-    if format.get("type").and_then(Value::as_str) != Some("json_schema") {
+    let Some(response_type) = format
+        .get("type")
+        .filter(|value| value.as_str() == Some("json_schema"))
+    else {
+        return response_format.clone();
+    };
+
+    let Some(Value::Object(json_schema)) = format.get("json_schema") else {
+        return response_format.clone();
+    };
+    if !matches!(json_schema.get("name"), Some(Value::String(_)))
+        || !matches!(json_schema.get("schema"), Some(Value::Object(_)))
+        || json_schema
+            .get("description")
+            .is_some_and(|value| !value.is_string())
+        || json_schema
+            .get("strict")
+            .is_some_and(|value| !value.is_boolean())
+    {
         return response_format.clone();
     }
 
-    let mut output = format.clone();
-    let Some(Value::Object(json_schema)) = output.remove("json_schema") else {
-        return response_format.clone();
-    };
-    output.extend(json_schema);
+    let mut output = Map::new();
+    output.insert("type".to_string(), response_type.clone());
+    for field in ["name", "description", "schema", "strict"] {
+        if let Some(value) = json_schema.get(field) {
+            output.insert(field.to_string(), value.clone());
+        }
+    }
     Value::Object(output)
 }
 

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -973,6 +973,64 @@ fn chat_json_schema_response_format_maps_to_responses_text_format() -> TestResul
     Ok(())
 }
 
+// Verifies nested fields cannot override the Responses format discriminator.
+#[test]
+fn chat_json_schema_response_format_ignores_nested_type_override() -> TestResult {
+    let output = translate_chat_response_format_to_responses(json!({
+        "type": "json_schema",
+        "json_schema": {
+            "type": "text",
+            "name": "answer",
+            "description": "A structured answer",
+            "schema": {"type": "object"},
+            "strict": true
+        }
+    }))?;
+
+    assert_eq!(
+        output,
+        json!({
+            "type": "json_schema",
+            "name": "answer",
+            "description": "A structured answer",
+            "schema": {"type": "object"},
+            "strict": true
+        })
+    );
+    Ok(())
+}
+
+// Verifies incomplete JSON schema wrappers remain unchanged instead of being partially flattened.
+#[test]
+fn chat_empty_json_schema_wrapper_is_preserved() -> TestResult {
+    let response_format = json!({"type": "json_schema", "json_schema": {}});
+
+    assert_eq!(
+        translate_chat_response_format_to_responses(response_format.clone())?,
+        response_format
+    );
+    Ok(())
+}
+
+fn translate_chat_response_format_to_responses(
+    response_format: Value,
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    let body = json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "Return JSON"}],
+        "response_format": response_format
+    });
+    let output = TranslationEngine::default()
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    Ok(output["text"]["format"].clone())
+}
+
 // Verifies OpenAI system/developer/reasoning fields map to Anthropic request fields.
 #[test]
 fn openai_request_translates_system_developer_and_reasoning_to_anthropic() -> TestResult {

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -933,6 +933,46 @@ fn responses_json_schema_text_format_maps_to_chat_response_format() -> TestResul
     Ok(())
 }
 
+// Verifies Chat response_format JSON schema fields flatten into Responses text.format.
+#[test]
+fn chat_json_schema_response_format_maps_to_responses_text_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "Return JSON"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "description": "A structured answer",
+                "schema": {"type": "object"},
+                "strict": true
+            }
+        }
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["text"]["format"],
+        json!({
+            "type": "json_schema",
+            "name": "answer",
+            "description": "A structured answer",
+            "schema": {"type": "object"},
+            "strict": true
+        })
+    );
+    Ok(())
+}
+
 // Verifies OpenAI system/developer/reasoning fields map to Anthropic request fields.
 #[test]
 fn openai_request_translates_system_developer_and_reasoning_to_anthropic() -> TestResult {


### PR DESCRIPTION
## What

Flatten Chat-compatible JSON schema response format fields when encoding an OpenAI Responses request. The Responses encoder now moves `name`, optional `description`, `schema`, and `strict` from the neutral `json_schema` wrapper directly into `text.format`.

Add a regression test covering OpenAI Chat to OpenAI Responses translation with a strict JSON schema contract.

## Why

The existing encoder forwarded the neutral Chat-compatible shape directly:

```json
{"text":{"format":{"type":"json_schema","json_schema":{"name":"answer","schema":{},"strict":true}}}}
```

The Responses API requires those fields directly under `text.format`. The malformed request is rejected before inference with HTTP 400: `Missing required parameter: 'text.format.name'.`

This affects translated structured-output traffic and provider-neutral requests constructed by libsy algorithms, including classifier or judge calls whose decision contract is encoded for a Responses backend. Plain-text requests, other response format types, and exact same-format Responses preservation are unchanged.

Closes #376

## How tested

- [x] `cargo fmt --all --check`
- [x] `cargo test -p switchyard-translation --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --exclude switchyard-py --locked`
- [x] Focused regression test failed before the encoder change and passed afterward.
- [x] Live NVIDIA Inference Hub control with the same model, prompt, and schema:
  - Unpatched engine-generated payload: HTTP 400, missing `text.format.name`.
  - Patched engine-generated payload: HTTP 200, `status: completed`, `{"answer":"live_translation_ok"}`.
- [ ] `uv run ruff check .` clean — not applicable; no Python files changed.
- [ ] `uv run mypy switchyard` clean — not applicable; no Python files changed.
- [ ] `uv run pytest tests/` green — not applicable; no Python behavior changed.
- [x] Manual smoke — live positive and negative Responses API controls described above.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class — not applicable; no Python classes added.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use — not applicable; no public symbols added.
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed — not required; this corrects existing advertised behavior without changing configuration or public APIs.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The change is intentionally confined to the Responses codec boundary. `decode_responses_text_format` already converts the flat Responses representation into the nested neutral representation; this adds the inverse mapping during encode. Non-`json_schema` formats and malformed/non-object extension values continue to pass through unchanged.

The full unfiltered `cargo test --workspace --locked` command reaches the existing standalone macOS PyO3 linker boundary for `switchyard-py` because Python symbols are not supplied by a plain Cargo invocation. All non-PyO3 workspace tests passed, and workspace Clippy compiled all targets successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON Schema response-format compatibility when translating Chat-style requests to the Responses API.
  * Preserves schema type, name, description, schema details, and strictness in the converted format.
  * Leaves unsupported or invalid response formats unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->