### PR TITLE
fix(metrics): extend LLM latency histogram buckets

### DIFF
--- a/crates/switchyard-server/src/metrics.rs
+++ b/crates/switchyard-server/src/metrics.rs
@@ -19,6 +19,13 @@ const ROUTING_OVERHEAD_BUCKETS_MS: &[f64] = &[
     0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
 ];
 
+/// Bucket boundaries for model-call and end-to-end LLM latency histograms.
+/// Retains the SDK defaults through 10 seconds and extends them for long generations.
+const LLM_LATENCY_BUCKETS_MS: &[f64] = &[
+    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0,
+    10_000.0, 15_000.0, 30_000.0, 60_000.0, 120_000.0, 300_000.0,
+];
+
 struct Metrics {
     registry: Registry,
     provider: SdkMeterProvider,
@@ -43,6 +50,7 @@ fn initialize() -> Result<Metrics, String> {
     let mut builder = SdkMeterProvider::builder()
         .with_reader(exporter)
         .with_view(routing_overhead_buckets)
+        .with_view(llm_latency_buckets)
         .with_resource(crate::observability::resource());
     if crate::observability::otlp_enabled("METRICS") {
         let exporter = opentelemetry_otlp::MetricExporter::builder()
@@ -79,6 +87,22 @@ fn routing_overhead_buckets(instrument: &Instrument) -> Option<Stream> {
             boundaries: ROUTING_OVERHEAD_BUCKETS_MS.to_vec(),
             // Cumulative min/max cover the whole process, so they aren't useful.
             record_min_max: false,
+        })
+        .build()
+        .ok()
+}
+
+fn llm_latency_buckets(instrument: &Instrument) -> Option<Stream> {
+    if !matches!(
+        instrument.name(),
+        "switchyard.model_call_latency_ms" | "switchyard.total_latency_ms"
+    ) {
+        return None;
+    }
+    Stream::builder()
+        .with_aggregation(Aggregation::ExplicitBucketHistogram {
+            boundaries: LLM_LATENCY_BUCKETS_MS.to_vec(),
+            record_min_max: true,
         })
         .build()
         .ok()

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -486,6 +486,15 @@ async fn metrics_exposes_switchyard_otel_instruments() -> TestResult {
         )
         .is_some()
     );
+    for metric in [
+        "switchyard_model_call_latency_ms_bucket",
+        "switchyard_total_latency_ms_bucket",
+    ] {
+        assert!(
+            metric_line(metrics, metric, &[("model", MODEL), ("le", "300000")]).is_some(),
+            "missing five-minute bucket for {metric}"
+        );
+    }
     assert!(
         metric_line(
             metrics,


### PR DESCRIPTION
## What

- add dedicated bucket boundaries for model-call and end-to-end LLM latency histograms
- preserve the OpenTelemetry SDK boundaries through 10 seconds and extend them to 15 seconds, 30 seconds, 60 seconds, 2 minutes, and 5 minutes
- verify that both Prometheus histograms expose the five-minute bucket

## Why

The OpenTelemetry SDK defaults stop at 10 seconds, so slower model calls fall into the `+Inf` bucket. That makes Prometheus quantiles unable to distinguish a 10-second response from a multi-minute LLM generation.

The dedicated view keeps the existing short-latency resolution while making the long tail observable.

Closes #262

## How tested

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p switchyard-server` — 56 tests passed
- [x] `cargo test --workspace --exclude switchyard-py` — 490 tests and doctests passed

A full workspace run was also attempted. It reached the unchanged `switchyard-py` cdylib and stopped on local macOS CPython symbol linking; all non-PyO3 workspace tests passed.

## Checklist

- [x] Regression coverage added for the changed metrics behavior
- [x] No public API or metric label changes
- [x] Commit signed off per the DCO

## Notes for reviewers

The boundaries are fixed to keep this bug fix focused, matching the existing routing-overhead view. Making them configurable can remain a separate change if operators need deployment-specific ranges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved latency metrics to capture model-call and end-to-end response times across a broader range, including delays up to five minutes.
  * Added minimum and maximum latency measurements for more complete performance monitoring.

* **Tests**
  * Added coverage confirming five-minute latency buckets are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->