### PR TITLE
fix(cli): preserve Claude Code background model override

### DIFF
--- a/switchyard/cli/launchers/claude_code_launcher.py
+++ b/switchyard/cli/launchers/claude_code_launcher.py
@@ -66,8 +66,9 @@ def _claude_env(port: int, model: str) -> dict[str, str]:
     * ``ANTHROPIC_BASE_URL`` — our proxy URL.
     * ``ANTHROPIC_AUTH_TOKEN`` — opaque token; skips Console OAuth.
     * ``ANTHROPIC_API_KEY=""`` — silences the auth-conflict warning.
-    * ``ANTHROPIC_MODEL`` / ``ANTHROPIC_SMALL_FAST_MODEL`` — initial
-      active model for the session.
+    * ``ANTHROPIC_MODEL`` — initial active model for the session.
+    * ``ANTHROPIC_SMALL_FAST_MODEL`` — existing background-model override,
+      falling back to the active model.
     * ``ANTHROPIC_CUSTOM_MODEL_OPTION`` — registers ``model`` as a custom
       slot in ``/model`` so the user can come back to it after toggling
       to a builtin.
@@ -79,7 +80,7 @@ def _claude_env(port: int, model: str) -> dict[str, str]:
         "ANTHROPIC_AUTH_TOKEN": "switchyard",
         "ANTHROPIC_API_KEY": "",
         "ANTHROPIC_MODEL": model,
-        "ANTHROPIC_SMALL_FAST_MODEL": model,
+        "ANTHROPIC_SMALL_FAST_MODEL": os.environ.get("ANTHROPIC_SMALL_FAST_MODEL", model),
         "ANTHROPIC_CUSTOM_MODEL_OPTION": model,
         "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
     }

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from switchyard.cli.launch_command import _config_path
+from switchyard.cli.launchers.claude_code_launcher import _claude_env
 from switchyard.cli.launchers.native_server import NativeServer
 from switchyard.cli.switchyard_cli import _build_parser
 
@@ -48,6 +49,17 @@ def test_default_config_is_packaged_openrouter_deployment() -> None:
     config = _config_path(None)
     assert config.name == "openrouter.toml"
     assert "OPENROUTER_API_KEY" in config.read_text()
+
+
+def test_claude_env_preserves_small_fast_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_SMALL_FAST_MODEL", "background-route")
+
+    env = _claude_env(4321, "agent-route")
+
+    assert env["ANTHROPIC_MODEL"] == "agent-route"
+    assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "background-route"
 
 
 def test_native_server_passes_config_directly_to_binding(


### PR DESCRIPTION
## What

Preserve an existing `ANTHROPIC_SMALL_FAST_MODEL` value when building the
Claude Code launcher environment. When the variable is unset, continue using
the active `--model` value as the fallback.

Add a regression test that keeps the primary agent route separate from an
explicit background route.

## Why

Claude Code uses its small/fast model setting for background requests such as
session-title generation. `_claude_env` previously assigned the launcher model
to both `ANTHROPIC_MODEL` and `ANTHROPIC_SMALL_FAST_MODEL`, overwriting any
background route configured by the user.

When the primary route can reach an agent, this sends the background request to
the same agent and can run it twice for one user question.

Leaving `ANTHROPIC_SMALL_FAST_MODEL` unset is not sufficient. Claude Code then
uses its own default model ID, which may not exist in a route table that matches
exact IDs. Preserving an explicit override lets deployments route background
traffic separately while retaining the current fallback behavior.

Closes #258

## How tested

- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest -s tests/test_launchers.py -q` — 8 passed
- [x] `uv run pytest -s tests/ -v` — 135 passed, 2 skipped
- [x] `uv run switchyard launch claude --help`

## Checklist

- [x] No class or filename changes.
- [x] No new public symbols.
- [x] Regression test added for the bug fix.
- [x] README and `--help` changes are not required; the CLI surface is unchanged.
- [x] Commit signed off per the DCO.

## Notes for reviewers

The launcher still falls back to `--model` when
`ANTHROPIC_SMALL_FAST_MODEL` is not set, so existing launcher behavior remains
unchanged unless the user supplies a background-model override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom `ANTHROPIC_SMALL_FAST_MODEL` environment settings when launching Claude.
  * Continued to set `ANTHROPIC_MODEL` to the selected agent model.
* **Tests**
  * Added regression coverage to verify environment overrides remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->