### PR TITLE
fix(translation): preserve reasoning order in mixed stream chunks

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -98,14 +98,6 @@ fn decode_openai_chat_stream(
             continue;
         };
         if let Some(delta) = choice.get("delta").and_then(Value::as_object) {
-            if let Some(text) = delta.get("content").and_then(Value::as_str)
-                && !text.is_empty()
-            {
-                out.push(LlmResponseChunk::TextDelta {
-                    index: 0,
-                    text: text.to_string(),
-                });
-            }
             if let Some(details) = delta
                 .get("reasoning_details")
                 .and_then(Value::as_array)
@@ -133,6 +125,14 @@ fn decode_openai_chat_stream(
                         });
                     }
                 }
+            }
+            if let Some(text) = delta.get("content").and_then(Value::as_str)
+                && !text.is_empty()
+            {
+                out.push(LlmResponseChunk::TextDelta {
+                    index: 0,
+                    text: text.to_string(),
+                });
             }
             if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
                 for tool_call in tool_calls {

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -5,8 +5,10 @@
 
 pub mod common;
 
+use std::collections::HashMap;
+
 use pretty_assertions::assert_eq;
-use serde_json::json;
+use serde_json::{Value, json};
 use switchyard_protocol::{LlmResponseStreamEvent, ResponseAccumulator, StopReason};
 use switchyard_translation::{
     LlmResponseChunk, StreamTranslationState, TranslationEngine, WireFormat, decode_stream_event,
@@ -15,6 +17,48 @@ use switchyard_translation::{
 use common::{REASONING_MODEL, text_and_encrypted_reasoning_details};
 
 type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+// Reduces Anthropic stream events to ordered labels (`<block>_start`, `<delta>`,
+// `<block>_stop`) so ordering assertions stay readable without restating each payload.
+fn event_labels(events: &[Value]) -> Vec<String> {
+    let mut block_types: HashMap<u64, String> = HashMap::new();
+    events
+        .iter()
+        .map(|event| {
+            let index = event
+                .get("index")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            match event
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+            {
+                "content_block_start" => {
+                    let block_type = event
+                        .get("content_block")
+                        .and_then(|block| block.get("type"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    block_types.insert(index, block_type.clone());
+                    format!("{block_type}_start")
+                }
+                "content_block_delta" => event
+                    .get("delta")
+                    .and_then(|delta| delta.get("type"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                "content_block_stop" => {
+                    let block_type = block_types.get(&index).cloned().unwrap_or_default();
+                    format!("{block_type}_stop")
+                }
+                other => other.to_string(),
+            }
+        })
+        .collect()
+}
 
 // Same-format replay returns the same parsed JSON value, including provider-specific fields.
 #[test]
@@ -384,51 +428,15 @@ fn openai_chat_mixed_reasoning_and_content_stream_in_reasoning_first_order() -> 
     )?;
 
     assert_eq!(
-        events,
+        event_labels(&events),
         vec![
-            json!({
-                "type": "message_start",
-                "message": {
-                    "id": "msg_chatcmpl-test",
-                    "type": "message",
-                    "role": "assistant",
-                    "model": "nvidia/nvidia/nemotron-3-ultra-nvfp4",
-                    "content": [],
-                    "stop_reason": null,
-                    "stop_sequence": null,
-                    "usage": {"input_tokens": 0, "output_tokens": 0}
-                }
-            }),
-            json!({
-                "type": "content_block_start",
-                "index": 0,
-                "content_block": {
-                    "type": "thinking",
-                    "thinking": "",
-                    "signature": ""
-                }
-            }),
-            json!({
-                "type": "content_block_delta",
-                "index": 0,
-                "delta": {"type": "thinking_delta", "thinking": "."}
-            }),
-            json!({
-                "type": "content_block_delta",
-                "index": 0,
-                "delta": {"type": "signature_delta", "signature": ""}
-            }),
-            json!({"type": "content_block_stop", "index": 0}),
-            json!({
-                "type": "content_block_start",
-                "index": 1,
-                "content_block": {"type": "text", "text": ""}
-            }),
-            json!({
-                "type": "content_block_delta",
-                "index": 1,
-                "delta": {"type": "text_delta", "text": "Hello"}
-            }),
+            "message_start",
+            "thinking_start",
+            "thinking_delta",
+            "signature_delta",
+            "thinking_stop",
+            "text_start",
+            "text_delta",
         ]
     );
     Ok(())

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -356,7 +356,7 @@ fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResu
     Ok(())
 }
 
-// Verifies mixed reasoning and content emit reasoning before text for Anthropic clients for Anthropic clients.
+// A mixed chunk must emit reasoning before text, matching the buffered decoder.
 #[test]
 fn openai_chat_mixed_reasoning_and_content_stream_in_reasoning_first_order() -> TestResult {
     let engine = TranslationEngine::default();

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -356,6 +356,84 @@ fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResu
     Ok(())
 }
 
+// Verifies mixed reasoning and content emit reasoning before text for Anthropic clients for Anthropic clients.
+#[test]
+fn openai_chat_mixed_reasoning_and_content_stream_in_reasoning_first_order() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let chunk = json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "model": "nvidia/nvidia/nemotron-3-ultra-nvfp4",
+        "choices": [{
+            "index": 0,
+            "delta": {
+                "reasoning_content": ".",
+                "content": "Hello"
+            },
+            "finish_reason": null
+        }]
+    });
+
+    let events = engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &chunk,
+    )?;
+
+    assert_eq!(
+        events,
+        vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "id": "msg_chatcmpl-test",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "nvidia/nvidia/nemotron-3-ultra-nvfp4",
+                    "content": [],
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 0, "output_tokens": 0}
+                }
+            }),
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "thinking",
+                    "thinking": "",
+                    "signature": ""
+                }
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "."}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": ""}
+            }),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""}
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "text_delta", "text": "Hello"}
+            }),
+        ]
+    );
+    Ok(())
+}
+
 // Verifies Anthropic usage and stop events become terminal OpenAI chunks.
 #[test]
 fn anthropic_stream_usage_and_stop_translate_to_openai_chunks() -> TestResult {


### PR DESCRIPTION
## What

Preserve reasoning-before-content order when an OpenAI Chat stream chunk contains both
`reasoning_content` and visible `content`.

Add a focused OpenAI Chat to Anthropic Messages stream regression test using the one-chunk
reproducer from Issue 242. The test asserts the complete thinking block, thinking close, and text
block event sequence.

## Why

Reasoning models can return reasoning and final content in the same stream delta. Emitting visible
content first makes the Anthropic translation close the text block and open a later thinking block,
which can interleave reasoning with the final answer. We hit this while streaming reasoning models
through the translation layer.

Closes #242

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green (`134 passed`, `2 deselected` with integration tests excluded)
- [ ] Manual smoke (not run; the issue's exact chunk is covered by the cross-format regression test)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] Focused regression test demonstrated red before the decoder change and green after it

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. No new classes or files.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. No new public symbols.
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. No customer-facing API surface changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The production diff only moves existing `content` delta emission below the existing reasoning-field
loop. Parsing, field precedence, tool calls, finish reasons, and error behavior are unchanged.

The regression test asserts the exact Anthropic event order from the reported reproducer: thinking
block start, reasoning delta, signature delta, thinking block stop, text block start, and text delta.
Chunks containing only reasoning or only content retain their existing output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now consistently deliver reasoning content before text when both arrive together.
  * Text extraction behavior remains unchanged.

* **Tests**
  * Added coverage to verify the correct ordering of reasoning and text content in translated streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->