### PR TITLE
fix(libsy): warn when the scorer cannot reach a picker's non-default tier

### DIFF
--- a/crates/libsy/src/algorithms/stage.rs
+++ b/crates/libsy/src/algorithms/stage.rs
@@ -22,8 +22,8 @@ use super::llm_class::{LlmClassifierConfig, LlmTaskClassifier, TaskClassifierCon
 use super::util::prompts::{SystemPromptProcessor, TargetPrompts};
 use super::util::stage::{
     DecisionSource, HandoffNoteConfig, PickerMode, StageClassifier, StageTargets,
-    max_efficient_confidence, record_decision_source, record_routing_decision,
-    scorer_cannot_leave_default,
+    max_capable_confidence, max_efficient_confidence, record_decision_source,
+    record_routing_decision, scorer_cannot_leave_default,
 };
 use super::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignalProcessor};
 use crate::core::algorithm::{Algorithm, Driver};
@@ -159,22 +159,29 @@ fn build_route(
             ),
         });
     }
-    // A threshold above the efficient ceiling silently disables the scorer for
-    // capable_first: every turn reads as "signals were weak" when in fact that
-    // branch cannot fire at all. Warn rather than reject, since the judge and the
-    // hard de-escalation shortcut still work and the setting stays a policy choice.
+    // A threshold above the scorer's ceiling in the direction that leaves the
+    // default tier silently disables the scorer: those turns read as "signals were
+    // weak" when in fact the branch cannot fire at all. Warn rather than reject —
+    // the hard overrides still fire, and the setting stays a policy choice.
     if scorer_cannot_leave_default(config.mode, config.confidence_threshold) {
+        let (picker, other_tier, ceiling) = match config.mode {
+            PickerMode::CapableFirst => ("capable_first", "efficient", max_efficient_confidence()),
+            PickerMode::EfficientFirst => ("efficient_first", "capable", max_capable_confidence()),
+        };
         tracing::warn!(
             confidence_threshold = config.confidence_threshold,
-            efficient_ceiling = max_efficient_confidence(),
-            "stage_router picker \"capable_first\" with confidence_threshold {} cannot de-escalate: \
-             production_intensity is the only signal on the efficient side, so the scorer tops out \
-             at {:.4}. Every turn will fall through to the judge, or to the capable tier when no \
-             judge is configured. Set confidence_threshold at or below {:.4} for the scorer to \
-             reach the efficient tier.",
+            ceiling,
+            "stage_router picker \"{}\" with confidence_threshold {} can never select the {} tier: \
+             the scorer tops out at {:.4} in that direction, so no signal clears the gate. Turns \
+             the hard overrides do not claim fall through to the judge, or to the default tier when \
+             no judge is configured. Set confidence_threshold at or below {:.4} for the scorer to \
+             reach the {} tier.",
+            picker,
             config.confidence_threshold,
-            max_efficient_confidence(),
-            max_efficient_confidence(),
+            other_tier,
+            ceiling,
+            ceiling,
+            other_tier,
         );
     }
     // The tiers are a fixed pair; their targets are whatever the deployment calls

--- a/crates/libsy/src/algorithms/stage.rs
+++ b/crates/libsy/src/algorithms/stage.rs
@@ -22,7 +22,8 @@ use super::llm_class::{LlmClassifierConfig, LlmTaskClassifier, TaskClassifierCon
 use super::util::prompts::{SystemPromptProcessor, TargetPrompts};
 use super::util::stage::{
     DecisionSource, HandoffNoteConfig, PickerMode, StageClassifier, StageTargets,
-    record_decision_source, record_routing_decision,
+    max_efficient_confidence, record_decision_source, record_routing_decision,
+    scorer_cannot_leave_default,
 };
 use super::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignalProcessor};
 use crate::core::algorithm::{Algorithm, Driver};
@@ -157,6 +158,24 @@ fn build_route(
                 config.confidence_threshold
             ),
         });
+    }
+    // A threshold above the efficient ceiling silently disables the scorer for
+    // capable_first: every turn reads as "signals were weak" when in fact that
+    // branch cannot fire at all. Warn rather than reject, since the judge and the
+    // hard de-escalation shortcut still work and the setting stays a policy choice.
+    if scorer_cannot_leave_default(config.mode, config.confidence_threshold) {
+        tracing::warn!(
+            confidence_threshold = config.confidence_threshold,
+            efficient_ceiling = max_efficient_confidence(),
+            "stage_router picker \"capable_first\" with confidence_threshold {} cannot de-escalate: \
+             production_intensity is the only signal on the efficient side, so the scorer tops out \
+             at {:.4}. Every turn will fall through to the judge, or to the capable tier when no \
+             judge is configured. Set confidence_threshold at or below {:.4} for the scorer to \
+             reach the efficient tier.",
+            config.confidence_threshold,
+            max_efficient_confidence(),
+            max_efficient_confidence(),
+        );
     }
     // The tiers are a fixed pair; their targets are whatever the deployment calls
     // them, and the classifier scores onto those names.

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -334,26 +334,48 @@ pub fn score_signal(signal: &ToolSignals) -> ScoreResult {
     }
 }
 
+/// Confidence a turn scoring `units` maxed signals lands on, after the squash.
+fn confidence_for_units(units: f64) -> f64 {
+    (SCORE_GAIN * SIGNAL_UNIT * units).tanh()
+}
+
 /// Highest confidence the scorer can reach toward the efficient tier.
 ///
 /// `production_intensity` is the only dimension on the efficient side and
 /// [`ratio`] bounds it to `1.0`, so the efficient direction has exactly one
 /// signal unit to work with — there is nothing for it to corroborate with. The
-/// `tanh` squash then pulls that unit down from `SCORE_GAIN * SIGNAL_UNIT` to
-/// roughly `0.4621`, which lands just under the commonly used `0.5` threshold.
+/// `tanh` squash then pulls that unit down to roughly `0.4621`, which lands just
+/// under the commonly used `0.5` threshold.
 pub fn max_efficient_confidence() -> f64 {
-    (SCORE_GAIN * SIGNAL_UNIT).tanh()
+    confidence_for_units(1.0)
+}
+
+/// Highest confidence the scorer can reach toward the capable tier.
+///
+/// Escalation stacks two units, not three: `severity` contributes one at its
+/// [`HARD_SEVERITY`] cap (critical is intercepted by the override), and
+/// `spinning` / `exploring` partition the not-producing case so only one of them
+/// can fire. `production_intensity` is zero whenever either does, so nothing
+/// subtracts. That caps escalation confidence at roughly `0.7616`.
+pub fn max_capable_confidence() -> f64 {
+    confidence_for_units(2.0)
 }
 
 /// True when `confidence_threshold` puts every scorer outcome out of reach of
 /// `mode`'s non-default tier, so the scorer can never change a turn's tier.
 ///
-/// Only [`PickerMode::CapableFirst`] can hit this: leaving its default means
-/// picking efficient, and that side caps at [`max_efficient_confidence`].
-/// Escalation stacks several dimensions, so `efficient_first` always has some
-/// reachable band and is never reported here.
+/// Both pickers can hit this, because `tanh` bounds confidence well below `1.0`
+/// in either direction — `capable_first` from
+/// [`max_efficient_confidence`], `efficient_first` from
+/// [`max_capable_confidence`]. Above its ceiling the scorer still runs and still
+/// reports a score, but it can only ever confirm the default tier.
 pub fn scorer_cannot_leave_default(mode: PickerMode, confidence_threshold: f64) -> bool {
-    matches!(mode, PickerMode::CapableFirst) && confidence_threshold > max_efficient_confidence()
+    let ceiling = match mode {
+        // Leaving the capable default means picking efficient, and vice versa.
+        PickerMode::CapableFirst => max_efficient_confidence(),
+        PickerMode::EfficientFirst => max_capable_confidence(),
+    };
+    confidence_threshold > ceiling
 }
 
 /// Hard **escalate** — force the capable tier no matter what the scorer would
@@ -689,12 +711,36 @@ mod tests {
     }
 
     #[test]
-    fn the_efficient_ceiling_sits_below_a_half() {
-        // tanh compresses one full signal unit (5.0 × 0.10) to ~0.4621, so the
-        // widely used 0.5 threshold sits above everything the efficient side can
-        // score. This is the constant the capable_first guard is built on.
+    fn error_and_stall_signals_are_the_only_ones_pushing_toward_capable() {
+        // The escalation ceiling is two units, not three: severity at its hard cap
+        // plus whichever of spinning/exploring fires. A deep turn that errored and
+        // is reading without producing reaches exactly that.
+        let mut signal = signal_from(json!([{"role": "user", "content": "hi"}]));
+        signal.severity = HARD_SEVERITY as f32;
+        signal.turn_depth = STALL_MIN_TURN_DEPTH;
+        signal.recent_read_count = 2;
+        let dimensions = dimensions_from_signal(&signal);
+        assert_eq!(dimensions.exploring, 1.0);
+        assert_eq!(dimensions.spinning, 0.0);
+        let scored = score_signal(&signal);
+        assert!(scored.score > 0.0, "expected a capable lean: {scored:?}");
+        // `severity` is an f32, so the widened 0.7 divides out a few ulps short of
+        // one whole unit. The ceiling itself is exact; the signal reaching it is not.
+        assert!(
+            (scored.confidence - max_capable_confidence()).abs() < 1e-7,
+            "an errored, exploring turn should reach the ceiling: {scored:?}"
+        );
+    }
+
+    #[test]
+    fn both_ceilings_sit_below_the_thresholds_operators_reach_for() {
+        // tanh compresses one signal unit to ~0.4621 and two to ~0.7616, so 0.5
+        // and 1.0 respectively sit above everything each side can score. These are
+        // the constants the picker guard is built on.
         assert!((max_efficient_confidence() - 0.462_117_157_260_009_7).abs() < 1e-12);
+        assert!((max_capable_confidence() - 0.761_594_155_955_764_9).abs() < 1e-12);
         assert!(max_efficient_confidence() < 0.5);
+        assert!(max_capable_confidence() < 1.0);
     }
 
     #[test]
@@ -712,16 +758,43 @@ mod tests {
     }
 
     #[test]
-    fn efficient_first_is_never_reported_as_inert() {
-        // Escalation has more signals to stack, and this guard only speaks to the
-        // efficient direction.
+    fn efficient_first_reports_an_unreachable_capable_tier() {
+        // Escalation has a second unit to stack, so its ceiling is higher — but
+        // `tanh` still keeps it short of 1.0, which the range check accepts.
+        assert!(scorer_cannot_leave_default(PickerMode::EfficientFirst, 1.0));
+        assert!(scorer_cannot_leave_default(PickerMode::EfficientFirst, 0.8));
         assert!(!scorer_cannot_leave_default(
             PickerMode::EfficientFirst,
             0.5
         ));
         assert!(!scorer_cannot_leave_default(
             PickerMode::EfficientFirst,
-            1.0
+            max_capable_confidence()
+        ));
+    }
+
+    #[test]
+    fn efficient_first_at_its_ceiling_never_picks_capable() {
+        // End-to-end on `pick_tier`, mirroring the capable_first case: the
+        // strongest possible escalation signal is handed on rather than resolved.
+        let mut signal = signal_from(json!([{"role": "user", "content": "hi"}]));
+        signal.severity = HARD_SEVERITY as f32;
+        signal.turn_depth = STALL_MIN_TURN_DEPTH;
+        signal.recent_read_count = 2;
+        assert!(matches!(
+            pick_tier(&signal, PickerMode::EfficientFirst, 1.0),
+            PickOutcome::ConsultClassifier {
+                default_tier: Tier::Efficient,
+                ..
+            }
+        ));
+        assert!(matches!(
+            pick_tier(&signal, PickerMode::EfficientFirst, 0.75),
+            PickOutcome::Resolved {
+                tier: Tier::Capable,
+                source: DecisionSource::Dimensions,
+                ..
+            }
         ));
     }
 

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -334,6 +334,28 @@ pub fn score_signal(signal: &ToolSignals) -> ScoreResult {
     }
 }
 
+/// Highest confidence the scorer can reach toward the efficient tier.
+///
+/// `production_intensity` is the only dimension on the efficient side and
+/// [`ratio`] bounds it to `1.0`, so the efficient direction has exactly one
+/// signal unit to work with — there is nothing for it to corroborate with. The
+/// `tanh` squash then pulls that unit down from `SCORE_GAIN * SIGNAL_UNIT` to
+/// roughly `0.4621`, which lands just under the commonly used `0.5` threshold.
+pub fn max_efficient_confidence() -> f64 {
+    (SCORE_GAIN * SIGNAL_UNIT).tanh()
+}
+
+/// True when `confidence_threshold` puts every scorer outcome out of reach of
+/// `mode`'s non-default tier, so the scorer can never change a turn's tier.
+///
+/// Only [`PickerMode::CapableFirst`] can hit this: leaving its default means
+/// picking efficient, and that side caps at [`max_efficient_confidence`].
+/// Escalation stacks several dimensions, so `efficient_first` always has some
+/// reachable band and is never reported here.
+pub fn scorer_cannot_leave_default(mode: PickerMode, confidence_threshold: f64) -> bool {
+    matches!(mode, PickerMode::CapableFirst) && confidence_threshold > max_efficient_confidence()
+}
+
 /// Hard **escalate** — force the capable tier no matter what the scorer would
 /// say. Fires on a critical error or a compacted context.
 fn should_escalate(signal: &ToolSignals) -> bool {
@@ -647,6 +669,84 @@ mod tests {
             scored.confidence < 0.5,
             "one signal should not clear 0.5: {scored:?}"
         );
+    }
+
+    #[test]
+    fn production_is_the_only_signal_pushing_toward_efficient() {
+        // The de-escalation ceiling is a property of the dimension set: only
+        // `production_intensity` is negative, and `ratio` bounds it to 1.0. A
+        // turn that is pure production therefore scores the strongest efficient
+        // confidence the scorer can ever produce.
+        let mut signal = signal_from(json!([{"role": "user", "content": "hi"}]));
+        signal.recent_write_count = 3;
+        signal.recent_edit_count = 1;
+        let scored = score_signal(&signal);
+        assert!(scored.score < 0.0, "expected an efficient lean: {scored:?}");
+        assert!(
+            (scored.confidence - max_efficient_confidence()).abs() < 1e-12,
+            "pure production should reach the ceiling: {scored:?}"
+        );
+    }
+
+    #[test]
+    fn the_efficient_ceiling_sits_below_a_half() {
+        // tanh compresses one full signal unit (5.0 × 0.10) to ~0.4621, so the
+        // widely used 0.5 threshold sits above everything the efficient side can
+        // score. This is the constant the capable_first guard is built on.
+        assert!((max_efficient_confidence() - 0.462_117_157_260_009_7).abs() < 1e-12);
+        assert!(max_efficient_confidence() < 0.5);
+    }
+
+    #[test]
+    fn capable_first_reports_an_unreachable_efficient_tier() {
+        // Above the ceiling the scorer cannot leave the capable default, so the
+        // combination is inert rather than merely selective.
+        assert!(scorer_cannot_leave_default(PickerMode::CapableFirst, 0.5));
+        assert!(scorer_cannot_leave_default(PickerMode::CapableFirst, 0.47));
+        assert!(!scorer_cannot_leave_default(PickerMode::CapableFirst, 0.45));
+        // The gate is inclusive, so the ceiling itself still fires.
+        assert!(!scorer_cannot_leave_default(
+            PickerMode::CapableFirst,
+            max_efficient_confidence()
+        ));
+    }
+
+    #[test]
+    fn efficient_first_is_never_reported_as_inert() {
+        // Escalation has more signals to stack, and this guard only speaks to the
+        // efficient direction.
+        assert!(!scorer_cannot_leave_default(
+            PickerMode::EfficientFirst,
+            0.5
+        ));
+        assert!(!scorer_cannot_leave_default(
+            PickerMode::EfficientFirst,
+            1.0
+        ));
+    }
+
+    #[test]
+    fn capable_first_above_the_ceiling_never_picks_efficient() {
+        // End-to-end on `pick_tier`: the strongest possible efficient signal is
+        // still handed on rather than resolved.
+        let mut signal = signal_from(json!([{"role": "user", "content": "hi"}]));
+        signal.recent_write_count = 3;
+        signal.recent_edit_count = 1;
+        assert!(matches!(
+            pick_tier(&signal, PickerMode::CapableFirst, 0.5),
+            PickOutcome::ConsultClassifier {
+                default_tier: Tier::Capable,
+                ..
+            }
+        ));
+        assert!(matches!(
+            pick_tier(&signal, PickerMode::CapableFirst, 0.45),
+            PickOutcome::Resolved {
+                tier: Tier::Efficient,
+                source: DecisionSource::Dimensions,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -350,6 +350,16 @@ pub fn max_efficient_confidence() -> f64 {
     confidence_for_units(1.0)
 }
 
+/// Signal units `severity` contributes at its hard cap.
+///
+/// A hair under one, not one: [`ToolSignals::severity`] is an `f32`, so the
+/// scorer divides the widened `0.7` by an `f64` [`HARD_SEVERITY`] and lands a few
+/// ulps short. The ceiling has to be built on the value a real signal produces —
+/// on the exact unit, the strongest escalation falls below its own ceiling.
+fn max_severity_units() -> f64 {
+    f64::from(HARD_SEVERITY as f32) / HARD_SEVERITY
+}
+
 /// Highest confidence the scorer can reach toward the capable tier.
 ///
 /// Escalation stacks two units, not three: `severity` contributes one at its
@@ -358,7 +368,7 @@ pub fn max_efficient_confidence() -> f64 {
 /// can fire. `production_intensity` is zero whenever either does, so nothing
 /// subtracts. That caps escalation confidence at roughly `0.7616`.
 pub fn max_capable_confidence() -> f64 {
-    confidence_for_units(2.0)
+    confidence_for_units(max_severity_units() + 1.0)
 }
 
 /// True when `confidence_threshold` puts every scorer outcome out of reach of
@@ -724,10 +734,8 @@ mod tests {
         assert_eq!(dimensions.spinning, 0.0);
         let scored = score_signal(&signal);
         assert!(scored.score > 0.0, "expected a capable lean: {scored:?}");
-        // `severity` is an f32, so the widened 0.7 divides out a few ulps short of
-        // one whole unit. The ceiling itself is exact; the signal reaching it is not.
         assert!(
-            (scored.confidence - max_capable_confidence()).abs() < 1e-7,
+            (scored.confidence - max_capable_confidence()).abs() < 1e-12,
             "an errored, exploring turn should reach the ceiling: {scored:?}"
         );
     }
@@ -738,9 +746,48 @@ mod tests {
         // and 1.0 respectively sit above everything each side can score. These are
         // the constants the picker guard is built on.
         assert!((max_efficient_confidence() - 0.462_117_157_260_009_7).abs() < 1e-12);
-        assert!((max_capable_confidence() - 0.761_594_155_955_764_9).abs() < 1e-12);
+        assert!((max_capable_confidence() - 0.761_594_152_379_704_8).abs() < 1e-12);
         assert!(max_efficient_confidence() < 0.5);
         assert!(max_capable_confidence() < 1.0);
+    }
+
+    #[test]
+    fn a_threshold_at_either_ceiling_still_resolves() {
+        // The guard stays silent at exactly the ceiling, so the strongest signal in
+        // each direction has to clear the inclusive gate there. This is the boundary
+        // an approximate ceiling would quietly break.
+        let mut producing = signal_from(json!([{"role": "user", "content": "hi"}]));
+        producing.recent_write_count = 3;
+        producing.recent_edit_count = 1;
+        assert!(matches!(
+            pick_tier(
+                &producing,
+                PickerMode::CapableFirst,
+                max_efficient_confidence()
+            ),
+            PickOutcome::Resolved {
+                tier: Tier::Efficient,
+                source: DecisionSource::Dimensions,
+                ..
+            }
+        ));
+
+        let mut stalled = signal_from(json!([{"role": "user", "content": "hi"}]));
+        stalled.severity = HARD_SEVERITY as f32;
+        stalled.turn_depth = STALL_MIN_TURN_DEPTH;
+        stalled.recent_read_count = 2;
+        assert!(matches!(
+            pick_tier(
+                &stalled,
+                PickerMode::EfficientFirst,
+                max_capable_confidence()
+            ),
+            PickOutcome::Resolved {
+                tier: Tier::Capable,
+                source: DecisionSource::Dimensions,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -34,7 +34,7 @@ pub use algorithms::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignals};
 pub use algorithms::util::stage::{
     CodingAgentDimensions, DECISION_SOURCE_KEY, DecisionSource, HandoffNoteConfig, PickOutcome,
     PickerMode, ScoreResult, StageClassifier, StageTargets, Tier, dimensions_from_signal,
-    pick_tier, score_signal,
+    max_efficient_confidence, pick_tier, score_signal, scorer_cannot_leave_default,
 };
 
 mod observability;

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -34,7 +34,8 @@ pub use algorithms::util::tool_signals::{DEFAULT_RECENT_WINDOW, ToolSignals};
 pub use algorithms::util::stage::{
     CodingAgentDimensions, DECISION_SOURCE_KEY, DecisionSource, HandoffNoteConfig, PickOutcome,
     PickerMode, ScoreResult, StageClassifier, StageTargets, Tier, dimensions_from_signal,
-    max_efficient_confidence, pick_tier, score_signal, scorer_cannot_leave_default,
+    max_capable_confidence, max_efficient_confidence, pick_tier, score_signal,
+    scorer_cannot_leave_default,
 };
 
 mod observability;


### PR DESCRIPTION
## What

Warns at route construction when a `stage_router` route pairs a picker with a `confidence_threshold` the scorer can never reach in the direction that leaves the default tier. No routing behaviour changes.

```rust
pub fn max_efficient_confidence() -> f64 { confidence_for_units(1.0) }  // 0.4621…
pub fn max_capable_confidence()   -> f64 { confidence_for_units(2.0) }  // 0.7616…

pub fn scorer_cannot_leave_default(mode, confidence_threshold) -> bool
```

## Why

Closes #264

`score_signal` sums one positive axis against one negative dimension, then squashes with `tanh`. Each direction has a hard ceiling below `1.0`:

| direction | units available | ceiling |
|---|---|---|
| efficient | `production_intensity` only, bounded to `1.0` by `ratio` | `0.4621` |
| capable | `severity` at its `HARD_SEVERITY` cap, plus one of `spinning` / `exploring` (they partition the not-producing case) | `0.7616` |

Above its ceiling the gate never opens, so the scorer can only ever confirm the default tier. The reporter measured 439 consecutive turns at `capable_first` + `0.5` with zero turns routed to the efficient tier and zero upstream errors. Nothing in the logs or in `routing_decisions.stage_router` separates "signals were weak this turn" from "this branch cannot fire at all".

`efficient_first` + `1.0` is the mirror case, and the `[0.0, 1.0]` range check accepts it today.

## How tested

- [x] `cargo test --workspace` green (23 test binaries, 0 failed)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all --check` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/ --ignore=tests/e2e` green (135 passed)
- [x] Manual smoke: captured the log for all four combinations — `capable_first` + `0.5` and `efficient_first` + `1.0` warn; `0.45` and `0.5` respectively stay silent.

`tests/e2e/test_closed_book_proxy_integration.py` fails locally, but it fails identically on a clean checkout of `main` — a pre-existing network-dependent failure, unrelated to this change.

Seven unit tests added. The two that pin the ceilings derive them from the dimension set rather than asserting literals, so they fail if the signal set ever changes.

## Checklist

- [x] Unit tests added for the bug fix.
- [x] New public symbols re-exported from `crates/libsy/src/lib.rs`.
- [x] Commits signed off per the DCO.
- [ ] Python-side checklist items are not applicable — Rust-only change, no customer-facing surface change.

## Notes for reviewers

**Which of the issue's three options this takes.** Option 1 (lower the default) no longer applies: `confidence_threshold` is a required TOML field with no default, and the Python paths the issue cites were removed when routing moved to Rust. Option 3 (add a second negative signal) changes routing behaviour and needs recalibration. This is option 2 — happy to re-scope if you prefer option 3.

**Warn, not reject.** The hard overrides (`should_escalate` / `should_deescalate`) run before the scorer and still fire, and the judge still resolves turns, so the route is not inert end to end — only the scorer is. Rejecting at load would break running deployments, including the `confidence_threshold = 1.0` fixture in `config.rs`.

**Placement.** The guard lives in `libsy` so it covers the TOML server path and the PyO3 bindings from one place, and the ceilings sit next to the `SCORE_GAIN` / `SIGNAL_UNIT` / `HARD_SEVERITY` constants they are derived from. Deployments on `capable_first` will see this alongside the existing "capable_first is experimental" warning in `config.rs`; collapsing the pair is an option if it reads as noise.

**The capable ceiling depends on the severity table.** It assumes `HARD_SEVERITY` is the strongest severity the scorer sees, which is what that constant's doc comment already states (critical is intercepted by the override). If a pattern with a severity between `0.7` and `1.0` is ever added to `ERROR_PATTERNS`, `max_capable_confidence` moves and its test fails — intentionally.

**Docs left alone.** #264 also flags four lines in `docs/routing_algorithms/stage_router_routing.md`. #288 is already rewriting that page, so touching it here would only conflict. A follow-up can point it at these helpers once that lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confidence-limit utilities for identifying efficient and capable maximum thresholds.
  * Added detection for thresholds that cannot move a picker beyond its default tier.

* **Bug Fixes**
  * Warnings now identify unreachable thresholds, the affected mode, and recommended values.
  * Routing preserves hard overrides and fall-through behavior for undecided turns.

* **Tests**
  * Added coverage for confidence ceilings, mode-specific thresholds, and picker behavior at supported limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->