### PR TITLE
ci: base full CI on changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      full_ci: ${{ github.event_name != 'pull_request' || (!startsWith(github.event.pull_request.title, 'docs') && steps.filter.outputs.full_ci == 'true') }}
+      full_ci: ${{ github.event_name != 'pull_request' || steps.filter.outputs.full_ci == 'true' }}
     steps:
       - name: Detect non-documentation changes
         id: filter
-        if: github.event_name == 'pull_request' && !startsWith(github.event.pull_request.title, 'docs')
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v4
         with:
           predicate-quantifier: every

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression checks for the primary CI workflow."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def test_full_ci_depends_on_changed_paths_not_pr_title() -> None:
+    """Ensure a docs-prefixed title cannot bypass substantive CI jobs."""
+    workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
+    workflow: dict[str, Any] = yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
+    changes = workflow["jobs"]["changes"]
+
+    full_ci = changes["outputs"]["full_ci"]
+    assert "pull_request.title" not in full_ci
+
+    filter_step = next(step for step in changes["steps"] if step.get("id") == "filter")
+    assert "pull_request.title" not in filter_step["if"]
+    assert filter_step["if"] == "github.event_name == 'pull_request'"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -3,20 +3,28 @@
 
 """Regression checks for the primary CI workflow."""
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 
-def test_full_ci_depends_on_changed_paths_not_pr_title() -> None:
+async def test_full_ci_depends_on_changed_paths_not_pr_title() -> None:
     """Ensure a docs-prefixed title cannot bypass substantive CI jobs."""
     workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
-    workflow: dict[str, Any] = yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
+    workflow_text = await asyncio.to_thread(workflow_path.read_text)
+    workflow: dict[str, Any] = await asyncio.to_thread(
+        yaml.load,
+        workflow_text,
+        Loader=yaml.BaseLoader,
+    )
     changes = workflow["jobs"]["changes"]
 
     full_ci = changes["outputs"]["full_ci"]
     assert "pull_request.title" not in full_ci
+    assert "github.event_name != 'pull_request'" in full_ci
+    assert "steps.filter.outputs.full_ci == 'true'" in full_ci
 
     filter_step = next(step for step in changes["steps"] if step.get("id") == "filter")
     assert "pull_request.title" not in filter_step["if"]


### PR DESCRIPTION
## What

- make the `changes` job derive `full_ci` from changed paths for every pull request
- keep the existing documentation-only path exclusions
- add a regression test that rejects PR-title checks in the path-classification flow

## Why

A `docs...` title could skip every substantive CI job even when the pull request changed Rust or Python code. Titles are descriptive metadata and must not override the changed-path classification.

Closes #402

## Validation

- `UV_CACHE_DIR=/tmp/switchyard-uv-cache UV_TOOL_DIR=/tmp/switchyard-uv-tools uvx --from pytest --with pyyaml pytest -s tests/test_ci_workflow.py -q -o addopts=` — 1 passed (the isolated runner reported two warnings for repository pytest options whose optional plugins were not installed)
- `ruff check .` — passed
- parsed `.github/workflows/ci.yml` with PyYAML `BaseLoader` — passed
- `git diff --check` — passed

No live provider calls or secrets were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Continuous integration now runs consistently for documentation-only pull requests.
  * Pull request titles no longer determine whether full CI runs.

* **Tests**
  * Added regression coverage to verify CI decisions are based on changed paths and event type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->