### PR TITLE
fix(translation): accept SSE data without a space

### DIFF
--- a/crates/switchyard-translation/src/helpers.rs
+++ b/crates/switchyard-translation/src/helpers.rs
@@ -583,6 +583,17 @@ mod tests {
     }
 
     #[test]
+    fn decode_stream_accepts_sse_data_without_optional_space() -> Result<(), LlmClientError> {
+        let sse = b"data:{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
+             data:[DONE]\n\n"
+            .to_vec();
+        let bytes = stream::once(async move { Ok::<Vec<u8>, LlmClientError>(sse) });
+        let chunks = decode_all(bytes, WireFormat::OpenAiChat)?;
+        assert_eq!(text_of(&chunks), "Hello");
+        Ok(())
+    }
+
+    #[test]
     fn stream_helpers_replay_same_format_provider_fields() -> Result<(), BoxError> {
         let provider_event = json!({
             "id": "chatcmpl-test",

--- a/crates/switchyard-translation/src/sse.rs
+++ b/crates/switchyard-translation/src/sse.rs
@@ -36,7 +36,10 @@ pub(crate) fn parse_json_sse_frame(
     let data = frame
         .lines()
         .filter(|line| !line.is_empty() && !line.starts_with(':'))
-        .filter_map(|line| line.strip_prefix("data: ").map(|l| l.to_string()))
+        .filter_map(|line| {
+            line.strip_prefix("data:")
+                .map(|value| value.strip_prefix(' ').unwrap_or(value).to_string())
+        })
         .fold(String::new(), |mut a, b| {
             a.reserve(b.len() + 1);
             a.push_str(&b);


### PR DESCRIPTION
## What

- accept both `data:{...}` and `data: {...}` SSE fields
- remove at most one optional ASCII space after the field-name colon
- cover a no-space JSON payload and `data:[DONE]` in the shared stream decoder

## Why

The SSE parser matched only the literal `data: ` prefix, so valid upstream events without the optional space were silently ignored.

Closes #399

## Validation

- `cargo test -p switchyard-translation decode_stream_accepts_sse_data_without_optional_space -- --nocapture` — passed
- `cargo test -p switchyard-translation` — passed
- `cargo fmt --all --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed with loopback access enabled for the repository's local mock servers
- `git diff --check` — passed

No live provider calls or secrets were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response parsing to accept data fields with or without a space after the colon.
  * Preserved support for termination markers such as `[DONE]`.
* **Tests**
  * Added regression coverage for both supported data field formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->