### PR TITLE
fix(server): validate configured base URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "prometheus",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry-prometheus = "0.32"
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics", "trace"] }
 parking_lot.workspace = true
 prometheus = "0.14"
+reqwest.workspace = true
 serde.workspace = true
 toml = "1.1"
 switchyard-llm-client.workspace = true

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -262,11 +262,42 @@ fn count_tokens_priority(target_name: &str, model_id: &ModelId) -> usize {
         .unwrap_or(3)
 }
 
+/// A client endpoint, parsed when the config loads rather than checked afterwards.
+///
+/// Holding a `HttpBaseUrl` is proof the value is an absolute HTTP(S) URL, so no
+/// later stage has to re-check it or can forget to.
+#[derive(Clone, Debug)]
+pub(crate) struct HttpBaseUrl(reqwest::Url);
+
+impl HttpBaseUrl {
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for HttpBaseUrl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        let url = reqwest::Url::parse(raw.trim()).map_err(|error| {
+            serde::de::Error::custom(format!("base_url must be an absolute HTTP(S) URL: {error}"))
+        })?;
+        if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+            return Err(serde::de::Error::custom(
+                "base_url must be an absolute HTTP(S) URL",
+            ));
+        }
+        Ok(Self(url))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct LlmClientConfig {
     pub(crate) format: ClientFormat,
-    pub(crate) base_url: String,
+    pub(crate) base_url: HttpBaseUrl,
     api_key_env: Option<String>,
     #[serde(default)]
     forward_auth: bool,
@@ -913,12 +944,6 @@ fn build_backend(
     config: &LlmClientConfig,
     extra_body: &BTreeMap<String, Value>,
 ) -> ServerResult<Backend> {
-    let base_url = config.base_url.trim();
-    if base_url.is_empty() {
-        return Err(ServerError::new(format!(
-            "llm client {client_name} base_url must not be empty"
-        )));
-    }
     if config.max_retries > MAX_CONFIGURED_RETRIES {
         return Err(ServerError::new(format!(
             "llm client {client_name} max_retries must be at most {MAX_CONFIGURED_RETRIES}"
@@ -952,7 +977,7 @@ fn build_backend(
         })
         .transpose()?;
     let http = HttpBackendConfig {
-        base_url: base_url.to_string(),
+        base_url: config.base_url.as_str().to_string(),
         api_key,
         forward_auth: config.forward_auth,
         extra_headers: config.extra_headers.clone(),
@@ -964,25 +989,7 @@ fn build_backend(
         ClientFormat::OpenAiResponses => Backend::OpenAiResponses(http),
         ClientFormat::AnthropicMessages => Backend::Anthropic(http),
     };
-    validate_backend_url(client_name, &backend)?;
     Ok(backend)
-}
-
-// Validate the endpoint after the backend applies the same format-specific URL
-// joining used for requests, so dry-run and request construction cannot diverge.
-fn validate_backend_url(client_name: &str, backend: &Backend) -> ServerResult<()> {
-    let endpoint = backend.url();
-    let url = reqwest::Url::parse(&endpoint).map_err(|error| {
-        ServerError::new(format!(
-            "llm client {client_name} base_url must resolve to an absolute HTTP(S) URL: {error}"
-        ))
-    })?;
-    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
-        return Err(ServerError::new(format!(
-            "llm client {client_name} base_url must resolve to an absolute HTTP(S) URL"
-        )));
-    }
-    Ok(())
 }
 
 const fn default_max_retries() -> u32 {
@@ -1448,22 +1455,6 @@ classify_trigger = "new_session""#,
     }
 
     #[test]
-    fn rejects_non_http_base_urls_during_construction() {
-        for base_url in ["not a url", "/v1", "ftp://example.test/v1"] {
-            let invalid = VALID_CONFIG.replacen(
-                "base_url = \"https://example.test/v1\"",
-                &format!("base_url = \"{base_url}\""),
-                1,
-            );
-            let message = error_message(&invalid);
-            assert!(
-                message.contains("llm client primary base_url"),
-                "unexpected error for {base_url}: {message}"
-            );
-        }
-    }
-
-    #[test]
     fn rejects_invalid_unreferenced_llm_client() {
         let invalid = format!(
             "{VALID_CONFIG}\n\
@@ -1473,7 +1464,7 @@ classify_trigger = "new_session""#,
         );
         let message = error_message(&invalid);
         assert!(
-            message.contains("llm client unused base_url"),
+            message.contains("base_url must be an absolute HTTP(S) URL"),
             "unexpected error: {message}"
         );
     }

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -957,11 +957,30 @@ fn build_backend(
         extra_body: extra_body.clone(),
         max_retries: config.max_retries,
     };
-    Ok(match config.format {
+    let backend = match config.format {
         ClientFormat::OpenAiChat => Backend::OpenAiChat(http),
         ClientFormat::OpenAiResponses => Backend::OpenAiResponses(http),
         ClientFormat::AnthropicMessages => Backend::Anthropic(http),
-    })
+    };
+    validate_backend_url(client_name, &backend)?;
+    Ok(backend)
+}
+
+// Validate the endpoint after the backend applies the same format-specific URL
+// joining used for requests, so dry-run and request construction cannot diverge.
+fn validate_backend_url(client_name: &str, backend: &Backend) -> ServerResult<()> {
+    let endpoint = backend.url();
+    let url = reqwest::Url::parse(&endpoint).map_err(|error| {
+        ServerError::new(format!(
+            "llm client {client_name} base_url must resolve to an absolute HTTP(S) URL: {error}"
+        ))
+    })?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(ServerError::new(format!(
+            "llm client {client_name} base_url must resolve to an absolute HTTP(S) URL"
+        )));
+    }
+    Ok(())
 }
 
 const fn default_max_retries() -> u32 {
@@ -1424,6 +1443,22 @@ classify_trigger = "new_session""#,
 
         server_state_from_toml(&configured)?;
         Ok(())
+    }
+
+    #[test]
+    fn rejects_non_http_base_urls_during_construction() {
+        for base_url in ["not a url", "/v1", "ftp://example.test/v1"] {
+            let invalid = VALID_CONFIG.replacen(
+                "base_url = \"https://example.test/v1\"",
+                &format!("base_url = \"{base_url}\""),
+                1,
+            );
+            let message = error_message(&invalid);
+            assert!(
+                message.contains("llm client primary base_url"),
+                "unexpected error for {base_url}: {message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -138,8 +138,10 @@ impl ServerConfig {
             .map(|name| (name.clone(), Vec::new()))
             .collect::<BTreeMap<String, Vec<ModelConfig>>>();
 
-        for name in self.llm_clients.keys() {
+        // Validate every declared client even when no target currently references it.
+        for (name, client_config) in &self.llm_clients {
             validate_value("llm client name", name)?;
+            build_backend(name, client_config, &BTreeMap::new())?;
         }
         for (target_name, target) in &self.targets {
             let client_config = self.llm_clients.get(&target.llm_client).ok_or_else(|| {
@@ -1459,6 +1461,21 @@ classify_trigger = "new_session""#,
                 "unexpected error for {base_url}: {message}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_invalid_unreferenced_llm_client() {
+        let invalid = format!(
+            "{VALID_CONFIG}\n\
+             [llm_clients.unused]\n\
+             format = \"openai_chat\"\n\
+             base_url = \"not a url\"\n"
+        );
+        let message = error_message(&invalid);
+        assert!(
+            message.contains("llm client unused base_url"),
+            "unexpected error: {message}"
+        );
     }
 
     #[test]

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -351,7 +351,7 @@ impl ServerState {
                 model: &target.id,
                 llm_client: DecisionLlmClientResponse {
                     format: client.format.wire_format(),
-                    base_url: &client.base_url,
+                    base_url: client.base_url.as_str(),
                 },
                 extra_body: &target.extra_body,
             })

--- a/crates/switchyard-server/tests/cli.rs
+++ b/crates/switchyard-server/tests/cli.rs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process-level regression coverage for the server CLI.
+
+use std::fs;
+use std::process::Command;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn dry_run_rejects_invalid_base_url() -> TestResult {
+    let directory = tempfile::tempdir()?;
+    let config = directory.path().join("routes.toml");
+    fs::write(
+        &config,
+        r#"
+schema_version = 1
+
+[llm_clients.invalid]
+format = "openai_chat"
+base_url = "not a url"
+
+[targets.invalid]
+id = "upstream-model"
+llm_client = "invalid"
+
+[routes.invalid]
+id = "test-route"
+type = "passthrough"
+target = "invalid"
+"#,
+    )?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_switchyard-server"))
+        .args(["--config", config.to_string_lossy().as_ref(), "--dry-run"])
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("llm client invalid base_url"), "{stderr}");
+    Ok(())
+}

--- a/crates/switchyard-server/tests/cli.rs
+++ b/crates/switchyard-server/tests/cli.rs
@@ -37,6 +37,9 @@ target = "invalid"
         .output()?;
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr)?;
-    assert!(stderr.contains("llm client invalid base_url"), "{stderr}");
+    assert!(
+        stderr.contains("base_url must be an absolute HTTP(S) URL"),
+        "{stderr}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## What

- validate each configured client's resolved upstream endpoint during deployment construction
- require an absolute `http` or `https` URL with a host
- use the existing backend-specific endpoint joining before validation
- add config-level invalid URL cases and a process-level `--dry-run` regression test

## Why

An invalid `base_url` passed `--dry-run` and failed only when the first request tried to build its upstream HTTP request. Construction now rejects the same resolved endpoint that request-time code would use, without contacting the upstream.

Closes #398

## Validation

- `cargo test -p switchyard-server rejects_non_http_base_urls_during_construction -- --nocapture` — passed
- `cargo test -p switchyard-server --test cli dry_run_rejects_invalid_base_url -- --nocapture` — passed
- `cargo test -p switchyard-server` — passed
- `cargo fmt --all --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed with loopback access enabled for the repository's local mock servers
- `git diff --check` — passed

No live provider calls or secrets were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for backend endpoint URLs, requiring absolute HTTP or HTTPS URLs with a valid host.
  * Improved configuration error reporting for malformed, relative, or unsupported endpoint URLs.
  * Added command-line coverage to ensure invalid URLs cause dry-run startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->