### PR TITLE
fix(server): preserve JSON rejection statuses

### DIFF
--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -531,7 +531,9 @@ async fn anthropic_count_tokens(
 ) -> Response {
     let body = match llm_json_body(body) {
         Ok(body) => body,
-        Err(message) => return anthropic_error_response(invalid_body_error(message)),
+        Err((status, message)) => {
+            return anthropic_error_response(invalid_body_error(status, message));
+        }
     };
     let (route, request) = match resolve_route(
         &state,
@@ -617,7 +619,7 @@ async fn handle_endpoint_inner(
             )
             .await
         }
-        Err(message) => invalid_body_error(message),
+        Err((status, message)) => invalid_body_error(status, message),
     };
     let response = render_error_response(response, wire_format);
     metrics::record_client_response(response.status().as_u16());
@@ -627,11 +629,17 @@ async fn handle_endpoint_inner(
 
 fn llm_json_body(
     body: std::result::Result<Json<Value>, JsonRejection>,
-) -> std::result::Result<Value, String> {
+) -> std::result::Result<Value, (StatusCode, String)> {
     match body {
         Ok(Json(value)) if value.is_object() => Ok(value),
-        Ok(_) => Err("Request body must be a JSON object".to_string()),
-        Err(error) => Err(format!("Request body must be valid JSON: {error}")),
+        Ok(_) => Err((
+            StatusCode::BAD_REQUEST,
+            "Request body must be a JSON object".to_string(),
+        )),
+        Err(error) => Err((
+            error.status(),
+            format!("Request body must be valid JSON: {error}"),
+        )),
     }
 }
 
@@ -649,7 +657,7 @@ fn resolve_route(
     wire_format: WireFormat,
 ) -> std::result::Result<(&RouteEntry, Request), Response> {
     let llm_request = decode_request(wire_format, &body)
-        .map_err(|error| invalid_body_error(error.to_string()))?;
+        .map_err(|error| invalid_body_error(StatusCode::BAD_REQUEST, error.to_string()))?;
     let requested_model = llm_request
         .model
         .clone()
@@ -992,13 +1000,8 @@ fn server_error(message: impl Into<String>) -> Response {
     )
 }
 
-fn invalid_body_error(message: impl Into<String>) -> Response {
-    error_response(
-        StatusCode::BAD_REQUEST,
-        message,
-        "invalid_request_error",
-        "invalid_body",
-    )
+fn invalid_body_error(status: StatusCode, message: impl Into<String>) -> Response {
+    error_response(status, message, "invalid_request_error", "invalid_body")
 }
 
 fn error_response(

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -25,7 +25,7 @@ use switchyard_llm_client::{
 use switchyard_protocol::ModelId;
 use switchyard_protocol::RoutedLlmClient;
 use switchyard_server::config::load_server_state;
-use switchyard_server::{ServerState, build_switchyard_router};
+use switchyard_server::{DEFAULT_MAX_REQUEST_BODY_BYTES, ServerState, build_switchyard_router};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -597,6 +597,27 @@ async fn send_with_headers(
         Body::empty()
     };
     let response = app.clone().oneshot(builder.body(request_body)?).await?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let bytes = response.into_body().collect().await?.to_bytes();
+    Ok(Response {
+        status,
+        headers,
+        bytes,
+    })
+}
+
+async fn send_raw_json(
+    app: &Router,
+    path: &str,
+    body: Vec<u8>,
+    content_type: Option<&str>,
+) -> TestResult<Response> {
+    let mut builder = HttpRequest::builder().method("POST").uri(path);
+    if let Some(content_type) = content_type {
+        builder = builder.header("content-type", content_type);
+    }
+    let response = app.clone().oneshot(builder.body(Body::from(body))?).await?;
     let status = response.status();
     let headers = response.headers().clone();
     let bytes = response.into_body().collect().await?.to_bytes();
@@ -1269,6 +1290,72 @@ async fn routes_dispatch_and_discovery_endpoints_are_stable() -> TestResult {
     let calls = upstream.calls.lock().await;
     assert_eq!(calls[0]["model"], "model/general");
     assert_eq!(calls[1]["model"], "model/code");
+    Ok(())
+}
+
+#[tokio::test]
+async fn json_extractor_statuses_keep_api_specific_error_envelopes() -> TestResult {
+    let (_upstream, app) = test_app(&[(ROUTE_MODEL, &["model/a"])]).await?;
+
+    for (content_type, expected_status) in [
+        (Some("application/json"), StatusCode::BAD_REQUEST),
+        (None, StatusCode::UNSUPPORTED_MEDIA_TYPE),
+        (Some("text/plain"), StatusCode::UNSUPPORTED_MEDIA_TYPE),
+    ] {
+        let body = if expected_status == StatusCode::BAD_REQUEST {
+            br#"{"model":"broken""#.to_vec()
+        } else {
+            br#"{"model":"valid-json"}"#.to_vec()
+        };
+        let response = send_raw_json(&app, "/v1/chat/completions", body, content_type).await?;
+        assert_eq!(response.status, expected_status);
+        let body = response.json()?;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["code"], "invalid_body");
+    }
+
+    let response = send_raw_json(
+        &app,
+        "/v1/chat/completions",
+        vec![b' '; DEFAULT_MAX_REQUEST_BODY_BYTES + 1],
+        Some("application/json"),
+    )
+    .await?;
+    assert_eq!(response.status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(response.json()?["error"]["code"], "invalid_body");
+
+    for (body, content_type, expected_status, expected_type) in [
+        (
+            br#"{"model":"broken""#.as_slice(),
+            Some("application/json"),
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+        ),
+        (
+            br#"{"model":"valid-json"}"#.as_slice(),
+            None,
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "api_error",
+        ),
+    ] {
+        let response = send_raw_json(&app, "/v1/messages", body.to_vec(), content_type).await?;
+        assert_eq!(response.status, expected_status);
+        let body = response.json()?;
+        assert_eq!(body["type"], "error");
+        assert_eq!(body["error"]["type"], expected_type);
+    }
+
+    let response = send_raw_json(
+        &app,
+        "/v1/messages",
+        vec![b' '; DEFAULT_MAX_REQUEST_BODY_BYTES + 1],
+        Some("application/json"),
+    )
+    .await?;
+    assert_eq!(response.status, StatusCode::PAYLOAD_TOO_LARGE);
+    let body = response.json()?;
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "request_too_large");
     Ok(())
 }
 


### PR DESCRIPTION
## What

- preserve the status code carried by Axum `JsonRejection`
- keep non-object and protocol-decode body errors at HTTP 400
- retain the existing OpenAI-compatible and Anthropic error renderers
- cover malformed JSON, missing/unsupported content type, and oversized bodies

## Why

The shared JSON helper reduced every extractor rejection to a string, and `invalid_body_error` then hard-coded HTTP 400. Clients therefore lost Axum's 415 and 413 distinctions, and Anthropic's existing `request_too_large` mapping was unreachable for oversized JSON bodies.

Closes #400

## Validation

- `cargo test -p switchyard-server --test server json_extractor_statuses_keep_api_specific_error_envelopes -- --nocapture` — passed
- `cargo test -p switchyard-server` — passed
- `cargo fmt --all --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed with loopback access enabled for the repository's local mock servers
- `git diff --check` — passed

No live provider calls or secrets were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid request bodies now preserve the appropriate HTTP status codes instead of being returned as generic bad requests.
  * Improved error responses for malformed JSON, unsupported media types, and oversized request bodies.
  * Consistent API-specific error envelopes are now returned across Chat Completions and Anthropic Messages endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->