### PR TITLE
chore(agent-dev): add GLAMR development container

### DIFF
--- a/.agent-dev/Dockerfile
+++ b/.agent-dev/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$TARGETPLATFORM rust:1.96.1-bookworm AS rust-toolchain
+
+FROM --platform=$TARGETPLATFORM python:3.12.13-slim-bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG UV_VERSION=0.11.8
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/home/sandbox/workspace/target \
+    VIRTUAL_ENV=/home/sandbox/workspace/.venv \
+    UV_PROJECT_ENVIRONMENT=/home/sandbox/workspace/.venv \
+    UV_CACHE_DIR=/opt/switchyard/uv-cache \
+    UV_LINK_MODE=copy \
+    PATH="/home/sandbox/workspace/.venv/bin:/usr/local/cargo/bin:${PATH}"
+
+COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    git \
+    iproute2 \
+    libssl-dev \
+    netcat-openbsd \
+    openssh-client \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && rustup component add clippy rustfmt rust-analyzer \
+    && cargo --version | grep 'cargo 1.96.1' \
+    && uv --version | grep "uv ${UV_VERSION}"
+
+WORKDIR /home/sandbox/workspace
+COPY . .
+
+RUN git rev-parse --is-inside-work-tree \
+    && git remote get-url origin \
+    && test -z "$(git status --porcelain)" \
+    && cargo fetch --locked \
+    && uv sync --locked \
+    && cargo fmt --all --check
+
+RUN useradd -m -s /bin/bash sandbox \
+    && mkdir -p /home/sandbox/job /home/sandbox/.cache /sandbox/job /opt/switchyard \
+    && chown -R sandbox:sandbox \
+        /home/sandbox \
+        /sandbox \
+        /opt/switchyard \
+        /usr/local/cargo \
+        /usr/local/rustup
+
+ENV HOME=/home/sandbox
+
+USER sandbox
+WORKDIR /home/sandbox/workspace

--- a/.agent-dev/Dockerfile
+++ b/.agent-dev/Dockerfile
@@ -49,6 +49,12 @@ RUN git rev-parse --is-inside-work-tree \
 
 RUN useradd -m -s /bin/bash sandbox \
     && mkdir -p /home/sandbox/job /home/sandbox/.cache /sandbox/job /opt/switchyard \
+    && printf '%s\n' \
+        'export VIRTUAL_ENV=/home/sandbox/workspace/.venv' \
+        'export UV_PROJECT_ENVIRONMENT=/home/sandbox/workspace/.venv' \
+        'export PATH="/home/sandbox/workspace/.venv/bin:/usr/local/cargo/bin:${PATH}"' \
+        > /etc/profile.d/switchyard-agent-dev.sh \
+    && chmod 0644 /etc/profile.d/switchyard-agent-dev.sh \
     && chown -R sandbox:sandbox \
         /home/sandbox \
         /sandbox \

--- a/.agent-dev/Dockerfile.dockerignore
+++ b/.agent-dev/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+.venv
+target
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.worktrees
+benchmark/datasets
+benchmark/tb_runs
+dist
+site

--- a/.agent-dev/README.md
+++ b/.agent-dev/README.md
@@ -1,0 +1,6 @@
+# Agent development container
+
+This directory enables NVIDIA's internal autonomous coding agent to build a
+self-contained Switchyard development environment. GLAMR builds and caches the
+Dockerfile from the resolved repository commit; no GitHub Actions image-build
+job is required.

--- a/.agent-dev/agent-dev.yaml
+++ b/.agent-dev/agent-dev.yaml
@@ -1,0 +1,6 @@
+version: 2
+build:
+  dockerfile: .agent-dev/Dockerfile
+  context: .
+default_execution_environment: repo_dev
+preferred_coding_agent: codex


### PR DESCRIPTION
## What

Add a version 2 `.agent-dev` contract and a self-contained Linux development image with the pinned Rust and Python toolchains used by Switchyard.

The image preserves the repository Git checkout, installs compiler and linker dependencies, syncs locked dependencies, and runs as the non-root `sandbox` user expected by GLAMR repo-dev jobs.

## Why

GLAMR coding runs need a reproducible Switchyard environment that can compile and test Rust code instead of depending on the coding sandbox base image.

## How tested

- [ ] `uv run ruff check .` clean
- [ ] `uv run mypy switchyard` clean
- [ ] `uv run pytest tests/` green
- [x] Built `.agent-dev/Dockerfile` locally for `linux/amd64`
- [x] Ran `cargo test --workspace` inside the built image: 492 tests plus doctests passed
- [x] Validated `.agent-dev/agent-dev.yaml` against the AgentHub version 2 contract parser

## Checklist

- [x] No public API changes
- [x] README added for the agent-development directory
- [x] Commits signed off for DCO

## Notes for reviewers

The Dockerfile-specific ignore file intentionally keeps `.git` in the build context because repo-dev agents need a writable checkout to commit and publish their work. Provider credentials are supplied at runtime rather than written into the checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a containerized Rust and Python development environment with validated toolchains, dependencies, formatting checks, and non-root execution.
  * Added configuration for the default development environment and preferred coding agent.
  * Improved build efficiency by excluding caches, generated files, and other unnecessary content from container builds.

* **Documentation**
  * Added setup and usage guidance for the development container, including caching and image-build details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->