### PR TITLE
fix(client): strip api-key and OpenAI org/project headers before forwarding

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -29,6 +29,7 @@ use crate::raw::RawResponse;
 
 // Headers this client owns or that are hop-by-hop. Backends apply an explicitly
 // enabled caller credential after generic metadata forwarding skips these.
+// Azure/OpenAI credentials and tenant selectors are also backend-owned.
 const RESERVED_HEADERS: &[&str] = &[
     "host",
     "content-length",
@@ -41,6 +42,9 @@ const RESERVED_HEADERS: &[&str] = &[
     "x-api-key",
     "chatgpt-account-id",
     "x-openai-fedramp",
+    "api-key",
+    "openai-organization",
+    "openai-project",
     "anthropic-beta",
     "anthropic-version",
     "content-type",
@@ -1807,6 +1811,18 @@ mod tests {
             "accept-encoding",
             http::HeaderValue::from_static("gzip, br"),
         );
+        headers.insert(
+            "api-key",
+            http::HeaderValue::from_static("client-azure-key"),
+        );
+        headers.insert(
+            "openai-organization",
+            http::HeaderValue::from_static("org-client"),
+        );
+        headers.insert(
+            "openai-project",
+            http::HeaderValue::from_static("proj-client"),
+        );
         let request = Request {
             llm_request: LlmRequest {
                 model: Some("gpt".to_string()),
@@ -1836,6 +1852,9 @@ mod tests {
             .ok_or("request recording should be enabled")?;
         let received = received.first().ok_or("expected one upstream request")?;
         assert!(!received.headers.contains_key("accept-encoding"));
+        assert!(!received.headers.contains_key("api-key"));
+        assert!(!received.headers.contains_key("openai-organization"));
+        assert!(!received.headers.contains_key("openai-project"));
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #419.

## What

`RESERVED_HEADERS` in `crates/libsy-llm-client/src/client.rs` strips `authorization` and `x-api-key` from forwarded client metadata, but not three headers of the same class:

- `api-key`, Azure OpenAI's credential header (the `x-`-less sibling of `x-api-key`)
- `openai-organization` and `openai-project`, OpenAI's billing and project selectors

`forward_metadata_headers` copies every non-reserved client header onto the upstream request, so a caller can set those three next to the backend's own credential. An invalid `openai-organization` makes OpenAI return `401 mismatched_organization`; a valid one bills a different org the key can reach; on an Azure deployment a client `api-key` is forwarded as the credential header.

This PR adds the three names to `RESERVED_HEADERS`. An operator that legitimately needs one of them upstream still sets it through the backend's `extra_headers`, which are applied after forwarding and are unaffected.

## Change

- Add `api-key`, `openai-organization`, `openai-project` to `RESERVED_HEADERS`.
- Refresh the comment above the list to describe the intent (the old comment pointed at a Python `_SENSITIVE_HEADERS` list that is not present in this tree).
- Add `strips_client_credential_and_tenant_headers`, a regression test that sends all three as client headers and asserts none reach the upstream while the backend bearer is preserved.

## Test

```
cargo test -p switchyard-llm-client
```

All existing tests pass; the new test and the existing `forwards_metadata_headers_except_reserved` both cover the reserved set. Reproduction steps for the original behavior are in #419.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented caller-provided metadata from overriding protected Azure and OpenAI authentication headers.
  * Ensured backend authorization remains intact while tenant and credential selector headers are filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->