### PR TITLE
fix(protocol): normalize nested metadata strings

### DIFF
--- a/crates/protocol/src/metadata.rs
+++ b/crates/protocol/src/metadata.rs
@@ -331,7 +331,10 @@ fn resolve_path(headers: &http::HeaderMap, path: &str) -> Option<String> {
     }
 
     match current {
-        serde_json::Value::String(s) => Some(s),
+        serde_json::Value::String(s) => {
+            let value = s.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        }
         serde_json::Value::Null => None,
         leaf => Some(leaf.to_string()),
     }
@@ -538,6 +541,27 @@ mod tests {
             None
         );
         assert_eq!(sy_header(&headers, "x-not-a-field"), None);
+    }
+
+    // Blank nested metadata must not mask a valid lower-priority session header.
+    #[test]
+    fn nested_metadata_strings_match_flat_header_normalization() {
+        let body = serde_json::json!({ "session_id": "  codex-session  " }).to_string();
+        let headers = slice_to_header_map(&[(CODEX_TURN_METADATA_HEADER, body.as_str())]);
+        assert_eq!(
+            sy_header(&headers, SWITCHYARD_SESSION_ID_HEADER).as_deref(),
+            Some("codex-session")
+        );
+
+        let blank_body = serde_json::json!({ "session_id": "   " }).to_string();
+        let headers = slice_to_header_map(&[
+            (CODEX_TURN_METADATA_HEADER, blank_body.as_str()),
+            (SESSION_ID_HEADER, "fallback-session"),
+        ]);
+        assert_eq!(
+            sy_header(&headers, SWITCHYARD_SESSION_ID_HEADER).as_deref(),
+            Some("fallback-session")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

- Normalize string leaves resolved from nested JSON metadata the same way as flat headers.
- Treat whitespace-only nested values as unresolved so lower-priority header fallbacks still apply.
- Add regression coverage for trimming and fallback behavior.

## Why

Nested JSON string values currently bypass the trimming and empty-value handling used by flat headers. A whitespace-only high-priority Codex session value can therefore mask a valid fallback session header and become a whitespace affinity identity.

This keeps metadata precedence consistent regardless of whether a value arrives in a flat header or inside structured turn metadata.

Related to #301.

## How tested

- [x] `uv run ruff check .` clean
- [ ] `uv run mypy switchyard` clean — on Windows, the unchanged POSIX launcher modules report 25 platform-stub errors; the clean upstream commit reports the same errors
- [ ] `uv run pytest tests/` green — on Windows, collection of the unchanged launcher tests requires `fcntl`; the clean upstream commit fails identically
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Focused regression test: `cargo test -p switchyard-protocol nested_metadata_strings_match_flat_header_normalization`
- [x] Manual smoke (N/A: header resolution is covered directly by the regression test)

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (N/A: no class or file added.)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (N/A: no public symbol added.)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (N/A: no customer-facing surface changed.)
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

Non-string JSON leaves keep their existing serialization behavior. The change only aligns nested string handling with the existing flat-header normalization contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested metadata values by trimming surrounding whitespace.
  * Treats blank values as unavailable and correctly falls back to lower-priority headers when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->