### PR TITLE
fix(llm-client): detect native sglang context-overflow messages

### DIFF
--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -25,6 +25,8 @@ const OPENAI_OVERFLOW_PHRASES: &[&str] = &[
     "context length is only",
     "please reduce the length of the input",
     "exceeds the maximum allowed input length",
+    "exceeds the maximum allowed length",
+    "is longer than the model's context length",
 ];
 
 // Anthropic has no structured `error.code`, so detection is phrase-based only.
@@ -338,6 +340,15 @@ mod tests {
         // Hub GLM (LiteLLM-wrapped): code is "400", detection relies on phrase match.
         assert!(backend.is_context_overflow(
             r#"{"error":{"message":"Input length 877338 exceeds the maximum allowed input length of 639968 tokens","code":"400"}}"#
+        ));
+        // Native SGLang: top-level envelope (no `error` key), caught by the raw-body phrase match.
+        // KV-pool rejection (managers/utils.py) and declared-context rejection
+        // (tokenizer_manager.py); both stable across v0.5.15-v0.5.17.
+        assert!(backend.is_context_overflow(
+            r#"{"object":"error","message":"Input length (700001 tokens) exceeds the maximum allowed length (536826 tokens). Use a shorter input or enable --allow-auto-truncate.","type":"BadRequestError","param":null,"code":400}"#
+        ));
+        assert!(backend.is_context_overflow(
+            r#"{"object":"error","message":"The input (12345 tokens) is longer than the model's context length (8192 tokens).","type":"BadRequestError","param":null,"code":400}"#
         ));
     }
 


### PR DESCRIPTION
SGLang reports context-window overflows with wording that matches nothing in `OPENAI_OVERFLOW_PHRASES`, so the failure is classified as a generic upstream 400 instead of `ContextWindowExceeded`, and context-window fallback routing never fires for SGLang backends.

SGLang rejects an over-length request from two places. The KV-pool admission check in `srt/managers/utils.py` returns:

```
Input length (700001 tokens) exceeds the maximum allowed length (536826 tokens). Use a shorter input or enable --allow-auto-truncate.
```

The declared-context check in `srt/managers/tokenizer_manager.py`, hit when the server runs with an explicit `--context-length`, returns:

```
The input (12345 tokens) is longer than the model's context length (8192 tokens).
```

The closest phrase in the list today is `exceeds the maximum allowed input length`, the LiteLLM-wrapped variant, which differs from the first message by one word.

This PR adds one phrase for each message. The wording is identical in v0.5.15.post1 and v0.5.17 (current latest), and SGLang's own test fixtures assert on "maximum allowed length", so a silent rewording upstream is unlikely.

The first test fixture is a verbatim capture from a live deployment. Both fixtures use SGLang's top-level `{"object":"error",...}` envelope with no `error` key, so they also cover the raw-body fallback in `is_overflow_body`.

Validation:

- `cargo test -p switchyard-llm-client`: 56 passed
- `cargo test --workspace` passes; `cargo fmt --check` and `cargo clippy` are clean
- Tested end to end against the live deployment through a passthrough route: a 700k-token request now returns the typed 400 `context_length_exceeded`; before the patch it returned the SGLang body wrapped as a generic upstream error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SGLang errors when an input exceeds the permitted length or model context limit.
  * Added coverage for multiple SGLang error response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->