### PR TITLE
docs(changelog): fix broken Metrics Reference link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@ traffic that sits between client applications and LLM backends.
   `--list-models`), and `verify` / `launch --smoke` round-trip checks.
 - **Observability** — Prometheus `/metrics`, a JSON `/v1/stats`
   (`/v1/routing/stats` alias), and per-request cost/token/latency stats. See
-  [Metrics Reference](docs/METRICS_REFERENCE.md).
+  [Metrics Reference](docs/internal/metrics_reference.md).
 - **Python library** — `SwitchyardRecipes` (`passthrough_recipe`,
   `random_routing_recipe`, `cascade_recipe`, `deterministic_routing_recipe`,
   …) and typed `ChatRequest` / `ChatResponse` containers for in-process use.


### PR DESCRIPTION
## What

The **Metrics Reference** link in the 0.2.0 release notes section of `CHANGELOG.md` points to `docs/METRICS_REFERENCE.md`, which no longer exists — the file now lives at `docs/internal/metrics_reference.md`.

## Verification

```bash
$ ls docs/METRICS_REFERENCE.md
ls: docs/METRICS_REFERENCE.md: No such file or directory
$ ls docs/internal/metrics_reference.md
docs/internal/metrics_reference.md
```

Small docs correction submitted directly as a PR.

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the metrics reference link in the 0.1.0 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->