### PR TITLE
docs(changelog): note packaging extras removal in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the FastAPI endpoints and legacy chain, the `switchyard-components` crate,
   and their compatibility PyO3 bindings are removed. Use `switchyard-server`
   with native TOML deployments, or `switchyard launch` for coding agents.
+- **Packaging extras `[server]`, `[gpu]`, and `[all]`** — dropped together
+  with the deprecated Python server stack; only `[cli]` remains. Install
+  server functionality via the standalone `switchyard-server` binary instead.
 
 ## [0.2.0]
 


### PR DESCRIPTION
## What

Adds a bullet to the Unreleased **Removed** section noting that the packaging extras `[server]`, `[gpu]`, and `[all]` were dropped together with the deprecated Python server stack — only `[cli]` remains.

## Why

The 0.1.0 release notes advertise `pip install nemo-switchyard` with extras `[server]`, `[cli]`, `[gpu]`, `[all]`. On current `main`, `[project.optional-dependencies]` defines only `cli`. The Unreleased section documents the server-stack removal but omits the extras removal, so users following the 0.1.0 packaging note get `nemo-switchyard does not provide the extra 'server'` warnings with silently missing dependencies.

## Verification

```bash
# main
$ grep -A2 'optional-dependencies' pyproject.toml | grep -E '^(server|gpu|all|cli) =' 
cli = [
# v0.1.0 tag
$ gh api 'repos/NVIDIA-NeMo/Switchyard/contents/pyproject.toml?ref=v0.1.0' --jq .content | base64 -d | grep -E '^(server|gpu|all) ='
server = [
```

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated packaging documentation to reflect that only the CLI extra remains.
  * Documented installation of server functionality through the standalone `switchyard-server` binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->