### PR TITLE
chore: ignore the paths the perf workflow writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,10 @@ benchmark/perf/results/*
 !benchmark/perf/results/.gitkeep
 benchmark/perf/example_report.md
 
+# Perf benchmark output (.github/workflows/perf.yml)
+perf-results/
+perf-input.jsonl
+
 # Terminal-Bench classifier run artifacts (server/harbor logs, agent
 # trajectories, asciinema recordings — re-generated per run)
 benchmark/tb_runs/

--- a/.gitignore
+++ b/.gitignore
@@ -131,8 +131,8 @@ benchmark/perf/results/*
 benchmark/perf/example_report.md
 
 # Perf benchmark output (.github/workflows/perf.yml)
-perf-results/
-perf-input.jsonl
+/perf-results/
+/perf-input.jsonl
 
 # Terminal-Bench classifier run artifacts (server/harbor logs, agent
 # trajectories, asciinema recordings — re-generated per run)


### PR DESCRIPTION
`.github/workflows/perf.yml` creates two paths at the repo root:

- `perf-results/`, the aiperf `--output-artifact-dir` for both the streaming and non streaming runs
- `perf-input.jsonl`, the 300 entry dataset generated inline by the "Generate perf input dataset" step

Neither is in `.gitignore`, so running the perf lane locally leaves two untracked paths behind, and the generated dataset is easy to commit by accident. In CI it does not matter, since the results are uploaded as a build artifact rather than committed.

One observation I left out of the diff, because it is a question about intent rather than a fix. The existing block above reads:

```
# Performance test results (keep example report and README)
benchmark/perf/results/*
!benchmark/perf/results/.gitkeep
benchmark/perf/example_report.md
```

`benchmark/perf/` is not in the tree and has no commits against it, and inside the block `.gitkeep` is the only path actually kept: the example report is ignored rather than kept, and there is no README exclusion. If that block is reserving the path for a planned sub harness, it should stay exactly as it is and I would not touch it. If it is a leftover, I am happy to remove it in a follow up commit here. Your call, I did not want to guess at intent in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded performance benchmark outputs and input files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->