### PR TITLE
docs(rust-api): lead with crates.io versions, keep git source for dev

### DIFF
--- a/docs/reference/rust_api.md
+++ b/docs/reference/rust_api.md
@@ -23,6 +23,14 @@ Applications embedding libsy normally depend on both crates:
 
 ```toml
 [dependencies]
+switchyard-libsy = "0.2.0"
+switchyard-protocol = "0.2.0"
+```
+
+For development against unreleased changes, use the git source instead:
+
+```toml
+[dependencies]
 switchyard-libsy = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git" }
 switchyard-protocol = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git" }
 ```


### PR DESCRIPTION
## What

The `Crate boundary` section of `docs/reference/rust_api.md` only shows git-source dependencies. This PR leads with the published crates.io versions (matching INSTALLATION.md) and keeps the git source as the explicit development-against-main option.

## Why

All four crates are published on crates.io at 0.2.0 (verified via the crates.io API), and INSTALLATION.md already recommends versioned dependencies. Pointing embedders at git deps by default bypasses semver and Cargo.lock resolution benefits.

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Rust API documentation with released version 0.2.0 crate dependency examples.
  * Retained the existing git-based development dependency example for comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->