### PR TITLE
docs(examples): add index README for examples directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Switchyard Examples
+
+Runnable examples for the Switchyard Python bindings and server.
+
+| Path | What it shows |
+|------|---------------|
+| [`libsy.py`](libsy.py) | Drive a libsy routing algorithm stream from Python — build a weighted `algorithms.random` route, consume `Step.Decision` / `Step.CallModel` / `Step.Done` from `run_stream`, and answer model calls with a custom async client. |
+| [`experimental/litellm/`](experimental/litellm/) | Experimental LiteLLM stage-router integration: benchmark route TOML, LiteLLM proxy config, compose stack, and tests. |
+| [`prometheus/`](prometheus/) | Drop-in Prometheus + Alertmanager configuration with recording and alert rules for a Switchyard deployment. |
+
+## Running the libsy example
+
+The example only needs the `nemo-switchyard` package installed:
+
+```bash
+uv run python examples/libsy.py
+```
+
+It uses an in-file `EchoClient` that returns a fixed completion, so no provider
+API keys are required. See [`examples/prometheus/README.md`](prometheus/README.md)
+and [`examples/experimental/litellm/README.md`](experimental/litellm/README.md)
+for the requirements of those examples.


### PR DESCRIPTION
## What

Adds `examples/README.md` indexing the three examples: `libsy.py` (keyless libsy streaming demo), `experimental/litellm/`, and `prometheus/`.

## Why

The examples directory has no entry point — `prometheus/` and `experimental/litellm/` have their own READMEs, but nothing tells a newcomer that `libsy.py` runs without any provider API keys (it uses the in-file `EchoClient`).

## Verification

Content sourced from `examples/libsy.py` (the `EchoClient` and `algorithms.random` usage) and the two sub-READMEs.

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide to the available runnable Switchyard examples.
  * Included instructions for running the `libsy.py` example with `uv`.
  * Clarified that the basic example does not require provider API keys.
  * Added references to setup requirements for the LiteLLM and Prometheus examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->