### PR TITLE
docs(getting-started): align telemetry section with known issue #5 (header not sent, opt-out env not implemented)

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -225,14 +225,12 @@ references, and route construction without starting the server.
 
 Check health: `curl http://localhost:4000/health`
 
-**Telemetry header opt-out**
+**Telemetry header**
 
-Switchyard adds an `X-Switchyard-Version` header to outbound LLM calls for
-release attribution. No request or response content is included. To disable:
-
-```bash
-export SWITCHYARD_TELEMETRY_OPT_OUT=1
-```
+Switchyard documents an `X-Switchyard-Version` header for release attribution
+on outbound LLM calls. No request or response content is included. The 0.2.0
+native server does not currently send this header upstream (see
+[Known Issues](known_issues.md)), so no opt-out is required at the moment.
 
 ---
 


### PR DESCRIPTION
## Problem

The Troubleshooting section of `docs/getting_started.md` instructs users to disable telemetry with:

```bash
export SWITCHYARD_TELEMETRY_OPT_OUT=1
```

Two problems, verified against the current tree:

1. **The opt-out environment variable does not exist.** `grep -r SWITCHYARD_TELEMETRY_OPT_OUT` across all `.rs` and `.py` sources returns zero hits. The variable appears only in this doc.
2. **The header it disables is not sent.** `grep -rni "switchyard.version" --include="*.rs" --include="*.py"` finds no code that sets an `X-Switchyard-Version` header on outbound calls. This is already acknowledged in `docs/known_issues.md` (0.2.0, item 5): "The native server does not send the documented `X-Switchyard-Version` header upstream."

So the section documents a working mechanism that is, in fact, a no-op today, and contradicts known_issues.md.

## Change

Rewrite the section to state the attribution design, cite the 0.2.0 known issue, and drop the instruction to export a variable that has no effect. Adds a cross-link to `known_issues.md`.

## Verification

- `grep -rn 'SWITCHYARD_TELEMETRY_OPT_OUT' .` → only `docs/getting_started.md` (pre-patch).
- `grep -rni 'x-switchyard-version' crates/ switchyard*` → zero code hits; only docs mention it.
- `docs/known_issues.md` item 5 confirms the header is not sent in 0.2.0.
- Relative link `known_issues.md` resolves (same directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry troubleshooting guidance to clarify that the 0.2.0 native server does not currently send the documented version header upstream.
  * Removed outdated telemetry opt-out instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->