### PR TITLE
fix(translation): accept SSE data fields with no space after the colon

### DIFF
--- a/crates/switchyard-translation/src/sse.rs
+++ b/crates/switchyard-translation/src/sse.rs
@@ -36,7 +36,18 @@ pub(crate) fn parse_json_sse_frame(
     let data = frame
         .lines()
         .filter(|line| !line.is_empty() && !line.starts_with(':'))
-        .filter_map(|line| line.strip_prefix("data: ").map(|l| l.to_string()))
+        .filter_map(|line| {
+            // Per the SSE spec the space after the colon is optional framing:
+            // the field name is everything before the first colon, and a single
+            // leading space is stripped from the value. A field line with no
+            // colon at all carries an empty value.
+            let value = match line.split_once(':') {
+                Some(("data", value)) => value,
+                None if line == "data" => "",
+                _ => return None,
+            };
+            Some(value.strip_prefix(' ').unwrap_or(value).to_string())
+        })
         .fold(String::new(), |mut a, b| {
             a.reserve(b.len() + 1);
             a.push_str(&b);
@@ -80,6 +91,35 @@ mod tests {
             return Err("expected a payload".into());
         };
         assert_eq!(value, json!({"n": 1}));
+        Ok(())
+    }
+
+    #[test]
+    fn parses_a_data_line_without_a_space_after_the_colon() -> Result<(), BoxError> {
+        // The space after `data:` is optional framing, not part of the value.
+        let SseFrame::Data(value) = parse_json_sse_frame("data:{\"text\":\"hi\"}\n", DONE)? else {
+            return Err("expected a payload".into());
+        };
+        assert_eq!(value, json!({"text": "hi"}));
+        Ok(())
+    }
+
+    #[test]
+    fn done_marker_is_recognised_without_a_space() -> Result<(), BoxError> {
+        assert!(matches!(
+            parse_json_sse_frame("data:[DONE]\n", DONE)?,
+            SseFrame::Done
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn field_names_are_matched_exactly() -> Result<(), BoxError> {
+        // `database:` must not be read as a `data` field.
+        assert!(matches!(
+            parse_json_sse_frame("database: {\"n\":1}\n", DONE)?,
+            SseFrame::Empty
+        ));
         Ok(())
     }
 

--- a/crates/switchyard-translation/src/sse.rs
+++ b/crates/switchyard-translation/src/sse.rs
@@ -29,6 +29,16 @@ pub(crate) fn done_marker(_format: WireFormat) -> Option<&'static str> {
     Some("[DONE]")
 }
 
+/// Value of a `data` field line; the space after the colon is optional framing.
+fn data_field_value(line: &str) -> Option<String> {
+    let value = match line.split_once(':') {
+        Some(("data", value)) => value,
+        None if line == "data" => "",
+        _ => return None,
+    };
+    Some(value.strip_prefix(' ').unwrap_or(value).to_string())
+}
+
 pub(crate) fn parse_json_sse_frame(
     frame: &str,
     done_marker: Option<&str>,
@@ -36,18 +46,7 @@ pub(crate) fn parse_json_sse_frame(
     let data = frame
         .lines()
         .filter(|line| !line.is_empty() && !line.starts_with(':'))
-        .filter_map(|line| {
-            // Per the SSE spec the space after the colon is optional framing:
-            // the field name is everything before the first colon, and a single
-            // leading space is stripped from the value. A field line with no
-            // colon at all carries an empty value.
-            let value = match line.split_once(':') {
-                Some(("data", value)) => value,
-                None if line == "data" => "",
-                _ => return None,
-            };
-            Some(value.strip_prefix(' ').unwrap_or(value).to_string())
-        })
+        .filter_map(data_field_value)
         .fold(String::new(), |mut a, b| {
             a.reserve(b.len() + 1);
             a.push_str(&b);


### PR DESCRIPTION
Closes #399.

## Problem

`parse_json_sse_frame` matched the `data` field with a literal prefix that includes the space:

```rust
.filter_map(|line| line.strip_prefix("data: ").map(|l| l.to_string()))
```

The [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) treats that space as optional framing, not part of the delimiter:

> Collect the characters on the line before the first U+003A COLON character (:), and let *field* be that string.
> Collect the characters on the line after the first U+003A COLON character (:), and let *value* be that string. **If *value* starts with a U+0020 SPACE character, remove it from *value*.**

So `data:{"delta":"hi"}` is a well-formed frame that this parser dropped. The frame then folded to an empty string and decoded to `SseFrame::Empty`, silently discarding the event — including a `data:[DONE]` terminator, which stopped being recognised as the end of the stream.

## Fix

Split on the first colon and match the field name, stripping at most one leading space from the value:

```rust
let value = match line.split_once(':') {
    Some(("data", value)) => value,
    None if line == "data" => "",
    _ => return None,
};
Some(value.strip_prefix(' ').unwrap_or(value).to_string())
```

The `None` arm covers the spec's other case — a field line with no colon is the field name with an empty value.

Matching the field name rather than a prefix also keeps a line like `database: {...}` from being read as a `data` field. The old `strip_prefix("data: ")` already got that right by accident; it is now covered by a test so the new parsing can't regress it.

Comment lines are unaffected: they are filtered before this point, and `:comment` splits to a field name of `""`, which does not match `data` either way.

## Tests

Three tests added to the existing module in `sse.rs`:

- `parses_a_data_line_without_a_space_after_the_colon` — the reported case
- `done_marker_is_recognised_without_a_space` — `data:[DONE]` still terminates the stream
- `field_names_are_matched_exactly` — `database:` is not a `data` field

The first two fail on `main`:

```
test sse::tests::done_marker_is_recognised_without_a_space ... FAILED
test sse::tests::parses_a_data_line_without_a_space_after_the_colon ... FAILED
Error: "expected a payload"
```

I also wrote a fourth test asserting that only *one* leading space is framing, then deleted it: this parser hands the value to `serde_json`, which ignores leading whitespace, so the distinction is not observable here. The behaviour is still spec-correct, it just isn't something this function can demonstrate, and I would rather not leave a test that passes for the wrong reason.

## Gates

| gate | result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test --workspace --exclude switchyard-py` | **501 passed, 0 failed** |
| `uv run ruff check .` | `All checks passed!` |
| `uv run mypy switchyard` | `Success: no issues found in 21 source files` |

Two pre-existing failures in my environment, both verified identical on a clean checkout of `main` and unrelated to this change:

- `cargo test --workspace` fails to link `switchyard-py` (pyo3 `symbol(s) not found for architecture arm64` — missing Python symbols in my local toolchain). Hence the `--exclude` above; I did not touch that crate.
- `uv run pytest tests/` fails `tests/e2e/test_closed_book_proxy_integration.py`, an e2e test that needs live services.

Commit is signed off per DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed event data with or without a space after the separator.
  * Correctly processes empty data fields and terminal markers.
  * Prevents similarly named fields from being interpreted as valid event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->