### PR TITLE
feat(translation): prepare requests for routed targets

### DIFF
--- a/crates/switchyard-translation/src/lib.rs
+++ b/crates/switchyard-translation/src/lib.rs
@@ -32,5 +32,6 @@ pub use llm::*;
 pub use policy::*;
 pub use stream::*;
 pub use util::{
-    PRESERVATION_METADATA_KEY, normalize_anthropic_tool_use_ids, sanitize_anthropic_tool_use_id,
+    PRESERVATION_METADATA_KEY, normalize_anthropic_tool_use_ids, prepare_request_for_target,
+    sanitize_anthropic_tool_use_id,
 };

--- a/crates/switchyard-translation/src/util.rs
+++ b/crates/switchyard-translation/src/util.rs
@@ -6,11 +6,12 @@
 use std::collections::BTreeMap;
 
 use serde_json::{Map, Value, json};
+use switchyard_protocol::ModelId;
 
 use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
-use crate::format::FormatId;
-use crate::llm::{ContentBlock, LlmRequest, Message, PreservationMetadata};
+use crate::format::{FormatId, WireFormat};
+use crate::llm::{ContentBlock, InstructionBlock, LlmRequest, Message, PreservationMetadata, Role};
 use crate::policy::{
     LossyConversionPolicy, PreservationPolicy, TranslationPolicy, UnknownFieldPolicy,
 };
@@ -269,6 +270,48 @@ pub fn exact_preserved_response(
     (policy.preservation != PreservationPolicy::Disabled)
         .then(|| preservation.responses.get(&format).cloned())
         .flatten()
+}
+
+/// Applies a selected target model and optionally prepends its system prompt.
+///
+/// Model-only preparation restamps built-in preserved bodies so exact replay uses the target.
+/// Adding a prompt invalidates preserved bodies because they predate that content mutation.
+/// Call this once per candidate using a request that has not already received a target prompt.
+pub fn prepare_request_for_target(
+    request: &mut LlmRequest,
+    target: &ModelId,
+    prompt: Option<&str>,
+) {
+    let target = target.to_string();
+    request.model = Some(target.clone());
+    if let Some(prompt) = prompt {
+        request.instructions.insert(
+            0,
+            InstructionBlock {
+                role: Role::System,
+                content: vec![ContentBlock::Text {
+                    text: prompt.to_string(),
+                }],
+            },
+        );
+        request.preservation.requests.clear();
+    } else {
+        stamp_preserved_request_models(&mut request.preservation, &target);
+    }
+}
+
+// Retains exact replay only where the built-in wire model field can be updated safely.
+fn stamp_preserved_request_models(preservation: &mut PreservationMetadata, target: &str) {
+    preservation.requests.retain(|format, body| {
+        let is_builtin = format.as_str() == WireFormat::OpenAiChat.as_str()
+            || format.as_str() == WireFormat::OpenAiResponses.as_str()
+            || format.as_str() == WireFormat::AnthropicMessages.as_str();
+        let Some(body) = is_builtin.then_some(body).and_then(Value::as_object_mut) else {
+            return false;
+        };
+        body.insert("model".to_string(), Value::String(target.to_string()));
+        true
+    });
 }
 
 /// Embeds preservation metadata into a translated wire body when requested.

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -8,12 +8,86 @@ pub mod common;
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
 use switchyard_translation::{
-    LossyConversionPolicy, TranslationEngine, TranslationPolicy, WireFormat,
+    FormatId, LossyConversionPolicy, TranslationEngine, TranslationPolicy, WireFormat,
+    prepare_request_for_target,
 };
 
 use common::{REASONING_MODEL, normalized_policy, shell_tool_call};
 
-type TestResult = std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+// A target prompt makes every preserved provider body stale.
+#[test]
+fn preparing_a_target_prompt_invalidates_exact_replay() -> TestResult {
+    let engine = TranslationEngine::default();
+    let policy = TranslationPolicy::default();
+    let body = json!({
+        "model": "route",
+        "messages": [
+            {"role": "system", "name": "caller", "content": "client prompt"},
+            {"role": "user", "content": "hi"}
+        ]
+    });
+    let mut request = engine
+        .decode_request(WireFormat::OpenAiChat, &body, &policy)?
+        .request;
+
+    prepare_request_for_target(
+        &mut request,
+        &"selected/model".into(),
+        Some("target prompt"),
+    );
+
+    assert!(request.preservation.requests.is_empty());
+    let encoded = engine
+        .encode_request(WireFormat::OpenAiChat, &request, &policy)?
+        .body;
+    assert_eq!(encoded["model"], "selected/model");
+    assert_eq!(encoded["messages"][0]["content"], "target prompt");
+    assert_eq!(encoded["messages"][1]["content"], "client prompt");
+    assert!(encoded["messages"][1].get("name").is_none());
+    Ok(())
+}
+
+// Model-only preparation retains provider fields while aligning exact replay with the target.
+#[test]
+fn preparing_without_a_prompt_preserves_exact_replay() -> TestResult {
+    let engine = TranslationEngine::default();
+    let policy = TranslationPolicy::default();
+    let body = json!({
+        "model": "route",
+        "messages": [{"role": "user", "content": "hi"}],
+        "provider_field": true
+    });
+    let mut request = engine
+        .decode_request(WireFormat::OpenAiChat, &body, &policy)?
+        .request;
+
+    prepare_request_for_target(&mut request, &"selected/model".into(), None);
+
+    assert_eq!(request.model.as_deref(), Some("selected/model"));
+    let preserved = &request.preservation.requests[&WireFormat::OpenAiChat.into()];
+    assert_eq!(preserved["model"], "selected/model");
+    assert_eq!(preserved["provider_field"], true);
+    let encoded = engine
+        .encode_request(WireFormat::OpenAiChat, &request, &policy)?
+        .body;
+    assert_eq!(encoded["model"], "selected/model");
+    assert_eq!(encoded["provider_field"], true);
+
+    let custom_format = FormatId::new("custom");
+    request
+        .preservation
+        .requests
+        .insert(custom_format.clone(), json!({"vendor_model": "route"}));
+    prepare_request_for_target(&mut request, &"fallback/model".into(), None);
+    assert_eq!(
+        request.preservation.requests[&WireFormat::OpenAiChat.into()]["model"],
+        "fallback/model"
+    );
+    assert!(!request.preservation.requests.contains_key(&custom_format));
+    Ok(())
+}
 
 // Verifies Anthropic-only request fields are dropped or mapped for OpenAI Chat.
 #[test]


### PR DESCRIPTION
## Summary

Adds one translation-layer helper for preparing a normalized request for a routed target.

This is part 1 of 3 for [#496](https://github.com/NVIDIA-NeMo/Switchyard/issues/496) / [SWITCH-1253](https://linear.app/nvidia/issue/SWITCH-1253/move-using-systempromptprocessor-out-of-stage-router-making-it). It adds the provider-aware operation used by libsy in #463; it does not change router behavior or TOML configuration by itself.

## Problem

A decoded request can contain both:

- Switchyard's normalized request, and
- an exact provider body retained for lossless same-format forwarding.

Changing only the normalized `model` is unsafe: exact replay can still send the route alias instead of the selected upstream model.

## Behavior

```rust
prepare_request_for_target(&mut request.llm_request, target, prompt);
```

- Always updates the normalized model.
- With no target prompt, updates the top-level `model` in preserved OpenAI Chat, OpenAI Responses, and Anthropic Messages bodies, retaining their provider-only fields.
- Discards custom or malformed preserved bodies when Switchyard cannot safely update their model.
- With a target prompt, prepends the normalized system instruction and clears preserved request bodies because they predate the content mutation.

The prompt path intentionally re-encodes from the normalized request; it does not retain or patch a second provider-body copy.

## API impact

This PR adds the public Rust function `switchyard_translation::prepare_request_for_target(...)`. It does not change Python APIs, server APIs, router construction, or the TOML schema.

## Suggested review

1. [Translation helper and tests](https://github.com/NVIDIA-NeMo/Switchyard/pull/455/files)
2. Confirm the no-prompt test both retains a provider-only field and emits the selected model.
3. Confirm the prompt test invalidates exact replay.

Unique change: one signed commit, `3e63c460` (3 files, +123/-5).

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest tests/ -v -m "not integration"` (113 passed)
- [x] Strict MkDocs build

## Stack

| PR | Layer | Responsibility |
|---|---|---|
| **#455** | Translation | Prepare one routed request without stale exact replay |
| [#463](https://github.com/NVIDIA-NeMo/Switchyard/pull/463) | libsy | Prepare selected, fallback, and routing-time candidates |
| [#464](https://github.com/NVIDIA-NeMo/Switchyard/pull/464) | Server | Add `targets.*.system_prompt`, compatibility, and integration coverage |