### PR TITLE
feat(libsy): count escalation judge verdicts

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -33,8 +33,9 @@ use tracing_subscriber::layer::{Context as LayerContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 
 use switchyard_libsy::{
-    AffinityRouter, Algorithm, Classifier, Driver, LibsyError, LlmClassifierConfig,
-    LlmTaskClassifier, PickerMode, StageRouter, StageRouterConfig, Step, TaskClassifierConfig,
+    AffinityRouter, Algorithm, Classifier, ClassifierContractConfig, Driver, EscalationJudgeConfig,
+    LibsyError, LlmClassifierConfig, LlmTaskClassifier, PickerMode, StageRouter, StageRouterConfig,
+    Step, TaskClassifierConfig,
 };
 use switchyard_llm_client::{ClientRouter, RunObservation, RunObserver};
 use switchyard_protocol::ModelId;
@@ -495,6 +496,26 @@ fn classifier_router(
                 base_threshold: 0.5,
                 ..TaskClassifierConfig::default()
             },
+        },
+    )?))
+}
+
+/// Escalation-mode counterpart to [`classifier_router`], on the packaged prompt and
+/// contract. `EscalationJudgeConfig::default()` requires two consecutive escalate
+/// verdicts to latch, so a single verdict is recorded without moving any traffic.
+fn escalation_router(
+    judge_model: &str,
+    efficient_model: &str,
+    capable_model: &str,
+) -> switchyard_libsy::Result<Arc<dyn Algorithm>> {
+    Ok(Arc::new(LlmTaskClassifier::new(
+        LlmClassifierConfig::Escalation {
+            judge_target: ModelId::from(judge_model),
+            efficient_target: ModelId::from(efficient_model),
+            capable_target: ModelId::from(capable_model),
+            contract: ClassifierContractConfig::default(),
+            config: EscalationJudgeConfig::default(),
+            max_output_tokens: 256,
         },
     )?))
 }
@@ -1342,6 +1363,112 @@ async fn classifier_fail_open_records_each_failure_stage() -> switchyard_libsy::
                 None,
                 "a valid verdict was counted as a fail-open"
             ),
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn escalation_judge_verdicts_are_counted_per_consultation() -> switchyard_libsy::Result<()> {
+    let _guard = serialize_test().lock().await;
+    let (_store, exporter, provider, _, _) = telemetry();
+    const ESCALATE: &str = r#"{"escalate": true, "reason": "same error four times"}"#;
+    const DECLINE: &str = r#"{"escalate": false, "reason": "tests passing, work landing"}"#;
+
+    // (judge_model, efficient, capable, judge outcome, expected verdict label)
+    let cases = [
+        (
+            "esc-escalate",
+            "esc-efficient",
+            "esc-capable",
+            JudgeOutcome::Reply(ESCALATE),
+            Some("escalate"),
+        ),
+        (
+            "esc-hold",
+            "esc-efficient",
+            "esc-capable",
+            JudgeOutcome::Reply(DECLINE),
+            Some("hold"),
+        ),
+        (
+            "esc-failed",
+            "esc-efficient",
+            "esc-capable",
+            JudgeOutcome::CallFailure,
+            None,
+        ),
+        // Both tiers on one model. `Classifier::routing_tier` already accepts this, and a
+        // decline then resolves to the same target an escalation would, so a verdict inferred
+        // from the routed target would be reported as an escalation. Counting the judge's own
+        // boolean is what keeps this correct.
+        (
+            "esc-same-target",
+            "esc-shared",
+            "esc-shared",
+            JudgeOutcome::Reply(DECLINE),
+            Some("hold"),
+        ),
+    ];
+
+    for (judge_model, efficient, capable, outcome, expected_verdict) in cases {
+        let client = Arc::new(JudgeClient {
+            judge_model: judge_model.into(),
+            outcome,
+        }) as Arc<dyn RoutedLlmClient>;
+        let (trace, _) = run(
+            escalation_router(judge_model, efficient, capable)?,
+            client,
+            classifier_request(),
+        )
+        .await?;
+
+        let snapshots = flushed_metrics(exporter, provider);
+        match expected_verdict {
+            Some(verdict) => {
+                assert_eq!(
+                    u64_counter_value(
+                        &snapshots,
+                        "switchyard.escalation_judge_verdicts",
+                        &[("judge_model", judge_model), ("verdict", verdict)],
+                    ),
+                    Some(1),
+                    "case {judge_model} did not count the verdict"
+                );
+                // The default `confirmations` is 2, so one escalate verdict is counted
+                // without latching. A verdict existing while traffic stays on the
+                // efficient tier is the property this metric exists to expose, and the
+                // reason it is not a duplicate of `switchyard.decisions`.
+                assert_eq!(
+                    trace[0].selected_model_id(),
+                    efficient,
+                    "case {judge_model} moved traffic on a single verdict"
+                );
+            }
+            // A judge that produced no verdict failed open. It belongs to
+            // `classifier_fail_open` and must leave the verdict counter untouched,
+            // otherwise the two metrics double-count the same consultation and the
+            // failure is reported as an opinion the judge never gave.
+            None => {
+                assert_eq!(
+                    u64_counter_value(
+                        &snapshots,
+                        "switchyard.escalation_judge_verdicts",
+                        &[("judge_model", judge_model)],
+                    ),
+                    None,
+                    "a failed judge call was counted as a verdict"
+                );
+                assert_eq!(
+                    u64_counter_value(
+                        &snapshots,
+                        "switchyard.classifier_fail_open",
+                        &[("judge_model", judge_model)],
+                    ),
+                    Some(1),
+                    "a failed judge call was not counted as a fail-open"
+                );
+            }
         }
     }
     Ok(())

--- a/crates/libsy/src/algorithms/util/escalation.rs
+++ b/crates/libsy/src/algorithms/util/escalation.rs
@@ -17,6 +17,7 @@ use super::llm_judge::{
 };
 use crate::core::classifier::{Classification, Score};
 use crate::core::state::State;
+use crate::observability::record_escalation_verdict;
 use crate::{LibsyError, Result};
 use switchyard_protocol::Request;
 
@@ -119,21 +120,36 @@ pub(crate) type EscalationJudge = StructuredJudge<EscalationInput, SerdeDecoder<
 pub(crate) struct EscalationPolicy {
     capable: ModelId,
     efficient: ModelId,
+    /// Judge target, for the `judge_model` label on the verdict counter.
+    judge_model: ModelId,
 }
 
 impl JudgePolicy for EscalationPolicy {
     type Verdict = EscalationVerdict;
 
+    /// Counts the verdict here, off the judge's own boolean, rather than off the tier the
+    /// verdict resolves to. The two are not interchangeable: a deployment that points
+    /// `capable` and `efficient` at the same model — which [`Classifier::routing_tier`] already
+    /// accepts — makes a decline indistinguishable from an escalation by target alone.
     fn to_classification(&self, verdict: Option<&EscalationVerdict>) -> Classification {
         match verdict {
-            Some(verdict) if verdict.escalate => Classification::Scores(vec![Score {
-                target: self.capable.clone(),
-                confidence: 1.0,
-            }]),
-            Some(_) => Classification::Scores(vec![Score {
-                target: self.efficient.clone(),
-                confidence: 1.0,
-            }]),
+            Some(verdict) if verdict.escalate => {
+                record_escalation_verdict(self.judge_model.as_str(), "escalate");
+                Classification::Scores(vec![Score {
+                    target: self.capable.clone(),
+                    confidence: 1.0,
+                }])
+            }
+            Some(_) => {
+                record_escalation_verdict(self.judge_model.as_str(), "hold");
+                Classification::Scores(vec![Score {
+                    target: self.efficient.clone(),
+                    confidence: 1.0,
+                }])
+            }
+            // No verdict: the judge failed open and `switchyard.classifier_fail_open` already
+            // counted it. Recording it here would report an opinion the judge never gave, and
+            // would count one consultation under both metrics.
             None => Classification::Ambiguous(Vec::new()),
         }
     }
@@ -161,8 +177,12 @@ pub(crate) fn build_judge(
             SerdeDecoder::new(),
             JudgeRuntimeConfig::new(max_output_tokens)?,
         ),
-        judge_target,
-        EscalationPolicy { capable, efficient },
+        judge_target.clone(),
+        EscalationPolicy {
+            capable,
+            efficient,
+            judge_model: judge_target,
+        },
     ))
 }
 

--- a/crates/libsy/src/observability.rs
+++ b/crates/libsy/src/observability.rs
@@ -201,6 +201,26 @@ pub(crate) fn record_classifier_fail_open(judge_model: &str, reason: &'static st
         );
 }
 
+/// Records an escalation judge verdict that resolved.
+///
+/// Counts judge *consultations*, not served traffic: a session stops consulting the judge
+/// once its streak reaches `confirmations`, so later turns route capable without
+/// incrementing this. A consultation that produced no usable verdict is counted by
+/// [`record_classifier_fail_open`] instead and never reaches here, so the two metrics
+/// partition every consultation exactly once.
+pub(crate) fn record_escalation_verdict(judge_model: &str, verdict: &'static str) {
+    meter()
+        .u64_counter("switchyard.escalation_judge_verdicts")
+        .build()
+        .add(
+            1,
+            &[
+                KeyValue::new("judge_model", judge_model.to_string()),
+                KeyValue::new("verdict", verdict),
+            ],
+        );
+}
+
 /// Records the resolution of one offloaded model call: the call counter and
 /// latency histogram, the `outcome`/`error`/token fields on `span`, and a warn
 /// log when the call failed.

--- a/docs/internal/metrics_reference.md
+++ b/docs/internal/metrics_reference.md
@@ -69,6 +69,26 @@ Each histogram emits `_bucket`, `_sum`, and `_count` series. Use
 `upstream_5xx`, `upstream_non_5xx`, `invalid_response`, `parse_error`, `client_error`, or
 `call_error`. The labels never include request or response text.
 
+## Escalation judge verdict counter
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `switchyard_escalation_judge_verdicts_total{judge_model,verdict}` | counter | Escalation judge consultations that produced a verdict. `verdict` is `escalate` or `hold`. |
+
+Counts **consultations, not served traffic**. An escalation route consults the judge on
+every unlatched turn; once the consecutive-escalate streak reaches `confirmations` the
+session routes to the capable tier without consulting the judge again, so later turns
+increment `switchyard_decisions_total` and not this. The two diverge by design, and the gap
+widens with session length.
+
+A consultation that produced no usable verdict is counted by
+`switchyard_classifier_fail_open_total` and never here, so the two metrics partition every
+consultation exactly once.
+
+The verdict is taken from the judge's own boolean rather than from the tier it resolves to.
+A deployment may point the capable and efficient targets at the same model, in which case a
+decline and an escalation are indistinguishable by target.
+
 ## Outcome counters for error-rate ratios
 
 The `outcome` label takes exactly three values:
@@ -151,8 +171,9 @@ into label space.
 | `le` | The configured histogram bucket boundaries. | Histogram buckets |
 | `algorithm` | One stable value per configured algorithm. | Routing-overhead histogram |
 | `tier` | Small enumerated set, optional. | Per-endpoint counters and histograms on algorithms that supply it |
-| `judge_model` | One per configured judge target. | Classifier fail-open counter |
+| `judge_model` | One per configured judge target. | Classifier fail-open counter, escalation verdict counter |
 | `reason` | Exactly 8 fixed error categories. | Classifier fail-open counter |
+| `verdict` | Exactly 2: `escalate`, `hold`. | Escalation verdict counter |
 
 ## Triage cheatsheet
 
@@ -162,4 +183,5 @@ into label space.
 | All counters at 0 after warm-up | Server just started with no traffic, or the scraper is hitting the wrong port. |
 | `switchyard_routing_overhead_ms_count` stuck at `0` | No successful algorithm run has recorded a successful routed model call. |
 | `switchyard_classifier_fail_open_total` rising | The judge target is failing or returning a response the classifier cannot parse. Check `judge_model` and `reason`. |
+| `switchyard_escalation_judge_verdicts_total{verdict="escalate"}` rising while the capable tier stays at zero | The streak is resetting before it reaches `confirmations`. Requests without a session id use unretained per-run state, so check that clients send `x-switchyard-session-id`, or lower `confirmations`. |
 | `switchyard_client_responses_total{outcome="retryable_error"}` rising | Either the upstream is genuinely flaky, or retries are exhausting; compare client responses with retryable upstream attempts. |


### PR DESCRIPTION
## What

`EscalationPolicy` maps the judge's verdict to a target and then discards it. `escalation.rs` contains no metric, span, or tracing call. This adds a counter, plus its entry in the metrics reference.

```
switchyard.escalation_judge_verdicts{judge_model, verdict}
```

`verdict` is `escalate` or `hold`. One counter, two labels, one call site.

## Why


`switchyard.classifier_fail_open` (#205) counts the judge's **failures**. Nothing counts its **decisions**, so an operator can see that the judge broke but not that it escalated on every turn, or on none.

That hides a documented failure mode. `confirmations` defaults to 2 and the streak is retained per session, and `fall_through.rs` notes that "requests without a session ID use unretained per-run state". A client omitting `x-switchyard-session-id` therefore resets the streak every turn and never latches, while still paying for a judge call on every turn.

Three arms, six turns each, against a deterministic local upstream:

| Arm | session header | judge | `decisions` | verdicts |
|---|---|---|---|---|
| A | present | escalates | capable=5, efficient=1 | escalate=2 |
| B | **absent** | escalates | efficient=6 | escalate=6 |
| C | present | declines | efficient=6 | hold=6 |

**B and C are identical on `decisions` and opposite on verdicts.** B burns a judge call every turn for nothing; C is healthy. The remedies differ: B needs a session header or `confirmations = 1`.

Arm A shows why this is not a duplicate of `switchyard.decisions`: six decisions, two verdicts. The judge stops being consulted once the streak reaches `confirmations`, so the two diverge with session length.

## Correctness and cardinality

The verdict is recorded in `EscalationPolicy::to_classification`, off the judge's own boolean, rather than downstream off the tier the verdict resolves to. The two are not interchangeable: a deployment may point the capable and efficient targets at the same model, which `Classifier::routing_tier` already handles explicitly, and a decline would then be indistinguishable from an escalation by target alone. There is a regression case for exactly this.

The fail-open branch is deliberately not recorded. `to_classification` returns `Ambiguous` when the verdict is missing, and that consultation is already counted by `classifier_fail_open`. The two metrics partition every consultation exactly once.

`verdict` is typed `&'static str`, so the label set is bounded by the type rather than by convention. `judge_model` is already used by `classifier_fail_open`. No request or response content enters label space.

## How tested

Not run: Python gates; this PR touches Rust observability and Markdown only.

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p switchyard-llm-client --test observability` green (11 passed)

Four cases in `crates/libsy-llm-client/tests/observability.rs`, mirroring `classifier_fail_open_records_each_failure_stage`:

| Case | Asserts |
|---|---|
| escalate verdict | `verdict="escalate"` is 1, **and the request still routed to the efficient tier** |
| decline | `verdict="hold"` is 1 |
| failed judge call | verdict counter **absent**, `classifier_fail_open` is 1 |
| both tiers on one model, decline | `verdict="hold"` is 1 |

The first pins non-duplication: the default `confirmations = 2` means a single verdict is counted while traffic stays put. The third pins the fail-open boundary. The fourth is the same-target regression.

Stashing only the recording calls while keeping the tests fails as expected:

```
assertion `left == right` failed: case escalate did not count the verdict
  left: None
 right: Some(1)
```

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. — N/A
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. — N/A
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. — N/A; `docs/internal/metrics_reference.md` updated with the metric, its cardinality row, and a triage entry.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

- `reason` is excluded from labels: it is free-form text from the judge and would need a bounded taxonomy designed first. Reasonable follow-up.
- This counts **consultations**, not traffic. The metrics reference says so explicitly, since the distinction is easy to miss.
- `linj/escalation-recovery-delatch` appears to touch the same area. This is meant to complement it: a de-latch path adds a third transition, which makes verdict counts more useful rather than less. Happy to rebase or defer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for escalation decisions, including escalation and hold verdicts by judging model.
  * Improved visibility into routing behavior, confirmation thresholds, and fail-open events.

* **Bug Fixes**
  * Corrected escalation reporting so unresolved verdicts remain ambiguous and failed consultations are counted accurately.

* **Documentation**
  * Documented the new escalation verdict metrics, label details, counting behavior, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->