### PR TITLE
fix(translation): decode Anthropic structured output into requests

### DIFF
--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -406,11 +406,14 @@ fn decode_anthropic_output_format(
         )?;
         return Ok(None);
     }
-    let Some(schema) = format.get("schema") else {
+    // A non-object schema would be forwarded verbatim into the neutral contract and
+    // reach the upstream as a malformed `json_schema.schema`, so it is refused here
+    // rather than handed on.
+    let Some(schema) = format.get("schema").filter(|schema| schema.is_object()) else {
         push_lossy(
             diagnostics,
             policy,
-            "Anthropic structured output requires format.schema; the requested format was dropped",
+            "Anthropic structured output requires format.schema to be an object; the requested format was dropped",
         )?;
         return Ok(None);
     };

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -28,6 +28,11 @@ use crate::util::{
     json_string, push_lossy, stable_id, string_value, validate_request_capabilities,
 };
 
+// Schema name applied when converting Anthropic structured output to the neutral
+// contract. Anthropic identifies the schema only by position, while the neutral
+// OpenAI shape requires a name, so requests that arrive this way share one.
+const ANTHROPIC_STRUCTURED_OUTPUT_SCHEMA_NAME: &str = "response";
+
 /// Format codec for Anthropic Messages payloads.
 pub struct AnthropicMessagesCodec;
 
@@ -58,7 +63,7 @@ impl FormatCodec for AnthropicMessagesCodec {
                 .map(ToOwned::to_owned),
             output: OutputParams {
                 max_output_tokens,
-                response_format: None,
+                response_format: decode_anthropic_output_format(body),
             },
             sampling: SamplingParams {
                 temperature: body.get("temperature").and_then(Value::as_f64),
@@ -146,6 +151,7 @@ impl FormatCodec for AnthropicMessagesCodec {
                 "top_k",
                 "thinking",
                 "output_config",
+                "output_format",
                 "stream",
             ],
         );
@@ -358,6 +364,32 @@ impl FormatCodec for AnthropicMessagesCodec {
             diagnostics: Vec::new(),
         })
     }
+}
+
+// Reads Anthropic's structured-output schema into the neutral response format.
+//
+// `output_config.format` is the current field; the top-level `output_format` is
+// the earlier beta spelling that Anthropic still accepts, so both are read and
+// the current one wins. The neutral contract is OpenAI-shaped and requires a
+// schema name that Anthropic never sends, so one is supplied here.
+fn decode_anthropic_output_format(body: &Map<String, Value>) -> Option<Value> {
+    let format = body
+        .get("output_config")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("format"))
+        .or_else(|| body.get("output_format"))
+        .and_then(Value::as_object)?;
+    if format.get("type").and_then(Value::as_str) != Some("json_schema") {
+        return None;
+    }
+    let schema = format.get("schema")?;
+    Some(json!({
+        "type": "json_schema",
+        "json_schema": {
+            "name": ANTHROPIC_STRUCTURED_OUTPUT_SCHEMA_NAME,
+            "schema": schema.clone(),
+        },
+    }))
 }
 
 /// Maps the neutral OpenAI-shaped JSON schema to Anthropic's output format.

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -28,11 +28,6 @@ use crate::util::{
     json_string, push_lossy, stable_id, string_value, validate_request_capabilities,
 };
 
-// Schema name applied when converting Anthropic structured output to the neutral
-// contract. Anthropic identifies the schema only by position, while the neutral
-// OpenAI shape requires a name, so requests that arrive this way share one.
-const ANTHROPIC_STRUCTURED_OUTPUT_SCHEMA_NAME: &str = "response";
-
 /// Format codec for Anthropic Messages payloads.
 pub struct AnthropicMessagesCodec;
 
@@ -367,16 +362,8 @@ impl FormatCodec for AnthropicMessagesCodec {
     }
 }
 
-// Reads Anthropic's structured-output schema into the neutral response format.
-//
-// `output_config.format` is the current field; the top-level `output_format` is
-// the earlier beta spelling that Anthropic still accepts, so both are read and
-// the current one wins. The neutral contract is OpenAI-shaped and requires a
-// schema name that Anthropic never sends, so one is supplied here.
-//
-// A format that cannot be mapped is reported rather than dropped in silence: the
-// caller asked for constrained output and would otherwise receive prose with no
-// indication that the constraint never reached the upstream.
+// Reads the current `output_config.format`, or the beta `output_format` it replaced,
+// into the neutral OpenAI-shaped response format.
 fn decode_anthropic_output_format(
     body: &Map<String, Value>,
     diagnostics: &mut Vec<TranslationDiagnostic>,
@@ -406,9 +393,7 @@ fn decode_anthropic_output_format(
         )?;
         return Ok(None);
     }
-    // A non-object schema would be forwarded verbatim into the neutral contract and
-    // reach the upstream as a malformed `json_schema.schema`, so it is refused here
-    // rather than handed on.
+    // A non-object schema would reach the upstream as a malformed `json_schema.schema`.
     let Some(schema) = format.get("schema").filter(|schema| schema.is_object()) else {
         push_lossy(
             diagnostics,
@@ -420,7 +405,8 @@ fn decode_anthropic_output_format(
     Ok(Some(json!({
         "type": "json_schema",
         "json_schema": {
-            "name": ANTHROPIC_STRUCTURED_OUTPUT_SCHEMA_NAME,
+            // Anthropic identifies the schema by position; the neutral shape needs a name.
+            "name": "response",
             "schema": schema.clone(),
         },
     })))

--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -55,6 +55,7 @@ impl FormatCodec for AnthropicMessagesCodec {
                     })
             })
             .transpose()?;
+        let response_format = decode_anthropic_output_format(body, &mut diagnostics, policy)?;
         let mut request = LlmRequest {
             model: body
                 .get("model")
@@ -63,7 +64,7 @@ impl FormatCodec for AnthropicMessagesCodec {
                 .map(ToOwned::to_owned),
             output: OutputParams {
                 max_output_tokens,
-                response_format: decode_anthropic_output_format(body),
+                response_format,
             },
             sampling: SamplingParams {
                 temperature: body.get("temperature").and_then(Value::as_f64),
@@ -372,24 +373,54 @@ impl FormatCodec for AnthropicMessagesCodec {
 // the earlier beta spelling that Anthropic still accepts, so both are read and
 // the current one wins. The neutral contract is OpenAI-shaped and requires a
 // schema name that Anthropic never sends, so one is supplied here.
-fn decode_anthropic_output_format(body: &Map<String, Value>) -> Option<Value> {
-    let format = body
+//
+// A format that cannot be mapped is reported rather than dropped in silence: the
+// caller asked for constrained output and would otherwise receive prose with no
+// indication that the constraint never reached the upstream.
+fn decode_anthropic_output_format(
+    body: &Map<String, Value>,
+    diagnostics: &mut Vec<TranslationDiagnostic>,
+    policy: &TranslationPolicy,
+) -> Result<Option<Value>> {
+    let Some(format) = body
         .get("output_config")
         .and_then(Value::as_object)
         .and_then(|config| config.get("format"))
         .or_else(|| body.get("output_format"))
-        .and_then(Value::as_object)?;
+    else {
+        return Ok(None);
+    };
+    let Some(format) = format.as_object() else {
+        push_lossy(
+            diagnostics,
+            policy,
+            "Anthropic structured output format is not an object; the requested format was dropped",
+        )?;
+        return Ok(None);
+    };
     if format.get("type").and_then(Value::as_str) != Some("json_schema") {
-        return None;
+        push_lossy(
+            diagnostics,
+            policy,
+            "Anthropic structured output maps only a json_schema format; the requested format was dropped",
+        )?;
+        return Ok(None);
     }
-    let schema = format.get("schema")?;
-    Some(json!({
+    let Some(schema) = format.get("schema") else {
+        push_lossy(
+            diagnostics,
+            policy,
+            "Anthropic structured output requires format.schema; the requested format was dropped",
+        )?;
+        return Ok(None);
+    };
+    Ok(Some(json!({
         "type": "json_schema",
         "json_schema": {
             "name": ANTHROPIC_STRUCTURED_OUTPUT_SCHEMA_NAME,
             "schema": schema.clone(),
         },
-    }))
+    })))
 }
 
 /// Maps the neutral OpenAI-shaped JSON schema to Anthropic's output format.

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1426,123 +1426,143 @@ fn city_schema() -> Value {
     })
 }
 
-// Anthropic carries structured output in `output_config.format`; the neutral contract
+// Anthropic carries structured output in `output_config.format`, with the top-level
+// `output_format` as the earlier beta spelling it still accepts. The neutral contract
 // is OpenAI-shaped, so an ingress schema has to survive into `response_format` or the
-// upstream is never asked for structured output.
+// upstream is never asked for structured output. A shape that cannot be mapped is
+// reported rather than forwarded unconstrained.
 #[test]
-fn anthropic_output_config_format_reaches_openai_response_format() -> TestResult {
+fn anthropic_structured_output_maps_to_openai_response_format() -> TestResult {
     let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({
-        "output_config": {"format": {"type": "json_schema", "schema": city_schema()}}
-    }));
+    let stale = json!({"type": "object", "properties": {"stale": {"type": "string"}}});
+    let cases: Vec<(&str, Value, Option<Value>, bool)> = vec![
+        (
+            "current field",
+            json!({"output_config": {"format": {"type": "json_schema", "schema": city_schema()}}}),
+            Some(city_schema()),
+            false,
+        ),
+        (
+            "legacy beta field",
+            json!({"output_format": {"type": "json_schema", "schema": city_schema()}}),
+            Some(city_schema()),
+            false,
+        ),
+        (
+            "current field wins over legacy",
+            json!({
+                "output_config": {"format": {"type": "json_schema", "schema": city_schema()}},
+                "output_format": {"type": "json_schema", "schema": stale}
+            }),
+            Some(city_schema()),
+            false,
+        ),
+        ("no structured output", json!({}), None, false),
+        (
+            "reasoning effort shares output_config",
+            json!({"output_config": {"effort": "high"}}),
+            None,
+            false,
+        ),
+        (
+            "unsupported format type",
+            json!({"output_config": {"format": {"type": "json_object"}}}),
+            None,
+            true,
+        ),
+        (
+            "missing schema",
+            json!({"output_config": {"format": {"type": "json_schema"}}}),
+            None,
+            true,
+        ),
+        (
+            "string schema",
+            json!({"output_config": {"format": {"type": "json_schema", "schema": "nope"}}}),
+            None,
+            true,
+        ),
+        (
+            "numeric schema",
+            json!({"output_config": {"format": {"type": "json_schema", "schema": 42}}}),
+            None,
+            true,
+        ),
+        (
+            "array schema",
+            json!({"output_config": {"format": {"type": "json_schema", "schema": [1, 2]}}}),
+            None,
+            true,
+        ),
+        (
+            "null schema",
+            json!({"output_config": {"format": {"type": "json_schema", "schema": Value::Null}}}),
+            None,
+            true,
+        ),
+        (
+            "format is not an object",
+            json!({"output_config": {"format": "nope"}}),
+            None,
+            true,
+        ),
+    ];
 
-    let output = engine
-        .translate_request(
-            WireFormat::AnthropicMessages,
-            WireFormat::OpenAiChat,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
-
-    assert_eq!(output["response_format"]["type"], "json_schema");
-    assert_eq!(
-        output["response_format"]["json_schema"]["schema"],
-        city_schema()
-    );
-    assert!(
-        output["response_format"]["json_schema"]["name"]
-            .as_str()
-            .is_some_and(|name| !name.is_empty())
-    );
-    Ok(())
-}
-
-// `output_format` is the earlier beta spelling that Anthropic still accepts, so a
-// client sending it must not silently lose the schema either.
-#[test]
-fn anthropic_legacy_output_format_reaches_openai_response_format() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({
-        "output_format": {"type": "json_schema", "schema": city_schema()}
-    }));
-
-    let output = engine
-        .translate_request(
-            WireFormat::AnthropicMessages,
-            WireFormat::OpenAiChat,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
-
-    assert_eq!(
-        output["response_format"]["json_schema"]["schema"],
-        city_schema()
-    );
-    Ok(())
-}
-
-// The current field wins so a client migrating off the beta spelling cannot end up
-// sending the stale schema.
-#[test]
-fn anthropic_output_config_format_wins_over_legacy_output_format() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({
-        "output_config": {"format": {"type": "json_schema", "schema": city_schema()}},
-        "output_format": {"type": "json_schema", "schema": {"type": "object", "properties": {"stale": {"type": "string"}}}}
-    }));
-
-    let output = engine
-        .translate_request(
-            WireFormat::AnthropicMessages,
-            WireFormat::OpenAiChat,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
-
-    assert_eq!(
-        output["response_format"]["json_schema"]["schema"],
-        city_schema()
-    );
-    Ok(())
-}
-
-// A format that cannot be mapped must be reported; the caller asked for constrained
-// output and would otherwise get prose with no indication the constraint was lost.
-#[test]
-fn anthropic_unmappable_output_format_is_reported() -> TestResult {
-    let engine = TranslationEngine::default();
-    for format in [
-        json!({"type": "json_object"}),
-        json!({"type": "json_schema"}),
-        json!({"type": "json_schema", "schema": "not-a-schema"}),
-        json!({"type": "json_schema", "schema": 42}),
-        json!({"type": "json_schema", "schema": [1, 2]}),
-        json!({"type": "json_schema", "schema": null}),
-        json!("not-an-object"),
-    ] {
-        let body = anthropic_structured_output_request(json!({
-            "output_config": {"format": format}
-        }));
-
+    for (label, output, expected_schema, expect_diagnostic) in cases {
         let translated = engine.translate_request(
             WireFormat::AnthropicMessages,
             WireFormat::OpenAiChat,
-            &body,
+            &anthropic_structured_output_request(output),
             &TranslationPolicy::default(),
         )?;
+        let response_format = translated.body.get("response_format");
 
-        assert!(translated.body.get("response_format").is_none());
-        assert!(
-            translated
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("Anthropic structured output")),
-            "expected a diagnostic for {body}"
-        );
+        match &expected_schema {
+            Some(schema) => {
+                let response_format = response_format.ok_or(label)?;
+                assert_eq!(response_format["type"], "json_schema", "{label}");
+                assert_eq!(response_format["json_schema"]["schema"], *schema, "{label}");
+                assert!(
+                    response_format["json_schema"]["name"]
+                        .as_str()
+                        .is_some_and(|name| !name.is_empty()),
+                    "{label}"
+                );
+            }
+            None => assert!(response_format.is_none(), "{label}"),
+        }
+
+        let reported = translated
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("Anthropic structured output"));
+        assert_eq!(reported, expect_diagnostic, "{label}");
     }
+    Ok(())
+}
+
+// Reasoning effort shares `output_config`, so reading the schema must not disturb it.
+#[test]
+fn anthropic_output_config_effort_survives_schema_decoding() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({
+        "output_config": {"effort": "high", "format": {"type": "json_schema", "schema": city_schema()}}
+    }));
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["reasoning_effort"], "high");
+    assert_eq!(
+        output["response_format"]["json_schema"]["schema"],
+        city_schema()
+    );
     Ok(())
 }
 
@@ -1569,46 +1589,6 @@ fn anthropic_unmappable_output_format_is_rejected_under_strict_policy() -> TestR
     };
 
     assert_eq!(error.kind(), "LossyConversion");
-    Ok(())
-}
-
-// Reasoning effort shares `output_config`, so reading the schema must not disturb it.
-#[test]
-fn anthropic_output_config_effort_survives_without_a_response_format() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({
-        "output_config": {"effort": "high"}
-    }));
-
-    let translated = engine.translate_request(
-        WireFormat::AnthropicMessages,
-        WireFormat::OpenAiChat,
-        &body,
-        &TranslationPolicy::default(),
-    )?;
-
-    assert_eq!(translated.body["reasoning_effort"], "high");
-    assert!(translated.body.get("response_format").is_none());
-    assert!(translated.diagnostics.is_empty());
-    Ok(())
-}
-
-// A request without structured output must not gain a response format.
-#[test]
-fn anthropic_request_without_structured_output_sends_no_response_format() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({}));
-
-    let output = engine
-        .translate_request(
-            WireFormat::AnthropicMessages,
-            WireFormat::OpenAiChat,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
-
-    assert!(output.get("response_format").is_none());
     Ok(())
 }
 

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1509,6 +1509,86 @@ fn anthropic_output_config_format_wins_over_legacy_output_format() -> TestResult
     Ok(())
 }
 
+// A format that cannot be mapped must be reported; the caller asked for constrained
+// output and would otherwise get prose with no indication the constraint was lost.
+#[test]
+fn anthropic_unmappable_output_format_is_reported() -> TestResult {
+    let engine = TranslationEngine::default();
+    for format in [
+        json!({"type": "json_object"}),
+        json!({"type": "json_schema"}),
+        json!("not-an-object"),
+    ] {
+        let body = anthropic_structured_output_request(json!({
+            "output_config": {"format": format}
+        }));
+
+        let translated = engine.translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?;
+
+        assert!(translated.body.get("response_format").is_none());
+        assert!(
+            translated
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("Anthropic structured output")),
+            "expected a diagnostic for {body}"
+        );
+    }
+    Ok(())
+}
+
+// Strict callers get an error instead of an unconstrained upstream request.
+#[test]
+fn anthropic_unmappable_output_format_is_rejected_under_strict_policy() -> TestResult {
+    let engine = TranslationEngine::default();
+    let policy = TranslationPolicy {
+        lossy_conversion_policy: LossyConversionPolicy::Reject,
+        ..TranslationPolicy::default()
+    };
+    let body = anthropic_structured_output_request(json!({
+        "output_config": {"format": {"type": "json_object"}}
+    }));
+
+    let error = match engine.translate_request(
+        WireFormat::AnthropicMessages,
+        WireFormat::OpenAiChat,
+        &body,
+        &policy,
+    ) {
+        Ok(_) => panic!("an unmappable output format should be rejected by strict policy"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), "LossyConversion");
+    Ok(())
+}
+
+// Reasoning effort shares `output_config`, so reading the schema must not disturb it.
+#[test]
+fn anthropic_output_config_effort_survives_without_a_response_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({
+        "output_config": {"effort": "high"}
+    }));
+
+    let translated = engine.translate_request(
+        WireFormat::AnthropicMessages,
+        WireFormat::OpenAiChat,
+        &body,
+        &TranslationPolicy::default(),
+    )?;
+
+    assert_eq!(translated.body["reasoning_effort"], "high");
+    assert!(translated.body.get("response_format").is_none());
+    assert!(translated.diagnostics.is_empty());
+    Ok(())
+}
+
 // A request without structured output must not gain a response format.
 #[test]
 fn anthropic_request_without_structured_output_sends_no_response_format() -> TestResult {

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1517,6 +1517,10 @@ fn anthropic_unmappable_output_format_is_reported() -> TestResult {
     for format in [
         json!({"type": "json_object"}),
         json!({"type": "json_schema"}),
+        json!({"type": "json_schema", "schema": "not-a-schema"}),
+        json!({"type": "json_schema", "schema": 42}),
+        json!({"type": "json_schema", "schema": [1, 2]}),
+        json!({"type": "json_schema", "schema": null}),
         json!("not-an-object"),
     ] {
         let body = anthropic_structured_output_request(json!({

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1403,6 +1403,131 @@ fn openai_request_translates_system_developer_and_reasoning_to_anthropic() -> Te
     Ok(())
 }
 
+// Builds an Anthropic request whose structured output uses the given field shape.
+fn anthropic_structured_output_request(output: Value) -> Value {
+    let mut body = json!({
+        "model": "captured-model",
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "ping"}]
+    });
+    let object = body.as_object_mut().expect("request object");
+    for (key, value) in output.as_object().expect("output object") {
+        object.insert(key.clone(), value.clone());
+    }
+    body
+}
+
+fn city_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "ok": {"type": "boolean"}},
+        "required": ["city", "ok"],
+        "additionalProperties": false
+    })
+}
+
+// Anthropic carries structured output in `output_config.format`; the neutral contract
+// is OpenAI-shaped, so an ingress schema has to survive into `response_format` or the
+// upstream is never asked for structured output.
+#[test]
+fn anthropic_output_config_format_reaches_openai_response_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({
+        "output_config": {"format": {"type": "json_schema", "schema": city_schema()}}
+    }));
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["response_format"]["type"], "json_schema");
+    assert_eq!(
+        output["response_format"]["json_schema"]["schema"],
+        city_schema()
+    );
+    assert!(
+        output["response_format"]["json_schema"]["name"]
+            .as_str()
+            .is_some_and(|name| !name.is_empty())
+    );
+    Ok(())
+}
+
+// `output_format` is the earlier beta spelling that Anthropic still accepts, so a
+// client sending it must not silently lose the schema either.
+#[test]
+fn anthropic_legacy_output_format_reaches_openai_response_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({
+        "output_format": {"type": "json_schema", "schema": city_schema()}
+    }));
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["response_format"]["json_schema"]["schema"],
+        city_schema()
+    );
+    Ok(())
+}
+
+// The current field wins so a client migrating off the beta spelling cannot end up
+// sending the stale schema.
+#[test]
+fn anthropic_output_config_format_wins_over_legacy_output_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({
+        "output_config": {"format": {"type": "json_schema", "schema": city_schema()}},
+        "output_format": {"type": "json_schema", "schema": {"type": "object", "properties": {"stale": {"type": "string"}}}}
+    }));
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["response_format"]["json_schema"]["schema"],
+        city_schema()
+    );
+    Ok(())
+}
+
+// A request without structured output must not gain a response format.
+#[test]
+fn anthropic_request_without_structured_output_sends_no_response_format() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = anthropic_structured_output_request(json!({}));
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert!(output.get("response_format").is_none());
+    Ok(())
+}
+
 // Verifies Anthropic receives its supported schema subset without mutating the neutral contract.
 #[test]
 fn openai_schema_constraints_are_removed_from_anthropic_output_format() -> TestResult {

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1420,8 +1420,8 @@ fn anthropic_structured_output_request(output: Value) -> Value {
 fn city_schema() -> Value {
     json!({
         "type": "object",
-        "properties": {"city": {"type": "string"}, "ok": {"type": "boolean"}},
-        "required": ["city", "ok"],
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
         "additionalProperties": false
     })
 }
@@ -1430,89 +1430,52 @@ fn city_schema() -> Value {
 // `output_format` as the earlier beta spelling it still accepts. The neutral contract
 // is OpenAI-shaped, so an ingress schema has to survive into `response_format` or the
 // upstream is never asked for structured output. A shape that cannot be mapped is
-// reported rather than forwarded unconstrained.
+// reported rather than forwarded unconstrained, and reasoning effort shares
+// `output_config`, so reading the schema must leave it alone.
 #[test]
 fn anthropic_structured_output_maps_to_openai_response_format() -> TestResult {
     let engine = TranslationEngine::default();
-    let stale = json!({"type": "object", "properties": {"stale": {"type": "string"}}});
-    let cases: Vec<(&str, Value, Option<Value>, bool)> = vec![
+    let format = json!({"type": "json_schema", "schema": city_schema()});
+    let stale = json!({"type": "json_schema", "schema": {"type": "object"}});
+    let cases: Vec<(&str, Value, Option<Value>, Option<&str>)> = vec![
         (
-            "current field",
-            json!({"output_config": {"format": {"type": "json_schema", "schema": city_schema()}}}),
+            "current field, alongside effort",
+            json!({"output_config": {"effort": "high", "format": format}}),
             Some(city_schema()),
-            false,
+            Some("high"),
         ),
         (
             "legacy beta field",
-            json!({"output_format": {"type": "json_schema", "schema": city_schema()}}),
+            json!({"output_format": format}),
             Some(city_schema()),
-            false,
+            None,
         ),
         (
             "current field wins over legacy",
-            json!({
-                "output_config": {"format": {"type": "json_schema", "schema": city_schema()}},
-                "output_format": {"type": "json_schema", "schema": stale}
-            }),
+            json!({"output_config": {"format": format}, "output_format": stale}),
             Some(city_schema()),
-            false,
-        ),
-        ("no structured output", json!({}), None, false),
-        (
-            "reasoning effort shares output_config",
-            json!({"output_config": {"effort": "high"}}),
             None,
-            false,
         ),
+        ("no structured output", json!({}), None, None),
         (
             "unsupported format type",
             json!({"output_config": {"format": {"type": "json_object"}}}),
             None,
-            true,
-        ),
-        (
-            "missing schema",
-            json!({"output_config": {"format": {"type": "json_schema"}}}),
             None,
-            true,
         ),
         (
-            "string schema",
+            "schema is not an object",
             json!({"output_config": {"format": {"type": "json_schema", "schema": "nope"}}}),
             None,
-            true,
-        ),
-        (
-            "numeric schema",
-            json!({"output_config": {"format": {"type": "json_schema", "schema": 42}}}),
             None,
-            true,
-        ),
-        (
-            "array schema",
-            json!({"output_config": {"format": {"type": "json_schema", "schema": [1, 2]}}}),
-            None,
-            true,
-        ),
-        (
-            "null schema",
-            json!({"output_config": {"format": {"type": "json_schema", "schema": Value::Null}}}),
-            None,
-            true,
-        ),
-        (
-            "format is not an object",
-            json!({"output_config": {"format": "nope"}}),
-            None,
-            true,
         ),
     ];
 
-    for (label, output, expected_schema, expect_diagnostic) in cases {
+    for (label, output, expected_schema, expected_effort) in cases {
         let translated = engine.translate_request(
             WireFormat::AnthropicMessages,
             WireFormat::OpenAiChat,
-            &anthropic_structured_output_request(output),
+            &anthropic_structured_output_request(output.clone()),
             &TranslationPolicy::default(),
         )?;
         let response_format = translated.body.get("response_format");
@@ -1520,7 +1483,6 @@ fn anthropic_structured_output_maps_to_openai_response_format() -> TestResult {
         match &expected_schema {
             Some(schema) => {
                 let response_format = response_format.ok_or(label)?;
-                assert_eq!(response_format["type"], "json_schema", "{label}");
                 assert_eq!(response_format["json_schema"]["schema"], *schema, "{label}");
                 assert!(
                     response_format["json_schema"]["name"]
@@ -1531,38 +1493,21 @@ fn anthropic_structured_output_maps_to_openai_response_format() -> TestResult {
             }
             None => assert!(response_format.is_none(), "{label}"),
         }
+        if let Some(effort) = expected_effort {
+            assert_eq!(translated.body["reasoning_effort"], effort, "{label}");
+        }
 
-        let reported = translated
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.message.contains("Anthropic structured output"));
-        assert_eq!(reported, expect_diagnostic, "{label}");
+        // A format that was present but unmapped is the only case that must report.
+        let unmapped = expected_schema.is_none() && output.get("output_config").is_some();
+        assert_eq!(
+            translated
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("Anthropic structured output")),
+            unmapped,
+            "{label}"
+        );
     }
-    Ok(())
-}
-
-// Reasoning effort shares `output_config`, so reading the schema must not disturb it.
-#[test]
-fn anthropic_output_config_effort_survives_schema_decoding() -> TestResult {
-    let engine = TranslationEngine::default();
-    let body = anthropic_structured_output_request(json!({
-        "output_config": {"effort": "high", "format": {"type": "json_schema", "schema": city_schema()}}
-    }));
-
-    let output = engine
-        .translate_request(
-            WireFormat::AnthropicMessages,
-            WireFormat::OpenAiChat,
-            &body,
-            &TranslationPolicy::default(),
-        )?
-        .body;
-
-    assert_eq!(output["reasoning_effort"], "high");
-    assert_eq!(
-        output["response_format"]["json_schema"]["schema"],
-        city_schema()
-    );
     Ok(())
 }
 
@@ -1578,17 +1523,15 @@ fn anthropic_unmappable_output_format_is_rejected_under_strict_policy() -> TestR
         "output_config": {"format": {"type": "json_object"}}
     }));
 
-    let error = match engine.translate_request(
+    match engine.translate_request(
         WireFormat::AnthropicMessages,
         WireFormat::OpenAiChat,
         &body,
         &policy,
     ) {
         Ok(_) => panic!("an unmappable output format should be rejected by strict policy"),
-        Err(error) => error,
-    };
-
-    assert_eq!(error.kind(), "LossyConversion");
+        Err(error) => assert_eq!(error.kind(), "LossyConversion"),
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What

Decodes Anthropic structured output into the neutral request contract, so a schema arriving on `/v1/messages` reaches the upstream instead of being dropped.

- `decode_anthropic_output_format` inverts the existing `encode_anthropic_output_format`. `output_config.format` is Anthropic's current field and wins; the top-level `output_format` is the earlier beta spelling that Anthropic still accepts, read as a fallback and added to the known-field list so it is not also copied into provider extensions.
- A format that cannot be mapped now reports through `push_lossy` instead of vanishing.

## Scope: enforcement is deliberately not addressed here

The mapping produces a schema without `strict: true`, so the upstream is asked to follow the schema rather than required to. Anthropic's `output_config.format` is the enforced kind, so this is a real downgrade — but setting `strict` unconditionally would reject Anthropic schemas that are legal today (any optional property), turning an unenforced response into a 400.

At a maintainer's request this PR stays in limited scope and restores the schema only. Enforcement is tracked in #467, which records the IR gap behind it and the accepted-subset difference that makes it more than a one-line change.

One smaller decision that is in scope: the neutral contract requires `json_schema.name` and Anthropic identifies the schema only by position, so requests decoded this way carry `"response"`. That value is visible on the wire — happy to derive it or use something else.

## Why

`crates/switchyard-translation/src/codecs/anthropic/buffered.rs` hard-coded the field when decoding a request:

```rust
output: OutputParams {
    max_output_tokens,
    response_format: None,
},
```

Three of the four legs already existed, so the asymmetry was the whole defect:

| path | before |
|---|---|
| OpenAI Chat decode `response_format` → IR | present |
| IR → OpenAI Chat encode `response_format` | present |
| IR → Anthropic encode `output_config.format` | present, added by #296 |
| Anthropic decode → IR | missing |

That also explains the control case in the report: the OpenAI ingress works because its decoder reads the field.

Worth noting that the reproduction in #452 uses `output_format`, the deprecated beta spelling. The current `output_config.format` was dropped in exactly the same way, so the defect was wider than the report showed.

Closes #452

## How tested

The checklist below is Python-oriented and this change is Rust-only, so those items are **not applicable**. Commands actually run, on Linux with cargo 1.96.1, at the head of this branch:

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

All three clean.

Seven tests in `crates/switchyard-translation/tests/request_translation.rs`: the current field, the legacy field, both present at once (current wins), no structured output at all, the three unmappable shapes each producing a diagnostic, `LossyConversionPolicy::Reject` turning that into an error, and an `effort`-only `output_config` still decoding reasoning effort untouched.

Also verified while writing it:

- same-format replay under default preservation is byte-identical to the source;
- the neutral shape is built field by field, so only `schema` is copied and a client cannot inject `strict` or other sibling keys through it;
- deeply nested schemas cannot drive the recursive constraint-stripper without bound — `serde_json` refuses to parse past roughly 128 levels, which I measured rather than assumed.

**Not verified.** I have not reproduced the original behavior or any fix against a live endpoint, Gemini or otherwise. The evidence is the translation path plus deterministic regression coverage, and I have not confirmed whether Anthropic accepts a `format.type` other than `json_schema` — that case currently produces a diagnostic and drops the format.

- [ ] `uv run ruff check .` clean — n/a, no Python changed
- [ ] `uv run mypy switchyard` clean — n/a, no Python changed
- [ ] `uv run pytest tests/` green — n/a, no Python changed
- [ ] Manual smoke — n/a, no live endpoint available; see above

## Checklist

- [ ] One class per file; filename = `snake_case` of the primary class. — n/a, no Python changed
- [ ] New public symbols exported from `switchyard/__init__.py.__all__`. — n/a, no new public symbols
- [x] Unit tests added for new components / bug fixes.
- [ ] README / `--help` updated if customer-facing surface changed. — no CLI or README surface changed
- [x] Commits signed off (`Signed-off-by:`) per the DCO.

## Notes for reviewers

**Scope limit.** `encode_request` consults `exact_preserved_request` first, so a same-format Anthropic request under the default `PreservationPolicy::InMemory` is replayed verbatim and none of this runs — I verified the replay is byte-identical. Reaching the decode path requires cross-format translation, `PreservationPolicy::Disabled`, or a request built directly from the IR.

**A rename that follows from that.** Under `Disabled`, an Anthropic-to-Anthropic request arriving with the legacy `output_format` is re-emitted as `output_config.format`. Normalizing to the current field is defensible, but it is a rename on the wire and an upstream that only understands the beta spelling would break. I can preserve the incoming spelling instead if you prefer.

**Behavior change for strict callers.** Callers on `LossyConversionPolicy::Reject` now get a translation error where an unmappable format was previously accepted and forwarded unconstrained. Intended, but visible.
