### PR TITLE
fix(translation): emit Responses tool arguments once when decoding

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -101,7 +101,7 @@ fn decode_responses_stream(
                 })
                 .unwrap_or_default()
         }
-        Some("response.output_item.added") => decode_responses_output_item_added(event),
+        Some("response.output_item.added") => decode_responses_output_item_added(event, state),
         Some("response.function_call_arguments.delta") => {
             let output_index = event
                 .get("output_index")
@@ -111,6 +111,14 @@ fn decode_responses_stream(
                 .get("delta")
                 .and_then(Value::as_str)
                 .map(|delta| {
+                    // Recorded so `response.output_item.done`, which repeats
+                    // the complete arguments, can tell it is a repeat.
+                    state
+                        .tool_states
+                        .entry(output_index as usize)
+                        .or_default()
+                        .decoded_arguments
+                        .push_str(delta);
                     vec![LlmResponseChunk::ToolCallDelta {
                         index: output_index as usize,
                         id: None,
@@ -325,7 +333,10 @@ fn finish_responses_stream(state: &mut StreamTranslationState) -> Vec<Value> {
 }
 
 // Converts Responses function-call item creation into a neutral tool-call delta.
-fn decode_responses_output_item_added(event: &Value) -> Vec<LlmResponseChunk> {
+fn decode_responses_output_item_added(
+    event: &Value,
+    state: &mut StreamTranslationState,
+) -> Vec<LlmResponseChunk> {
     let Some(item) = event.get("item").and_then(Value::as_object) else {
         return Vec::new();
     };
@@ -336,6 +347,19 @@ fn decode_responses_output_item_added(event: &Value) -> Vec<LlmResponseChunk> {
         .get("output_index")
         .and_then(Value::as_u64)
         .unwrap_or(0) as usize;
+    let arguments_delta = item
+        .get("arguments")
+        .and_then(Value::as_str)
+        .filter(|arguments| !arguments.is_empty())
+        .map(ToOwned::to_owned);
+    if let Some(arguments) = arguments_delta.as_deref() {
+        state
+            .tool_states
+            .entry(index)
+            .or_default()
+            .decoded_arguments
+            .push_str(arguments);
+    }
     vec![LlmResponseChunk::ToolCallDelta {
         index,
         id: item
@@ -347,18 +371,14 @@ fn decode_responses_output_item_added(event: &Value) -> Vec<LlmResponseChunk> {
             .get("name")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
-        arguments_delta: item
-            .get("arguments")
-            .and_then(Value::as_str)
-            .filter(|arguments| !arguments.is_empty())
-            .map(ToOwned::to_owned),
+        arguments_delta,
     }]
 }
 
 // Emits a final tool-call argument delta when Responses only supplies arguments at item end.
 fn decode_responses_output_item_done(
     event: &Value,
-    state: &StreamTranslationState,
+    state: &mut StreamTranslationState,
 ) -> Vec<LlmResponseChunk> {
     let Some(item) = event.get("item").and_then(Value::as_object) else {
         return Vec::new();
@@ -372,12 +392,13 @@ fn decode_responses_output_item_done(
         .unwrap_or(0) as usize;
     let arguments = item.get("arguments").and_then(Value::as_str);
     if let Some(arguments) = arguments {
-        let existing = state
-            .tool_states
-            .get(&index)
-            .map(|tool| tool.arguments.as_str())
-            .unwrap_or("");
-        if !arguments.is_empty() && arguments != existing {
+        // Compared against what THIS decoder has seen. Reading the encoder's
+        // `arguments` instead only deduplicates when a single state performs
+        // both halves of the translation, and silently duplicates when a
+        // caller buffers the stream with its own state.
+        let tool = state.tool_states.entry(index).or_default();
+        if !arguments.is_empty() && arguments != tool.decoded_arguments {
+            tool.decoded_arguments.push_str(arguments);
             return vec![LlmResponseChunk::ToolCallDelta {
                 index,
                 id: None,

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -69,6 +69,14 @@ pub(crate) struct StreamToolState {
     pub(crate) id: Option<String>,
     pub(crate) name: Option<String>,
     pub(crate) arguments: String,
+    /// Arguments observed while DECODING the source stream.
+    ///
+    /// Separate from `arguments`, which encoders accumulate. A decoder that
+    /// deduplicates against `arguments` only works when one state performs
+    /// both halves of the translation; when a caller buffers a stream with its
+    /// own state and encodes later, the field is empty and the duplicate is
+    /// emitted.
+    pub(crate) decoded_arguments: String,
     pub(crate) pending_arguments: String,
     pub(crate) started: bool,
     pub(crate) content_index: Option<usize>,

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -1198,3 +1198,52 @@ fn responses_incomplete_event_translates_to_chat_length_finish() -> TestResult {
     assert_eq!(terminal["choices"][0]["finish_reason"], "length");
     Ok(())
 }
+
+// Decoding alone must yield the function-call arguments exactly once.
+//
+// `response.output_item.done` repeats the complete arguments that the delta
+// events already carried, so the decoder drops it when it matches what it has
+// seen. That comparison reads state the DECODER never writes — it is filled by
+// the Anthropic encoder — so it only holds when one state happens to do both
+// halves. libsy buffers a turn with its own state and no Anthropic encode, and
+// the arguments are then emitted twice.
+//
+// Observed through switchyard-server 0.2.0 against a live Azure gpt-5.6
+// target: every llm_classifier route doubled its streamed tool arguments,
+// while passthrough over the identical path was correct. Claude Code rejects
+// the result with "InputValidationError: parameter type is expected as
+// 'object' but provided as 'string'".
+#[test]
+fn responses_decode_emits_tool_arguments_once() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state = StreamTranslationState::default();
+    let arguments = r#"{"skill":"demo:thing","args":{}}"#;
+
+    let upstream = [
+        json!({"type": "response.output_item.added", "output_index": 0,
+               "item": {"type": "function_call", "call_id": "call_1",
+                        "name": "Skill", "arguments": ""}}),
+        json!({"type": "response.function_call_arguments.delta",
+               "output_index": 0, "delta": arguments}),
+        json!({"type": "response.output_item.done", "output_index": 0,
+               "item": {"type": "function_call", "call_id": "call_1",
+                        "name": "Skill", "arguments": arguments}}),
+    ];
+
+    let mut seen = String::new();
+    for event in upstream {
+        let decoded = engine.decode_stream_event(&mut state, WireFormat::OpenAiResponses, event)?;
+        for chunk in decoded.normalized() {
+            if let LlmResponseChunk::ToolCallDelta {
+                arguments_delta: Some(delta),
+                ..
+            } = chunk
+            {
+                seen.push_str(delta);
+            }
+        }
+    }
+
+    assert_eq!(seen, arguments);
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -1199,20 +1199,7 @@ fn responses_incomplete_event_translates_to_chat_length_finish() -> TestResult {
     Ok(())
 }
 
-// Decoding alone must yield the function-call arguments exactly once.
-//
-// `response.output_item.done` repeats the complete arguments that the delta
-// events already carried, so the decoder drops it when it matches what it has
-// seen. That comparison reads state the DECODER never writes — it is filled by
-// the Anthropic encoder — so it only holds when one state happens to do both
-// halves. libsy buffers a turn with its own state and no Anthropic encode, and
-// the arguments are then emitted twice.
-//
-// Observed through switchyard-server 0.2.0 against a live Azure gpt-5.6
-// target: every llm_classifier route doubled its streamed tool arguments,
-// while passthrough over the identical path was correct. Claude Code rejects
-// the result with "InputValidationError: parameter type is expected as
-// 'object' but provided as 'string'".
+// A completion event must not repeat function-call arguments from delta events.
 #[test]
 fn responses_decode_emits_tool_arguments_once() -> TestResult {
     let engine = TranslationEngine::default();


### PR DESCRIPTION
## What

Fixes duplicated function-call arguments when decoding an OpenAI Responses stream.

`response.output_item.done` repeats the complete arguments that the delta events already carried, so `decode_responses_output_item_done` suppresses it when it matches what has been seen. That comparison read `StreamToolState::arguments` — a field **no decoder writes**. It is populated by the Anthropic encoder (`codecs/anthropic/stream.rs`), so the check only held when a single `StreamTranslationState` performed both halves of the translation.

The decoder now accumulates into its own `decoded_arguments`, so deduplication holds regardless of which state encodes, or whether anything encodes at all.

## Why

`libsy` buffers a streamed turn with its own state and encodes later (`algorithms/advisor_gate/turn.rs`), so the guard always saw an empty string. Every `llm_classifier` route emitted the tool arguments twice. `passthrough` was unaffected, because one state does both decode and encode there.

Observed against switchyard-server 0.2.0 with a live Azure `gpt-5.6` target. An Anthropic client accumulating `input_json_delta` received:

```
{"skill":"demo:thing","args":{}}{"skill":"demo:thing","args":{}}
```

Claude Code rejects that with `InputValidationError: The parameter '' type is expected as 'object' but provided as 'string'`, so every tool-using agent session fails on any `llm_classifier` route.

Measured across route types, same tool and prompt:

| Route | Streamed tool arguments |
|---|---|
| `passthrough` | correct |
| `llm_classifier` (capability) | doubled |
| `llm_classifier` (escalation) | doubled, and JSON-encoded again by the replay path |

The extra encoding in escalation mode disappears once the duplication is fixed; it was a consequence, not a separate defect.

### Why this survived to 0.2.0

It requires four things at once: Anthropic Messages inbound, Responses upstream, streaming, and a route that decodes with its own state. `benchmark/server-configs/tb-lite-llm-classifier-*.toml` uses `format = "openai_chat"`, so classifier benchmarks never exercise the Responses upstream; and the Codex path is Responses-in/Responses-out, where `encode_stream_event` replays preserved JSON verbatim and never touches the normalized chunks.

Anthropic-in with Responses-upstream is forced by pairing Claude Code with a GPT-5.6 target, which requires `/v1/responses` for function tools with a reasoning effort.

## How tested

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (excluding `switchyard-py`, which does not link outside a Python build env locally)
- [x] `cargo test --workspace --exclude switchyard-py` green
- [x] New regression test `responses_decode_emits_tool_arguments_once` fails before the change and passes after
- [x] Manual smoke: rebuilt `switchyard-server`, ran an `llm_classifier` escalation route against Azure `gpt-5.6` through a real Anthropic Messages client. Accumulated `partial_json` before: `{"skill":…}{"skill":…}` string-wrapped; after: `{"args":{},"skill":"demo:thing"}`, parsing as an object.

Python gates were not run — this change is Rust-only.

## Checklist

- [x] Unit tests added for the bug fix.
- [x] Commits signed off per the DCO.
- [ ] README / `--help` unchanged — no customer-facing surface change.

## Notes for reviewers

- The regression test asserts at the **decoder** boundary deliberately. A test that decodes and encodes through one state passes even with the bug present, which is exactly how it hid.
- I checked the other decoders: `openai_chat` forwards its argument deltas without deduplicating, and Chat Completions has no terminal repeat, so it does not share the flaw. Only the Anthropic encoder touches `tool_states`.
- Touches the same file as #416, which hardens the Responses encoder and request decoder. The concerns do not overlap, but a textual conflict is possible.
- Not exercised: parallel tool calls, where the per-`output_index` accumulation matters more than in the single-call reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming function-call arguments being duplicated when responses are buffered or processed across multiple translation steps.
  * Ensured accumulated tool-call arguments are emitted exactly once and preserve the original JSON content.

* **Tests**
  * Added regression coverage for streamed function-call argument handling, including incremental updates and completed items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->