### PR TITLE
docs: Remove old x-model-router-rationale header

### DIFF
--- a/docs/routing_algorithms/stage_router_routing.md
+++ b/docs/routing_algorithms/stage_router_routing.md
@@ -265,7 +265,6 @@ Each response carries two routing headers:
 | Header | Content |
 |---|---|
 | `x-model-router-selected-model` | The model ID the turn was routed to. |
-| `x-model-router-rationale` | Human-readable routing reason (e.g. `stage_router selected weak (confidence 0.612)`). |
 
 ### Decision sources
 


### PR DESCRIPTION
We don't provide free-form routing info to the user, just the model that
was selected. The free-form info goes in logs.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation for the `x-model-router-rationale` response header from the observability guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->