### PR TITLE
fix(cli): report launcher config errors without tracebacks

### DIFF
--- a/crates/switchyard-py/src/errors.rs
+++ b/crates/switchyard-py/src/errors.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Error mapping for the libsy Python binding.
+//! Error mapping for the Python bindings.
 
 use pyo3::create_exception;
 use pyo3::exceptions::PyRuntimeError;
@@ -9,6 +9,7 @@ use pyo3::prelude::*;
 
 create_exception!(_switchyard_rust, LibsyError, PyRuntimeError);
 create_exception!(_switchyard_rust, ContextWindowExceededError, PyRuntimeError);
+create_exception!(_switchyard_rust, ServerConfigError, PyRuntimeError);
 
 /// Converts libsy execution failures into one stable Python exception.
 pub(crate) fn py_libsy_error(error: impl std::fmt::Display) -> PyErr {
@@ -20,5 +21,9 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add(
         "ContextWindowExceededError",
         module.py().get_type::<ContextWindowExceededError>(),
+    )?;
+    module.add(
+        "ServerConfigError",
+        module.py().get_type::<ServerConfigError>(),
     )
 }

--- a/crates/switchyard-py/src/server_bindings.rs
+++ b/crates/switchyard-py/src/server_bindings.rs
@@ -19,6 +19,8 @@ use switchyard_server::{
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+use crate::errors::ServerConfigError;
+
 const DEFAULT_SHUTDOWN_TIMEOUT_SECS: f64 = 2.0;
 
 /// Running loopback server backed entirely by the native Rust implementation.
@@ -38,7 +40,8 @@ impl PyServer {
     #[pyo3(signature = (config, port=0))]
     fn new(config: PathBuf, port: u16) -> PyResult<Self> {
         initialize_observability().map_err(server_error)?;
-        let state = load_server_state(config).map_err(server_error)?;
+        let state = load_server_state(config)
+            .map_err(|error| ServerConfigError::new_err(error.to_string()))?;
         let caller_auth_by_model = state
             .models()
             .map(|model| {
@@ -177,6 +180,7 @@ fn server_error(error: impl std::fmt::Display) -> PyErr {
 
 pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let server_module = PyModule::new(module.py(), "server")?;
+    server_module.add("ServerConfigError", module.getattr("ServerConfigError")?)?;
     server_module.add_class::<PyServer>()?;
     module.add_submodule(&server_module)?;
     Ok(())

--- a/switchyard/cli/launchers/native_server.py
+++ b/switchyard/cli/launchers/native_server.py
@@ -16,6 +16,10 @@ log = logging.getLogger(__name__)
 _LOCAL_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 
+class NativeServerConfigError(RuntimeError):
+    """Raised when a native server deployment configuration is invalid."""
+
+
 class HttpStatsSource(StatsSource):
     """Read launcher statistics from the native server."""
 
@@ -39,9 +43,12 @@ class NativeServer:
     """Host one TOML deployment through the PyO3 Rust server binding."""
 
     def __init__(self, config: Path) -> None:
-        from switchyard_rust.server import Server
+        from switchyard_rust.server import Server, ServerConfigError
 
-        self._server = Server(config, port=0)
+        try:
+            self._server = Server(config, port=0)
+        except ServerConfigError as exc:
+            raise NativeServerConfigError(str(exc)) from exc
         self.port: int = self._server.port
         self.base_url: str = self._server.base_url
         self.stats: StatsSource = HttpStatsSource(self.base_url)
@@ -55,4 +62,4 @@ class NativeServer:
         self._server.close()
 
 
-__all__ = ["HttpStatsSource", "NativeServer"]
+__all__ = ["HttpStatsSource", "NativeServer", "NativeServerConfigError"]

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -12,6 +12,7 @@ from switchyard.cli.launch_command import (
     cmd_launch_codex,
     cmd_launch_openclaw,
 )
+from switchyard.cli.launchers.native_server import NativeServerConfigError
 
 
 def _add_launch_parser(
@@ -73,7 +74,10 @@ def main() -> None:
     if not hasattr(args, "func"):
         parser.print_help()
         raise SystemExit(1)
-    args.func(args)
+    try:
+        args.func(args)
+    except NativeServerConfigError as exc:
+        parser.exit(1, f"error: {exc}\n")
 
 
 if __name__ == "__main__":

--- a/switchyard_rust/server.py
+++ b/switchyard_rust/server.py
@@ -12,6 +12,9 @@ from switchyard_rust._native import load_native
 
 if TYPE_CHECKING:
 
+    class ServerConfigError(RuntimeError):
+        """Raised when a native server deployment configuration is invalid."""
+
     @final
     class Server:
         """Running loopback instance of the native Switchyard server."""
@@ -39,10 +42,10 @@ if TYPE_CHECKING:
 
 
 def __getattr__(name: str) -> object:
-    if name == "Server":
+    if name in {"Server", "ServerConfigError"}:
         native: Any = load_native()
-        return native.server.Server
+        return getattr(native.server, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["Server"]
+__all__ = ["Server", "ServerConfigError"]

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -4,6 +4,7 @@
 """Contract tests for the minimal coding-agent launcher surface."""
 
 import argparse
+import sys
 from pathlib import Path
 
 import pytest
@@ -11,8 +12,8 @@ import pytest
 from switchyard.cli.launch_command import _config_path
 from switchyard.cli.launchers.claude_code_launcher import _claude_env
 from switchyard.cli.launchers.codex_cli_launcher import _codex_env, _provider_overrides
-from switchyard.cli.launchers.native_server import NativeServer
-from switchyard.cli.switchyard_cli import _build_parser
+from switchyard.cli.launchers.native_server import NativeServer, NativeServerConfigError
+from switchyard.cli.switchyard_cli import _build_parser, main
 
 
 def _subparsers(parser: argparse.ArgumentParser) -> dict[str, argparse.ArgumentParser]:
@@ -121,6 +122,40 @@ def test_native_server_passes_config_directly_to_binding(
     }
     assert server.port == 4321
     assert config.exists()
+
+
+def test_native_server_identifies_missing_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    with pytest.raises(NativeServerConfigError, match="OPENROUTER_API_KEY"):
+        NativeServer(_config_path(None))
+
+
+def test_cli_prints_configuration_error_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def invalid_config(_args: argparse.Namespace) -> None:
+        raise NativeServerConfigError(
+            "OPENROUTER_API_KEY: environment variable not found"
+        )
+
+    monkeypatch.setattr("switchyard.cli.switchyard_cli.cmd_launch_claude", invalid_config)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["switchyard", "launch", "claude", "--model", "switchyard"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().err == (
+        "error: OPENROUTER_API_KEY: environment variable not found\n"
+    )
 
 
 def test_missing_explicit_config_is_a_cli_error(tmp_path: Path) -> None:

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -4,7 +4,6 @@
 """Contract tests for the minimal coding-agent launcher surface."""
 
 import argparse
-import sys
 from pathlib import Path
 
 import pytest
@@ -12,8 +11,8 @@ import pytest
 from switchyard.cli.launch_command import _config_path
 from switchyard.cli.launchers.claude_code_launcher import _claude_env
 from switchyard.cli.launchers.codex_cli_launcher import _codex_env, _provider_overrides
-from switchyard.cli.launchers.native_server import NativeServer, NativeServerConfigError
-from switchyard.cli.switchyard_cli import _build_parser, main
+from switchyard.cli.launchers.native_server import NativeServer
+from switchyard.cli.switchyard_cli import _build_parser
 
 
 def _subparsers(parser: argparse.ArgumentParser) -> dict[str, argparse.ArgumentParser]:
@@ -122,40 +121,6 @@ def test_native_server_passes_config_directly_to_binding(
     }
     assert server.port == 4321
     assert config.exists()
-
-
-def test_native_server_identifies_missing_api_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-
-    with pytest.raises(NativeServerConfigError, match="OPENROUTER_API_KEY"):
-        NativeServer(_config_path(None))
-
-
-def test_cli_prints_configuration_error_without_traceback(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    def invalid_config(_args: argparse.Namespace) -> None:
-        raise NativeServerConfigError(
-            "OPENROUTER_API_KEY: environment variable not found"
-        )
-
-    monkeypatch.setattr("switchyard.cli.switchyard_cli.cmd_launch_claude", invalid_config)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["switchyard", "launch", "claude", "--model", "switchyard"],
-    )
-
-    with pytest.raises(SystemExit) as exc_info:
-        main()
-
-    assert exc_info.value.code == 1
-    assert capsys.readouterr().err == (
-        "error: OPENROUTER_API_KEY: environment variable not found\n"
-    )
 
 
 def test_missing_explicit_config_is_a_cli_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

A missing `OPENROUTER_API_KEY` exits correctly but prints a full Python traceback. This makes an expected configuration failure look like an internal crash.

Tracks [SWITCH-1251](https://linear.app/nvidia/issue/SWITCH-1251/oss-020usability-missing-openrouter-api-key-prints-a-full-python).

## What

Expose native configuration failures as `ServerConfigError` and render them as a one-line CLI error. Unexpected server runtime failures remain `RuntimeError` and keep their traceback.

The reported failure now reads:

```text
error: invalid server config /home/ayush-lab/Work/Switchyard/switchyard/cli/defaults/openrouter.toml: llm client openrouter could not read api_key_env OPENROUTER_API_KEY: environment variable not found
```

## How

`load_server_state` maps configuration failures to a typed PyO3 exception. The launcher translates only that exception, and the CLI exits through `argparse`.

## Where to Start Review

Start with `crates/switchyard-py/src/server_bindings.rs`, then follow the exception through `switchyard/cli/launchers/native_server.py` and `switchyard/cli/switchyard_cli.py`.

## Test Plan

- `uv run pytest tests/ -v` — 147 passed
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `uv run ruff check .`
- `uv run mypy switchyard`
- Manual missing-key launch: exit 1, one error line, no traceback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated configuration errors for invalid native server settings.
  * Exposed server configuration errors through the Python API.

* **Bug Fixes**
  * The CLI now reports configuration problems with a clear error message and exits cleanly with status 1 instead of showing a traceback.
  * Missing required API configuration is now identified specifically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->