### PR TITLE
fix(cli): forward OpenClaw arguments unchanged

### DIFF
--- a/switchyard/cli/launchers/openclaw_launcher.py
+++ b/switchyard/cli/launchers/openclaw_launcher.py
@@ -152,8 +152,8 @@ def _openclaw_env(workspace: str) -> dict[str, str]:
 
 
 def _openclaw_command(openclaw_bin: str, openclaw_args: list[str]) -> list[str]:
-    """Build the OpenClaw interactive command."""
-    return [openclaw_bin, "chat", *openclaw_args]
+    """Build the OpenClaw command, defaulting to interactive chat."""
+    return [openclaw_bin, *(openclaw_args or ["chat"])]
 
 
 def _supervise_openclaw(

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -8,10 +8,12 @@ from pathlib import Path
 
 import pytest
 
+from switchyard.cli.command_utils import strip_forwarded_args
 from switchyard.cli.launch_command import _config_path
 from switchyard.cli.launchers.claude_code_launcher import _claude_env
 from switchyard.cli.launchers.codex_cli_launcher import _codex_env, _provider_overrides
 from switchyard.cli.launchers.native_server import NativeServer
+from switchyard.cli.launchers.openclaw_launcher import _openclaw_command
 from switchyard.cli.switchyard_cli import _build_parser
 
 
@@ -44,6 +46,27 @@ def test_launcher_surface_is_model_config_and_forwarded_args(agent: str) -> None
     assert args.model == "switchyard"
     assert args.config is None
     assert vars(args)[f"{agent}_args"] == ["--", "--version"]
+
+
+@pytest.mark.parametrize(
+    ("agent_args", "expected"),
+    [
+        ([], ["openclaw", "chat"]),
+        (["--", "--version"], ["openclaw", "--version"]),
+        (["--", "chat", "--help"], ["openclaw", "chat", "--help"]),
+    ],
+)
+def test_openclaw_uses_forwarded_args_as_the_complete_argument_list(
+    agent_args: list[str],
+    expected: list[str],
+) -> None:
+    launch = _subparsers(_build_parser())["launch"]
+    parser = _subparsers(launch)["openclaw"]
+    args = parser.parse_args(["--model", "switchyard", *agent_args])
+
+    command = _openclaw_command("openclaw", strip_forwarded_args(args.openclaw_args))
+
+    assert command == expected
 
 
 def test_default_config_is_packaged_openrouter_deployment() -> None:


### PR DESCRIPTION
```text
switchyard launch openclaw --model switchyard -- --version
```

Switchyard currently starts this command:

```text
openclaw chat --version
```

The launcher inserts `chat` before every forwarded argument, so OpenClaw receives the root `--version` option under the `chat` subcommand instead of unchanged after the executable.

## Fix

Arguments after `--` now form the complete OpenClaw argument list. With no forwarded arguments, the launcher still starts `openclaw chat`, so ordinary interactive launches do not change.

Callers that intend to pass chat-specific options now include the subcommand explicitly:

```text
switchyard launch openclaw --model switchyard -- chat --help
```

Compatibility note: a caller that relied on the launcher to insert `chat` before forwarded options must now forward `chat` explicitly. Launches without forwarded arguments are unchanged.

## Evidence

```text
Before: ['openclaw', 'chat', '--version']
After:  ['openclaw', '--version']
Default: ['openclaw', 'chat']
Explicit chat: ['openclaw', 'chat', '--help']
```

## Testing

`uv run pytest tests/test_launchers.py -q` runs the parser-to-command regression and reports `12 passed`.

Fixes: ba72705b2eb8a2370d52644daa2a8cff8b13443e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenClaw command handling so explicitly provided arguments are passed through exactly as entered.
  * Preserved the default chat command when no arguments are supplied.

* **Tests**
  * Added coverage for default behavior and custom argument forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->