### PR TITLE
docs(changelog): note translation, server, and CLI changes in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **`Algorithm::route` returns `RoutingOutcome`** — instead of the bare final
-  `Result`, so callers observe the full routing outcome (see #458 for the
-  design). (#459)
+- **`Algorithm::route` returns `Result<RoutingOutcome>`** — instead of the
+  bare final `Result`, so callers observe the full routing outcome (see #458
+  for the design). (#459)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   harnesses, middle-out transcript truncation, fail-open consults, and an
   `advisor_gate` block in `/v1/stats` covering verdicts, consult failures, and
   REDO-discarded turns.
+- **switchyard-server container image** — a root `Dockerfile` builds the
+  server container image, consolidating the benchmark Dockerfile into it.
+  (#421)
+- **Run-span task metadata** — `task_kind` and `agent_role` are recorded on
+  the run span, so routing telemetry can be segmented by the semantic class of
+  work; span fields only, no new metric labels. (#249)
+- **Unified LLM-classifier bindings** — LLM-classifier routing is available
+  through the native PyO3 bindings, unifying the Python-side surface. (#465)
+
+### Changed
+
+- **`Algorithm::route` returns `RoutingOutcome`** — instead of the bare final
+  `Result`, so callers observe the full routing outcome (see #458 for the
+  design). (#459)
 
 ### Removed
 
@@ -26,6 +40,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Packaging extras `[server]`, `[gpu]`, and `[all]`** — dropped together
   with the deprecated Python server stack; only `[cli]` remains. Install
   server functionality via the standalone `switchyard-server` binary instead.
+
+### Fixed
+
+- **Reasoning order in mixed stream chunks** — the OpenAI Chat stream decoder
+  emits reasoning deltas before content deltas from the same chunk, so
+  interleaved reasoning is no longer reordered. (#387)
+- **Anthropic structured output in requests** — a schema arriving on
+  `/v1/messages` now reaches the neutral request and the forwarded upstream
+  body; unmappable output formats produce diagnostics instead of silent drops.
+  (#462)
+- **Responses tool arguments emitted once** — `output_item.done` repeats the
+  complete function-call arguments the delta events already carried; the
+  decoder suppresses the repeat when they match. (#469)
+- **Content filter stops as Anthropic refusal** — `StopReason::ContentFilter`
+  maps to Anthropic's `refusal` stop reason (and back) instead of `end_turn`,
+  so moderation stops remain distinguishable. (#370)
+- **JSON rejection statuses preserved** — request-body rejections keep the
+  underlying status code instead of always returning 400. (#406)
+- **Launcher config errors without tracebacks** — `switchyard launch` reports
+  configuration errors as messages rather than Python tracebacks. (#475)
+- **Default log level** — logging defaults to `info` for all crates instead of
+  discarding logs from crates without an explicit level; an unnecessary `rand`
+  callback was removed on the way. (#471)
 
 ## [0.2.0]
 


### PR DESCRIPTION
## What

The `Unreleased` section of `CHANGELOG.md` has not been updated since the advisor-gate entry landed (Aug 17). Since then, 11 user-visible changes have merged with no changelog entry, even though the file's header states "All notable changes to Switchyard are documented here" (Keep a Changelog):

- **Added**: switchyard-server container image (#421), run-span `task_kind`/`agent_role` metadata (#249), unified LLM-classifier bindings (#465)
- **Changed**: `Algorithm::route` returns `RoutingOutcome` (#459) — an API-visible change for `libsy` callers
- **Fixed**: reasoning order in mixed stream chunks (#387), Anthropic structured output decoded into requests (#462), Responses tool arguments emitted once (#469), content filter stops as Anthropic refusal (#370), JSON rejection statuses preserved (#406), launcher config errors without tracebacks (#475), default log level (#471)

This PR adds those entries. Section order follows Keep a Changelog (Added / Changed / Removed / Fixed); each entry is one to three lines written from the merged PR's own description, with the PR number appended.

## Scope

Only changes merged after the advisor-gate entry (the last `Unreleased` write) are covered — earlier Aug 17 commits were visible when that entry was written and are left as-is.

## Verification

- Entry list cross-checked against `git log` since 2026-08-17 23:34 UTC (the advisor PR merge), excluding docs-only commits (#473, #476) and changes already covered by existing entries (#371/#382/#383).
- Wording for each entry derived from the corresponding commit message / PR description, not paraphrased from memory.
- Docs-only change; no code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container image and run-span metadata details.
  * Unified bindings for LLM classifiers.
  * Routing now reports the resulting outcome.
* **Bug Fixes**
  * Improved stream ordering and structured-output handling.
  * Prevented duplicate tool arguments.
  * Corrected content-filter stop reasons and JSON rejection statuses.
  * Improved launcher configuration error reporting.
  * Restored expected default logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->