### PR TITLE
fix(python): allow workspace tests on macOS

### DIFF
--- a/crates/switchyard-py/Cargo.toml
+++ b/crates/switchyard-py/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 futures.workspace = true
 http.workspace = true
 switchyard-libsy.workspace = true
-pyo3 = { version = "0.28.3", features = ["abi3-py310", "extension-module"] }
+pyo3 = { version = "0.28.3", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 pythonize = "0.28.0"
 serde.workspace = true


### PR DESCRIPTION
## What

Stop enabling PyO3's deprecated `extension-module` feature unconditionally in `switchyard-py`.

The package continues to use `abi3-py310`. Maturin, already constrained to `>=1.9,<2.0` and currently locked at 1.13.1, enables extension-module behavior when it builds the Python package.

## Why

With `pyo3/extension-module` enabled as a Cargo feature, PyO3 disables linking to `libpython` for every target. That is correct for a packaged extension module, but it also affects Rust test binaries. On macOS, a plain:

```text
cargo test --workspace
```

then fails while linking `switchyard-py` with unresolved `_Py*` symbols. The failure was previously documented as a local limitation in #411, and several PRs have worked around it by excluding `switchyard-py`.

Modern PyO3 and maturin support selecting extension-module mode only while packaging. Removing the always-on feature restores normal test linking without changing the built Python extension.

PyO3 guidance: https://pyo3.rs/main/building-and-distribution.html#the-pyo3_build_extension_module-environment-variable

## How tested

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` on Apple Silicon macOS — complete workspace passed, including `switchyard-py`
- [x] `uv sync` — maturin built and installed the local extension successfully
- [x] Imported `switchyard_rust._switchyard_rust` from the fresh environment
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest tests/ -v -m "not integration"` — 143 passed, 2 deselected

## Impact

- Cargo tests link correctly on macOS.
- Linux CI behavior remains supported.
- Published and development Python extensions continue to be built through maturin with extension-module semantics.
- No runtime API or package ABI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python integration configuration while preserving compatibility with Python 3.10 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->