### PR TITLE
chore(ci): run proxy benchmark manually

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,9 +1,6 @@
-name: Perf Benchmark
+name: Perf Benchmark (manual)
 
 on:
-  pull_request:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       concurrency:
@@ -12,11 +9,6 @@ on:
       request_count:
         description: "aiperf --request-count"
         default: "200"
-
-# Cancel superseded PR runs; keep main builds.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
```yaml
on:
  pull_request:
  push:
    branches: [main]
```

Every pull request and `main` push starts the proxy benchmark. The latest post-merge run spent 51 minutes waiting for a runner and then occupied that runner for four minutes:

```text
workflow created: 2026-08-19T22:34:23Z
job started:      2026-08-19T23:25:43Z
job completed:    2026-08-19T23:29:43Z
```

Run: https://github.com/NVIDIA-NeMo/Switchyard/actions/runs/32309422644

## Fix

The workflow now runs only when someone selects `Run workflow`. This removes the proxy benchmark from automatic pull-request and `main` CI while keeping the same AIPerf inputs available for manual measurements.

The downside is that CI no longer runs this performance check automatically. A developer must start it when a routing or proxy change needs performance evidence.

## Before and after

```text
Before: pull_request, push to main, workflow_dispatch
After:  workflow_dispatch only
```

The required `CI Success` and `DCO` checks are unchanged.

## Testing

```text
git diff --check
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/perf.yml")'
```

Both commands pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performance checks now run only when manually started.
  * Automatic runs for pull requests and code updates have been removed.
  * Superseded performance runs are no longer automatically cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->