### PR TITLE
fix(libsy): redact upstream error content from judge warning logs

### DIFF
--- a/crates/libsy/src/algorithms/util.rs
+++ b/crates/libsy/src/algorithms/util.rs
@@ -6,6 +6,7 @@ pub(crate) mod classifier_contract;
 pub mod escalation;
 pub(crate) mod llm_judge;
 pub(crate) mod prompts;
+pub(crate) mod robustness;
 pub(crate) mod stage;
 pub mod subagent;
 pub(crate) mod target_selector;

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -17,6 +17,8 @@ use switchyard_protocol::{
     completion_text,
 };
 
+use super::robustness::{safe_client_error, safe_error_summary};
+
 use super::classifier_contract::ClassifierContract;
 use crate::core::algorithm::Driver;
 use crate::core::classifier::{Classification, Classifier};
@@ -243,23 +245,40 @@ where
                 vec![self.target.clone()],
             )
             .await
-            .inspect_err(|error| report_fail_open(judge_model, error, libsy_error_reason(error)))
+            .inspect_err(|error| {
+                report_fail_open(
+                    judge_model,
+                    safe_error_summary(error),
+                    libsy_error_reason(error),
+                )
+            })
             .ok()?;
         let aggregate = response
             .llm_response
             .into_agg()
             .await
-            .inspect_err(|error| report_fail_open(judge_model, error, client_error_reason(error)))
+            .inspect_err(|error| {
+                report_fail_open(
+                    judge_model,
+                    safe_client_error(error),
+                    client_error_reason(error),
+                )
+            })
             .ok()?;
         self.judge
             .parse(&aggregate)
-            .inspect_err(|error| report_fail_open(judge_model, error, "parse_error"))
+            .inspect_err(|error| {
+                report_fail_open(judge_model, safe_error_summary(error), "parse_error")
+            })
             .ok()
     }
 }
 
 /// Logs and counts a judge failure with a bounded label that excludes message content.
-fn report_fail_open(judge_model: &str, error: &dyn std::fmt::Display, reason: &'static str) {
+/// `error` must already be redacted: `LlmClientError::UpstreamHttp`'s `Display` interpolates the
+/// raw upstream body, which can quote the conversation back. Callers pass a
+/// `robustness::safe_*` summary rather than the error itself.
+fn report_fail_open(judge_model: &str, error: String, reason: &'static str) {
     tracing::warn!(
         target: "libsy",
         judge_model,

--- a/crates/libsy/src/algorithms/util/robustness.rs
+++ b/crates/libsy/src/algorithms/util/robustness.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hardening helpers shared by classifier-style inner-LLM callers.
+//!
+//! Consulting a model to make a routing decision fails in ways the routed call does
+//! not, and those failures are logged on a path that runs for every turn. The
+//! natural `Display` of an error is not safe there: an upstream error body is echoed
+//! verbatim, and both bodies and decode failures can embed the conversation or the
+//! model's reply. [`safe_error_summary`] is the redaction those log sites use.
+
+use switchyard_protocol::LlmClientError;
+
+use crate::LibsyError;
+
+/// A loggable description of `error` that carries no conversation or response content.
+///
+/// Each case contributes only vetted operational detail: the failure's class, the
+/// target or model it concerns, and a status code where one exists. Anything sourced
+/// from outside the process is reduced to its class.
+///
+/// The match is deliberately exhaustive rather than defaulting to `to_string()`, so a
+/// new [`LibsyError`] variant cannot start leaking content by omission.
+pub(crate) fn safe_error_summary(error: &LibsyError) -> String {
+    match error {
+        LibsyError::ClientCall { target, source } => {
+            format!(
+                "client call to target {target:?} failed: {}",
+                safe_client_error(source)
+            )
+        }
+        // `message` is a `String` with no constraint on its contents. Callers build it
+        // from static text today, but nothing stops one embedding a response or an
+        // upstream error, so only the class is reported.
+        LibsyError::AlgorithmError { .. } => "algorithm error".to_string(),
+        LibsyError::Driver(_) => "algorithm driver failed".to_string(),
+        // The operation is a static label, but the boxed source comes from a user
+        // extension and is unvetted.
+        LibsyError::External { operation, .. } => format!("{operation} failed"),
+        // The remaining variants render only structural detail: configured target
+        // names and fixed strings, nothing request-derived.
+        LibsyError::TargetNotFound { .. }
+        | LibsyError::NoTargets
+        | LibsyError::MissingFinalResponse => error.to_string(),
+    }
+}
+
+/// The client half of [`safe_error_summary`].
+///
+/// `UpstreamHttp` is the sharp edge: its `Display` interpolates the raw upstream
+/// body, which routinely quotes the request back. Boxed transport, decode, and FFI
+/// sources are reduced for the same reason.
+pub(crate) fn safe_client_error(error: &LlmClientError) -> String {
+    match error {
+        LlmClientError::UpstreamHttp { status, .. } => format!("upstream HTTP {status}"),
+        LlmClientError::ContextWindowExceeded { model, .. } => {
+            format!("context window exceeded for model {model}")
+        }
+        LlmClientError::Timeout { .. } => "upstream request timed out".to_string(),
+        LlmClientError::Transport { .. } => "upstream transport error".to_string(),
+        LlmClientError::InvalidResponse { .. } => "invalid upstream response".to_string(),
+        LlmClientError::Ffi { .. } => "foreign function interface error".to_string(),
+        LlmClientError::InvalidRequest { .. } => "invalid request".to_string(),
+        LlmClientError::RequestTranslation(_) => "request translation failed".to_string(),
+        LlmClientError::RequestEncoding(_) => "outbound request encoding failed".to_string(),
+        LlmClientError::ResponseTranslation(_) => "response translation failed".to_string(),
+        // `message` is unconstrained here too, so the class is reported without it.
+        LlmClientError::Configuration { .. } => "client configuration error".to_string(),
+        // Free-form by definition.
+        LlmClientError::General(_) => "client call failed".to_string(),
+        // `LlmClientError` is `#[non_exhaustive]`, so a wildcard is required. A future
+        // variant is unvetted until it is given an arm above.
+        _ => "client call failed".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use switchyard_protocol::ModelId;
+
+    use super::*;
+
+    /// The conversation text a leaking log line would expose.
+    const SECRET: &str = "patient name is Jane Doe";
+
+    #[test]
+    fn an_upstream_body_never_reaches_the_summary() {
+        let error = LibsyError::ClientCall {
+            target: ModelId::new("weak"),
+            source: LlmClientError::UpstreamHttp {
+                status: http::StatusCode::BAD_REQUEST,
+                body: format!(r#"{{"error":{{"message":"bad request: {SECRET}"}}}}"#),
+            },
+        };
+
+        let summary = safe_error_summary(&error);
+
+        // The status and target survive; the body does not.
+        assert!(summary.contains("upstream HTTP 400"), "{summary}");
+        assert!(summary.contains("weak"), "{summary}");
+        assert!(!summary.contains(SECRET), "{summary}");
+        // Guard against the redaction silently regressing to `Display`.
+        assert!(error.to_string().contains(SECRET));
+    }
+
+    #[test]
+    fn boxed_sources_are_reduced_to_their_class() {
+        for source in [
+            LlmClientError::Transport {
+                source: std::io::Error::other(SECRET).into(),
+            },
+            LlmClientError::InvalidResponse {
+                source: std::io::Error::other(SECRET).into(),
+            },
+            LlmClientError::Timeout {
+                source: std::io::Error::other(SECRET).into(),
+            },
+        ] {
+            let summary = safe_client_error(&source);
+            assert!(!summary.contains(SECRET), "{summary}");
+            assert!(!summary.is_empty());
+        }
+    }
+
+    #[test]
+    fn context_overflow_keeps_the_model_but_not_the_message() {
+        let summary = safe_client_error(&LlmClientError::ContextWindowExceeded {
+            model: ModelId::new("weak"),
+            message: SECRET.to_string(),
+        });
+        assert!(summary.contains("weak"), "{summary}");
+        assert!(!summary.contains(SECRET), "{summary}");
+    }
+
+    #[test]
+    fn an_algorithm_error_message_is_reduced_to_its_class() {
+        // `AlgorithmError::message` is an unconstrained `String`. Callers build it from
+        // static text today, but the summary must not depend on that holding.
+        let summary = safe_error_summary(&LibsyError::AlgorithmError {
+            message: format!("judge reply did not parse: {SECRET}"),
+        });
+        assert_eq!(summary, "algorithm error");
+        assert!(!summary.contains(SECRET), "{summary}");
+    }
+
+    #[test]
+    fn a_client_configuration_message_is_reduced_to_its_class() {
+        let summary = safe_client_error(&LlmClientError::Configuration {
+            message: SECRET.to_string(),
+        });
+        assert_eq!(summary, "client configuration error");
+    }
+
+    #[test]
+    fn a_general_error_is_reduced_to_its_class() {
+        let summary = safe_client_error(&LlmClientError::General(SECRET.to_string()));
+        assert!(!summary.contains(SECRET), "{summary}");
+    }
+
+    #[test]
+    fn an_extension_failure_keeps_its_label_but_not_its_source() {
+        let error = LibsyError::external("loading extension", std::io::Error::other(SECRET));
+
+        let summary = safe_error_summary(&error);
+
+        assert_eq!(summary, "loading extension failed");
+        assert!(error.to_string().contains(SECRET));
+    }
+
+    #[test]
+    fn structural_variants_keep_their_detail() {
+        let summary = safe_error_summary(&LibsyError::TargetNotFound {
+            target: ModelId::new("strong"),
+        });
+        assert!(summary.contains("strong"), "{summary}");
+    }
+}


### PR DESCRIPTION
Closes #278.

## What

When an `llm_classifier` route consults its judge model and that call fails, the route logs a warning and proceeds without a verdict. That warning currently includes the underlying error rendered in full. This change replaces it with a summary that reports the failure's class, the target or model involved, and an HTTP status where one exists, and nothing else.

## Why

The log line is in `report_fail_open`, in `crates/libsy/src/algorithms/util/llm_judge.rs`, and it runs on every turn where the judge is unavailable. It formats the error with `error = %error`, which uses the error's `Display` implementation.

For `LlmClientError::UpstreamHttp` that implementation is:

```rust
#[error("upstream returned HTTP {status}: {body}")]
```

`body` is the upstream response body verbatim. Providers commonly echo the offending request back in a 400, and the judge's request contains a condensed view of the user's conversation. A failing judge therefore writes conversation content into the logs once per turn.

Example: a judge call rejected with `{"error":{"message":"bad request: <user text>"}}` currently logs that whole string. After this change it logs `client call to target "weak" failed: upstream HTTP 400`.

## What is added

A new module, `crates/libsy/src/algorithms/util/robustness.rs`, with two functions used by the three call sites in `llm_judge.rs`:

- `safe_error_summary(&LibsyError)`
- `safe_client_error(&LlmClientError)`

`report_fail_open` now takes an already-redacted `String` rather than a `&dyn Display`, so a caller cannot pass the raw error by accident.

Two details worth keeping in review:

- The match over `LibsyError` is exhaustive rather than falling back to `to_string()`. A new variant then fails to compile instead of silently logging its `Display` output. `LlmClientError` is `#[non_exhaustive]` so it needs a wildcard, but every current variant has an explicit arm.
- `an_upstream_body_never_reaches_the_summary` asserts both that the summary omits the sensitive text **and** that `error.to_string()` still contains it. The second assertion is what fails if the redaction is ever bypassed.

## Relationship to other work

#428 redacts transport and timeout errors at the server's HTTP response boundary, so they are not returned to callers. This is the separate log boundary inside the routing library. Neither covers the other.

#205 added the bounded `reason` label and the `switchyard.classifier_fail_open` metric on this same line. That work is unchanged here; only the `error` field is affected.

## How tested

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run pytest tests/ -m "not integration"` — 157 passed
- `uv run ruff check .`
- Commits signed off per the DCO

Eight unit tests cover the redaction cases, including boxed transport and decode sources, context-window overflow, and the free-form `General` variant.

Note for anyone reading the CodeRabbit panel: the "Docstring Coverage" check measures Python docstrings and this diff is Rust only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging to prevent sensitive upstream response details and raw error messages from being recorded.
  * Error reports now retain only safe operational details, such as error types, targets, models, and HTTP status codes.

* **Tests**
  * Added coverage verifying sensitive information is consistently removed from logged error summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->