### PR TITLE
build: Update dev server config, secure it

### DIFF
--- a/dev-server/config.toml
+++ b/dev-server/config.toml
@@ -12,11 +12,12 @@ api_key_env = "NVIDIA_API_KEY"
 [targets.capable]
 id = "openai/openai/gpt-5.6-sol"
 llm_client = "inference_hub"
-extra_body = { output_config = { effort = "medium" } }
+extra_body = { reasoning = { effort = "medium" } }
 
 [targets.efficient]
 id = "openai/openai/gpt-5.6-luna"
 llm_client = "inference_hub"
+extra_body = { reasoning = { effort = "medium" } }
 
 # Basic routes
 

--- a/dev-server/config.toml
+++ b/dev-server/config.toml
@@ -3,51 +3,36 @@ schema_version = 1
 # Everything is on Inference Hub
 
 [llm_clients.inference_hub]
-format = "openai_chat"
+format = "openai_responses"
 base_url = "https://inference-api.nvidia.com/v1"
 api_key_env = "NVIDIA_API_KEY"
 
-# The simple ones first
+# The two models our algos use
 
-[targets.oss20b]
-id = "nvidia/openai/gpt-oss-20b"
+[targets.capable]
+id = "openai/openai/gpt-5.6-sol"
+llm_client = "inference_hub"
+extra_body = { output_config = { effort = "medium" } }
+
+[targets.efficient]
+id = "openai/openai/gpt-5.6-luna"
 llm_client = "inference_hub"
 
-[targets.dsflash]
-id = "nvidia_dynamo/deepseek-ai/deepseek-v4-flash-nvfp4-elb"
-llm_client = "inference_hub"
+# Basic routes
 
 [routes.random]
 id = "switchyard/random"
 type = "random"
-targets = ["oss20b", "dsflash"]
+targets = ["capable", "efficient"]
 
 [routes.passthrough]
 id = "switchyard/passthrough"
 type = "passthrough"
-target = "oss20b"
+target = "efficient"
 
 [routes.noop]
 id = "switchyard/noop"
 type = "noop"
-
-# The two models are main algos use
-
-[llm_clients.nvidia_anthropic]
-format = "anthropic_messages"
-base_url = "https://inference-api.nvidia.com"
-api_key_env = "NVIDIA_API_KEY"
-
-[targets.capable]
-id = "aws/anthropic/bedrock-claude-opus-4-8"
-llm_client = "nvidia_anthropic"
-
-[targets.capable.extra_body.output_config]
-effort = "medium"
-
-[targets.efficient]
-id = "nvidia/zai-org/glm-5.2"
-llm_client = "inference_hub"
 
 # Stage
 
@@ -76,4 +61,15 @@ weak_target = "efficient"
 base_threshold = 0.5
 classify_trigger = "new_session"
 message_hash_fallback = true
+
+# Advisor
+
+[routes.advisor]
+id = "switchyard/advisor"
+type = "advisor"
+executor_target = "efficient"
+advisor_target = "capable"
+max_reviews = 3
+gate_stall_turns = 30
+gate_min_tool_results = 3
 

--- a/dev-server/switchyard.service
+++ b/dev-server/switchyard.service
@@ -2,20 +2,26 @@
 Description=Switchyard Server
 
 [Service]
-ExecStart=/usr/local/bin/switchyard-server -p 443 --config /etc/switchyard/config.toml --tls-key /etc/switchyard/key.pem --tls-cert /etc/switchyard/cert.pem
+# Create a temporary user to run as, extra security
+DynamicUser=yes
+
+# systemd loads these for us and makes them accessible
+LoadCredential=config.toml:/etc/switchyard/config.toml
+LoadCredential=tls-key.pem:/etc/switchyard/key.pem
+LoadCredential=tls-cert.pem:/etc/switchyard/cert.pem
+
+# %d is where systemd put those files
+ExecStart=/usr/local/bin/switchyard-server \
+    -p 443 \
+    --config %d/config.toml \
+    --tls-key %d/tls-key.pem \
+    --tls-cert %d/tls-cert.pem
+
 Restart=on-failure
 Environment="NVIDIA_API_KEY=<PUT-THE-KEY-HERE>"
-User=root
-Group=root
 
-# Start root, then harden/drop
-NoNewPrivileges=yes
 PrivateDevices=yes
-ProtectSystem=strict
 ProtectHome=yes
-ReadOnlyPaths=/etc/switchyard
-CapabilityBoundingSet=
-AmbientCapabilities=
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
1. dev server config

Use only two models, a capable and an efficient.
- Capable is Sol
- Efficient is Luna

Add "advisor" algorithm at `switchyard/advisor`

2. systemd unit

Use the wonderful `DynamicUser` and `LoadCredential`.

This allows the binary and config to be owned by root. systemd invents
a new user, that has no home directory, owns nothing, and cannot login,
to run the process as.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an advisor route that combines efficient execution with capable review.
  * Random and passthrough routing now use updated inference targets.
  * Advisor workflows support configurable review, stall, and tool-result limits.

* **Improvements**
  * Updated inference requests to use OpenAI Responses formatting.
  * Improved service startup security through temporary identities and protected credential loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->