### PR TITLE
fix: re-emit captured provider extensions when encoding to the Responses format

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -178,6 +178,8 @@ impl FormatCodec for OpenAiResponsesCodec {
         if request.stream {
             body.insert("stream".to_string(), Value::Bool(true));
         }
+        copy_responses_request_extensions(&mut body, &request.extensions.fields);
+
         let body = embed_preservation(Value::Object(body), &request.preservation, _policy);
         Ok(EncodedRequest { body, diagnostics })
     }
@@ -1327,4 +1329,32 @@ fn encode_responses_usage(usage: &Usage) -> Value {
         "input_tokens_details": {"cached_tokens": usage.cached_input_tokens().unwrap_or(0)},
         "output_tokens_details": {"reasoning_tokens": usage.reasoning_tokens.unwrap_or(0)},
     })
+}
+
+/// Re-emits captured request extensions that the Responses format accepts.
+///
+/// The allowlist is Responses-specific: Chat-only fields such as
+/// `stream_options` and `top_logprobs` are deliberately absent, so they stay
+/// dropped on a Chat-to-Responses hop. Fields already present in `body` are
+/// left untouched — anything the encoder generated is authoritative over a
+/// captured extension of the same name.
+fn copy_responses_request_extensions(
+    body: &mut Map<String, Value>,
+    extensions: &Map<String, Value>,
+) {
+    for field in [
+        "metadata",
+        "parallel_tool_calls",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "safety_identifier",
+        "service_tier",
+        "store",
+        "user",
+    ] {
+        if let Some(value) = extensions.get(field) {
+            body.entry(field.to_string())
+                .or_insert_with(|| value.clone());
+        }
+    }
 }

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -960,7 +960,49 @@ fn responses_deferred_message_stays_after_matching_tool_result_for_openai_chat()
     Ok(())
 }
 
-// Verifies Chat-compatible Responses extension fields survive translation.
+// Verifies Responses-compatible extension fields survive a Chat-to-Responses
+// hop, and that Chat-only fields are excluded rather than passed through.
+#[test]
+fn chat_compatible_extensions_survive_to_responses() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {"trace": "abc"},
+        "parallel_tool_calls": false,
+        "prompt_cache_key": "session-1",
+        "prompt_cache_retention": "24h",
+        "safety_identifier": "safe-1",
+        "service_tier": "flex",
+        "store": false,
+        "stream_options": {"include_usage": true},
+        "top_logprobs": 2,
+        "user": "u-123"
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["metadata"], json!({"trace": "abc"}));
+    assert_eq!(output["parallel_tool_calls"], false);
+    assert_eq!(output["prompt_cache_key"], "session-1");
+    assert_eq!(output["prompt_cache_retention"], "24h");
+    assert_eq!(output["safety_identifier"], "safe-1");
+    assert_eq!(output["service_tier"], "flex");
+    assert_eq!(output["store"], false);
+    assert_eq!(output["user"], "u-123");
+    // Chat-only fields are not in the Responses allowlist, so they stay dropped.
+    assert!(output.get("stream_options").is_none());
+    assert!(output.get("top_logprobs").is_none());
+    Ok(())
+}
+
 #[test]
 fn responses_chat_compatible_extensions_survive_to_openai_chat() -> TestResult {
     let engine = TranslationEngine::default();


### PR DESCRIPTION
Closes #508.

## What

Re-emit captured provider extensions when encoding a request to the Responses format, mirroring the allowlist the chat encoder already has.

## Why

`openai_chat` decode captures unknown top-level fields (including `prompt_cache_key` and `prompt_cache_retention`) into `extensions` (`crates/switchyard-translation/src/codecs/openai_chat/buffered.rs:158-173`), and the encode-to-chat allowlist re-emits them (`copy_openai_chat_request_extensions`, `buffered.rs:930-954`); the existing `responses_chat_compatible_extensions_survive_to_openai_chat` test proves the responses-to-chat direction round-trips.

The reverse direction had no mirror: the Responses `encode_request` (`codecs/responses/buffered.rs`) built its body field by field and performed no extension re-emission, so any-source-to-responses translation dropped `prompt_cache_key`, a field the Responses API natively supports, even though decode preserved it. This bites chat-to-responses and modified responses-to-responses hops.

This PR adds `copy_responses_request_extensions` with the Responses-compatible subset of the chat allowlist (`metadata`, `parallel_tool_calls`, `prompt_cache_key`, `prompt_cache_retention`, `safety_identifier`, `service_tier`, `store`, `user`; the chat-only `stream_options` and `top_logprobs` are excluded), called at the same point in encoding.

## How tested

- [x] `uv run ruff check .` clean (no Python changes)
- [x] `uv run mypy switchyard` clean (no Python changes)
- [x] `uv run pytest tests/` green (no Python changes)
- [x] Rust on the pinned toolchain (1.96.1): `cargo fmt --check` and clippy clean; `cargo test -p switchyard-translation` green (142 tests). The new test, `chat_compatible_extensions_survive_to_responses`, mirrors the existing responses-to-chat test in the opposite direction and fails without the encoder change.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (n/a, Rust only)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (n/a)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (n/a)
- [x] Commits signed off (`Signed-off-by:`) per the DCO.

## Notes for reviewers

- Same-format responses-to-responses passthrough already preserved these fields byte-identically; this change only affects the translated path.
- Complements #233's caching work; unrelated to the content-block `cache_control` question from closed #183 (top-level fields only, no block semantics).
- 59 lines including the test, per the focused-fix lane in CONTRIBUTING.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved supported request options when translating OpenAI Chat requests to OpenAI Responses requests.
  * Retained metadata, tool settings, caching options, safety identifiers, service tier, storage preferences, and user identifiers without overwriting generated values.

* **Tests**
  * Added coverage confirming these request options are preserved during translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->