### PR TITLE
feat(libsy): expose routing metadata from state.extra to Python

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -10,7 +10,7 @@
 //! and model name. Counters are cumulative across flushes; the helpers take the
 //! latest (max) matching data point.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -39,7 +39,7 @@ use switchyard_libsy::{
     StageRouterConfig, Step, TaskClassifierConfig,
 };
 use switchyard_llm_client::{ClientRouter, RunObservation, RunObserver};
-use switchyard_protocol::ModelId;
+use switchyard_protocol::{Decision, ModelId};
 use switchyard_protocol::{
     ContentBlock, LlmRequest, LlmResponse, Message, Metadata, Request, Response, Role,
     RoutedLlmClient, ToolCall, ToolResult, Usage, WireFormat,
@@ -476,6 +476,7 @@ impl Algorithm for SingleCallAlgo {
             .ok_or(LibsyError::NoTargets)?
             .clone();
         tracing::info!("picked '{target}'");
+        driver.decide(Decision::new(target.clone(), true), HashMap::new()).await?;
         Ok(RoutingOutcome::route_to(target.into(), Vec::new(), request))
     }
 }
@@ -1205,6 +1206,7 @@ async fn failed_call_records_error_outcome_and_warn_logs() -> switchyard_libsy::
             Ok(Step::CallModel(call)) => {
                 call.respond(Err(test_error("synthetic upstream failure")))?;
             }
+            Ok(Step::Decision { .. }) => {}
             Ok(Step::Done(_)) => {
                 return Err(test_error("expected the failed call to fail the run"));
             }

--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -467,7 +467,7 @@ impl Algorithm for SingleCallAlgo {
 
     async fn route(
         self: Arc<Self>,
-        _driver: Driver,
+        driver: Driver,
         request: Request,
     ) -> switchyard_libsy::Result<RoutingOutcome> {
         let target = self

--- a/crates/libsy/src/algorithms/advisor_gate.rs
+++ b/crates/libsy/src/algorithms/advisor_gate.rs
@@ -32,8 +32,8 @@ use std::time::Instant;
 
 use parking_lot::Mutex;
 use switchyard_protocol::{
-    ContentBlock, InstructionBlock, LlmRequest, Message, ModelId, OutputParams, Request, Role,
-    SamplingParams,
+    ContentBlock, Decision, InstructionBlock, LlmRequest, Message, ModelId, OutputParams, Request,
+    Role, SamplingParams,
 };
 
 use crate::core::algorithm::{Algorithm, Driver, RoutingOutcome};
@@ -324,6 +324,7 @@ impl AdvisorGate {
         // (including ContextWindowExceeded) propagate for the host's
         // client-visible mapping.
         if self.check_exhausted(scope) {
+            driver.decide(Decision::new(self.executor.clone(), true), HashMap::new()).await?;
             return Ok(RoutingOutcome::route_to(
                 self.executor.clone(),
                 Vec::new(),
@@ -333,6 +334,7 @@ impl AdvisorGate {
 
         // Gated phase: generate the turn once, fully buffered, so the gate
         // can inspect it before the client sees anything.
+        driver.decide(Decision::new(self.executor.clone(), true), HashMap::new()).await?;
         let response = driver
             .call_model(request.clone(), vec![self.executor.clone()])
             .await?;

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -29,8 +29,9 @@ use tokio::sync::Mutex as AsyncMutex;
 use crate::core::algorithm::{self, Algorithm, Driver};
 use crate::core::classifier::{Classification, Classifier, Score};
 use crate::core::processor::{Event, Processor};
+use crate::core::state::WithExtra;
 use crate::{LibsyError, Result, RoutingOutcome};
-use switchyard_protocol::{ModelId, Request, Response};
+use switchyard_protocol::{Decision, ModelId, Request, Response};
 
 struct SessionState<S> {
     state: Arc<AsyncMutex<S>>,
@@ -114,7 +115,7 @@ impl FallThrough<()> {
 
 impl<S> FallThrough<S>
 where
-    S: Default + Send + 'static,
+    S: Default + Send + WithExtra + 'static,
 {
     /// Creates a router that retains one private `S` per session.
     pub fn new_with_state(targets: Vec<ModelId>) -> Self {
@@ -272,6 +273,7 @@ where
                 .find_map(|c| c.routing_tier(&target))
         });
         tracing::info!(algorithm=self.name, target=%score.target, confidence=score.confidence, tier = ?tier, "Model selected");
+        driver.decide(Decision::new(target.clone(), true), state.routing_extra()).await?;
 
         // 4. Post-decision replay: every processor sees the selection so stateful ones
         //    can bind it, and may rewrite the outbound request (e.g. add a target prompt).
@@ -325,7 +327,7 @@ fn session_id(request: &Request) -> Option<String> {
 #[async_trait]
 impl<S> Algorithm for FallThrough<S>
 where
-    S: Default + Send + 'static,
+    S: Default + Send + WithExtra + 'static,
 {
     fn name(&self) -> &str {
         &self.name
@@ -343,7 +345,14 @@ mod tests {
     use crate::{SystemPromptProcessor, TargetPrompts};
 
     use crate::core::testing::{Serve, echo, reply, test_drive};
+    use crate::StateValue;
     use switchyard_protocol::{LlmRequest, Message, Metadata, Role, completion_text, text_request};
+
+    impl WithExtra for u32 {
+        fn routing_extra(&self) -> HashMap<String, StateValue> {
+            HashMap::new()
+        }
+    }
 
     #[derive(Debug, thiserror::Error)]
     #[error("{0}")]
@@ -515,7 +524,7 @@ mod tests {
         serve: impl Serve,
     ) -> Result<(String, ModelId)>
     where
-        S: Default + Send + 'static,
+        S: Default + Send + WithExtra + 'static,
     {
         let (selected_model, response) = test_drive(router.clone(), request, serve).await?;
         let text = response
@@ -533,7 +542,7 @@ mod tests {
         serve: impl Serve,
     ) -> Result<(String, ModelId)>
     where
-        S: Default + Send + 'static,
+        S: Default + Send + WithExtra + 'static,
     {
         run_request(router, request(), serve).await
     }
@@ -838,6 +847,12 @@ mod tests {
         #[derive(Default)]
         struct TurnState {
             count: u32,
+        }
+
+        impl WithExtra for TurnState {
+            fn routing_extra(&self) -> HashMap<String, StateValue> {
+                HashMap::new()
+            }
         }
 
         // Increments the session turn count on every request.

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -220,6 +220,8 @@ impl JudgePolicy for TaskClassifierPolicy {
         }])
     }
 
+    /// Writes judge fields to `state.extra`: `judge_p_solve` (scalar), `judge_crux`,
+    /// `judge_primary_rule`, and `judge_capability_boundary` (strings). No-op when `verdict` is `None`.
     fn record_to_state(&self, verdict: Option<&Self::Verdict>, state: &mut State) {
         let Some(verdict) = verdict else { return };
         state.extra.insert("judge_p_solve".into(), StateValue::Scalar(verdict.p_solve as f32));
@@ -1009,6 +1011,27 @@ mod tests {
             .ok_or_else(|| LibsyError::AlgorithmError {
                 message: "policy abstained".to_string(),
             })
+    }
+
+    #[test]
+    fn record_to_state_writes_judge_keys() {
+        // Known verdict values must appear verbatim in state.extra so Python callers can read them.
+        let policy = policy();
+        let v = verdict(0.75, "core_capability", "high_confidence");
+        let mut state = State::default();
+        policy.record_to_state(Some(&v), &mut state);
+        assert_eq!(state.extra.get("judge_p_solve"), Some(&StateValue::Scalar(0.75_f32)));
+        assert_eq!(state.extra.get("judge_crux"), Some(&StateValue::String("test crux".to_string())));
+        assert_eq!(state.extra.get("judge_primary_rule"), Some(&StateValue::String("high_confidence".to_string())));
+        assert_eq!(state.extra.get("judge_capability_boundary"), Some(&StateValue::String("core_capability".to_string())));
+    }
+
+    #[test]
+    fn record_to_state_is_noop_without_verdict() {
+        let policy = policy();
+        let mut state = State::default();
+        policy.record_to_state(None, &mut state);
+        assert!(state.extra.is_empty());
     }
 
     /// Records what each target received; answers the judge with a supported verdict and

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -219,6 +219,14 @@ impl JudgePolicy for TaskClassifierPolicy {
             confidence: 1.0,
         }])
     }
+
+    fn record_to_state(&self, verdict: Option<&Self::Verdict>, state: &mut State) {
+        let Some(verdict) = verdict else { return };
+        state.extra.insert("judge_p_solve".into(), StateValue::Scalar(verdict.p_solve as f32));
+        state.extra.insert("judge_crux".into(), StateValue::String(verdict.crux.clone()));
+        state.extra.insert("judge_primary_rule".into(), StateValue::String(verdict.primary_rule.clone()));
+        state.extra.insert("judge_capability_boundary".into(), StateValue::String(verdict.capability_boundary.clone()));
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/libsy/src/algorithms/noop.rs
+++ b/crates/libsy/src/algorithms/noop.rs
@@ -3,11 +3,12 @@
 
 //! Test-only algorithm that returns a hard-coded response without calling a backend.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use switchyard_protocol::{
-    AggLlmResponse, ContentBlock, LlmResponse, ModelId, Request, Response, ResponseOutput, Role,
-    StopReason,
+    AggLlmResponse, ContentBlock, Decision, LlmResponse, ModelId, Request, Response,
+    ResponseOutput, Role, StopReason,
 };
 
 use crate::core::algorithm::{Algorithm, Driver};
@@ -22,12 +23,13 @@ impl Algorithm for Noop {
         "noop"
     }
 
-    async fn route(self: Arc<Self>, _driver: Driver, request: Request) -> Result<RoutingOutcome> {
+    async fn route(self: Arc<Self>, driver: Driver, request: Request) -> Result<RoutingOutcome> {
         let streaming = request.llm_request.stream;
         let model_id = request
             .model_id()
             .unwrap_or_else(|| ModelId::from("switchyard/noop"));
         tracing::info!(target = %model_id, "noop returned its synthetic response");
+        driver.decide(Decision::new(model_id.clone(), true), HashMap::new()).await?;
         let aggregate = AggLlmResponse {
             id: Some("switchyard-noop".to_string()),
             model: Some(model_id.to_string()),

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -3,6 +3,7 @@
 
 //! Direct parent routing with an optional delegated-work classifier cascade.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use switchyard_protocol::{ModelId, Request};

--- a/crates/libsy/src/algorithms/passthrough.rs
+++ b/crates/libsy/src/algorithms/passthrough.rs
@@ -3,7 +3,7 @@
 
 //! Direct parent routing with an optional delegated-work classifier cascade.
 
-use std::collections::HashMap;
+
 use std::sync::Arc;
 
 use switchyard_protocol::{ModelId, Request};

--- a/crates/libsy/src/algorithms/util/llm_judge.rs
+++ b/crates/libsy/src/algorithms/util/llm_judge.rs
@@ -200,6 +200,11 @@ pub trait JudgePolicy: Send + Sync {
     type Verdict: Send + Sync;
 
     fn to_classification(&self, verdict: Option<&Self::Verdict>) -> Classification;
+
+    /// Write verdict-derived signals to `state.extra` for downstream observers.
+    /// The default no-op is suitable for policies that expose no additional metadata.
+    #[allow(unused_variables)]
+    fn record_to_state(&self, verdict: Option<&Self::Verdict>, state: &mut State) {}
 }
 
 /// A classifier that calls one judge target and routes through its verdict policy.
@@ -333,6 +338,7 @@ where
             });
         };
         let verdict = self.verdict(state, request, driver).await;
+        self.policy.record_to_state(verdict.as_ref(), state);
         // A judge consultation is a side call, never the turn's answer.
         Ok((self.policy.to_classification(verdict.as_ref()), None))
     }

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -775,6 +775,28 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn classifier_writes_signal_keys_to_state_extra() -> Result<()> {
+        // A signal with known values produces exact state.extra entries that Python callers rely on.
+        let signal = ToolSignals {
+            severity: HARD_SEVERITY as f32,
+            ..Default::default()
+        };
+        let dims = dimensions_from_signal(&signal);
+        let scored = score_signal(&signal);
+        let mut state = state_with(signal);
+        StageClassifier::new(tiers(), PickerMode::EfficientFirst, 0.5)
+            .score(&mut state, &mut Request::default(), None)
+            .await?;
+        assert_eq!(state.extra.get("signal_severity"), Some(&StateValue::Scalar(dims.severity as f32)));
+        assert_eq!(state.extra.get("signal_spinning"), Some(&StateValue::Scalar(dims.spinning as f32)));
+        assert_eq!(state.extra.get("signal_exploring"), Some(&StateValue::Scalar(dims.exploring as f32)));
+        assert_eq!(state.extra.get("signal_production_intensity"), Some(&StateValue::Scalar(dims.production_intensity as f32)));
+        assert_eq!(state.extra.get("signal_score"), Some(&StateValue::Scalar(scored.score as f32)));
+        assert_eq!(state.extra.get("signal_confidence"), Some(&StateValue::Scalar(scored.confidence as f32)));
+        Ok(())
+    }
+
     const ESCALATION: &str = "recovering from an error";
     const DEESCALATION: &str = "settled — carry on";
 

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -562,6 +562,18 @@ impl Classifier<State> for StageClassifier {
 
         let outcome = pick_tier(signal, self.mode, self.confidence_threshold);
         record_score_metrics(signal, &outcome);
+
+        // Write signal dimensions and score to state.extra before branching so both the
+        // Resolved and ConsultClassifier paths carry the full signal picture.
+        let dims = dimensions_from_signal(signal);
+        let scored = score_signal(signal);
+        state.extra.insert("signal_severity".into(), StateValue::Scalar(dims.severity as f32));
+        state.extra.insert("signal_spinning".into(), StateValue::Scalar(dims.spinning as f32));
+        state.extra.insert("signal_exploring".into(), StateValue::Scalar(dims.exploring as f32));
+        state.extra.insert("signal_production_intensity".into(), StateValue::Scalar(dims.production_intensity as f32));
+        state.extra.insert("signal_score".into(), StateValue::Scalar(scored.score as f32));
+        state.extra.insert("signal_confidence".into(), StateValue::Scalar(scored.confidence as f32));
+
         match outcome {
             PickOutcome::Resolved {
                 tier,

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -199,7 +199,7 @@ impl Driver {
             .send(Ok(Step::Decision { decision: decision.clone(), extra }))
             .await
             .map_err(|_| DriverError::StreamClosed)?;
-        observability::record_decision(&self.algorithm, &decision);
+        observability::record_decision(&self.algorithm, &ModelId::from(decision.selected_model_id()));
         Ok(())
     }
 
@@ -208,18 +208,11 @@ impl Driver {
     /// item on failure. Internal: called once by [`run_stream`](Algorithm::run_stream)
     /// when the algorithm finishes.
     pub(crate) async fn finish(&self, result: Result<RoutingOutcome>) -> Result<()> {
-        let selected_model = result
-            .as_ref()
-            .ok()
-            .map(|outcome| outcome.selected_model_id.clone());
         let step = result.map(|outcome| Step::Done(Box::new(outcome)));
         self.step_tx
             .send(step)
             .await
             .map_err(|_| DriverError::StreamClosed)?;
-        if let Some(selected_model) = selected_model {
-            observability::record_decision(&self.algorithm, &selected_model);
-        }
         Ok(())
     }
 }

--- a/crates/libsy/src/core/algorithm.rs
+++ b/crates/libsy/src/core/algorithm.rs
@@ -4,7 +4,7 @@
 //! The [`Algorithm`] trait and its [`Driver`] — the orchestration contract every
 //! algorithm implements and the offload channel it uses for routing-time model calls.
 
-use std::{future::Future, panic::AssertUnwindSafe, pin::Pin, sync::Arc, time::Instant};
+use std::{collections::HashMap, future::Future, panic::AssertUnwindSafe, pin::Pin, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
 use futures::{FutureExt, Stream, StreamExt};
@@ -19,9 +19,10 @@ use tracing::Instrument;
 /// [`switchyard_protocol::LlmResponseStreamEvent`] is its host/algorithm envelope; and
 /// [`switchyard_protocol::LlmResponse`] carries either a live
 /// [`switchyard_protocol::LlmResponseStream`] or the terminal aggregate.
-use switchyard_protocol::{ModelId, Request, Response};
+use switchyard_protocol::{Decision, ModelId, Request, Response};
 
 use crate::{DriverError, LibsyError, Result, observability};
+use crate::core::state::StateValue;
 
 /// A boxed, `Send` stream of [`Step`]s — the output of
 /// [`Algorithm::run_stream`]. Boxed so the trait method that produces it keeps
@@ -187,6 +188,22 @@ impl Driver {
         result
     }
 
+    /// Publish a routing [`Decision`] as a [`Step::Decision`] on the stream.
+    /// Each successfully published decision is counted and logged; a decision
+    /// the stream never accepted is not recorded.
+    ///
+    /// `extra` is the snapshot of routing metadata collected in `state.extra` at
+    /// decision time; pass `HashMap::new()` when no state is available.
+    pub async fn decide(&self, decision: Decision, extra: HashMap<String, StateValue>) -> Result<()> {
+        self.step_tx
+            .send(Ok(Step::Decision { decision: decision.clone(), extra }))
+            .await
+            .map_err(|_| DriverError::StreamClosed)?;
+        observability::record_decision(&self.algorithm, &decision);
+        Ok(())
+    }
+
+
     /// Emit the terminal step: [`Step::Done`] on `Ok`, or an `Err` stream
     /// item on failure. Internal: called once by [`run_stream`](Algorithm::run_stream)
     /// when the algorithm finishes.
@@ -212,6 +229,14 @@ pub enum Step {
     /// The algorithm needs this model call performed. The host serves it and fulfills
     /// it with [`CallModel::respond`]. Boxed: it is by far the largest variant.
     CallModel(Box<CallModel>),
+    /// A routing decision the algorithm made, published via [`Driver::decide`] as it
+    /// happens (rather than collected into a trace returned at the end).
+    Decision {
+        /// The routing choice.
+        decision: Decision,
+        /// Routing-metadata snapshot from `state.extra` at decision time.
+        extra: HashMap<String, StateValue>,
+    },
     /// The algorithm finished with its routing outcome — the last step of a run.
     Done(Box<RoutingOutcome>),
 }
@@ -254,6 +279,7 @@ where
                     None => break, // stream has ended, no more steps
                     Some(item) => match item? {
                         Step::CallModel(call) => in_flight.push(serve(*call)),
+                        Step::Decision { .. } => {}
                         Step::Done(outcome) => {
                             final_outcome = Some(*outcome);
                             break;
@@ -444,6 +470,7 @@ mod tests {
                 .first()
                 .ok_or(LibsyError::NoTargets)?
                 .clone();
+            driver.decide(Decision::new(target.clone(), true), HashMap::new()).await?;
             let response = driver
                 .call_model(request.clone(), vec![target.clone()])
                 .await?;
@@ -594,7 +621,7 @@ mod tests {
             let (driver, step_rx) = Driver::new("test");
             drop(step_rx);
             let result = driver
-                .call_model(request(), vec![ModelId::from("closed")])
+                .decide(Decision::new(ModelId::from("closed"), true), HashMap::new())
                 .await;
             assert!(matches!(
                 result,
@@ -713,6 +740,9 @@ mod tests {
                         metadata: None,
                     }))?;
                 }
+                Step::Decision { decision, .. } => {
+                    assert_eq!(decision.selected_model_id(), "offload/model");
+                }
                 Step::Done(outcome) => {
                     let response = outcome
                         .response
@@ -800,6 +830,7 @@ mod tests {
                 Ok(Step::CallModel(call)) => {
                     call.respond(Err(test_error("upstream model call failed")))?;
                 }
+                Ok(Step::Decision { .. }) => {}
                 Ok(Step::Done(..)) => {
                     return Err(test_error(
                         "expected the offload error to propagate, got a response",

--- a/crates/libsy/src/core/state.rs
+++ b/crates/libsy/src/core/state.rs
@@ -32,3 +32,26 @@ pub struct State {
     /// Algorithm-specific state keyed by stable internal names.
     pub extra: HashMap<String, StateValue>,
 }
+
+/// Provides access to the [`StateValue`] map accumulated during algorithm execution.
+///
+/// Implemented on state types that carry routing metadata. The map is cloned once and
+/// attached to the published [`crate::core::algorithm::Step::Decision`], so downstream
+/// observers (e.g. Python bindings) can read signal fields without parsing log output.
+pub trait WithExtra {
+    /// Returns a snapshot of the extra routing metadata accumulated so far.
+    fn routing_extra(&self) -> HashMap<String, StateValue>;
+}
+
+impl WithExtra for State {
+    fn routing_extra(&self) -> HashMap<String, StateValue> {
+        self.extra.clone()
+    }
+}
+
+/// Stateless compositions carry no extra; callers receive an empty map.
+impl WithExtra for () {
+    fn routing_extra(&self) -> HashMap<String, StateValue> {
+        HashMap::new()
+    }
+}

--- a/crates/libsy/src/core/state.rs
+++ b/crates/libsy/src/core/state.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use crate::algorithms::util::tool_signals::ToolSignals;
 
 /// A value in a session's [`State`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StateValue {
     /// Text value.
     String(String),

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -8,7 +8,7 @@ mod core;
 pub use core::algorithm::{Algorithm, CallModel, Driver, RoutingOutcome, Step, StepStream, drive};
 pub use core::classifier::{Classification, Classifier, Score};
 pub use core::processor::{Event, Processor};
-pub use core::state::{State, StateValue};
+pub use core::state::{State, StateValue, WithExtra};
 
 mod error;
 pub use error::{DriverError, LibsyError, Result};

--- a/crates/protocol/src/model_id.rs
+++ b/crates/protocol/src/model_id.rs
@@ -147,6 +147,33 @@ impl PartialEq<ModelId> for String {
     }
 }
 
+/// A routing choice: the model selected by an algorithm and whether that call is the final answer.
+///
+/// Published by [`switchyard_libsy::Driver::decide`] as a [`switchyard_libsy::Step::Decision`]
+/// so downstream observers see each routing choice as it happens.
+#[derive(Debug, Clone)]
+pub struct Decision {
+    selected_model_id: ModelId,
+    is_answer_call: bool,
+}
+
+impl Decision {
+    /// Creates a new decision.
+    pub fn new(selected_model_id: impl Into<ModelId>, is_answer_call: bool) -> Self {
+        Self { selected_model_id: selected_model_id.into(), is_answer_call }
+    }
+
+    /// The model selected by this routing decision.
+    pub fn selected_model_id(&self) -> &str {
+        self.selected_model_id.as_str()
+    }
+
+    /// Whether this call is expected to produce the final answer to the user.
+    pub fn is_answer_call(&self) -> bool {
+        self.is_answer_call
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/crates/switchyard-py/src/libsy_bindings.rs
+++ b/crates/switchyard-py/src/libsy_bindings.rs
@@ -15,12 +15,12 @@ use switchyard_libsy::{
     Algorithm, CallModel, ClassifierContractConfig, ClassifierResponseFormat, ClassifyTrigger,
     CustomClassifierConfig, CustomClassifierPolicy, EscalationJudgeConfig, HandoffNoteConfig,
     LibsyError as RustLibsyError, LlmClassifierConfig, LlmFallback, LlmTaskClassifier, Noop,
-    PickerMode, Random, RoutingOutcome, StageRouter, StageRouterConfig, Step as RustStep,
-    StepStream, TaskClassifierConfig,
+    PickerMode, Random, RoutingOutcome, StageRouter, StageRouterConfig, StateValue,
+    Step as RustStep, StepStream, TaskClassifierConfig,
 };
 use switchyard_protocol::{
-    LlmClientError, LlmResponse, LlmResponseStream, LlmResponseStreamEvent, Metadata, ModelId,
-    Request, Response,
+    Decision, LlmClientError, LlmResponse, LlmResponseStream, LlmResponseStreamEvent, Metadata,
+    ModelId, Request, Response,
 };
 use tokio::sync::Mutex;
 
@@ -345,6 +345,20 @@ impl PyLlmFallback {
     }
 }
 
+/// A routing choice produced by an algorithm.
+#[pyclass(name = "Decision", module = "switchyard.libsy", frozen)]
+struct PyDecision {
+    inner: Decision,
+    /// Routing metadata snapshot from `state.extra` at decision time.
+    extra: HashMap<String, StateValue>,
+}
+
+impl From<Decision> for PyDecision {
+    fn from(inner: Decision) -> Self {
+        Self { inner, extra: HashMap::new() }
+    }
+}
+
 /// A normalized aggregate response or a live stream of normalized response events.
 #[pyclass(name = "LlmResponse", module = "switchyard.libsy", frozen)]
 enum PyLlmResponse {
@@ -381,6 +395,39 @@ fn python_client_error(py: Python<'_>, error: PyErr, model: &ModelId) -> LlmClie
         }
     } else {
         ffi_error(error)
+    }
+}
+
+#[pymethods]
+impl PyDecision {
+    /// The model id selected by the routing decision.
+    #[getter]
+    fn selected_model_id(&self) -> &str {
+        self.inner.selected_model_id()
+    }
+
+    /// Return the scalar routing metadata value for `key`, or `None` if absent or non-scalar.
+    fn get(&self, key: &str) -> Option<f32> {
+        match self.extra.get(key)? {
+            StateValue::Scalar(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Return the string routing metadata value for `key`, or `None` if absent or non-string.
+    fn get_str(&self, key: &str) -> Option<String> {
+        match self.extra.get(key)? {
+            StateValue::String(v) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Decision(selected_model_id={:?}, is_answer_call={})",
+            self.inner.selected_model_id(),
+            self.inner.is_answer_call()
+        )
     }
 }
 
@@ -601,6 +648,8 @@ fn response_to_python(py: Python<'_>, response: LlmResponse) -> PyResult<Py<PyAn
 enum PyStep {
     /// The host must serve the model call before the algorithm can continue.
     CallModel { call: Py<PyModelCall> },
+    /// A routing decision published by the algorithm as it happens.
+    Decision { decision: Py<PyDecision> },
     /// The terminal routing outcome.
     Done { outcome: Py<PyRoutingOutcome> },
 }
@@ -675,6 +724,11 @@ fn step_to_python(step: RustStep) -> PyResult<PyStep> {
         RustStep::CallModel(call) => Python::attach(|py| {
             Ok(PyStep::CallModel {
                 call: Py::new(py, PyModelCall::new(py, *call)?)?,
+            })
+        }),
+        RustStep::Decision { decision, extra } => Python::attach(|py| {
+            Ok(PyStep::Decision {
+                decision: Py::new(py, PyDecision { inner: decision, extra })?,
             })
         }),
         RustStep::Done(outcome) => {
@@ -856,6 +910,7 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     libsy_module.add_class::<PyLlmFallback>()?;
     libsy_module.add_class::<PyLlmResponse>()?;
     libsy_module.add_class::<PyLlmResponseStream>()?;
+    libsy_module.add_class::<PyDecision>()?;
     libsy_module.add_class::<PyModelCall>()?;
     libsy_module.add_class::<PyRunStream>()?;
     libsy_module.add_class::<PyRoutingOutcome>()?;

--- a/switchyard_rust/libsy.py
+++ b/switchyard_rust/libsy.py
@@ -97,6 +97,21 @@ if TYPE_CHECKING:
         ) -> None: ...
 
     @final
+    class Decision:
+        """A semantic routing choice produced by an algorithm."""
+
+        @property
+        def selected_model_id(self) -> str: ...
+
+        def get(self, key: str) -> float | None:
+            """Return the scalar routing metadata value for *key*, or ``None`` if absent or non-scalar."""
+            ...
+
+        def get_str(self, key: str) -> str | None:
+            """Return the string routing metadata value for *key*, or ``None`` if absent or non-string."""
+            ...
+
+    @final
     class ModelCall:
         @property
         def algorithm(self) -> str: ...
@@ -130,6 +145,11 @@ if TYPE_CHECKING:
         class CallModel:
             __match_args__: ClassVar[tuple[Literal["call"]]] = ("call",)
             call: ModelCall
+
+        @final
+        class Decision:
+            __match_args__: ClassVar[tuple[Literal["decision"]]] = ("decision",)
+            decision: Decision
 
         @final
         class Done:


### PR DESCRIPTION
## Summary

Exposes internal routing decision signals from Rust algorithm state to Python callers via `PyDecision`. Previously, the only way to read routing signals from Python was to parse the reasoning string. Now every `Decision` step carries a typed metadata snapshot that Python can query by key.

## Python contract

`Decision` (exposed as `switchyard.libsy.Decision`) gains two new methods:

```python
decision.get(key: str) -> float | None
decision.get_str(key: str) -> str | None
```

`get` returns a scalar (`f32`) value or `None` if the key is absent or holds a non-scalar value.  
`get_str` returns a string value or `None` if the key is absent or holds a non-string value.

### Keys written by `StageClassifier` (tool-signal path)

Present when the algorithm ran `StageClassifier` (i.e. there were tool signals to score). Absent when the session has no tool calls yet.

| Key | Type | Description |
|-----|------|-------------|
| `signal_severity` | `float` | Severity dimension of the tool signal |
| `signal_spinning` | `float` | Spinning/stuck dimension |
| `signal_exploring` | `float` | Exploration dimension |
| `signal_production_intensity` | `float` | Production-intensity dimension |
| `signal_score` | `float` | Composite score (`score_signal().score`) |
| `signal_confidence` | `float` | `abs(score)` — confidence in the direction |

All six are written **before** the `Resolved` / `ConsultClassifier` branch, so they are present regardless of which path was taken (including the below-threshold fallback that sets confidence to 0).

### Keys written by `TaskClassifierPolicy` (LLM judge path)

Present only when the judge ran and returned a verdict. Absent if the judge timed out, errored, or was not configured.

| Key | Type | Description |
|-----|------|-------------|
| `judge_p_solve` | `float` | Model's estimated probability of solving the task |
| `judge_crux` | `str` | One-line description of the task's core difficulty |
| `judge_primary_rule` | `str` | Primary routing rule that applied |
| `judge_capability_boundary` | `str` | Capability boundary the task sits at |

### Example usage

```python
async for step in stream:
    if isinstance(step, Decision):
        severity   = step.get("signal_severity")    # float | None
        confidence = step.get("signal_confidence")  # float | None
        p_solve    = step.get("judge_p_solve")       # float | None
        crux       = step.get_str("judge_crux")      # str   | None
```

## Implementation

- New `WithExtra` trait on `state.rs` — lets `FallThrough<S>` snapshot `extra` without losing genericity; `()` returns an empty map for stateless compositions
- `Step::Decision` changed from a tuple variant to a struct variant carrying `extra: HashMap<String, StateValue>`
- `Driver::decide()` takes the snapshot as a second argument
- `StageClassifier::score()` writes signal fields before the `match outcome` so both `Resolved` and `ConsultClassifier` branches capture them
- `JudgePolicy` gains a default no-op `record_to_state`; `TaskClassifierPolicy` overrides it to write the judge fields
- `PyDecision` in `switchyard-py` carries the snapshot and exposes `get` / `get_str` via `#[pymethods]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Routing decisions now preserve metadata collected during classification and execution.
  - Python integrations can retrieve decision metadata as numeric or text values.
  - Classifier results now record signals, confidence, and validated judge details for downstream inspection.

- **Improvements**
  - Decision tracing consistently retains associated metadata across execution paths.
  - Routing components now provide standardized metadata snapshots, including when no additional data is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->