### PR TITLE
feat(server): decouple upstream model name from target id via upstream_model

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -59,21 +59,29 @@ const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
 /// pin a wire format, plus any `other_backends` reachable over additional formats.
 #[derive(Clone, Debug)]
 pub struct ModelConfig {
+    /// Lookup key — the name callers address this model by (e.g. a target id that
+    /// must be unique across a deployment).
     model_name: ModelId,
+    /// The model id written into upstream requests. May differ from `model_name`
+    /// when a target remaps the model en route to its backend.
+    wire_model: ModelId,
     default_backend: Backend,
     other_backends: Option<Vec<Backend>>,
 }
 
 impl ModelConfig {
     /// A model named `model_name` served by `default_backend`, optionally reachable
-    /// over additional wire formats via `other_backends`.
+    /// over additional wire formats via `other_backends`. Upstream requests carry
+    /// `wire_model`; pass the same name when no remap is wanted.
     pub fn new(
         model_name: impl Into<ModelId>,
         default_backend: Backend,
         other_backends: Option<Vec<Backend>>,
+        wire_model: impl Into<ModelId>,
     ) -> Self {
         Self {
             model_name: model_name.into(),
+            wire_model: wire_model.into(),
             default_backend,
             other_backends,
         }
@@ -165,14 +173,21 @@ impl TranslatingLlmClient {
             metadata,
             ..
         } = request;
-        llm_request.model = Some(model.to_string());
+        // Resolve the wire model through the config table so the upstream request
+        // carries the remapped name when one is configured.
+        let wire_model = self
+            .model_to_config
+            .get(model)
+            .map(|config| config.wire_model.clone())
+            .unwrap_or_else(|| model.clone());
+        llm_request.model = Some(wire_model.to_string());
         let http_response = self
             .send_encoded(
                 backend,
                 WireFormat::AnthropicMessages,
                 llm_request,
                 metadata.as_ref(),
-                model,
+                &wire_model,
                 UpstreamEndpoint::CountTokens,
             )
             .await?;
@@ -400,12 +415,17 @@ impl TranslatingLlmClient {
             .ok_or_else(|| LlmClientError::InvalidRequest {
                 message: "no model given".to_string(),
             })?;
-        llm_request.model = Some(model_id.to_string());
+        // The lookup key names the model for routing and response restamping; the
+        // wire model is what the upstream provider actually receives.
+        let config = self.model_to_config.get(&model_id);
+        let wire_model = config
+            .map(|config| config.wire_model.clone())
+            .unwrap_or_else(|| model_id.clone());
+        llm_request.model = Some(wire_model.to_string());
 
         let orig_format = metadata.as_ref().and_then(|m| m.wire_format);
         let wire_format = orig_format.unwrap_or(
-            self.model_to_config
-                .get(&model_id)
+            config
                 .map(|config| config.default_backend.wire_format())
                 .ok_or_else(|| LlmClientError::Configuration {
                     message: format!("no backend configured for model {model_id:?}"),
@@ -423,7 +443,7 @@ impl TranslatingLlmClient {
                 wire_format,
                 llm_request,
                 metadata.as_ref(),
-                &model_id,
+                &wire_model,
                 UpstreamEndpoint::Completion,
             )
             .await?;
@@ -889,6 +909,7 @@ mod tests {
             "gpt",
             Backend::OpenAiChat(config(base_url)),
             None,
+            "gpt",
         )]
     }
 
@@ -898,7 +919,12 @@ mod tests {
     ) -> Vec<ModelConfig> {
         let mut backend = config(base_url);
         backend.extra_body = extra_body;
-        vec![ModelConfig::new("gpt", Backend::OpenAiChat(backend), None)]
+        vec![ModelConfig::new(
+            "gpt",
+            Backend::OpenAiChat(backend),
+            None,
+            "gpt",
+        )]
     }
 
     fn anthropic_map(base_url: &str) -> Vec<ModelConfig> {
@@ -906,6 +932,7 @@ mod tests {
             "claude",
             Backend::Anthropic(config(base_url)),
             None,
+            "claude",
         )]
     }
 
@@ -914,6 +941,7 @@ mod tests {
             "gpt",
             Backend::OpenAiChat(config_with_retries(base_url, max_retries)),
             None,
+            "gpt",
         )]
     }
 
@@ -1340,6 +1368,40 @@ mod tests {
             )
             .await?;
         // The body_partial_json matcher asserts the upstream saw model "gpt".
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn wire_model_remaps_the_upstream_name()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        // The lookup key is a unique target id; the upstream must receive the bare
+        // model name it actually serves.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(wiremock::matchers::body_partial_json(json!({"model": "deepseek-v4-flash"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1", "model": "deepseek-v4-flash",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let configs = vec![ModelConfig::new(
+            "deepseek-v4-flash@sensenova",
+            Backend::OpenAiChat(config(&format!("{}/v1", server.uri()))),
+            None,
+            "deepseek-v4-flash",
+        )];
+        let client = TranslatingLlmClient::new(&configs)?;
+        let response = client
+            .call_rewrite_model(
+                request_for(Some("deepseek-v4-flash@sensenova"), false),
+                Some(&ModelId::from("deepseek-v4-flash@sensenova")),
+            )
+            .await?;
+        // The body_partial_json matcher asserts the upstream saw the bare model.
         Ok(())
     }
 

--- a/crates/libsy-llm-client/src/run.rs
+++ b/crates/libsy-llm-client/src/run.rs
@@ -689,8 +689,8 @@ mod tests {
         };
         let client = Arc::new(
             TranslatingLlmClient::new(&[
-                ModelConfig::new("weak", backend(), None),
-                ModelConfig::new("strong", backend(), None),
+                ModelConfig::new("weak", backend(), None, "weak"),
+                ModelConfig::new("strong", backend(), None, "strong"),
             ])
             .map_err(|error| LibsyError::external("building test client", error))?,
         );

--- a/crates/switchyard-server/src/config.rs
+++ b/crates/switchyard-server/src/config.rs
@@ -157,6 +157,10 @@ impl ServerConfig {
                 target.id.clone(),
                 build_backend(&target.llm_client, client_config, &target.extra_body)?,
                 None,
+                target
+                    .upstream_model
+                    .clone()
+                    .unwrap_or_else(|| target.id.clone()),
             ));
         }
 
@@ -311,6 +315,11 @@ pub(crate) struct LlmClientConfig {
 #[serde(deny_unknown_fields)]
 pub(crate) struct TargetConfig {
     pub(crate) id: ModelId,
+    /// The model id written into upstream requests. Defaults to `id`, so existing
+    /// single-supplier configs are unaffected; set it when the same model is served
+    /// by multiple clients and each target needs its own unique routing `id`.
+    #[serde(default)]
+    pub(crate) upstream_model: Option<ModelId>,
     pub(crate) llm_client: String,
     #[serde(default)]
     pub(crate) extra_body: BTreeMap<String, Value>,

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -453,7 +453,7 @@ fn random_state_with_retries(
         .collect::<HashSet<_>>();
     let model_configs = target_models
         .into_iter()
-        .map(|model| ModelConfig::new(model, backend.clone(), None))
+        .map(|model| ModelConfig::new(model.clone(), backend.clone(), None, model))
         .collect::<Vec<_>>();
     let client: Arc<dyn RoutedLlmClient> = Arc::new(TranslatingLlmClient::new(&model_configs)?);
     let entries = routes


### PR DESCRIPTION
# feat(server): decouple upstream model name from target id via `upstream_model`

## Problem

A target's `id` currently serves two roles at once:

1. **Routing label** — how routes, fallback logic, stats, and logs refer to the target.
2. **Upstream model name** — the exact model id written into requests sent to the provider.

This makes it impossible to configure **the same model served by multiple providers**
(e.g. `deepseek-v4-flash` from DeepSeek official and from an aggregator). Because
`Random::new` deduplicates targets by model id (`rand.rs:52-55`) and the client keys
its models by id, identical ids collide:

```
target X reuses model id deepseek-v4-flash on llm client Y; only one target per id
is kept and the other is dropped.
random route pool: random targets must be unique
```

Users who want multi-supplier redundancy for one model — a core reliability use case —
currently cannot express it in the config surface.

## Solution

Introduce an explicit, optional `upstream_model` field that separates the two concerns:

- **Lookup key** stays the target `id` (e.g. `deepseek-v4-flash@sensenova`) — routing,
  fallback exclusion, error reporting, stats, and response restamping are untouched.
- **Wire name** becomes `upstream_model` when set (e.g. `deepseek-v4-flash`), falling
  back to `id` so every existing single-supplier setup is unaffected.

### Changes (4 files, +82/−11)

| Crate | File | Change |
|---|---|---|
| switchyard-server | `src/config.rs` | `TargetConfig` gains `#[serde(default)] upstream_model: Option<ModelId>`; registration passes key = `id`, wire = `upstream_model.unwrap_or(id)` |
| libsy-llm-client | `src/client.rs` | `ModelConfig` gains a `wire_model` field (4th ctor arg). Lookup remains keyed by `model_name`; `call_rewrite_model` and `count_tokens` now write `wire_model` into the upstream request |
| libsy-llm-client | `src/client.rs` tests | new `wire_model_remaps_the_upstream_name` test (wiremock asserts the upstream receives the bare model name); existing ctor call sites updated |
| libsy-llm-client / switchyard-server | `run.rs`, `tests/server.rs` | mechanical ctor-arg updates |

`libsy` is unchanged: algorithms only ever see the routing `ModelId`.

## Example

```toml
[targets."deepseek-v4-flash@deepseek"]
id = "deepseek-v4-flash@deepseek"          # unique routing label
upstream_model = "deepseek-v4-flash"       # actual model id sent upstream
llm_client = "deepseek"

[targets."deepseek-v4-flash@sensenova"]
id = "deepseek-v4-flash@sensenova"
upstream_model = "deepseek-v4-flash"
llm_client = "sensenova"

[routes.pool]
type = "random"
targets = ["deepseek-v4-flash@deepseek", "deepseek-v4-flash@sensenova"]
weights = [1, 1]
```

Requests to `pool` now spread across providers, each receiving the correct bare model
id on the wire.

## Verification

- `cargo check -p switchyard-server -p switchyard-llm-client`: 0 errors
- `cargo test -p switchyard-server -p switchyard-llm-client`: 153 passed / 0 failed
  (includes the new remap test)
- `cargo fmt --check`: clean; `cargo clippy`: no warnings
- End-to-end (3-provider pool, live keys): 6 consecutive calls → HTTP 200 ×6,
  distributed across ≥3 distinct supplier instances, each upstream receiving the bare
  model name; zeroing one instance's weight redirects all traffic with no errors

## Compatibility

Configs without `upstream_model` behave identically (wire name falls back to `id`);
all pre-existing tests pass unchanged apart from the added constructor argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate routing and upstream model names.
  * Targets can optionally specify the model identifier sent to upstream services.
  * When unspecified, the routing identifier is used automatically.
  * Model remapping now applies consistently to token counting and completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->