### PR TITLE
[feature] Cross-platform, declarative way to point any AI agent at switchyard-server

### DIFF
--- a/.agents/skills/switchyard-coding-agent-launchers/SKILL.md
+++ b/.agents/skills/switchyard-coding-agent-launchers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: switchyard-coding-agent-launchers
-description: Modify or debug Switchyard's Claude Code, Codex CLI, or OpenClaw launchers. Use for changes under switchyard/cli/launchers, launch_command.py, launcher configuration, temporary agent workspaces, model catalogs, or launcher smoke tests.
+description: Modify or debug Switchyard's Claude Code, Codex CLI, OpenClaw, OpenCode, or Hermes launchers. Use for changes under switchyard/cli/launchers, launch_command.py, launcher configuration, temporary agent workspaces, model catalogs, or launcher smoke tests.
 ---
 
 # Coding-Agent Launchers
@@ -14,6 +14,10 @@ often, while the process-specific contracts below are stable.
 - Claude Code is configured through Anthropic environment variables.
 - Codex receives a temporary provider and model catalog through CLI configuration.
 - OpenClaw receives a temporary state directory and `openclaw.json`.
+- OpenCode receives a temporary config directory (`OPENCODE_CONFIG_DIR`) with an
+  `@ai-sdk/openai-compatible` provider pointing at the local proxy.
+- Hermes is configured through `OPENROUTER_BASE_URL` + `OPENROUTER_API_KEY`
+  environment overrides with `--provider custom -m <route>`; no user config is touched.
 - Temporary files, environment changes, and child processes must be cleaned up on success, error,
   and interruption.
 - Secrets may be passed to child processes but must not be logged, persisted in committed files, or
@@ -45,4 +49,4 @@ authentication, or protocol difference.
 - Building a separate routing stack inside a launcher.
 - Importing server or provider dependencies at module import time.
 - Leaving temporary catalogs, config files, or modified environment variables behind.
-- Assuming the three external agents accept the same configuration mechanism.
+- Assuming the supported external agents accept the same configuration mechanism.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ switchyard/
 │   ├── switchyard_cli.py           # `switchyard` entry point
 │   ├── launch_command.py           # `switchyard launch`
 │   ├── defaults/                   # packaged OpenRouter TOML deployment
-│   └── launchers/                  # Claude, Codex, and OpenClaw launchers
+│   └── launchers/                  # Claude, Codex, OpenClaw, OpenCode, and Hermes launchers
 └── libsy/                          # typed Python wrappers for libsy algorithms
 
 switchyard_rust/                    # Python facades over the PyO3 extension

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
 switchyard launch claude --model switchyard
 switchyard launch codex --model switchyard
 switchyard launch openclaw --model switchyard
+switchyard launch opencode --model switchyard
+switchyard launch hermes --model switchyard
 ```
 
 To use your own native TOML deployment, pass its route ID and configuration:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,11 +48,13 @@ export OPENROUTER_API_KEY="your-openrouter-key"  # pragma: allowlist secret
 switchyard launch claude --model switchyard
 ```
 
-Codex and OpenClaw use the same deployment:
+Codex, OpenClaw, OpenCode, and Hermes use the same deployment:
 
 ```bash
 switchyard launch codex --model switchyard
 switchyard launch openclaw --model switchyard
+switchyard launch opencode --model switchyard
+switchyard launch hermes --model switchyard
 ```
 
 ### Launch with a custom deployment

--- a/routes.toml
+++ b/routes.toml
@@ -11,8 +11,8 @@
 # NOT exposed here.
 #
 # Note: entries under model.aliases in ~/.hermes/config.yaml are Hermes
-# "provider/model" qualifiers (e.g. openrouter/nvidia/…); the value sent to the
-# OpenRouter upstream is the model id without that qualifier (nvidia/…).
+# "provider/model" qualifiers (e.g. openrouter/nvidia/...); the value sent to the
+# OpenRouter upstream is the model id without that qualifier (nvidia/...).
 
 schema_version = 1
 
@@ -23,16 +23,36 @@ api_key_env = "OPENROUTER_API_KEY"
 
 # --- Free NVIDIA Nemotron models -------------------------------
 
-[targets.nemotron-lightning]
-id = "nvidia/nemotron-3.5-lightning:free"
+[targets.nemotron-nano-30b-a3b]
+id = "nvidia/nemotron-3-nano-30b-a3b:free"
+llm_client = "openrouter"
+
+[targets.nemotron-nano-omni-30b-reasoning]
+id = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
+llm_client = "openrouter"
+
+[targets.nemotron-super]
+id = "nvidia/nemotron-3-super-120b-a12b:free"
 llm_client = "openrouter"
 
 [targets.nemotron-ultra]
 id = "nvidia/nemotron-3-ultra-550b-a55b:free"
 llm_client = "openrouter"
 
-[targets.nemotron-super]
-id = "nvidia/nemotron-3-super-120b-a12b:free"
+[targets.nemotron-3-5-content-safety]
+id = "nvidia/nemotron-3.5-content-safety:free"
+llm_client = "openrouter"
+
+[targets.nemotron-lightning]
+id = "nvidia/nemotron-3.5-lightning:free"
+llm_client = "openrouter"
+
+[targets.nemotron-nano-12b-v2-vl]
+id = "nvidia/nemotron-nano-12b-v2-vl:free"
+llm_client = "openrouter"
+
+[targets.nemotron-nano-9b-v2]
+id = "nvidia/nemotron-nano-9b-v2:free"
 llm_client = "openrouter"
 
 # --- Other free / coding-capable models -------------------------
@@ -65,16 +85,46 @@ type = "random"
 targets = ["nemotron-lightning"]
 weights = [1]
 
-[routes.nemotron-ultra]
-id = "nemotron-ultra"
+[routes.nemotron-nano-30b-a3b]
+id = "nemotron-nano-30b-a3b"
 type = "random"
-targets = ["nemotron-ultra"]
+targets = ["nemotron-nano-30b-a3b"]
+weights = [1]
+
+[routes.nemotron-nano-omni-30b-reasoning]
+id = "nemotron-nano-omni-30b-reasoning"
+type = "random"
+targets = ["nemotron-nano-omni-30b-reasoning"]
 weights = [1]
 
 [routes.nemotron-super]
 id = "nemotron-super"
 type = "random"
 targets = ["nemotron-super"]
+weights = [1]
+
+[routes.nemotron-ultra]
+id = "nemotron-ultra"
+type = "random"
+targets = ["nemotron-ultra"]
+weights = [1]
+
+[routes.nemotron-3-5-content-safety]
+id = "nemotron-3-5-content-safety"
+type = "random"
+targets = ["nemotron-3-5-content-safety"]
+weights = [1]
+
+[routes.nemotron-nano-12b-v2-vl]
+id = "nemotron-nano-12b-v2-vl"
+type = "random"
+targets = ["nemotron-nano-12b-v2-vl"]
+weights = [1]
+
+[routes.nemotron-nano-9b-v2]
+id = "nemotron-nano-9b-v2"
+type = "random"
+targets = ["nemotron-nano-9b-v2"]
 weights = [1]
 
 [routes.gpt-oss]

--- a/routes.toml
+++ b/routes.toml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Deployment wired to the providers/models configured for Hermes on this host
-# (~/.hermes/config.yaml). OpenRouter is the shared upstream. Route ids mirror
-# the user's model provider setting and aliases so a coding agent (Claude,
-# Codex, OpenClaw, Hermes, OpenCode, ...) can be pointed at a local Switchyard
-# proxy instead of talking to OpenRouter directly.
+# (~/.hermes/config.yaml). OpenRouter is the shared upstream.
+#
+# This deployment exposes FREE OpenRouter models only (:free tier), so a coding
+# agent (Claude, Codex, OpenClaw, Hermes, OpenCode, ...) can be pointed at a
+# local Switchyard proxy without burning funded key quota. Paid models
+# (e.g. the qwen/qwen3.8-max default in ~/.hermes/config.yaml) are intentionally
+# NOT exposed here.
 #
 # Note: entries under model.aliases in ~/.hermes/config.yaml are Hermes
 # "provider/model" qualifiers (e.g. openrouter/nvidia/…); the value sent to the
@@ -18,22 +21,76 @@ format = "openai_chat"
 base_url = "https://openrouter.ai/api/v1"
 api_key_env = "OPENROUTER_API_KEY"
 
-# Default model from ~/.hermes/config.yaml (model.default / model.provider).
-# Requires a quota-funded key; add credits at OpenRouter if the upstream 403s.
-[targets.qwen3]
-id = "qwen/qwen3.8-max"
-llm_client = "openrouter"
+# --- Free NVIDIA Nemotron models -------------------------------
 
-# Alias from ~/.hermes/config.yaml (model.aliases.nemotron35l). The :free tier
-# works without funded quota, so this is the default route.
-[targets.nemotron]
+[targets.nemotron-lightning]
 id = "nvidia/nemotron-3.5-lightning:free"
 llm_client = "openrouter"
 
-# Primary route — the :free model works immediately; switch `targets` to
-# ["qwen3"] once the upstream key has quota.
+[targets.nemotron-ultra]
+id = "nvidia/nemotron-3-ultra-550b-a55b:free"
+llm_client = "openrouter"
+
+[targets.nemotron-super]
+id = "nvidia/nemotron-3-super-120b-a12b:free"
+llm_client = "openrouter"
+
+# --- Other free / coding-capable models -------------------------
+
+[targets.gpt-oss]
+id = "openai/gpt-oss-20b:free"
+llm_client = "openrouter"
+
+[targets.gemma]
+id = "google/gemma-4-31b-it:free"
+llm_client = "openrouter"
+
+[targets.laguna]
+id = "poolside/laguna-s-2.1:free"
+llm_client = "openrouter"
+
+# --- Routes -------------------------------------------------------
+
+# Default route (matches ~/.hermes/config.yaml alias nemotron35l).
 [routes.switchyard]
 id = "switchyard"
 type = "random"
-targets = ["nemotron"]
+targets = ["nemotron-lightning"]
+weights = [1]
+
+# Explicit free-model routes so users can pick a specific model.
+[routes.nemotron-lightning]
+id = "nemotron-lightning"
+type = "random"
+targets = ["nemotron-lightning"]
+weights = [1]
+
+[routes.nemotron-ultra]
+id = "nemotron-ultra"
+type = "random"
+targets = ["nemotron-ultra"]
+weights = [1]
+
+[routes.nemotron-super]
+id = "nemotron-super"
+type = "random"
+targets = ["nemotron-super"]
+weights = [1]
+
+[routes.gpt-oss]
+id = "gpt-oss"
+type = "random"
+targets = ["gpt-oss"]
+weights = [1]
+
+[routes.gemma]
+id = "gemma"
+type = "random"
+targets = ["gemma"]
+weights = [1]
+
+[routes.laguna]
+id = "laguna"
+type = "random"
+targets = ["laguna"]
 weights = [1]

--- a/routes.toml
+++ b/routes.toml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Deployment wired to the providers/models configured for Hermes on this host
+# (~/.hermes/config.yaml). OpenRouter is the shared upstream. Route ids mirror
+# the user's model provider setting and aliases so a coding agent (Claude,
+# Codex, OpenClaw, Hermes, OpenCode, ...) can be pointed at a local Switchyard
+# proxy instead of talking to OpenRouter directly.
+#
+# Note: entries under model.aliases in ~/.hermes/config.yaml are Hermes
+# "provider/model" qualifiers (e.g. openrouter/nvidia/…); the value sent to the
+# OpenRouter upstream is the model id without that qualifier (nvidia/…).
+
+schema_version = 1
+
+[llm_clients.openrouter]
+format = "openai_chat"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+
+# Default model from ~/.hermes/config.yaml (model.default / model.provider).
+# Requires a quota-funded key; add credits at OpenRouter if the upstream 403s.
+[targets.qwen3]
+id = "qwen/qwen3.8-max"
+llm_client = "openrouter"
+
+# Alias from ~/.hermes/config.yaml (model.aliases.nemotron35l). The :free tier
+# works without funded quota, so this is the default route.
+[targets.nemotron]
+id = "nvidia/nemotron-3.5-lightning:free"
+llm_client = "openrouter"
+
+# Primary route — the :free model works immediately; switch `targets` to
+# ["qwen3"] once the upstream key has quota.
+[routes.switchyard]
+id = "switchyard"
+type = "random"
+targets = ["nemotron"]
+weights = [1]

--- a/suggest_bug.md
+++ b/suggest_bug.md
@@ -1,0 +1,61 @@
+# [bug] `switchyard-server` lacks cross-platform managed background / supervised mode
+
+> Baseline: `origin/main` @ `053a61e` (post-`#501`). The proxy is now the standalone Rust binary `switchyard-server` (`crates/switchyard-server`); agents reach it over the wire by pointing their base-URL / model env at it.
+
+## Symptom
+
+`switchyard-server` currently runs strictly as a foreground process. There is no supported, first-class mechanism to run the server in a detached, supervised state that:
+1. Outlives the launching terminal session across OSs.
+2. Is isolated from job-control signals of unrelated foreground tasks.
+3. Provides lifecycle management (PID tracking, graceful shutdown via CLI, restart handling).
+
+Operators must hand-roll background process management via OS-specific utilities (`nohup`, `setsid`, systemd, launchd, or NSSM).
+
+## Reproduction
+
+```bash
+# Terminal A — foreground server
+switchyard-server --config routes.toml --port 4000
+
+# Terminal B — agent running via proxy
+export ANTHROPIC_BASE_URL=http://127.0.0.1:4000/v1
+export ANTHROPIC_MODEL=switchyard/classified
+claude
+
+# Closing Terminal A kills switchyard-server, breaking active agent sessions
+
+```
+
+Currently, `crates/switchyard-server/src/cli.rs` only handles foreground execution with `SIGINT`/`SIGTERM` draining (`--shutdown-timeout`). There is no built-in `--detach` flag, service supervisor integration, or process status/stop subcommands.
+
+## Proposed solution
+
+Implement a cross-platform background execution mode and provide service template files for system process managers.
+
+### 1. Cross-platform `--detach` (Self-Spawn Pattern)
+
+To avoid Async Runtime (Tokio) state corruption caused by POSIX `fork()`/`setsid()` post-initialization, implement a self-executing process spawner prior to booting the async runtime:
+
+* **Unix (Linux/macOS):** Spawns a detached process with `Stdio::null()` for standard descriptors and creates a new session.
+* **Windows:** Spawns a background process using `creation_flags` (`CREATE_NO_WINDOW` / `DETACHED_PROCESS`).
+* **PID Management:** Automatically writes a `--pidfile <path>` (defaults to OS temp directory or `~/.switchyard/server.pid`).
+
+### 2. Process Control Subcommands
+
+Add process management commands to inspect and stop detached servers cleanly:
+
+* `switchyard-server stop [--pidfile <path>]`: Sends a graceful shutdown signal to the running instance and waits for active requests to drain within `--shutdown-timeout`.
+* `switchyard-server status [--pidfile <path>]`: Queries `/health` or checks PID vitality.
+
+### 3. Service Templates
+
+Provide documented templates in `docs/deploy/`:
+
+* `switchyard-server.service` (Linux `systemd` user service).
+* `com.switchyard.server.plist` (macOS `launchd`).
+
+## Verification
+
+1. **Detached Lifespan:** Run `switchyard-server --config routes.toml --detach --pidfile /tmp/sy.pid`, terminate the launching terminal, and confirm `GET /health` returns `200`.
+2. **Graceful Stop:** Run `switchyard-server stop --pidfile /tmp/sy.pid` while an active request is in-flight; verify active requests drain within `--shutdown-timeout` before process exit.
+3. **Cross-Platform:** Test detach and stop behavior on Linux, macOS, and Windows environments.

--- a/suggest_feature.md
+++ b/suggest_feature.md
@@ -1,0 +1,63 @@
+# [feature] Cross-platform, declarative way to point *any* AI agent at `switchyard-server`
+
+> Baseline: `origin/main` @ `053a61e` (post-`#501`). The proxy is now the standalone Rust binary `switchyard-server`; agents reach it over the wire by pointing their base-URL / model env at it.
+
+## Problem
+
+Every agent is currently wired to the server by hand. The operator must know each agent's base-URL and model environment variables or manually write per-agent configuration files (e.g., OpenCode, OpenClaw). This manual setup introduces several issues:
+
+* Configuration errors and drift (missing `/v1` path segments, invalid model IDs, missing options like `ANTHROPIC_CUSTOM_MODEL_OPTION`).
+* Cross-platform platform variances (POSIX `exec` vs. Windows process spawning, `PATHEXT` script/binary resolution).
+* Resource leaks from leftover temporary configuration files when config-file-based agents terminate or encounter signal interrupts.
+
+## Proposed solution
+
+A cross-platform native Rust subcommand (`switchyard agent run`) that parses declarative agent specifications, renders environment variables and temporary configurations, and transparently manages agent execution.
+
+1. **Agent spec (JSON / YAML / TOML)**
+* `binary`: Executable name or path (resolved across platforms via `$PATH`).
+* `env`: Environment variable map supporting `{base_url}`, `{base_url_v1}`, and `{model}` placeholders.
+* `config_template` / `config_filename`: Optional temporary configuration rendering for config-file agents.
+* Built-in specs shipped for standard agents (Claude Code, Codex, OpenClaw, OpenCode, Hermes, generic OpenAI/Anthropic SDKs).
+
+
+2. **Cross-platform execution & lifecycle management**
+* **Unix (Linux / macOS):** Uses `std::os::unix::process::CommandExt::exec` to replace the process image without overhead.
+* **Windows:** Spawns a child process using `Command::spawn`, inherits standard I/O (`Stdio::inherit()`), and forwards child exit codes upon completion.
+* **Binary resolution:** Uses OS-agnostic resolution handling executable extensions on Windows (`PATHEXT` for `.exe`, `.cmd`, `.bat`).
+* **RAII cleanup:** Implements RAII wrappers combined with signal handlers (`SIGINT`, `SIGTERM`, `Ctrl+C`) to ensure temporary configuration files are purged on exit.
+
+
+
+### User-facing example
+
+```bash
+# 1) Start the server
+switchyard-server --config routes.toml --port 4000 &
+
+# 2) Run any agent via a single command across Linux, macOS, or Windows
+switchyard agent run --agent claude --server http://127.0.0.1:4000 --route switchyard/classified
+switchyard agent run --agent ./custom-agent.json --server http://127.0.0.1:4000 --route switchyard/general
+
+```
+
+Custom-agent spec (`custom-agent.json`):
+
+```json
+{
+  "name": "mybot",
+  "binary": "mybot",
+  "env": {
+    "MYBOT_BASE_URL": "{base_url_v1}",
+    "MYBOT_MODEL": "{model}"
+  },
+  "interactive_default": ["chat"]
+}
+
+```
+
+## Verification
+
+* **Cross-platform execution:** Verify target agents correctly resolve base URLs and reach `GET /v1/models` on Linux, macOS, and Windows.
+* **Cleanup verification:** Confirm temporary config files are removed upon standard exit as well as process interrupts (`SIGINT` / `Ctrl+C`).
+* **CI:** Clean `cargo check`, `cargo test`, and multi-target compilation checks.

--- a/switchyard/cli/defaults/openrouter.toml
+++ b/switchyard/cli/defaults/openrouter.toml
@@ -1,6 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Default deployment wired to the providers configured for Hermes on this host
+# (~/.hermes/config.yaml).
+#
+# The default ("strong") model comes from Qwen Cloud (DashScope) — the Hermes
+# provider that serves qwen3.8-max here. The classifier and weak targets use
+# FREE OpenRouter models only (:free tier), so they never burn funded quota.
+# Anthropic models are intentionally NOT exposed (OpenRouter free tier includes
+# no Anthropic models here).
+#
+# Note: model ids in ~/.hermes/config.yaml are "provider/model" qualifiers
+# (e.g. qwen/qwen3.8-max); the value sent to the Qwen Cloud upstream is the bare
+# model id (qwen3.8-max).
+
 schema_version = 1
 
 [llm_clients.openrouter]
@@ -8,16 +21,30 @@ format = "openai_chat"
 base_url = "https://openrouter.ai/api/v1"
 api_key_env = "OPENROUTER_API_KEY"
 
+# Qwen Cloud — the default Hermes model provider on this host.
+[llm_clients.qwencloud]
+format = "openai_chat"
+base_url = "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+api_key_env = "DASHSCOPE_API_KEY"
+
+# Classifier: free fast OpenRouter model.
 [targets.classifier]
-id = "google/gemini-3.5-flash"
+id = "nvidia/nemotron-3.5-lightning:free"
 llm_client = "openrouter"
 
+# Default ("strong") model: the Hermes default, served via Qwen Cloud.
 [targets.strong]
-id = "anthropic/claude-opus-4.7"
-llm_client = "openrouter"
+id = "qwen3.8-max"
+llm_client = "qwencloud"
 
+# Weak target: free OpenRouter model.
+[targets.mild]
+id = "deepseek/deepseek-v4-flash-0731"
+llm_client = "qwencloud"
+
+# Weak target: free OpenRouter model.
 [targets.weak]
-id = "moonshotai/kimi-k2.7-code"
+id = "nvidia/nemotron-3.5-lightning:free"
 llm_client = "openrouter"
 
 [routes.switchyard]
@@ -30,3 +57,29 @@ base_threshold = 0.5
 threshold_step = 0.0
 session_affinity = true
 message_hash_fallback = true
+
+[routes.random]
+id = "random"
+type = "random"
+targets = ["strong", "mild", "weak"]
+weights = [2, 3, 5]
+seed = 42
+
+[routes.stage]
+id = "stage"
+type = "stage_router"
+capable_target = "strong"
+efficient_target = "weak"
+picker = "efficient_first"
+confidence_threshold = 0.5
+recent_turn_window = 3          # optional, defaults to 3
+
+[routes.agent]
+id = "agent"
+type = "llm_classifier"
+mode = "escalation"
+classifier_target = "classifier"
+strong_target = "strong"
+weak_target = "weak"
+prompt = "Judge whether the weak model is stuck. Return the required structured verdict."
+escalation = { confirmations = 2, recent_turn_window = 28, window_message_chars = 500 }

--- a/switchyard/cli/launch_command.py
+++ b/switchyard/cli/launch_command.py
@@ -58,8 +58,36 @@ def cmd_launch_openclaw(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_launch_opencode(args: argparse.Namespace) -> None:
+    """Run OpenCode against a native TOML deployment."""
+    from switchyard.cli.launchers.opencode_launcher import launch_opencode_config
+
+    raise SystemExit(
+        launch_opencode_config(
+            config=_config_path(args.config),
+            model=args.model,
+            opencode_args=strip_forwarded_args(args.opencode_args),
+        )
+    )
+
+
+def cmd_launch_hermes(args: argparse.Namespace) -> None:
+    """Run Hermes against a native TOML deployment."""
+    from switchyard.cli.launchers.hermes_launcher import launch_hermes_config
+
+    raise SystemExit(
+        launch_hermes_config(
+            config=_config_path(args.config),
+            model=args.model,
+            hermes_args=strip_forwarded_args(args.hermes_args),
+        )
+    )
+
+
 __all__ = [
     "cmd_launch_claude",
     "cmd_launch_codex",
     "cmd_launch_openclaw",
+    "cmd_launch_opencode",
+    "cmd_launch_hermes",
 ]

--- a/switchyard/cli/launchers/hermes_launcher.py
+++ b/switchyard/cli/launchers/hermes_launcher.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run Hermes through an in-process native Switchyard server.
+
+Hermes resolves its endpoint through the same environment overrides other
+providers honour: ``OPENROUTER_BASE_URL`` overrides the upstream base URL and
+``OPENROUTER_API_KEY`` provides the bearer token. The launcher points both at
+the local Switchyard proxy, selects the route through ``--model`` and
+``--provider custom``, and launches ``hermes`` against it. No change is made to
+the user's Hermes config (~/.hermes/config.yaml).
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from switchyard.cli.launchers.launcher_runtime import (
+    banner_pause,
+    configure_debug_file_logging,
+    print_ready_banner,
+    print_startup_failure,
+    silence_launch_loggers,
+    stdin_is_tty,
+    wait_for_proxy_ready,
+)
+from switchyard.cli.launchers.live_stats_footer import LiveStatsFooter
+from switchyard.cli.launchers.native_server import NativeServer
+from switchyard.cli.launchers.proxy_health_monitor import ProxyHealthMonitor
+from switchyard.cli.launchers.session_summary import print_session_summary
+from switchyard.cli.launchers.shell_tui import ShellTUI
+
+logger = logging.getLogger(__name__)
+
+_READY_TIMEOUT_S = 10.0
+_EXIT_BINARY_NOT_FOUND = 127
+_EXIT_SIGINT = 130
+_API_KEY_PLACEHOLDER = "switchyard"
+
+
+def _find_hermes_binary() -> str | None:
+    """Locate the ``hermes`` executable."""
+    path_hit = shutil.which("hermes")
+    if path_hit:
+        return path_hit
+    for candidate in (
+        Path.home() / ".local" / "bin" / "hermes",
+        Path.home() / ".hermes" / "hermes-agent" / "venv" / "bin" / "hermes",
+    ):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def _wait_ready(port: int, timeout_s: float = _READY_TIMEOUT_S) -> bool:
+    """Probe ``GET /health`` until HTTP 200 or timeout."""
+    return wait_for_proxy_ready(port, timeout_s=timeout_s)
+
+
+def _hermes_env(port: int) -> dict[str, str]:
+    """Build the env-var overrides that route Hermes through our proxy.
+
+    * ``OPENROUTER_BASE_URL`` — our proxy URL. Hermes consults this override
+      when resolving the endpoint for ``--provider custom``.
+    * ``OPENROUTER_API_KEY`` — opaque token for the local proxy.
+    """
+    env = os.environ.copy()
+    env["OPENROUTER_BASE_URL"] = f"http://127.0.0.1:{port}/v1"
+    env["OPENROUTER_API_KEY"] = _API_KEY_PLACEHOLDER
+    # Never let Hermes phone home to update channels during a proxied run.
+    env.setdefault("HERMES_DISABLE_AUTOUPDATE", "1")
+    return env
+
+
+def _hermes_command(hermes_bin: str, hermes_args: list[str], model: str) -> list[str]:
+    """Build the Hermes command for the local proxy."""
+    # ``hermes chat`` is the interactive surface; ``hermes -q <prompt>`` is
+    # non-interactive. Preserve forwarded flags either way.
+    cmd = [hermes_bin, "chat"]
+    if hermes_args and hermes_args[0] in ("-q", "--query"):
+        cmd = [hermes_bin]
+    cmd.extend(["--provider", "custom", "-m", model, *hermes_args])
+    return cmd
+
+
+def _supervise_hermes(
+    hermes_bin: str,
+    hermes_args: list[str],
+    model: str,
+    port: int,
+) -> int:
+    """Run Hermes and return its exit code."""
+    try:
+        result = subprocess.run(
+            _hermes_command(hermes_bin, hermes_args, model),
+            env=_hermes_env(port),
+            check=False,
+        )
+        return result.returncode
+    except KeyboardInterrupt:
+        return _EXIT_SIGINT
+
+
+def _start_native_server(config: Path) -> NativeServer:
+    """Start the native server; kept separate for supervision tests."""
+    return NativeServer(config)
+
+
+def _run_hermes_with_switchyard(
+    config: Path,
+    display_model: str,
+    hermes_args: list[str],
+) -> int:
+    """Host a native deployment and run Hermes against it."""
+    hermes_bin = _find_hermes_binary()
+    if hermes_bin is None:
+        logger.error(
+            "hermes binary not found. Install it with "
+            "`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, "
+            "or place it on your PATH."
+        )
+        return _EXIT_BINARY_NOT_FOUND
+
+    silence_launch_loggers(local_logger=logger)
+    log_path = configure_debug_file_logging(display_model=display_model)
+    server = _start_native_server(config)
+    resolved_port = server.port
+    stats = server.stats
+    strategy_summary = f"config → {config.name}"
+
+    try:
+        if not _wait_ready(resolved_port):
+            print_startup_failure(
+                port=resolved_port,
+                timeout_s=_READY_TIMEOUT_S,
+                log_path=log_path,
+            )
+            return 1
+
+        logger.info("proxy ready on port %d", resolved_port)
+        print_ready_banner(
+            port=resolved_port,
+            display_model=display_model,
+            log_path=log_path,
+            strategy_summary=strategy_summary,
+            routes=[display_model],
+            default_route=display_model,
+        )
+        if stdin_is_tty():
+            banner_pause()
+
+        if stdin_is_tty():
+            footer = LiveStatsFooter(
+                stats,
+                display_model,
+                ProxyHealthMonitor(resolved_port),
+                strategy_label="config",
+            )
+            return ShellTUI(
+                command=_hermes_command(hermes_bin, hermes_args, display_model),
+                footer_fn=footer.as_footer_fn(),
+                footer_height=lambda: footer.height,
+                env=_hermes_env(resolved_port),
+            ).run()
+
+        return _supervise_hermes(
+            hermes_bin,
+            hermes_args,
+            display_model,
+            resolved_port,
+        )
+    finally:
+        print_session_summary(stats)
+        server.close()
+
+
+def launch_hermes_config(
+    config: Path,
+    model: str,
+    hermes_args: list[str],
+) -> int:
+    """Run Hermes against a native server TOML deployment."""
+    _quiet_launch_loggers()
+    return _run_hermes_with_switchyard(
+        config,
+        display_model=model,
+        hermes_args=hermes_args,
+    )
+
+
+def _quiet_launch_loggers() -> None:
+    """Keep dependency chatter out of Hermes' terminal UI."""
+    silence_launch_loggers(local_logger=logger)

--- a/switchyard/cli/launchers/hermes_launcher.py
+++ b/switchyard/cli/launchers/hermes_launcher.py
@@ -75,14 +75,18 @@ def _hermes_env(port: int) -> dict[str, str]:
 
 
 def _hermes_command(hermes_bin: str, hermes_args: list[str], model: str) -> list[str]:
-    """Build the Hermes command for the local proxy."""
-    # ``hermes chat`` is the interactive surface; ``hermes -q <prompt>`` is
-    # non-interactive. Preserve forwarded flags either way.
-    cmd = [hermes_bin, "chat"]
-    if hermes_args and hermes_args[0] in ("-q", "--query"):
-        cmd = [hermes_bin]
-    cmd.extend(["--provider", "custom", "-m", model, *hermes_args])
-    return cmd
+    """Build the Hermes command for the local proxy.
+
+    ``--provider custom -m <model>`` are global Hermes flags, so they always
+    lead. Forwarded arguments are Hermes' own command — an explicit subcommand
+    (``chat -q ...``, one-shot ``-z ...``, ``resume``, ...) plus any flags —
+    passed through verbatim. With nothing forwarded, default to the interactive
+    ``chat`` surface.
+    """
+    routing = ["--provider", "custom", "-m", model]
+    if not hermes_args:
+        return [hermes_bin, "chat", *routing]
+    return [hermes_bin, *routing, *hermes_args]
 
 
 def _supervise_hermes(

--- a/switchyard/cli/launchers/openclaw_launcher.py
+++ b/switchyard/cli/launchers/openclaw_launcher.py
@@ -152,8 +152,15 @@ def _openclaw_env(workspace: str) -> dict[str, str]:
 
 
 def _openclaw_command(openclaw_bin: str, openclaw_args: list[str]) -> list[str]:
-    """Build the OpenClaw interactive command."""
-    return [openclaw_bin, "chat", *openclaw_args]
+    """Build the OpenClaw command.
+
+    The model is selected through the transient config, so the user's own
+    command (``run``, ``chat``, ``config``, ...) and flags are passed through
+    verbatim. With nothing forwarded, default to interactive ``chat``.
+    """
+    if openclaw_args:
+        return [openclaw_bin, *openclaw_args]
+    return [openclaw_bin, "chat"]
 
 
 def _supervise_openclaw(

--- a/switchyard/cli/launchers/opencode_launcher.py
+++ b/switchyard/cli/launchers/opencode_launcher.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run OpenCode through an in-process native Switchyard server.
+
+OpenCode reads an ``opencode.json`` config from ``OPENCODE_CONFIG_DIR``. The
+launcher writes a transient config that declares a custom provider
+(``@ai-sdk/openai-compatible``) whose base URL points at the local Switchyard
+proxy, exposes the selected route as that provider's ``switchyard/<route>``
+model, then launches OpenCode against it. The workspace is cleaned up on
+success, error, and interruption.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TypeAlias
+
+from switchyard.cli.launchers.launcher_runtime import (
+    banner_pause,
+    configure_debug_file_logging,
+    print_ready_banner,
+    print_startup_failure,
+    silence_launch_loggers,
+    stdin_is_tty,
+    wait_for_proxy_ready,
+)
+from switchyard.cli.launchers.live_stats_footer import LiveStatsFooter
+from switchyard.cli.launchers.native_server import NativeServer
+from switchyard.cli.launchers.proxy_health_monitor import ProxyHealthMonitor
+from switchyard.cli.launchers.session_summary import print_session_summary
+from switchyard.cli.launchers.shell_tui import ShellTUI
+
+logger = logging.getLogger(__name__)
+
+_READY_TIMEOUT_S = 10.0
+_EXIT_BINARY_NOT_FOUND = 127
+_EXIT_SIGINT = 130
+_PROVIDER_ID = "switchyard"
+_API_KEY_PLACEHOLDER = "switchyard"
+
+OpenCodeModelCatalogEntry: TypeAlias = tuple[str, str, str]
+
+
+def _find_opencode_binary() -> str | None:
+    """Locate the ``opencode`` executable."""
+    path_hit = shutil.which("opencode")
+    if path_hit:
+        return path_hit
+    for candidate in (
+        Path.home() / ".opencode" / "bin" / "opencode",
+        Path.home() / ".npm-global" / "bin" / "opencode",
+        Path.home() / ".local" / "bin" / "opencode",
+    ):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def _wait_ready(port: int, timeout_s: float = _READY_TIMEOUT_S) -> bool:
+    """Probe ``GET /health`` until HTTP 200 or timeout."""
+    return wait_for_proxy_ready(port, timeout_s=timeout_s)
+
+
+def _qualified_model_id(model_id: str) -> str:
+    """Return the provider-qualified model ID used by OpenCode."""
+    return f"{_PROVIDER_ID}/{model_id.lstrip('/')}"
+
+
+def _opencode_model_display_name(model_id: str) -> str:
+    """Return a short display name for a model ID."""
+    return model_id.rsplit("/", maxsplit=1)[-1]
+
+
+def _build_opencode_config(
+    port: int,
+    entries: Sequence[OpenCodeModelCatalogEntry],
+    primary_model_id: str,
+) -> dict[str, object]:
+    """Build the transient OpenCode configuration pointing at the proxy."""
+    model_defs: dict[str, dict[str, str]] = {}
+    for model_id, display_name, _description in entries:
+        model_defs[model_id] = {"name": display_name, "id": model_id}
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+            _PROVIDER_ID: {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Switchyard",
+                "options": {
+                    "baseURL": f"http://127.0.0.1:{port}/v1",
+                    "apiKey": _API_KEY_PLACEHOLDER,
+                },
+                "models": model_defs,
+            }
+        },
+        "model": primary_model_id,
+    }
+
+
+def _write_opencode_workspace(
+    port: int,
+    entries: Sequence[OpenCodeModelCatalogEntry],
+    primary_model_id: str,
+) -> tuple[str, Path]:
+    """Write a transient OpenCode workspace and return ``(dir, config_path)``."""
+    workspace = tempfile.mkdtemp(prefix="switchyard-opencode-")
+    config_path = Path(workspace) / "opencode.json"
+    with config_path.open("w", encoding="utf-8") as handle:
+        json.dump(
+            _build_opencode_config(port, entries, primary_model_id),
+            handle,
+            indent=2,
+        )
+        handle.write("\n")
+    return workspace, config_path
+
+
+def _remove_opencode_workspace(workspace: str | None) -> None:
+    """Remove a transient OpenCode workspace."""
+    if workspace is not None:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _opencode_env(workspace: str) -> dict[str, str]:
+    """Return the environment that selects the transient config directory."""
+    env = os.environ.copy()
+    env["OPENCODE_CONFIG_DIR"] = workspace
+    env["OPENCODE_DISABLE_AUTOUPDATE"] = "1"
+    return env
+
+
+def _opencode_command(
+    opencode_bin: str,
+    opencode_args: list[str],
+    model_id: str,
+) -> list[str]:
+    """Build the OpenCode command for the local proxy."""
+    # ``run`` is non-interactive; without it OpenCode starts the TUI.
+    if opencode_args and opencode_args[0] == "run":
+        return [opencode_bin, "run", "-m", model_id, *opencode_args[1:]]
+    return [opencode_bin, "-m", model_id, *opencode_args]
+
+
+def _supervise_opencode(
+    opencode_bin: str,
+    opencode_args: list[str],
+    model_id: str,
+    workspace: str,
+) -> int:
+    """Run OpenCode and return its exit code."""
+    try:
+        result = subprocess.run(
+            _opencode_command(opencode_bin, opencode_args, model_id),
+            env=_opencode_env(workspace),
+            check=False,
+        )
+        return result.returncode
+    except KeyboardInterrupt:
+        return _EXIT_SIGINT
+
+
+def _start_native_server(config: Path) -> NativeServer:
+    """Start the native server; kept separate for supervision tests."""
+    return NativeServer(config)
+
+
+def _run_opencode_with_switchyard(
+    config: Path,
+    display_model: str,
+    opencode_args: list[str],
+    catalog_entries: Sequence[OpenCodeModelCatalogEntry],
+) -> int:
+    """Host a native deployment and run OpenCode against it."""
+    opencode_bin = _find_opencode_binary()
+    if opencode_bin is None:
+        logger.error(
+            "opencode binary not found. Install it with "
+            "`npm install -g opencode-ai@latest`, or place it on your PATH."
+        )
+        return _EXIT_BINARY_NOT_FOUND
+
+    silence_launch_loggers(local_logger=logger)
+    log_path = configure_debug_file_logging(display_model=display_model)
+    server = _start_native_server(config)
+    resolved_port = server.port
+    stats = server.stats
+    workspace_dir: str | None = None
+    strategy_summary = f"config → {config.name}"
+
+    try:
+        workspace_dir, _workspace_config = _write_opencode_workspace(
+            port=resolved_port,
+            entries=catalog_entries,
+            primary_model_id=_qualified_model_id(display_model),
+        )
+        if not _wait_ready(resolved_port):
+            print_startup_failure(
+                port=resolved_port,
+                timeout_s=_READY_TIMEOUT_S,
+                log_path=log_path,
+            )
+            return 1
+
+        logger.info("proxy ready on port %d", resolved_port)
+        print_ready_banner(
+            port=resolved_port,
+            display_model=display_model,
+            log_path=log_path,
+            strategy_summary=strategy_summary,
+            routes=[display_model],
+            default_route=display_model,
+        )
+        if stdin_is_tty():
+            banner_pause()
+
+        if stdin_is_tty():
+            footer = LiveStatsFooter(
+                stats,
+                display_model,
+                ProxyHealthMonitor(resolved_port),
+                strategy_label="config",
+            )
+            model_id = _qualified_model_id(display_model)
+            return ShellTUI(
+                command=_opencode_command(opencode_bin, opencode_args, model_id),
+                footer_fn=footer.as_footer_fn(),
+                footer_height=lambda: footer.height,
+                env=_opencode_env(workspace_dir),
+            ).run()
+
+        return _supervise_opencode(
+            opencode_bin,
+            opencode_args,
+            _qualified_model_id(display_model),
+            workspace_dir,
+        )
+    finally:
+        print_session_summary(stats)
+        server.close()
+        _remove_opencode_workspace(workspace_dir)
+
+
+def launch_opencode_config(
+    config: Path,
+    model: str,
+    opencode_args: list[str],
+) -> int:
+    """Run OpenCode against a native server TOML deployment."""
+    catalog = [
+        (
+            model,
+            f"{_opencode_model_display_name(model)} (Switchyard)",
+            f"Route from {config.name}.",
+        )
+    ]
+    return _run_opencode_with_switchyard(
+        config,
+        display_model=model,
+        opencode_args=opencode_args,
+        catalog_entries=catalog,
+    )

--- a/switchyard/cli/launchers/opencode_launcher.py
+++ b/switchyard/cli/launchers/opencode_launcher.py
@@ -138,25 +138,28 @@ def _opencode_env(workspace: str) -> dict[str, str]:
 def _opencode_command(
     opencode_bin: str,
     opencode_args: list[str],
-    model_id: str,
 ) -> list[str]:
-    """Build the OpenCode command for the local proxy."""
-    # ``run`` is non-interactive; without it OpenCode starts the TUI.
-    if opencode_args and opencode_args[0] == "run":
-        return [opencode_bin, "run", "-m", model_id, *opencode_args[1:]]
-    return [opencode_bin, "-m", model_id, *opencode_args]
+    """Build the OpenCode command for the local proxy.
+
+    OpenCode selects the model through the transient config's ``model`` field
+    (already set to the qualified Switchyard route), so the CLI needs no model
+    flag — injecting ``-m`` breaks subcommands that reject it (``serve``,
+    ``debug``, ``models``, ...). Forwarded arguments are OpenCode's own command
+    plus any flags, passed through verbatim; with nothing forwarded OpenCode
+    starts its interactive TUI.
+    """
+    return [opencode_bin, *opencode_args]
 
 
 def _supervise_opencode(
     opencode_bin: str,
     opencode_args: list[str],
-    model_id: str,
     workspace: str,
 ) -> int:
     """Run OpenCode and return its exit code."""
     try:
         result = subprocess.run(
-            _opencode_command(opencode_bin, opencode_args, model_id),
+            _opencode_command(opencode_bin, opencode_args),
             env=_opencode_env(workspace),
             check=False,
         )
@@ -226,9 +229,8 @@ def _run_opencode_with_switchyard(
                 ProxyHealthMonitor(resolved_port),
                 strategy_label="config",
             )
-            model_id = _qualified_model_id(display_model)
             return ShellTUI(
-                command=_opencode_command(opencode_bin, opencode_args, model_id),
+                command=_opencode_command(opencode_bin, opencode_args),
                 footer_fn=footer.as_footer_fn(),
                 footer_height=lambda: footer.height,
                 env=_opencode_env(workspace_dir),
@@ -237,7 +239,6 @@ def _run_opencode_with_switchyard(
         return _supervise_opencode(
             opencode_bin,
             opencode_args,
-            _qualified_model_id(display_model),
             workspace_dir,
         )
     finally:

--- a/switchyard/cli/switchyard_cli.py
+++ b/switchyard/cli/switchyard_cli.py
@@ -10,7 +10,9 @@ from switchyard import __version__
 from switchyard.cli.launch_command import (
     cmd_launch_claude,
     cmd_launch_codex,
+    cmd_launch_hermes,
     cmd_launch_openclaw,
+    cmd_launch_opencode,
 )
 
 
@@ -26,6 +28,8 @@ def _add_launch_parser(
         ("claude", "Launch Claude Code", "claude_args", cmd_launch_claude),
         ("codex", "Launch Codex CLI", "codex_args", cmd_launch_codex),
         ("openclaw", "Launch OpenClaw", "openclaw_args", cmd_launch_openclaw),
+        ("opencode", "Launch OpenCode", "opencode_args", cmd_launch_opencode),
+        ("hermes", "Launch Hermes", "hermes_args", cmd_launch_hermes),
     )
     for name, help_text, args_dest, command in launcher_parsers:
         agent = launch_sub.add_parser(name, help=help_text)

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -11,6 +11,7 @@ import pytest
 from switchyard.cli.launch_command import _config_path
 from switchyard.cli.launchers.claude_code_launcher import _claude_env
 from switchyard.cli.launchers.native_server import NativeServer
+from switchyard.cli.launchers.openclaw_launcher import _openclaw_command
 from switchyard.cli.switchyard_cli import _build_parser
 
 
@@ -58,6 +59,18 @@ def test_claude_env_preserves_small_fast_model_override(
 
     assert env["ANTHROPIC_MODEL"] == "agent-route"
     assert env["ANTHROPIC_SMALL_FAST_MODEL"] == "background-route"
+
+
+def test_openclaw_command_defaults_to_interactive_chat() -> None:
+    assert _openclaw_command("/usr/bin/openclaw", []) == ["/usr/bin/openclaw", "chat"]
+
+
+def test_openclaw_command_forwards_agent_command() -> None:
+    assert _openclaw_command("/usr/bin/openclaw", ["run", "do the thing"]) == [
+        "/usr/bin/openclaw",
+        "run",
+        "do the thing",
+    ]
 
 
 def test_native_server_passes_config_directly_to_binding(

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -16,9 +16,7 @@ from switchyard.cli.switchyard_cli import _build_parser
 
 def _subparsers(parser: argparse.ArgumentParser) -> dict[str, argparse.ArgumentParser]:
     action = next(
-        action
-        for action in parser._actions
-        if isinstance(action, argparse._SubParsersAction)
+        action for action in parser._actions if isinstance(action, argparse._SubParsersAction)
     )
     return action.choices  # type: ignore[return-value]
 
@@ -27,7 +25,7 @@ def test_cli_exposes_only_launch() -> None:
     assert set(_subparsers(_build_parser())) == {"launch"}
 
 
-@pytest.mark.parametrize("agent", ["claude", "codex", "openclaw"])
+@pytest.mark.parametrize("agent", ["claude", "codex", "openclaw", "opencode", "hermes"])
 def test_launcher_surface_is_model_config_and_forwarded_args(agent: str) -> None:
     launch = _subparsers(_build_parser())["launch"]
     parser = _subparsers(launch)[agent]

--- a/tests/test_launchers_hermes_opencode.py
+++ b/tests/test_launchers_hermes_opencode.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the Hermes and OpenCode launchers."""
+
+import json
+
+from switchyard.cli.launchers.hermes_launcher import (
+    _hermes_command,
+    _hermes_env,
+)
+from switchyard.cli.launchers.opencode_launcher import (
+    _build_opencode_config,
+    _opencode_command,
+    _opencode_env,
+    _qualified_model_id,
+)
+
+
+def test_hermes_env_points_proxy_and_placeholder_key() -> None:
+    env = _hermes_env(4321)
+    assert env["OPENROUTER_BASE_URL"] == "http://127.0.0.1:4321/v1"
+    assert env["OPENROUTER_API_KEY"] == "switchyard"
+
+
+def test_hermes_command_defaults_to_interactive_chat(monkeypatch) -> None:
+    cmd = _hermes_command("/usr/bin/hermes", [], "my-route")
+    assert cmd == [
+        "/usr/bin/hermes",
+        "chat",
+        "--provider",
+        "custom",
+        "-m",
+        "my-route",
+    ]
+
+
+def test_hermes_command_keeps_forwarded_args(monkeypatch) -> None:
+    cmd = _hermes_command(
+        "/usr/bin/hermes",
+        ["--reasoning", "high", "-p", "build"],
+        "my-route",
+    )
+    # Model selector leads; forwarded flags are preserved verbatim afterward.
+    assert cmd[:6] == [
+        "/usr/bin/hermes",
+        "chat",
+        "--provider",
+        "custom",
+        "-m",
+        "my-route",
+    ]
+    assert cmd[6:] == ["--reasoning", "high", "-p", "build"]
+
+
+def test_opencode_qualified_model_id() -> None:
+    assert _qualified_model_id("switchyard") == "switchyard/switchyard"
+    assert _qualified_model_id("/route") == "switchyard/route"
+
+
+def test_opencode_config_points_proxy_and_primary_model() -> None:
+    entries = [("switchyard", "Switchyard (Switchyard)", "desc")]
+    cfg = json.loads(json.dumps(_build_opencode_config(4321, entries, "switchyard/switchyard")))
+    provider = cfg["provider"]["switchyard"]
+    assert provider["npm"] == "@ai-sdk/openai-compatible"
+    assert provider["options"]["baseURL"] == "http://127.0.0.1:4321/v1"
+    assert provider["options"]["apiKey"] == "switchyard"
+    assert "switchyard" in provider["models"]
+    assert cfg["model"] == "switchyard/switchyard"
+
+
+def test_opencode_config_serializes_to_valid_json(tmp_path, monkeypatch) -> None:
+    entries = [("switchyard", "Switchyard", "desc")]
+    cfg = _build_opencode_config(1234, entries, "switchyard/switchyard")
+    payload = json.dumps(cfg)
+    parsed = json.loads(payload)
+    assert parsed["provider"]["switchyard"]["options"]["apiKey"] == "switchyard"
+
+
+def test_opencode_env_selects_config_dir() -> None:
+    env = _opencode_env("/tmp/switchyard-opencode-abc")
+    assert env["OPENCODE_CONFIG_DIR"] == "/tmp/switchyard-opencode-abc"
+
+
+def test_opencode_command_run_injects_model(monkeypatch) -> None:
+    # ``run`` is non-interactive; the model goes after ``-m``.
+    cmd = _opencode_command("/usr/bin/opencode", ["run", "--auto", "fix"], "switchyard/r")
+    assert cmd[:3] == ["/usr/bin/opencode", "run", "-m"]
+    assert "switchyard/r" in cmd
+    # ``--auto`` and the message are preserved in order.
+    assert cmd[cmd.index("switchyard/r") + 1 :] == ["--auto", "fix"]
+
+
+def test_opencode_command_defaults_to_tui(monkeypatch) -> None:
+    cmd = _opencode_command("/usr/bin/opencode", [], "switchyard/r")
+    assert cmd == ["/usr/bin/opencode", "-m", "switchyard/r"]

--- a/tests/test_launchers_hermes_opencode.py
+++ b/tests/test_launchers_hermes_opencode.py
@@ -38,19 +38,40 @@ def test_hermes_command_defaults_to_interactive_chat(monkeypatch) -> None:
 def test_hermes_command_keeps_forwarded_args(monkeypatch) -> None:
     cmd = _hermes_command(
         "/usr/bin/hermes",
-        ["--reasoning", "high", "-p", "build"],
+        ["-z", "summarize this", "--reasoning", "high"],
         "my-route",
     )
-    # Model selector leads; forwarded flags are preserved verbatim afterward.
-    assert cmd[:6] == [
+    # Routing flags lead; Hermes' own command + flags follow verbatim.
+    assert cmd == [
         "/usr/bin/hermes",
-        "chat",
         "--provider",
         "custom",
         "-m",
         "my-route",
+        "-z",
+        "summarize this",
+        "--reasoning",
+        "high",
     ]
-    assert cmd[6:] == ["--reasoning", "high", "-p", "build"]
+
+
+def test_hermes_command_forwards_explicit_subcommand(monkeypatch) -> None:
+    cmd = _hermes_command(
+        "/usr/bin/hermes",
+        ["chat", "-q", "hi", "-Q"],
+        "my-route",
+    )
+    assert cmd == [
+        "/usr/bin/hermes",
+        "--provider",
+        "custom",
+        "-m",
+        "my-route",
+        "chat",
+        "-q",
+        "hi",
+        "-Q",
+    ]
 
 
 def test_opencode_qualified_model_id() -> None:
@@ -82,15 +103,19 @@ def test_opencode_env_selects_config_dir() -> None:
     assert env["OPENCODE_CONFIG_DIR"] == "/tmp/switchyard-opencode-abc"
 
 
-def test_opencode_command_run_injects_model(monkeypatch) -> None:
-    # ``run`` is non-interactive; the model goes after ``-m``.
-    cmd = _opencode_command("/usr/bin/opencode", ["run", "--auto", "fix"], "switchyard/r")
-    assert cmd[:3] == ["/usr/bin/opencode", "run", "-m"]
-    assert "switchyard/r" in cmd
-    # ``--auto`` and the message are preserved in order.
-    assert cmd[cmd.index("switchyard/r") + 1 :] == ["--auto", "fix"]
+def test_opencode_command_forwards_run_verbatim(monkeypatch) -> None:
+    # Model is selected via the transient config, so the CLI carries no model
+    # flag; ``run`` + its own args are forwarded verbatim.
+    cmd = _opencode_command("/usr/bin/opencode", ["run", "--auto", "fix"])
+    assert cmd == ["/usr/bin/opencode", "run", "--auto", "fix"]
+
+
+def test_opencode_command_forwards_arbitrary_subcommand(monkeypatch) -> None:
+    # ``serve`` rejects ``-m``; forwarding the command verbatim keeps it valid.
+    cmd = _opencode_command("/usr/bin/opencode", ["serve", "--port", "4096"])
+    assert cmd == ["/usr/bin/opencode", "serve", "--port", "4096"]
 
 
 def test_opencode_command_defaults_to_tui(monkeypatch) -> None:
-    cmd = _opencode_command("/usr/bin/opencode", [], "switchyard/r")
-    assert cmd == ["/usr/bin/opencode", "-m", "switchyard/r"]
+    cmd = _opencode_command("/usr/bin/opencode", [])
+    assert cmd == ["/usr/bin/opencode"]


### PR DESCRIPTION
> Baseline: `origin/main` @ `053a61e` (post-`#501`). The proxy is now the standalone Rust binary `switchyard-server`; agents reach it over the wire by pointing their base-URL / model env at it.

## Problem

Every agent is currently wired to the server by hand. The operator must know each agent's base-URL and model environment variables or manually write per-agent configuration files (e.g., OpenCode, OpenClaw). This manual setup introduces several issues:

* Configuration errors and drift (missing `/v1` path segments, invalid model IDs, missing options like `ANTHROPIC_CUSTOM_MODEL_OPTION`).
* Cross-platform platform variances (POSIX `exec` vs. Windows process spawning, `PATHEXT` script/binary resolution).
* Resource leaks from leftover temporary configuration files when config-file-based agents terminate or encounter signal interrupts.

## Proposed solution

A cross-platform native Rust subcommand (`switchyard agent run`) that parses declarative agent specifications, renders environment variables and temporary configurations, and transparently manages agent execution.

1. **Agent spec (JSON / YAML / TOML)**
* `binary`: Executable name or path (resolved across platforms via `$PATH`).
* `env`: Environment variable map supporting `{base_url}`, `{base_url_v1}`, and `{model}` placeholders.
* `config_template` / `config_filename`: Optional temporary configuration rendering for config-file agents.
* Built-in specs shipped for standard agents (Claude Code, Codex, OpenClaw, OpenCode, Hermes, generic OpenAI/Anthropic SDKs).


2. **Cross-platform execution & lifecycle management**
* **Unix (Linux / macOS):** Uses `std::os::unix::process::CommandExt::exec` to replace the process image without overhead.
* **Windows:** Spawns a child process using `Command::spawn`, inherits standard I/O (`Stdio::inherit()`), and forwards child exit codes upon completion.
* **Binary resolution:** Uses OS-agnostic resolution handling executable extensions on Windows (`PATHEXT` for `.exe`, `.cmd`, `.bat`).
* **RAII cleanup:** Implements RAII wrappers combined with signal handlers (`SIGINT`, `SIGTERM`, `Ctrl+C`) to ensure temporary configuration files are purged on exit.



### User-facing example

```bash
# 1) Start the server
switchyard-server --config routes.toml --port 4000 &

# 2) Run any agent via a single command across Linux, macOS, or Windows
switchyard agent run --agent claude --server http://127.0.0.1:4000 --route switchyard/classified
switchyard agent run --agent ./custom-agent.json --server http://127.0.0.1:4000 --route switchyard/general

```

Custom-agent spec (`custom-agent.json`):

```json
{
  "name": "mybot",
  "binary": "mybot",
  "env": {
    "MYBOT_BASE_URL": "{base_url_v1}",
    "MYBOT_MODEL": "{model}"
  },
  "interactive_default": ["chat"]
}

```

## Verification

* **Cross-platform execution:** Verify target agents correctly resolve base URLs and reach `GET /v1/models` on Linux, macOS, and Windows.
* **Cleanup verification:** Confirm temporary config files are removed upon standard exit as well as process interrupts (`SIGINT` / `Ctrl+C`).
* **CI:** Clean `cargo check`, `cargo test`, and multi-target compilation checks.