### PR TITLE
docs(agents): fix broken Rust bullet and stale crate list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,8 @@ crates/protocol/                    # provider-neutral protocol types
 crates/switchyard-server/           # native HTTP server and TOML config
 crates/switchyard-translation/      # wire-format codecs
 crates/switchyard-py/               # libsy and server PyO3 bindings
+crates/switchyard-skill-distillation/  # skill-distillation records and port traits
+crates/switchyard-soak/             # release-candidate soak tester
 
 tests/                              # Unit tests (pytest)
 ```
@@ -236,8 +238,8 @@ cargo test --workspace
 - **Type hints**: throughout. `py.typed` marker present; mypy runs strict.
 - **Async**: async-only. If you need sync, use `asyncio.run()`.
 - **Testing**: `respx` for HTTP mocking, `pytest-mock` for general mocking. `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` needed.
-- **Rust**: Panicking calls such as `panic!()`, `unwrap()` and `.except()` are not allowed in production source code. Propagate errors with `?`. They are allowed in tests.
-  return typed errors, or match explicitly in tests so failures stay intentional and visible.
+- **Rust**: Panicking calls such as `panic!()`, `unwrap()`, and `.expect()` are not allowed in production source code (they are allowed in tests).
+  Propagate errors with `?` — return typed errors, or match explicitly in tests so failures stay intentional and visible.
 - **Comments**: For Rust changes, add concise comments for module/file intent, public structs/enums,
   public methods, private helpers with non-obvious behavior, and tests that encode important
   behavior. Prefer one-line comments when enough. Add block comments before complex validation,


### PR DESCRIPTION
## Summary
- Fix a broken/orphaned sentence in `AGENTS.md`: the Rust style bullet had a dangling second line ("return typed errors, or match explicitly…") with no subject. Merged it into the preceding sentence and corrected `.except()` → `.expect()`.
- Update the **Project Structure** block to list the `switchyard-skill-distillation` and `switchyard-soak` crates that exist in the workspace but were missing from the diagram.

## Verification
- `git diff` shows 4 insertions, 2 deletions in `AGENTS.md` only.
- Cross-checked crate list against `origin/main` `Cargo.toml` workspace members and the actual `crates/` tree.

## Test plan
- [x] Confirmed no other doc/code mismatches on `origin/main` (spell-check + manual read-through of all 44 markdown docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for two new project capabilities.
  * Clarified Rust error-handling conventions, including appropriate use of `.expect()` and error propagation with `?`.
  * Specified that panicking calls are permitted only in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->