### PR TITLE
fix: encode Responses image and file inputs as wire shapes, not IR enums

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -1067,7 +1067,7 @@ fn openai_text_part(text: &str) -> Value {
 }
 
 // Maps IR image sources to OpenAI Chat image content parts when possible.
-fn openai_image_part(source: &ImageSource) -> Option<Value> {
+pub(crate) fn openai_image_part(source: &ImageSource) -> Option<Value> {
     match source {
         ImageSource::Url { url, detail } => {
             let mut image_url = json!({"url": url});
@@ -1119,7 +1119,7 @@ fn openai_raw_image_part(raw: &Value) -> Option<Value> {
 }
 
 // Converts image sources to deterministic text fallback content.
-fn image_source_text(source: &ImageSource) -> String {
+pub(crate) fn image_source_text(source: &ImageSource) -> String {
     match source {
         ImageSource::Url { url, detail } => json_string(&json!({
             "url": url,
@@ -1134,7 +1134,7 @@ fn image_source_text(source: &ImageSource) -> String {
 }
 
 // Maps IR file sources to OpenAI Chat file content parts when possible.
-fn openai_file_part(source: &FileSource) -> Option<Value> {
+pub(crate) fn openai_file_part(source: &FileSource) -> Option<Value> {
     match source {
         FileSource::FileId(file_id) => Some(json!({"type": "file", "file": {"file_id": file_id}})),
         FileSource::FileData { data, filename } => {
@@ -1167,7 +1167,7 @@ fn openai_raw_file_part(raw: &Value) -> Option<Value> {
 }
 
 // Converts file sources to deterministic text fallback content.
-fn file_source_text(source: &FileSource) -> String {
+pub(crate) fn file_source_text(source: &FileSource) -> String {
     match source {
         FileSource::FileId(file_id) => json_string(&json!({"file_id": file_id})),
         FileSource::FileData { data, filename } => json_string(&json!({

--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -1066,7 +1066,11 @@ fn openai_text_part(text: &str) -> Value {
     json!({"type": "text", "text": text})
 }
 
-// Maps IR image sources to OpenAI Chat image content parts when possible.
+/// Maps an IR image source to an OpenAI Chat `image_url` content part.
+///
+/// Returns `None` when the source cannot be mapped, such as a `Base64` image
+/// with no `media_type` or a `Raw` value that does not match a recognized
+/// shape; callers fall back to [`image_source_text`] in that case.
 pub(crate) fn openai_image_part(source: &ImageSource) -> Option<Value> {
     match source {
         ImageSource::Url { url, detail } => {
@@ -1118,7 +1122,10 @@ fn openai_raw_image_part(raw: &Value) -> Option<Value> {
     }))
 }
 
-// Converts image sources to deterministic text fallback content.
+/// Converts an image source to a deterministic JSON text fallback.
+///
+/// Used when [`openai_image_part`] cannot map the source to a native
+/// content part, so the image data is still preserved as readable text.
 pub(crate) fn image_source_text(source: &ImageSource) -> String {
     match source {
         ImageSource::Url { url, detail } => json_string(&json!({
@@ -1133,7 +1140,11 @@ pub(crate) fn image_source_text(source: &ImageSource) -> String {
     }
 }
 
-// Maps IR file sources to OpenAI Chat file content parts when possible.
+/// Maps an IR file source to an OpenAI Chat `file` content part.
+///
+/// Returns `None` when the source cannot be mapped, such as a `Raw` value
+/// that is not a base64 Anthropic document; callers fall back to
+/// [`file_source_text`] in that case.
 pub(crate) fn openai_file_part(source: &FileSource) -> Option<Value> {
     match source {
         FileSource::FileId(file_id) => Some(json!({"type": "file", "file": {"file_id": file_id}})),
@@ -1166,7 +1177,10 @@ fn openai_raw_file_part(raw: &Value) -> Option<Value> {
     Some(json!({"type": "file", "file": file}))
 }
 
-// Converts file sources to deterministic text fallback content.
+/// Converts a file source to a deterministic JSON text fallback.
+///
+/// Used when [`openai_file_part`] cannot map the source to a native
+/// content part, so the file data is still preserved as readable text.
 pub(crate) fn file_source_text(source: &FileSource) -> String {
     match source {
         FileSource::FileId(file_id) => json_string(&json!({"file_id": file_id})),

--- a/crates/switchyard-translation/src/codecs/openai_chat/mod.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/mod.rs
@@ -9,4 +9,7 @@ mod stream;
 pub use buffered::OpenAiChatCodec;
 pub use stream::OpenAiChatStreamCodec;
 
-pub(crate) use buffered::{decode_file_source, decode_image_source};
+pub(crate) use buffered::{
+    decode_file_source, decode_image_source, file_source_text, image_source_text, openai_file_part,
+    openai_image_part,
+};

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -11,7 +11,10 @@ use crate::codecs::common::{
     collect_responses_reasoning_text, encrypted_reasoning_data, encrypted_reasoning_item_id,
     is_known_role_name, provider_extensions, reasoning_text_from_blocks, text_from_blocks,
 };
-use crate::codecs::openai_chat::{decode_file_source, decode_image_source};
+use crate::codecs::openai_chat::{
+    decode_file_source, decode_image_source, file_source_text, image_source_text, openai_file_part,
+    openai_image_part,
+};
 use crate::codecs::{
     DecodedRequest, DecodedResponse, EncodedRequest, EncodedResponse, FormatCodec,
 };
@@ -19,9 +22,9 @@ use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::llm::{
-    AggLlmResponse, ContentBlock, InstructionBlock, LlmRequest, MediaSource, Message, OutputParams,
-    ProviderExtensions, ReasoningParams, ResponseOutput, Role, SamplingParams, StopReason,
-    ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
+    AggLlmResponse, ContentBlock, FileSource, ImageSource, InstructionBlock, LlmRequest,
+    MediaSource, Message, OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput,
+    Role, SamplingParams, StopReason, ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
 };
 use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
 use crate::util::{
@@ -1407,9 +1410,17 @@ fn encode_responses_content(
             ContentBlock::Refusal { text } => {
                 blocks.push(json!({"type": "refusal", "refusal": text}));
             }
-            ContentBlock::Image { source } => {
-                blocks.push(json!({"type": "input_image", "image_url": source}));
-            }
+            ContentBlock::Image { source } => match responses_image_part(source) {
+                Some(part) => blocks.push(part),
+                None => {
+                    push_lossy(
+                        diagnostics,
+                        policy,
+                        "Responses codec could not map image content",
+                    )?;
+                    blocks.push(json!({"type": "input_text", "text": image_source_text(source)}));
+                }
+            },
             ContentBlock::Audio { source } => blocks.push(match source {
                 MediaSource::Raw(raw) => json!({"type": "input_text", "text": json_string(raw)}),
                 MediaSource::Url { url, media_type } => json!({
@@ -1434,9 +1445,17 @@ fn encode_responses_content(
                     "video": {"media_type": media_type, "data": data},
                 }),
             }),
-            ContentBlock::File { source } => {
-                blocks.push(json!({"type": "input_file", "file": source}));
-            }
+            ContentBlock::File { source } => match responses_file_part(source) {
+                Some(part) => blocks.push(part),
+                None => {
+                    push_lossy(
+                        diagnostics,
+                        policy,
+                        "Responses codec could not map file content",
+                    )?;
+                    blocks.push(json!({"type": "input_text", "text": file_source_text(source)}));
+                }
+            },
             ContentBlock::Unknown { raw, .. } => {
                 push_lossy(
                     diagnostics,
@@ -1451,6 +1470,29 @@ fn encode_responses_content(
         }
     }
     Ok(Value::Array(blocks))
+}
+
+// Maps IR image sources to Responses input_image parts when possible.
+//
+// Responses `image_url` is a plain string, unlike the Chat object shape, so
+// this reuses the Chat mapping (URL, data URI, raw-shape recognition) and
+// lifts its fields into the flat Responses layout.
+fn responses_image_part(source: &ImageSource) -> Option<Value> {
+    let chat_part = openai_image_part(source)?;
+    let image_url = chat_part.get("image_url")?;
+    let url = image_url.get("url")?.as_str()?;
+    let mut part = json!({"type": "input_image", "image_url": url});
+    if let Some(detail) = image_url.get("detail") {
+        part["detail"] = detail.clone();
+    }
+    Some(part)
+}
+
+// Maps IR file sources to Responses input_file parts when possible.
+fn responses_file_part(source: &FileSource) -> Option<Value> {
+    let mut part = openai_file_part(source)?;
+    part["type"] = Value::String("input_file".to_string());
+    Some(part)
 }
 
 // Encodes normalized tool definitions into Responses tool JSON.

--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -23,8 +23,8 @@ use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::llm::{
     AggLlmResponse, ContentBlock, FileSource, ImageSource, InstructionBlock, LlmRequest,
-    MediaSource, Message, OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput,
-    Role, SamplingParams, StopReason, ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
+    MediaSource, Message, OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput, Role,
+    SamplingParams, StopReason, ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
 };
 use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
 use crate::util::{
@@ -1490,8 +1490,12 @@ fn responses_image_part(source: &ImageSource) -> Option<Value> {
 
 // Maps IR file sources to Responses input_file parts when possible.
 fn responses_file_part(source: &FileSource) -> Option<Value> {
-    let mut part = openai_file_part(source)?;
-    part["type"] = Value::String("input_file".to_string());
+    let chat_part = openai_file_part(source)?;
+    let file = chat_part.get("file")?.as_object()?;
+    let mut part = json!({"type": "input_file"});
+    for (key, value) in file {
+        part[key] = value.clone();
+    }
     Some(part)
 }
 

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -2884,3 +2884,103 @@ fn responses_parallel_custom_tool_calls_pair_with_their_outputs() -> TestResult 
     );
     Ok(())
 }
+
+// Verifies Chat image and file parts encode as wire-valid Responses input parts,
+// not serialized IR enums (image_url must be a string, files keyed under "file").
+#[test]
+fn openai_chat_image_and_file_parts_translate_to_valid_responses_input() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-4o",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe these."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.test/image.png", "detail": "high"}
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,aW1hZ2U="}
+                },
+                {"type": "file", "file": {"file_id": "file_123"}},
+                {
+                    "type": "file",
+                    "file": {"file_data": "ZG9jdW1lbnQ=", "filename": "report.pdf"}
+                }
+            ]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["input"][0]["content"],
+        json!([
+            {"type": "input_text", "text": "Describe these."},
+            {
+                "type": "input_image",
+                "image_url": "https://example.test/image.png",
+                "detail": "high"
+            },
+            {"type": "input_image", "image_url": "data:image/png;base64,aW1hZ2U="},
+            {"type": "input_file", "file_id": "file_123"},
+            {
+                "type": "input_file",
+                "file_data": "ZG9jdW1lbnQ=",
+                "filename": "report.pdf"
+            }
+        ])
+    );
+    Ok(())
+}
+
+// Verifies Anthropic base64 images become Responses data-URI image_url strings.
+#[test]
+fn anthropic_base64_image_translates_to_responses_data_uri() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is this?"},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "aW1hZ2U="
+                    }
+                }
+            ]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["input"][0]["content"],
+        json!([
+            {"type": "input_text", "text": "What is this?"},
+            {"type": "input_image", "image_url": "data:image/png;base64,aW1hZ2U="}
+        ])
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

Fix the OpenAI Responses request encoder so image and file content uses Responses wire shapes instead of serialized protocol enums.

- Image URLs stay strings, base64 images become data URLs, and detail is preserved.
- Files use the flat Responses fields: file_id, or file_data with an optional filename.
- Shared OpenAI media mapping lives in a private codec module. Chat and Responses still build their own outer wire shapes.
- Sources that cannot be mapped keep the existing lossy text fallback and diagnostic.

## Why

A Chat image routed to an OpenAI Responses backend was encoded with an object under image_url. The Responses API requires a string there and rejected the request with a 400. Files had the same underlying problem: the encoder serialized Switchyard protocol enums instead of the flat Responses wire format.

Same-format round trips usually replay the preserved request, so they did not expose this. Fresh Chat-to-Responses and Anthropic-to-Responses translations did.

## How tested

- Focused translation tests cover Chat image and file input, plus Anthropic base64 image and document input.
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p switchyard-translation
- cargo test --workspace
- Captured the full outbound request through switchyard-server with a local upstream and checked the flat image and file shapes.
- Sent buffered and streaming Chat image requests through switchyard-server to the live OpenAI Responses API. Both returned valid Chat responses.

## API impact

No public Rust or Python API changes. The observable change is limited to correcting invalid Responses request bodies.

## Checklist

- [x] Unit tests added for the bug fix.
- [x] Commits signed off for DCO.