### PR TITLE
docs(security): use standard NVIDIA policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,50 +1,31 @@
-# Security Policy
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
 
-## Reporting a vulnerability
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-We take security issues in Switchyard seriously. **Please do not file a public GitHub issue for security vulnerabilities.**
+http://www.apache.org/licenses/LICENSE-2.0
 
-To report a vulnerability, please email NVIDIA's Product Security Incident Response Team (PSIRT) at **psirt@nvidia.com**. NVIDIA PSIRT will acknowledge your report and coordinate any required fix and disclosure timeline.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 
-For details on NVIDIA's product security process, see <https://www.nvidia.com/en-us/security/>.
+# Report a Security Vulnerability
 
-When reporting, please include:
+To report a potential security vulnerability in any NVIDIA product, please use either:
+* This web form: [Security Vulnerability Submission Form](https://www.nvidia.com/en-us/support/submit-security-vulnerability/), or
+* Send email to: [NVIDIA PSIRT](mailto:psirt@nvidia.com)
 
-- A description of the vulnerability and its potential impact.
-- Steps to reproduce, ideally with a minimal example.
-- The version of Switchyard affected (commit SHA or release tag).
-- Any known mitigations or workarounds.
-- Whether you would like to be credited in the public disclosure.
+If reporting a potential vulnerability via email, please encrypt it using NVIDIA’s public PGP key ([see PGP Key page](https://www.nvidia.com/en-us/security/pgp-key/)) and include the following information:
+1. Product/Driver name and version/branch that contains the vulnerability
+2. Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
+3. Instructions to reproduce the vulnerability
+4. Proof-of-concept or exploit code
+5. Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
 
-## Supported versions
-
-Switchyard follows a rolling-release model on the `main` branch. Security fixes are landed on `main` and included in the next published release. Older release tags are not patched separately unless the issue is severe and the older version is still in broad use.
-
-| Version | Security fixes |
-| --- | --- |
-| Latest `main` and most recent release | Yes |
-| Older releases | Best-effort only |
-
-## Disclosure timeline
-
-NVIDIA PSIRT typically follows a coordinated-disclosure process:
-
-1. **Acknowledgement** — within 5 business days of report.
-2. **Triage and reproduction** — within 30 days.
-3. **Fix development and validation** — timeline depends on severity and complexity.
-4. **Public disclosure** — coordinated with the reporter; CVEs are filed where appropriate.
-
-We ask that reporters refrain from public disclosure until a fix is available and a disclosure date has been agreed.
-
-## Scope
-
-In scope for security reports:
-
-- Vulnerabilities in the Switchyard library or CLI that allow privilege escalation, credential leakage, denial of service against a Switchyard server, request smuggling, or unauthenticated access to protected endpoints.
-- Supply-chain issues in Switchyard's published artifacts.
-
-Out of scope:
-
-- Vulnerabilities in upstream LLM providers (OpenAI, Anthropic, etc.) — report to those providers directly.
-- Findings against your own private fork of Switchyard that are not present in `main`.
-- Theoretical issues without a demonstrated impact.
+See https://www.nvidia.com/en-us/security/ for past NVIDIA Security Bulletins and Notices.


### PR DESCRIPTION
## Why

The existing security policy publishes Switchyard-specific disclosure timelines that NVIDIA Product Security did not approve. [SWITCH-1320](https://linear.app/nvidia/issue/SWITCH-1320/replace-switchyard-securitymd-with-standard-nvidia-version) asks us to use the standard NVIDIA policy.

## What

Replace the repository-root `SECURITY.md` with the current policy from [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/blob/main/SECURITY.md).

This does not change product behavior or address NVBugs 6648053 or 6648081.

## How

Copied the approved policy verbatim, including its SPDX header, reporting channels, PGP guidance, and requested report fields.

## Where to Start Review

`SECURITY.md` is the only changed file.

## Test Plan

- Confirmed `SECURITY.md` matches the TensorRT-LLM source byte-for-byte.
- `git diff --check`
- `uv run ruff check .`
- `uv run pytest tests/ -v` — 115 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security reporting guidance with NVIDIA’s standard vulnerability submission process.
  * Added web and email reporting options, PGP encryption requirements, and requested report details.
  * Added links to NVIDIA security bulletins and removed previous policy-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->