### PR TITLE
feat(runner): expose safe route failure summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "strum_macros",
  "switchyard-libsy",
  "switchyard-llm-client",
  "switchyard-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ switchyard-protocol = { path = "crates/protocol", version = "0.2.0" }
 switchyard-runner = { path = "crates/switchyard-runner", version = "0.2.0" }
 switchyard-server = { path = "crates/switchyard-server", version = "0.2.0" }
 switchyard-translation = { path = "crates/switchyard-translation", version = "0.2.0" }
+strum_macros = "0.28"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes", "std"] }

--- a/crates/switchyard-runner/Cargo.toml
+++ b/crates/switchyard-runner/Cargo.toml
@@ -20,6 +20,7 @@ serde.workspace = true
 serde_json.workspace = true
 switchyard-llm-client.workspace = true
 switchyard-protocol.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 toml = "1.1"
 tracing.workspace = true

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Safe, structured summaries of route-execution failures for telemetry.
+
+use libsy::LibsyError;
+use switchyard_protocol::{LlmClientError, ModelId};
+
+use crate::RunnerError;
+
+/// Stable class of a terminal route-execution failure.
+///
+/// This deliberately carries no provider message, response body, or source
+/// error. It is suitable for logs and telemetry, not client-facing rendering.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RouteFailureCategory {
+    /// The upstream returned a non-success HTTP response.
+    UpstreamHttp,
+    /// The selected target rejected the request because its context window was exceeded.
+    ContextWindowExceeded,
+    /// The upstream request timed out.
+    Timeout,
+    /// The upstream could not be reached or the request could not be sent.
+    Transport,
+    /// The upstream response could not be decoded or validated.
+    InvalidResponse,
+    /// Decoding the inbound request failed in translation.
+    RequestTranslation,
+    /// Encoding the request for the upstream failed in translation.
+    RequestEncoding,
+    /// Decoding or encoding the response failed in translation.
+    ResponseTranslation,
+    /// The request cannot be served as supplied.
+    InvalidRequest,
+    /// The configured route or client cannot serve the request.
+    Configuration,
+    /// The routing algorithm or driver could not produce an outcome.
+    Algorithm,
+    /// A failure without a safe, more specific category.
+    Other,
+}
+
+impl RouteFailureCategory {
+    /// Returns the stable telemetry value for this category.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UpstreamHttp => "upstream_http",
+            Self::ContextWindowExceeded => "context_window_exceeded",
+            Self::Timeout => "timeout",
+            Self::Transport => "transport",
+            Self::InvalidResponse => "invalid_response",
+            Self::RequestTranslation => "request_translation",
+            Self::RequestEncoding => "request_encoding",
+            Self::ResponseTranslation => "response_translation",
+            Self::InvalidRequest => "invalid_request",
+            Self::Configuration => "configuration",
+            Self::Algorithm => "algorithm",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// When a terminal failure occurred relative to response delivery.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RouteFailurePhase {
+    /// The route failed before returning a response to its caller.
+    BeforeResponse,
+    /// A previously returned streaming response failed while it was consumed.
+    DuringStream,
+}
+
+impl RouteFailurePhase {
+    /// Returns the stable telemetry value for this phase.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BeforeResponse => "before_response",
+            Self::DuringStream => "during_stream",
+        }
+    }
+}
+
+/// Safe, structured terminal-failure data for routing telemetry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RouteFailureSummary {
+    /// Stable failure classification.
+    pub category: RouteFailureCategory,
+    /// Whether the error preceded response delivery or occurred while streaming.
+    pub phase: RouteFailurePhase,
+    /// Upstream HTTP status, when directly available.
+    pub upstream_status: Option<u16>,
+    /// Selected target that failed, when the runner knows it.
+    pub target: Option<ModelId>,
+}
+
+impl RunnerError {
+    /// Returns a safe telemetry summary for a failure before response delivery.
+    pub fn execution_failure_summary(&self) -> RouteFailureSummary {
+        match self {
+            Self::Algorithm(LibsyError::ClientCall { target, source }) => {
+                client_failure_summary(source, RouteFailurePhase::BeforeResponse, Some(target))
+            }
+            Self::Client(source) => {
+                client_failure_summary(source, RouteFailurePhase::BeforeResponse, None)
+            }
+            Self::Configuration { .. } => summary(
+                RouteFailureCategory::Configuration,
+                RouteFailurePhase::BeforeResponse,
+                None,
+                None,
+            ),
+            Self::UnknownRouteModel(_)
+            | Self::IncompatibleCallerFormat(_)
+            | Self::CountTokensUnsupported => summary(
+                RouteFailureCategory::InvalidRequest,
+                RouteFailurePhase::BeforeResponse,
+                None,
+                None,
+            ),
+            Self::Algorithm(_) => summary(
+                RouteFailureCategory::Algorithm,
+                RouteFailurePhase::BeforeResponse,
+                None,
+                None,
+            ),
+        }
+    }
+}
+
+/// Returns a safe telemetry summary for an error yielded by an active response stream.
+///
+/// `served_model` should be the target recorded on the response before its stream was returned.
+pub fn stream_failure_summary(
+    error: &LlmClientError,
+    served_model: Option<&ModelId>,
+) -> RouteFailureSummary {
+    client_failure_summary(error, RouteFailurePhase::DuringStream, served_model)
+}
+
+fn client_failure_summary(
+    error: &LlmClientError,
+    phase: RouteFailurePhase,
+    target: Option<&ModelId>,
+) -> RouteFailureSummary {
+    let (category, upstream_status) = match error {
+        LlmClientError::UpstreamHttp { status, .. } => {
+            (RouteFailureCategory::UpstreamHttp, Some(status.as_u16()))
+        }
+        LlmClientError::ContextWindowExceeded { .. } => {
+            (RouteFailureCategory::ContextWindowExceeded, None)
+        }
+        LlmClientError::Timeout { .. } => (RouteFailureCategory::Timeout, None),
+        LlmClientError::Transport { .. } => (RouteFailureCategory::Transport, None),
+        LlmClientError::InvalidResponse { .. } => (RouteFailureCategory::InvalidResponse, None),
+        LlmClientError::RequestTranslation(_) => (RouteFailureCategory::RequestTranslation, None),
+        LlmClientError::RequestEncoding(_) => (RouteFailureCategory::RequestEncoding, None),
+        LlmClientError::ResponseTranslation(_) => (RouteFailureCategory::ResponseTranslation, None),
+        LlmClientError::InvalidRequest { .. } => (RouteFailureCategory::InvalidRequest, None),
+        LlmClientError::Configuration { .. } => (RouteFailureCategory::Configuration, None),
+        LlmClientError::Ffi { .. } | LlmClientError::General(_) => {
+            (RouteFailureCategory::Other, None)
+        }
+        _ => (RouteFailureCategory::Other, None),
+    };
+    summary(category, phase, upstream_status, target)
+}
+
+fn summary(
+    category: RouteFailureCategory,
+    phase: RouteFailurePhase,
+    upstream_status: Option<u16>,
+    target: Option<&ModelId>,
+) -> RouteFailureSummary {
+    RouteFailureSummary {
+        category,
+        phase,
+        upstream_status,
+        target: target.cloned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "patient name is Jane Doe";
+
+    #[test]
+    fn execution_summary_keeps_http_status_and_target_without_body() {
+        let error = RunnerError::Algorithm(LibsyError::ClientCall {
+            target: ModelId::from("strong"),
+            source: LlmClientError::UpstreamHttp {
+                status: reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                body: format!("upstream response: {SECRET}"),
+            },
+        });
+
+        let summary = error.execution_failure_summary();
+
+        assert_eq!(summary.category, RouteFailureCategory::UpstreamHttp);
+        assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
+        assert_eq!(summary.upstream_status, Some(503));
+        assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("strong"));
+        assert!(!format!("{summary:?}").contains(SECRET));
+    }
+
+    #[test]
+    fn execution_summary_reduces_untrusted_messages_to_categories() {
+        let error = RunnerError::Algorithm(LibsyError::AlgorithmError {
+            message: SECRET.to_string(),
+        });
+
+        let summary = error.execution_failure_summary();
+
+        assert_eq!(summary.category, RouteFailureCategory::Algorithm);
+        assert_eq!(summary.target, None);
+        assert!(!format!("{summary:?}").contains(SECRET));
+    }
+
+    #[test]
+    fn stream_summary_preserves_served_target_without_source_text() {
+        let error = LlmClientError::Timeout {
+            source: std::io::Error::other(SECRET).into(),
+        };
+
+        let summary = stream_failure_summary(&error, Some(&ModelId::from("fallback")));
+
+        assert_eq!(summary.category, RouteFailureCategory::Timeout);
+        assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
+        assert_eq!(
+            summary.target.as_ref().map(ModelId::as_str),
+            Some("fallback")
+        );
+        assert!(!format!("{summary:?}").contains(SECRET));
+    }
+
+    #[test]
+    fn client_error_categories_have_stable_telemetry_values() {
+        let cases = vec![
+            (
+                LlmClientError::ContextWindowExceeded {
+                    model: ModelId::from("weak"),
+                    message: SECRET.to_string(),
+                },
+                RouteFailureCategory::ContextWindowExceeded,
+                "context_window_exceeded",
+            ),
+            (
+                LlmClientError::Transport {
+                    source: std::io::Error::other(SECRET).into(),
+                },
+                RouteFailureCategory::Transport,
+                "transport",
+            ),
+            (
+                LlmClientError::InvalidResponse {
+                    source: std::io::Error::other(SECRET).into(),
+                },
+                RouteFailureCategory::InvalidResponse,
+                "invalid_response",
+            ),
+            (
+                LlmClientError::RequestTranslation(SECRET.to_string()),
+                RouteFailureCategory::RequestTranslation,
+                "request_translation",
+            ),
+            (
+                LlmClientError::RequestEncoding(SECRET.to_string()),
+                RouteFailureCategory::RequestEncoding,
+                "request_encoding",
+            ),
+            (
+                LlmClientError::ResponseTranslation(SECRET.to_string()),
+                RouteFailureCategory::ResponseTranslation,
+                "response_translation",
+            ),
+            (
+                LlmClientError::Configuration {
+                    message: SECRET.to_string(),
+                },
+                RouteFailureCategory::Configuration,
+                "configuration",
+            ),
+            (
+                LlmClientError::InvalidRequest {
+                    message: SECRET.to_string(),
+                },
+                RouteFailureCategory::InvalidRequest,
+                "invalid_request",
+            ),
+            (
+                LlmClientError::General(SECRET.to_string()),
+                RouteFailureCategory::Other,
+                "other",
+            ),
+        ];
+
+        for (error, category, value) in cases {
+            let summary = stream_failure_summary(&error, None);
+            assert_eq!(summary.category, category);
+            assert_eq!(summary.category.as_str(), value);
+            assert!(!format!("{summary:?}").contains(SECRET));
+        }
+    }
+
+    #[test]
+    fn direct_client_errors_do_not_claim_a_target() {
+        let error = RunnerError::Client(LlmClientError::Timeout {
+            source: std::io::Error::other(SECRET).into(),
+        });
+
+        let summary = error.execution_failure_summary();
+
+        assert_eq!(summary.category, RouteFailureCategory::Timeout);
+        assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
+        assert_eq!(summary.target, None);
+        assert!(!format!("{summary:?}").contains(SECRET));
+    }
+
+    #[test]
+    fn runner_request_and_configuration_errors_are_classified() {
+        let configuration = RunnerError::configuration(SECRET);
+        assert_eq!(
+            configuration.execution_failure_summary().category,
+            RouteFailureCategory::Configuration
+        );
+
+        let unsupported = RunnerError::CountTokensUnsupported;
+        assert_eq!(
+            unsupported.execution_failure_summary().category,
+            RouteFailureCategory::InvalidRequest
+        );
+    }
+}

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -144,6 +144,12 @@ fn client_failure_summary(
     phase: RouteFailurePhase,
     target: Option<&ModelId>,
 ) -> RouteFailureSummary {
+    let target = target.or(match error {
+        // Context-window errors carry the resolved target model when a caller has not
+        // already supplied the route's selected or served target.
+        LlmClientError::ContextWindowExceeded { model, .. } => Some(model),
+        _ => None,
+    });
     let (category, upstream_status) = match error {
         LlmClientError::UpstreamHttp { status, .. } => {
             (RouteFailureCategory::UpstreamHttp, Some(status.as_u16()))
@@ -233,6 +239,24 @@ mod tests {
             summary.target.as_ref().map(ModelId::as_str),
             Some("fallback")
         );
+        assert!(!format!("{summary:?}").contains(SECRET));
+    }
+
+    #[test]
+    fn stream_summary_uses_context_window_model_without_a_served_target() {
+        let error = LlmClientError::ContextWindowExceeded {
+            model: ModelId::from("weak"),
+            message: SECRET.to_string(),
+        };
+
+        let summary = stream_failure_summary(&error, None);
+
+        assert_eq!(
+            summary.category,
+            RouteFailureCategory::ContextWindowExceeded
+        );
+        assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
+        assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("weak"));
         assert!(!format!("{summary:?}").contains(SECRET));
     }
 

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -4,6 +4,7 @@
 //! Safe, structured summaries of route-execution failures for telemetry.
 
 use libsy::LibsyError;
+use strum_macros::IntoStaticStr;
 use switchyard_protocol::{LlmClientError, ModelId};
 
 use crate::RunnerError;
@@ -13,7 +14,8 @@ use crate::RunnerError;
 /// This deliberately carries no provider message, response body, or source
 /// error. It is suitable for logs and telemetry, not client-facing rendering.
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, IntoStaticStr, PartialEq)]
+#[strum(serialize_all = "snake_case")]
 pub enum RouteErrorKind {
     /// The upstream returned a non-success HTTP response.
     UpstreamHttp,
@@ -43,21 +45,8 @@ pub enum RouteErrorKind {
 
 impl RouteErrorKind {
     /// Returns the stable telemetry value for this kind.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::UpstreamHttp => "upstream_http",
-            Self::ContextWindowExceeded => "context_window_exceeded",
-            Self::Timeout => "timeout",
-            Self::Transport => "transport",
-            Self::InvalidResponse => "invalid_response",
-            Self::RequestTranslation => "request_translation",
-            Self::RequestEncoding => "request_encoding",
-            Self::ResponseTranslation => "response_translation",
-            Self::InvalidRequest => "invalid_request",
-            Self::Configuration => "configuration",
-            Self::Algorithm => "algorithm",
-            Self::Other => "other",
-        }
+    pub fn as_str(self) -> &'static str {
+        self.into()
     }
 }
 

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -71,7 +71,7 @@ impl RouteErrorPhase {
 /// Safe, structured terminal-failure data for routing telemetry.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
-pub struct RouteFailureSummary {
+pub struct RouteErrorSummary {
     /// Stable failure classification.
     pub kind: RouteErrorKind,
     /// Whether the error preceded response delivery or occurred while streaming.
@@ -84,7 +84,7 @@ pub struct RouteFailureSummary {
 
 impl RunnerError {
     /// Returns a safe telemetry summary for a failure before response delivery.
-    pub fn execution_failure_summary(&self) -> RouteFailureSummary {
+    pub fn execution_failure_summary(&self) -> RouteErrorSummary {
         match self {
             Self::Algorithm(LibsyError::ClientCall { target, source }) => {
                 client_failure_summary(source, RouteErrorPhase::BeforeResponse, Some(target))
@@ -122,7 +122,7 @@ impl RunnerError {
 pub fn stream_failure_summary(
     error: &LlmClientError,
     served_model: Option<&ModelId>,
-) -> RouteFailureSummary {
+) -> RouteErrorSummary {
     client_failure_summary(error, RouteErrorPhase::DuringStream, served_model)
 }
 
@@ -130,7 +130,7 @@ fn client_failure_summary(
     error: &LlmClientError,
     phase: RouteErrorPhase,
     target: Option<&ModelId>,
-) -> RouteFailureSummary {
+) -> RouteErrorSummary {
     let target = target.or(match error {
         // Context-window errors carry the resolved target model when a caller has not
         // already supplied the route's selected or served target.
@@ -163,8 +163,8 @@ fn summary(
     phase: RouteErrorPhase,
     upstream_status: Option<u16>,
     target: Option<&ModelId>,
-) -> RouteFailureSummary {
-    RouteFailureSummary {
+) -> RouteErrorSummary {
+    RouteErrorSummary {
         kind,
         phase,
         upstream_status,

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -14,7 +14,7 @@ use crate::RunnerError;
 /// error. It is suitable for logs and telemetry, not client-facing rendering.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RouteFailureCategory {
+pub enum RouteErrorKind {
     /// The upstream returned a non-success HTTP response.
     UpstreamHttp,
     /// The selected target rejected the request because its context window was exceeded.
@@ -37,12 +37,12 @@ pub enum RouteFailureCategory {
     Configuration,
     /// The routing algorithm or driver could not produce an outcome.
     Algorithm,
-    /// A failure without a safe, more specific category.
+    /// A failure without a safe, more specific kind.
     Other,
 }
 
-impl RouteFailureCategory {
-    /// Returns the stable telemetry value for this category.
+impl RouteErrorKind {
+    /// Returns the stable telemetry value for this kind.
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::UpstreamHttp => "upstream_http",
@@ -86,7 +86,7 @@ impl RouteFailurePhase {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RouteFailureSummary {
     /// Stable failure classification.
-    pub category: RouteFailureCategory,
+    pub kind: RouteErrorKind,
     /// Whether the error preceded response delivery or occurred while streaming.
     pub phase: RouteFailurePhase,
     /// Upstream HTTP status, when directly available.
@@ -106,7 +106,7 @@ impl RunnerError {
                 client_failure_summary(source, RouteFailurePhase::BeforeResponse, None)
             }
             Self::Configuration { .. } => summary(
-                RouteFailureCategory::Configuration,
+                RouteErrorKind::Configuration,
                 RouteFailurePhase::BeforeResponse,
                 None,
                 None,
@@ -114,13 +114,13 @@ impl RunnerError {
             Self::UnknownRouteModel(_)
             | Self::IncompatibleCallerFormat(_)
             | Self::CountTokensUnsupported => summary(
-                RouteFailureCategory::InvalidRequest,
+                RouteErrorKind::InvalidRequest,
                 RouteFailurePhase::BeforeResponse,
                 None,
                 None,
             ),
             Self::Algorithm(_) => summary(
-                RouteFailureCategory::Algorithm,
+                RouteErrorKind::Algorithm,
                 RouteFailurePhase::BeforeResponse,
                 None,
                 None,
@@ -150,37 +150,35 @@ fn client_failure_summary(
         LlmClientError::ContextWindowExceeded { model, .. } => Some(model),
         _ => None,
     });
-    let (category, upstream_status) = match error {
+    let (kind, upstream_status) = match error {
         LlmClientError::UpstreamHttp { status, .. } => {
-            (RouteFailureCategory::UpstreamHttp, Some(status.as_u16()))
+            (RouteErrorKind::UpstreamHttp, Some(status.as_u16()))
         }
         LlmClientError::ContextWindowExceeded { .. } => {
-            (RouteFailureCategory::ContextWindowExceeded, None)
+            (RouteErrorKind::ContextWindowExceeded, None)
         }
-        LlmClientError::Timeout { .. } => (RouteFailureCategory::Timeout, None),
-        LlmClientError::Transport { .. } => (RouteFailureCategory::Transport, None),
-        LlmClientError::InvalidResponse { .. } => (RouteFailureCategory::InvalidResponse, None),
-        LlmClientError::RequestTranslation(_) => (RouteFailureCategory::RequestTranslation, None),
-        LlmClientError::RequestEncoding(_) => (RouteFailureCategory::RequestEncoding, None),
-        LlmClientError::ResponseTranslation(_) => (RouteFailureCategory::ResponseTranslation, None),
-        LlmClientError::InvalidRequest { .. } => (RouteFailureCategory::InvalidRequest, None),
-        LlmClientError::Configuration { .. } => (RouteFailureCategory::Configuration, None),
-        LlmClientError::Ffi { .. } | LlmClientError::General(_) => {
-            (RouteFailureCategory::Other, None)
-        }
-        _ => (RouteFailureCategory::Other, None),
+        LlmClientError::Timeout { .. } => (RouteErrorKind::Timeout, None),
+        LlmClientError::Transport { .. } => (RouteErrorKind::Transport, None),
+        LlmClientError::InvalidResponse { .. } => (RouteErrorKind::InvalidResponse, None),
+        LlmClientError::RequestTranslation(_) => (RouteErrorKind::RequestTranslation, None),
+        LlmClientError::RequestEncoding(_) => (RouteErrorKind::RequestEncoding, None),
+        LlmClientError::ResponseTranslation(_) => (RouteErrorKind::ResponseTranslation, None),
+        LlmClientError::InvalidRequest { .. } => (RouteErrorKind::InvalidRequest, None),
+        LlmClientError::Configuration { .. } => (RouteErrorKind::Configuration, None),
+        LlmClientError::Ffi { .. } | LlmClientError::General(_) => (RouteErrorKind::Other, None),
+        _ => (RouteErrorKind::Other, None),
     };
-    summary(category, phase, upstream_status, target)
+    summary(kind, phase, upstream_status, target)
 }
 
 fn summary(
-    category: RouteFailureCategory,
+    kind: RouteErrorKind,
     phase: RouteFailurePhase,
     upstream_status: Option<u16>,
     target: Option<&ModelId>,
 ) -> RouteFailureSummary {
     RouteFailureSummary {
-        category,
+        kind,
         phase,
         upstream_status,
         target: target.cloned(),
@@ -205,7 +203,7 @@ mod tests {
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.category, RouteFailureCategory::UpstreamHttp);
+        assert_eq!(summary.kind, RouteErrorKind::UpstreamHttp);
         assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
         assert_eq!(summary.upstream_status, Some(503));
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("strong"));
@@ -220,7 +218,7 @@ mod tests {
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.category, RouteFailureCategory::Algorithm);
+        assert_eq!(summary.kind, RouteErrorKind::Algorithm);
         assert_eq!(summary.target, None);
         assert!(!format!("{summary:?}").contains(SECRET));
     }
@@ -233,7 +231,7 @@ mod tests {
 
         let summary = stream_failure_summary(&error, Some(&ModelId::from("fallback")));
 
-        assert_eq!(summary.category, RouteFailureCategory::Timeout);
+        assert_eq!(summary.kind, RouteErrorKind::Timeout);
         assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
         assert_eq!(
             summary.target.as_ref().map(ModelId::as_str),
@@ -251,10 +249,7 @@ mod tests {
 
         let summary = stream_failure_summary(&error, None);
 
-        assert_eq!(
-            summary.category,
-            RouteFailureCategory::ContextWindowExceeded
-        );
+        assert_eq!(summary.kind, RouteErrorKind::ContextWindowExceeded);
         assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("weak"));
         assert!(!format!("{summary:?}").contains(SECRET));
@@ -268,63 +263,63 @@ mod tests {
                     model: ModelId::from("weak"),
                     message: SECRET.to_string(),
                 },
-                RouteFailureCategory::ContextWindowExceeded,
+                RouteErrorKind::ContextWindowExceeded,
                 "context_window_exceeded",
             ),
             (
                 LlmClientError::Transport {
                     source: std::io::Error::other(SECRET).into(),
                 },
-                RouteFailureCategory::Transport,
+                RouteErrorKind::Transport,
                 "transport",
             ),
             (
                 LlmClientError::InvalidResponse {
                     source: std::io::Error::other(SECRET).into(),
                 },
-                RouteFailureCategory::InvalidResponse,
+                RouteErrorKind::InvalidResponse,
                 "invalid_response",
             ),
             (
                 LlmClientError::RequestTranslation(SECRET.to_string()),
-                RouteFailureCategory::RequestTranslation,
+                RouteErrorKind::RequestTranslation,
                 "request_translation",
             ),
             (
                 LlmClientError::RequestEncoding(SECRET.to_string()),
-                RouteFailureCategory::RequestEncoding,
+                RouteErrorKind::RequestEncoding,
                 "request_encoding",
             ),
             (
                 LlmClientError::ResponseTranslation(SECRET.to_string()),
-                RouteFailureCategory::ResponseTranslation,
+                RouteErrorKind::ResponseTranslation,
                 "response_translation",
             ),
             (
                 LlmClientError::Configuration {
                     message: SECRET.to_string(),
                 },
-                RouteFailureCategory::Configuration,
+                RouteErrorKind::Configuration,
                 "configuration",
             ),
             (
                 LlmClientError::InvalidRequest {
                     message: SECRET.to_string(),
                 },
-                RouteFailureCategory::InvalidRequest,
+                RouteErrorKind::InvalidRequest,
                 "invalid_request",
             ),
             (
                 LlmClientError::General(SECRET.to_string()),
-                RouteFailureCategory::Other,
+                RouteErrorKind::Other,
                 "other",
             ),
         ];
 
-        for (error, category, value) in cases {
+        for (error, kind, value) in cases {
             let summary = stream_failure_summary(&error, None);
-            assert_eq!(summary.category, category);
-            assert_eq!(summary.category.as_str(), value);
+            assert_eq!(summary.kind, kind);
+            assert_eq!(summary.kind.as_str(), value);
             assert!(!format!("{summary:?}").contains(SECRET));
         }
     }
@@ -337,7 +332,7 @@ mod tests {
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.category, RouteFailureCategory::Timeout);
+        assert_eq!(summary.kind, RouteErrorKind::Timeout);
         assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
         assert_eq!(summary.target, None);
         assert!(!format!("{summary:?}").contains(SECRET));
@@ -347,14 +342,14 @@ mod tests {
     fn runner_request_and_configuration_errors_are_classified() {
         let configuration = RunnerError::configuration(SECRET);
         assert_eq!(
-            configuration.execution_failure_summary().category,
-            RouteFailureCategory::Configuration
+            configuration.execution_failure_summary().kind,
+            RouteErrorKind::Configuration
         );
 
         let unsupported = RunnerError::CountTokensUnsupported;
         assert_eq!(
-            unsupported.execution_failure_summary().category,
-            RouteFailureCategory::InvalidRequest
+            unsupported.execution_failure_summary().kind,
+            RouteErrorKind::InvalidRequest
         );
     }
 }

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -52,21 +52,19 @@ impl RouteErrorKind {
 
 /// When a terminal failure occurred relative to response delivery.
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug)]
-pub enum RouteFailurePhase {
+#[derive(Clone, Copy, Debug, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum RouteErrorPhase {
     /// The route failed before returning a response to its caller.
     BeforeResponse,
     /// A previously returned streaming response failed while it was consumed.
     DuringStream,
 }
 
-impl RouteFailurePhase {
+impl RouteErrorPhase {
     /// Returns the stable telemetry value for this phase.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::BeforeResponse => "before_response",
-            Self::DuringStream => "during_stream",
-        }
+    pub fn as_str(self) -> &'static str {
+        self.into()
     }
 }
 
@@ -77,7 +75,7 @@ pub struct RouteFailureSummary {
     /// Stable failure classification.
     pub kind: RouteErrorKind,
     /// Whether the error preceded response delivery or occurred while streaming.
-    pub phase: RouteFailurePhase,
+    pub phase: RouteErrorPhase,
     /// Upstream HTTP status, when directly available.
     pub upstream_status: Option<u16>,
     /// Selected target that failed, when the runner knows it.
@@ -89,14 +87,14 @@ impl RunnerError {
     pub fn execution_failure_summary(&self) -> RouteFailureSummary {
         match self {
             Self::Algorithm(LibsyError::ClientCall { target, source }) => {
-                client_failure_summary(source, RouteFailurePhase::BeforeResponse, Some(target))
+                client_failure_summary(source, RouteErrorPhase::BeforeResponse, Some(target))
             }
             Self::Client(source) => {
-                client_failure_summary(source, RouteFailurePhase::BeforeResponse, None)
+                client_failure_summary(source, RouteErrorPhase::BeforeResponse, None)
             }
             Self::Configuration { .. } => summary(
                 RouteErrorKind::Configuration,
-                RouteFailurePhase::BeforeResponse,
+                RouteErrorPhase::BeforeResponse,
                 None,
                 None,
             ),
@@ -104,13 +102,13 @@ impl RunnerError {
             | Self::IncompatibleCallerFormat(_)
             | Self::CountTokensUnsupported => summary(
                 RouteErrorKind::InvalidRequest,
-                RouteFailurePhase::BeforeResponse,
+                RouteErrorPhase::BeforeResponse,
                 None,
                 None,
             ),
             Self::Algorithm(_) => summary(
                 RouteErrorKind::Algorithm,
-                RouteFailurePhase::BeforeResponse,
+                RouteErrorPhase::BeforeResponse,
                 None,
                 None,
             ),
@@ -125,12 +123,12 @@ pub fn stream_failure_summary(
     error: &LlmClientError,
     served_model: Option<&ModelId>,
 ) -> RouteFailureSummary {
-    client_failure_summary(error, RouteFailurePhase::DuringStream, served_model)
+    client_failure_summary(error, RouteErrorPhase::DuringStream, served_model)
 }
 
 fn client_failure_summary(
     error: &LlmClientError,
-    phase: RouteFailurePhase,
+    phase: RouteErrorPhase,
     target: Option<&ModelId>,
 ) -> RouteFailureSummary {
     let target = target.or(match error {
@@ -162,7 +160,7 @@ fn client_failure_summary(
 
 fn summary(
     kind: RouteErrorKind,
-    phase: RouteFailurePhase,
+    phase: RouteErrorPhase,
     upstream_status: Option<u16>,
     target: Option<&ModelId>,
 ) -> RouteFailureSummary {
@@ -193,7 +191,7 @@ mod tests {
         let summary = error.execution_failure_summary();
 
         assert!(matches!(summary.kind, RouteErrorKind::UpstreamHttp));
-        assert!(matches!(summary.phase, RouteFailurePhase::BeforeResponse));
+        assert!(matches!(summary.phase, RouteErrorPhase::BeforeResponse));
         assert_eq!(summary.upstream_status, Some(503));
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("strong"));
         assert!(!format!("{summary:?}").contains(SECRET));
@@ -221,7 +219,7 @@ mod tests {
         let summary = stream_failure_summary(&error, Some(&ModelId::from("fallback")));
 
         assert!(matches!(summary.kind, RouteErrorKind::Timeout));
-        assert!(matches!(summary.phase, RouteFailurePhase::DuringStream));
+        assert!(matches!(summary.phase, RouteErrorPhase::DuringStream));
         assert_eq!(
             summary.target.as_ref().map(ModelId::as_str),
             Some("fallback")
@@ -242,7 +240,7 @@ mod tests {
             summary.kind,
             RouteErrorKind::ContextWindowExceeded
         ));
-        assert!(matches!(summary.phase, RouteFailurePhase::DuringStream));
+        assert!(matches!(summary.phase, RouteErrorPhase::DuringStream));
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("weak"));
         assert!(!format!("{summary:?}").contains(SECRET));
     }
@@ -304,6 +302,12 @@ mod tests {
     }
 
     #[test]
+    fn route_error_phases_have_stable_telemetry_values() {
+        assert_eq!(RouteErrorPhase::BeforeResponse.as_str(), "before_response");
+        assert_eq!(RouteErrorPhase::DuringStream.as_str(), "during_stream");
+    }
+
+    #[test]
     fn direct_client_errors_do_not_claim_a_target() {
         let error = RunnerError::Client(LlmClientError::Timeout {
             source: std::io::Error::other(SECRET).into(),
@@ -312,7 +316,7 @@ mod tests {
         let summary = error.execution_failure_summary();
 
         assert!(matches!(summary.kind, RouteErrorKind::Timeout));
-        assert!(matches!(summary.phase, RouteFailurePhase::BeforeResponse));
+        assert!(matches!(summary.phase, RouteErrorPhase::BeforeResponse));
         assert_eq!(summary.target, None);
         assert!(!format!("{summary:?}").contains(SECRET));
     }

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -84,13 +84,13 @@ pub struct RouteErrorSummary {
 
 impl RunnerError {
     /// Returns a safe telemetry summary for a failure before response delivery.
-    pub fn execution_failure_summary(&self) -> RouteErrorSummary {
+    pub fn execution_error_summary(&self) -> RouteErrorSummary {
         match self {
             Self::Algorithm(LibsyError::ClientCall { target, source }) => {
-                client_failure_summary(source, RouteErrorPhase::BeforeResponse, Some(target))
+                client_error_summary(source, RouteErrorPhase::BeforeResponse, Some(target))
             }
             Self::Client(source) => {
-                client_failure_summary(source, RouteErrorPhase::BeforeResponse, None)
+                client_error_summary(source, RouteErrorPhase::BeforeResponse, None)
             }
             Self::Configuration { .. } => summary(
                 RouteErrorKind::Configuration,
@@ -119,14 +119,14 @@ impl RunnerError {
 /// Returns a safe telemetry summary for an error yielded by an active response stream.
 ///
 /// `served_model` should be the target recorded on the response before its stream was returned.
-pub fn stream_failure_summary(
+pub fn stream_error_summary(
     error: &LlmClientError,
     served_model: Option<&ModelId>,
 ) -> RouteErrorSummary {
-    client_failure_summary(error, RouteErrorPhase::DuringStream, served_model)
+    client_error_summary(error, RouteErrorPhase::DuringStream, served_model)
 }
 
-fn client_failure_summary(
+fn client_error_summary(
     error: &LlmClientError,
     phase: RouteErrorPhase,
     target: Option<&ModelId>,
@@ -179,7 +179,7 @@ mod tests {
     const SECRET: &str = "patient name is Jane Doe";
 
     #[test]
-    fn execution_summary_keeps_http_status_and_target_without_body() {
+    fn execution_error_summary_keeps_http_status_and_target_without_body() {
         let error = RunnerError::Algorithm(LibsyError::ClientCall {
             target: ModelId::from("strong"),
             source: LlmClientError::UpstreamHttp {
@@ -188,7 +188,7 @@ mod tests {
             },
         });
 
-        let summary = error.execution_failure_summary();
+        let summary = error.execution_error_summary();
 
         assert!(matches!(summary.kind, RouteErrorKind::UpstreamHttp));
         assert!(matches!(summary.phase, RouteErrorPhase::BeforeResponse));
@@ -198,12 +198,12 @@ mod tests {
     }
 
     #[test]
-    fn execution_summary_reduces_untrusted_messages_to_kinds() {
+    fn execution_error_summary_reduces_untrusted_messages_to_kinds() {
         let error = RunnerError::Algorithm(LibsyError::AlgorithmError {
             message: SECRET.to_string(),
         });
 
-        let summary = error.execution_failure_summary();
+        let summary = error.execution_error_summary();
 
         assert!(matches!(summary.kind, RouteErrorKind::Algorithm));
         assert_eq!(summary.target, None);
@@ -211,12 +211,12 @@ mod tests {
     }
 
     #[test]
-    fn stream_summary_preserves_served_target_without_source_text() {
+    fn stream_error_summary_preserves_served_target_without_source_text() {
         let error = LlmClientError::Timeout {
             source: std::io::Error::other(SECRET).into(),
         };
 
-        let summary = stream_failure_summary(&error, Some(&ModelId::from("fallback")));
+        let summary = stream_error_summary(&error, Some(&ModelId::from("fallback")));
 
         assert!(matches!(summary.kind, RouteErrorKind::Timeout));
         assert!(matches!(summary.phase, RouteErrorPhase::DuringStream));
@@ -228,13 +228,13 @@ mod tests {
     }
 
     #[test]
-    fn stream_summary_uses_context_window_model_without_a_served_target() {
+    fn stream_error_summary_uses_context_window_model_without_a_served_target() {
         let error = LlmClientError::ContextWindowExceeded {
             model: ModelId::from("weak"),
             message: SECRET.to_string(),
         };
 
-        let summary = stream_failure_summary(&error, None);
+        let summary = stream_error_summary(&error, None);
 
         assert!(matches!(
             summary.kind,
@@ -295,7 +295,7 @@ mod tests {
         ];
 
         for (error, value) in cases {
-            let summary = stream_failure_summary(&error, None);
+            let summary = stream_error_summary(&error, None);
             assert_eq!(summary.kind.as_str(), value);
             assert!(!format!("{summary:?}").contains(SECRET));
         }
@@ -313,7 +313,7 @@ mod tests {
             source: std::io::Error::other(SECRET).into(),
         });
 
-        let summary = error.execution_failure_summary();
+        let summary = error.execution_error_summary();
 
         assert!(matches!(summary.kind, RouteErrorKind::Timeout));
         assert!(matches!(summary.phase, RouteErrorPhase::BeforeResponse));
@@ -325,13 +325,13 @@ mod tests {
     fn runner_request_and_configuration_errors_are_classified() {
         let configuration = RunnerError::configuration(SECRET);
         assert!(matches!(
-            configuration.execution_failure_summary().kind,
+            configuration.execution_error_summary().kind,
             RouteErrorKind::Configuration
         ));
 
         let unsupported = RunnerError::CountTokensUnsupported;
         assert!(matches!(
-            unsupported.execution_failure_summary().kind,
+            unsupported.execution_error_summary().kind,
             RouteErrorKind::InvalidRequest
         ));
     }

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -14,7 +14,7 @@ use crate::RunnerError;
 /// This deliberately carries no provider message, response body, or source
 /// error. It is suitable for logs and telemetry, not client-facing rendering.
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, IntoStaticStr, PartialEq)]
+#[derive(Clone, Copy, Debug, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RouteErrorKind {
     /// The upstream returned a non-success HTTP response.
@@ -52,7 +52,7 @@ impl RouteErrorKind {
 
 /// When a terminal failure occurred relative to response delivery.
 #[non_exhaustive]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug)]
 pub enum RouteFailurePhase {
     /// The route failed before returning a response to its caller.
     BeforeResponse,
@@ -72,7 +72,7 @@ impl RouteFailurePhase {
 
 /// Safe, structured terminal-failure data for routing telemetry.
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct RouteFailureSummary {
     /// Stable failure classification.
     pub kind: RouteErrorKind,
@@ -192,22 +192,22 @@ mod tests {
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.kind, RouteErrorKind::UpstreamHttp);
-        assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
+        assert!(matches!(summary.kind, RouteErrorKind::UpstreamHttp));
+        assert!(matches!(summary.phase, RouteFailurePhase::BeforeResponse));
         assert_eq!(summary.upstream_status, Some(503));
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("strong"));
         assert!(!format!("{summary:?}").contains(SECRET));
     }
 
     #[test]
-    fn execution_summary_reduces_untrusted_messages_to_categories() {
+    fn execution_summary_reduces_untrusted_messages_to_kinds() {
         let error = RunnerError::Algorithm(LibsyError::AlgorithmError {
             message: SECRET.to_string(),
         });
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.kind, RouteErrorKind::Algorithm);
+        assert!(matches!(summary.kind, RouteErrorKind::Algorithm));
         assert_eq!(summary.target, None);
         assert!(!format!("{summary:?}").contains(SECRET));
     }
@@ -220,8 +220,8 @@ mod tests {
 
         let summary = stream_failure_summary(&error, Some(&ModelId::from("fallback")));
 
-        assert_eq!(summary.kind, RouteErrorKind::Timeout);
-        assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
+        assert!(matches!(summary.kind, RouteErrorKind::Timeout));
+        assert!(matches!(summary.phase, RouteFailurePhase::DuringStream));
         assert_eq!(
             summary.target.as_ref().map(ModelId::as_str),
             Some("fallback")
@@ -238,76 +238,66 @@ mod tests {
 
         let summary = stream_failure_summary(&error, None);
 
-        assert_eq!(summary.kind, RouteErrorKind::ContextWindowExceeded);
-        assert_eq!(summary.phase, RouteFailurePhase::DuringStream);
+        assert!(matches!(
+            summary.kind,
+            RouteErrorKind::ContextWindowExceeded
+        ));
+        assert!(matches!(summary.phase, RouteFailurePhase::DuringStream));
         assert_eq!(summary.target.as_ref().map(ModelId::as_str), Some("weak"));
         assert!(!format!("{summary:?}").contains(SECRET));
     }
 
     #[test]
-    fn client_error_categories_have_stable_telemetry_values() {
+    fn client_error_kinds_have_stable_telemetry_values() {
         let cases = vec![
             (
                 LlmClientError::ContextWindowExceeded {
                     model: ModelId::from("weak"),
                     message: SECRET.to_string(),
                 },
-                RouteErrorKind::ContextWindowExceeded,
                 "context_window_exceeded",
             ),
             (
                 LlmClientError::Transport {
                     source: std::io::Error::other(SECRET).into(),
                 },
-                RouteErrorKind::Transport,
                 "transport",
             ),
             (
                 LlmClientError::InvalidResponse {
                     source: std::io::Error::other(SECRET).into(),
                 },
-                RouteErrorKind::InvalidResponse,
                 "invalid_response",
             ),
             (
                 LlmClientError::RequestTranslation(SECRET.to_string()),
-                RouteErrorKind::RequestTranslation,
                 "request_translation",
             ),
             (
                 LlmClientError::RequestEncoding(SECRET.to_string()),
-                RouteErrorKind::RequestEncoding,
                 "request_encoding",
             ),
             (
                 LlmClientError::ResponseTranslation(SECRET.to_string()),
-                RouteErrorKind::ResponseTranslation,
                 "response_translation",
             ),
             (
                 LlmClientError::Configuration {
                     message: SECRET.to_string(),
                 },
-                RouteErrorKind::Configuration,
                 "configuration",
             ),
             (
                 LlmClientError::InvalidRequest {
                     message: SECRET.to_string(),
                 },
-                RouteErrorKind::InvalidRequest,
                 "invalid_request",
             ),
-            (
-                LlmClientError::General(SECRET.to_string()),
-                RouteErrorKind::Other,
-                "other",
-            ),
+            (LlmClientError::General(SECRET.to_string()), "other"),
         ];
 
-        for (error, kind, value) in cases {
+        for (error, value) in cases {
             let summary = stream_failure_summary(&error, None);
-            assert_eq!(summary.kind, kind);
             assert_eq!(summary.kind.as_str(), value);
             assert!(!format!("{summary:?}").contains(SECRET));
         }
@@ -321,8 +311,8 @@ mod tests {
 
         let summary = error.execution_failure_summary();
 
-        assert_eq!(summary.kind, RouteErrorKind::Timeout);
-        assert_eq!(summary.phase, RouteFailurePhase::BeforeResponse);
+        assert!(matches!(summary.kind, RouteErrorKind::Timeout));
+        assert!(matches!(summary.phase, RouteFailurePhase::BeforeResponse));
         assert_eq!(summary.target, None);
         assert!(!format!("{summary:?}").contains(SECRET));
     }
@@ -330,15 +320,15 @@ mod tests {
     #[test]
     fn runner_request_and_configuration_errors_are_classified() {
         let configuration = RunnerError::configuration(SECRET);
-        assert_eq!(
+        assert!(matches!(
             configuration.execution_failure_summary().kind,
             RouteErrorKind::Configuration
-        );
+        ));
 
         let unsupported = RunnerError::CountTokensUnsupported;
-        assert_eq!(
+        assert!(matches!(
             unsupported.execution_failure_summary().kind,
             RouteErrorKind::InvalidRequest
-        );
+        ));
     }
 }

--- a/crates/switchyard-runner/src/failure.rs
+++ b/crates/switchyard-runner/src/failure.rs
@@ -82,6 +82,7 @@ impl RouteFailurePhase {
 }
 
 /// Safe, structured terminal-failure data for routing telemetry.
+#[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RouteFailureSummary {
     /// Stable failure classification.

--- a/crates/switchyard-runner/src/lib.rs
+++ b/crates/switchyard-runner/src/lib.rs
@@ -13,7 +13,7 @@ pub use algorithm::{
     AdvisorTriggerConfig, AlgorithmConfigError, AlgorithmSpec, ClassifierMode,
     ClassifierPolicyConfig, LlmClassifierRouteConfig, StageClassifierConfig, SubagentRouteConfig,
 };
-pub use failure::{RouteErrorKind, RouteFailurePhase, RouteFailureSummary, stream_failure_summary};
+pub use failure::{RouteErrorKind, RouteErrorPhase, RouteFailureSummary, stream_failure_summary};
 pub use route::{
     CallerAuthKind, CountTokensTarget, ModelCapabilities, Route, RunOutput, RunnerError,
 };

--- a/crates/switchyard-runner/src/lib.rs
+++ b/crates/switchyard-runner/src/lib.rs
@@ -5,12 +5,16 @@
 
 mod algorithm;
 mod config;
+mod failure;
 mod route;
 mod runner;
 
 pub use algorithm::{
     AdvisorTriggerConfig, AlgorithmConfigError, AlgorithmSpec, ClassifierMode,
     ClassifierPolicyConfig, LlmClassifierRouteConfig, StageClassifierConfig, SubagentRouteConfig,
+};
+pub use failure::{
+    RouteFailureCategory, RouteFailurePhase, RouteFailureSummary, stream_failure_summary,
 };
 pub use route::{
     CallerAuthKind, CountTokensTarget, ModelCapabilities, Route, RunOutput, RunnerError,

--- a/crates/switchyard-runner/src/lib.rs
+++ b/crates/switchyard-runner/src/lib.rs
@@ -13,7 +13,7 @@ pub use algorithm::{
     AdvisorTriggerConfig, AlgorithmConfigError, AlgorithmSpec, ClassifierMode,
     ClassifierPolicyConfig, LlmClassifierRouteConfig, StageClassifierConfig, SubagentRouteConfig,
 };
-pub use failure::{RouteErrorKind, RouteErrorPhase, RouteErrorSummary, stream_failure_summary};
+pub use failure::{RouteErrorKind, RouteErrorPhase, RouteErrorSummary, stream_error_summary};
 pub use route::{
     CallerAuthKind, CountTokensTarget, ModelCapabilities, Route, RunOutput, RunnerError,
 };

--- a/crates/switchyard-runner/src/lib.rs
+++ b/crates/switchyard-runner/src/lib.rs
@@ -13,9 +13,7 @@ pub use algorithm::{
     AdvisorTriggerConfig, AlgorithmConfigError, AlgorithmSpec, ClassifierMode,
     ClassifierPolicyConfig, LlmClassifierRouteConfig, StageClassifierConfig, SubagentRouteConfig,
 };
-pub use failure::{
-    RouteFailureCategory, RouteFailurePhase, RouteFailureSummary, stream_failure_summary,
-};
+pub use failure::{RouteErrorKind, RouteFailurePhase, RouteFailureSummary, stream_failure_summary};
 pub use route::{
     CallerAuthKind, CountTokensTarget, ModelCapabilities, Route, RunOutput, RunnerError,
 };

--- a/crates/switchyard-runner/src/lib.rs
+++ b/crates/switchyard-runner/src/lib.rs
@@ -13,7 +13,7 @@ pub use algorithm::{
     AdvisorTriggerConfig, AlgorithmConfigError, AlgorithmSpec, ClassifierMode,
     ClassifierPolicyConfig, LlmClassifierRouteConfig, StageClassifierConfig, SubagentRouteConfig,
 };
-pub use failure::{RouteErrorKind, RouteErrorPhase, RouteFailureSummary, stream_failure_summary};
+pub use failure::{RouteErrorKind, RouteErrorPhase, RouteErrorSummary, stream_failure_summary};
 pub use route::{
     CallerAuthKind, CountTokensTarget, ModelCapabilities, Route, RunOutput, RunnerError,
 };


### PR DESCRIPTION
## What

Adds a public, redaction-safe terminal-failure summary API to `switchyard-runner`. It covers route-execution failures before response delivery and typed failures yielded by active response streams.

## Why

This is deliberately more than a wrapper over existing error types:

- It creates a stable, host-agnostic telemetry contract at the runner boundary, so integration plugins do not couple to the internal `RunnerError` → `LibsyError` → `LlmClientError` layout.
- It combines protocol error class with runner-only context: whether the failure happened before a response or during stream consumption, the terminal target when known, and a directly available HTTP status.
- It makes redaction structural: provider response bodies, free-form messages, request/response content, and boxed sources have no representation in the public summary.
- It publishes stable string values and uses forward-compatible enums and struct construction, so consumers can record telemetry without parsing display strings or blocking future summary fields.

The NeMo Relay dynamic plugin is the immediate consumer: it will map these summaries into structured routing-error marks for Relay OpenTelemetry logs. Plugin adoption is intentionally deferred to a separate change.

Closes #536

## How tested

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest tests/ -v` (115 passed)
- [x] `uv run --only-group docs mkdocs build --strict`
- [x] Focused regression coverage for redaction, HTTP status, explicit and inferred targets, pre-response errors, and stream errors.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use.
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The API intentionally does not change routing, retry, fallback, or client-facing HTTP behavior. It is an additive observability surface that keeps provider diagnostics out of telemetry by default.