### PR TITLE
docs(config): add GAIB Token Kiosk provider preset and guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,9 +15,10 @@ operate the Rust server directly.
 ### Prerequisites
 
 - Git, a native build toolchain, and Rust with Cargo
-- An API key for OpenRouter, OpenAI, Anthropic, or another OpenAI-compatible endpoint.
+- An API key for OpenRouter, OpenAI, Anthropic, GAIB Token Kiosk, or another OpenAI-compatible endpoint.
   To use OpenRouter, create an account at [openrouter.ai](https://openrouter.ai/)
   and generate a key from the [OpenRouter keys page](https://openrouter.ai/keys).
+  To use GAIB Token Kiosk, set `base_url = "https://agent-router.gaib.ai/v1"` (see `examples/routes.token_kiosk.toml`).
 
 On Ubuntu or WSL, install the build prerequisites and Rust with `rustup`:
 

--- a/examples/routes.token_kiosk.toml
+++ b/examples/routes.token_kiosk.toml
@@ -1,0 +1,32 @@
+schema_version = 1
+
+# GAIB Token Kiosk provider integration preset
+# Base URL: https://agent-router.gaib.ai/v1
+
+[llm_clients.token_kiosk_openai]
+format = "openai_chat"
+base_url = "https://agent-router.gaib.ai/v1"
+api_key_env = "TOKEN_KIOSK_API_KEY"
+
+[llm_clients.token_kiosk_anthropic]
+format = "anthropic_messages"
+base_url = "https://agent-router.gaib.ai/v1"
+api_key_env = "TOKEN_KIOSK_API_KEY"
+
+[targets.token_kiosk_gpt]
+id = "gpt-4o"
+llm_client = "token_kiosk_openai"
+
+[targets.token_kiosk_claude]
+id = "claude-3-5-sonnet-20241022"
+llm_client = "token_kiosk_anthropic"
+
+[routes.token_kiosk_chat]
+id = "token-kiosk-openai"
+type = "passthrough"
+target = "token_kiosk_gpt"
+
+[routes.token_kiosk_messages]
+id = "token-kiosk-anthropic"
+type = "passthrough"
+target = "token_kiosk_claude"


### PR DESCRIPTION
### Summary
Adds **GAIB Token Kiosk** (`https://agent-router.gaib.ai/v1`) as an OpenAI-compatible / Anthropic-compatible provider client integration preset and documentation example.

### Changes
- Adds `examples/routes.token_kiosk.toml` with pre-configured `llm_clients` and targets for GAIB Token Kiosk endpoints (`openai_chat` and `anthropic_messages` formats).
- Updates `docs/getting_started.md` to list GAIB Token Kiosk as a supported OpenAI-compatible provider.

Signed-off-by: hgaib <hung.cheng@gaib.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GAIB Token Kiosk routing preset with OpenAI and Anthropic clients.
  - Added support for GPT-4o and Claude targets with chat and messages passthrough routes.

- **Documentation**
  - Updated setup guidance to include GAIB Token Kiosk as an API-key provider.
  - Documented the required `base_url` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->