### PR TITLE
fix(llm-client): fall back when the first stream event is a context overflow

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -5,16 +5,18 @@
 //! request, call the configured backend over HTTP, decode the neutral response.
 
 use std::collections::{BTreeMap, HashMap};
+use std::future::ready;
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
-use futures_util::StreamExt;
+use futures_util::{StreamExt, stream};
 use http::StatusCode;
 use reqwest::RequestBuilder;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
 use serde_json::{Map, Value};
 use switchyard_protocol::{
-    LlmRequest, LlmResponse, Metadata, ModelId, Request, Response, RoutedLlmClient,
+    LlmRequest, LlmResponse, LlmResponseChunk, LlmResponseStreamEvent, Metadata, ModelId, Request,
+    Response, RoutedLlmClient,
 };
 use switchyard_translation::{
     WireFormat, decode_aggregated_response, decode_request, decode_stream,
@@ -445,8 +447,23 @@ impl TranslatingLlmClient {
                         }
                     })
                 });
-                let chunks = decode_stream(bytes, wire_format)?;
-                LlmResponse::Stream(chunks)
+                let mut chunks = decode_stream(bytes, wire_format)?;
+                // Providers reject an over-ceiling streaming request with an in-band
+                // error event on an HTTP 200. Classify the first event before returning
+                // the stream: nothing has reached the caller yet, so an overflow can
+                // still fail the call and let routing try the next candidate.
+                match chunks.next().await {
+                    None => LlmResponse::Stream(stream::empty().boxed()),
+                    Some(first) => {
+                        if let Some(message) = first_event_overflow(&first, backend) {
+                            return Err(LlmClientError::ContextWindowExceeded {
+                                model: model_id.clone(),
+                                message,
+                            });
+                        }
+                        LlmResponse::Stream(stream::once(ready(first)).chain(chunks).boxed())
+                    }
+                }
             }
             EncodedResponse::Buffered { body, .. } => {
                 let body = serde_json::from_slice::<Value>(&body).map_err(|error| {
@@ -593,6 +610,25 @@ impl AttemptFailure {
             _ => false,
         }
     }
+}
+
+// The overflow message when a stream's first event is an in-band provider rejection
+// of the whole request, rather than the start of a response.
+fn first_event_overflow(
+    first: &Result<LlmResponseStreamEvent>,
+    backend: &Backend,
+) -> Option<String> {
+    first
+        .as_ref()
+        .ok()?
+        .normalized()
+        .iter()
+        .find_map(|chunk| match chunk {
+            LlmResponseChunk::StreamError { message } if backend.is_context_overflow(message) => {
+                Some(message.clone())
+            }
+            _ => None,
+        })
 }
 
 // Uses Retry-After when supplied, capped so an upstream cannot stall a request indefinitely.

--- a/crates/libsy-llm-client/src/run.rs
+++ b/crates/libsy-llm-client/src/run.rs
@@ -729,4 +729,136 @@ mod tests {
         assert_eq!(&*client.calls.lock(), &[ModelId::from("weak")]);
         Ok(())
     }
+
+    // Verbatim shape of an SGLang admission rejection on a streaming session:
+    // HTTP 200, and the overflow arrives as the first SSE event.
+    const OVERFLOW_SSE: &str = "data: {\"error\":{\"code\":400,\"message\":\"Input length (600013 tokens) exceeds the maximum allowed length (536826 tokens). Use a shorter input or enable --allow-auto-truncate.\",\"object\":\"error\",\"param\":null,\"type\":\"BAD_REQUEST\"},\"model\":\"weak\"}\n\ndata: [DONE]\n\n";
+
+    // A normal one-turn streamed answer, as the second candidate serves it.
+    const STRONG_SSE: &str = "data: {\"id\":\"answer\",\"model\":\"strong\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":null}]}\n\ndata: {\"id\":\"answer\",\"model\":\"strong\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+
+    /// Runs a streaming request through the weak→strong candidate loop, serving
+    /// `weak_sse` from the first candidate and [`STRONG_SSE`] from the second.
+    /// The server is returned so response streams stay readable after the call.
+    async fn run_streaming_candidates(
+        weak_sse: &'static str,
+    ) -> (
+        MockServer,
+        Arc<Mutex<Vec<String>>>,
+        Result<(ModelId, Response)>,
+    ) {
+        let server = MockServer::start().await;
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let observed_calls = Arc::clone(&calls);
+        Mock::given(method("POST"))
+            .respond_with(move |request: &wiremock::Request| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(&request.body).unwrap_or(serde_json::Value::Null);
+                let model = body["model"].as_str().unwrap_or_default().to_string();
+                observed_calls.lock().push(model.clone());
+                let sse = if model == "weak" {
+                    weak_sse
+                } else {
+                    STRONG_SSE
+                };
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse)
+            })
+            .mount(&server)
+            .await;
+
+        let backend = || {
+            Backend::OpenAiChat(HttpBackendConfig {
+                base_url: format!("{}/v1", server.uri()),
+                api_key: None,
+                forward_auth: false,
+                extra_headers: BTreeMap::new(),
+                extra_body: BTreeMap::new(),
+                max_retries: 0,
+            })
+        };
+        let client = Arc::new(
+            TranslatingLlmClient::new(&[
+                ModelConfig::new("weak", backend(), None),
+                ModelConfig::new("strong", backend(), None),
+            ])
+            .expect("building test client"),
+        );
+        let algorithm = Arc::new(CandidateAlgorithm {
+            models: vec!["weak".into(), "strong".into()],
+        });
+        let mut llm_request = text_request(Some("auto".to_string()), "hello".to_string());
+        llm_request.stream = true;
+        let request = Request {
+            llm_request,
+            raw_request: None,
+            metadata: None,
+        };
+        let result = run(algorithm, ClientRouter::single(client), request, None).await;
+        (server, calls, result)
+    }
+
+    #[tokio::test]
+    async fn first_stream_event_overflow_falls_back_to_the_next_candidate() -> Result<()> {
+        // Nothing has reached the caller when the first event arrives, so an overflow
+        // there falls through to the next candidate exactly as its buffered twin does.
+        let (_server, calls, result) = run_streaming_candidates(OVERFLOW_SSE).await;
+        let (_, response) = result?;
+        assert_eq!(&*calls.lock(), &["weak", "strong"]);
+        assert_eq!(response.served_model().map(ModelId::as_str), Some("strong"));
+        let aggregate = response
+            .llm_response
+            .into_agg()
+            .await
+            .map_err(|source| LibsyError::client_call("strong", source))?;
+        assert_eq!(completion_text(&aggregate), "ok");
+
+        // Only a classified overflow re-routes; any other in-band error event still
+        // streams through to the consumer without trying another candidate.
+        let (_server, calls, result) = run_streaming_candidates(
+            "data: {\"error\":{\"code\":500,\"message\":\"engine exploded\",\"object\":\"error\"},\"model\":\"weak\"}\n\ndata: [DONE]\n\n",
+        )
+        .await;
+        let (_, response) = result?;
+        assert_eq!(&*calls.lock(), &["weak"]);
+        let error = response
+            .llm_response
+            .into_agg()
+            .await
+            .expect_err("the in-band error should surface to the consumer");
+        assert!(error.to_string().contains("engine exploded"));
+
+        // Once content has streamed, a retry would repeat delivered output, so a later
+        // overflow event keeps today's semantics and surfaces during aggregation.
+        let (_server, calls, result) = run_streaming_candidates(
+            "data: {\"id\":\"turn\",\"model\":\"weak\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"partial\"},\"finish_reason\":null}]}\n\ndata: {\"error\":{\"code\":400,\"message\":\"Input length (600013 tokens) exceeds the maximum allowed length (536826 tokens).\",\"object\":\"error\",\"type\":\"BAD_REQUEST\"},\"model\":\"weak\"}\n\ndata: [DONE]\n\n",
+        )
+        .await;
+        let (_, response) = result?;
+        assert_eq!(&*calls.lock(), &["weak"]);
+        let error = response
+            .llm_response
+            .into_agg()
+            .await
+            .expect_err("the mid-stream overflow should surface to the consumer");
+        assert!(
+            error
+                .to_string()
+                .contains("exceeds the maximum allowed length")
+        );
+
+        // A stream that ends before any event is not a classified failure; it still
+        // aggregates to an empty response.
+        let (_server, calls, result) = run_streaming_candidates("data: [DONE]\n\n").await;
+        let (_, response) = result?;
+        assert_eq!(&*calls.lock(), &["weak"]);
+        let aggregate = response
+            .llm_response
+            .into_agg()
+            .await
+            .map_err(|source| LibsyError::client_call("weak", source))?;
+        assert_eq!(completion_text(&aggregate), "");
+        Ok(())
+    }
 }

--- a/docs/operations/context_window.md
+++ b/docs/operations/context_window.md
@@ -17,6 +17,13 @@ way — HTTP 413 or 422, for example — is not recognized as one. The request
 fails on the spot with the upstream's status code, and the upstream's body is
 returned inside Switchyard's error message.
 
+Streaming requests are covered as well. Some engines reject an over-limit
+streaming request with HTTP 200 and deliver the error as the first stream
+event; when that first event carries a message matching the phrases above, the
+call fails as an overflow and falls through before anything reaches the client.
+An error event arriving after content has streamed is not retried — delivered
+output cannot be taken back — and surfaces to the client as before.
+
 ## Configuration
 
 There is no eviction key. A route falls through whenever it has more than one


### PR DESCRIPTION
## What

Streaming calls now classify the first stream event before the call is declared successful. If that event is an in-band error whose message matches the existing overflow phrases (`is_context_overflow`), the call fails as `ContextWindowExceeded` and the ordered candidate loop falls through — same path, log line, and metrics as a buffered overflow 400. Any other first event (content, a non-overflow error, a transport failure) is reattached to the front of the stream and everything behaves as before. Errors after the first content event keep today's semantics: delivered output cannot be retried.

~30 LOC in `crates/libsy-llm-client/src/client.rs`, four regression tests, and a short addition to `docs/operations/context_window.md`.

## Why

Ordered candidate fallback works for buffered requests but never engages for streaming ones. When a request carries `"stream": true`, an engine that rejects it for context overflow answers `200 OK` + `text/event-stream` and delivers the rejection as the first SSE event:

```text
data: {"error":{"code":400,"message":"Input length (600013 tokens) exceeds the maximum allowed length (536826 tokens). Use a shorter input or enable --allow-auto-truncate.","object":"error","param":null,"type":"BAD_REQUEST"},"model":"short_ctx"}

data: [DONE]
```

Because a streaming call is declared successful as soon as response headers arrive, the error event is never classified, no fallback fires, and the client receives the overflow from a route whose purpose is to absorb it. Agent clients stream by default, so context-window fall-through never engages for exactly the traffic it targets. At the moment the first event arrives nothing has been forwarded to the caller, so retrying on the next candidate is invisible to it.

Closes #531

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green (the Docker-compose e2e needs a local daemon; verified it fails identically on unpatched `main`, unrelated to this change)
- [x] `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all green
- [x] Manual smoke: replayed 900 streaming requests from recorded agentic coding traces through a two-tier route (admission ceilings 536,826 / 1,048,576 tokens, two SGLang deployments behind an OpenAI-compatible gateway, concurrency 4). Before the patch: 26 over-ceiling requests, all errored to the client, second tier idle. With the patch: 18 over-ceiling requests, all rerouted and served by the second tier (largest 600,029 tokens), zero overflow errors reaching clients; the largest request served by the first tier was 536,761 tokens, so the tiering boundary lands exactly on the admission limits.

New tests (in `run.rs`, driving a streaming request through `TranslatingLlmClient` and the candidate loop against a mock SSE server):

- `first_stream_event_overflow_falls_back_to_the_next_candidate` — replays the captured rejection frame verbatim; asserts the second candidate serves and its stream aggregates intact.
- `non_overflow_first_stream_events_are_delivered_unchanged` — a non-overflow first-event error streams through; no fallback.
- `overflow_after_content_stays_within_the_stream` — an overflow-phrased error after content does not reroute; surfaces during aggregation as today.
- `empty_streams_are_returned_without_fallback` — a stream ending before any event aggregates to an empty response; no fallback, no error.

The pre-existing boundary tests (`streams_are_outside_the_candidate_fallback_boundary`, `candidate_failures_follow_the_fallback_policy`) pass unchanged.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (n/a — no Python changes)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (n/a — no new public symbols)
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. (`docs/operations/context_window.md` now documents the streaming case)
- [x] Commits signed off (`Signed-off-by`) per the DCO.

## Notes for reviewers

- **Semantic shift, deliberate:** streaming success now means "first event received" rather than "headers received," so client TTFB moves by one upstream event. Engines send nothing before their admission check, so in practice it is the same instant.
- **Scope is first-event-only on purpose** — the boundary #390 drew for transport errors on the escalation router. Mid-stream errors (even overflow-phrased) and non-overflow first events keep exact current behavior; each case is pinned by a test.
- **A transport error as the first item is reattached, not converted** into a candidate failure. Kept minimal intentionally; easy follow-up if broader first-event handling is wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming requests now detect context-window errors before displaying output and can automatically fall back when appropriate.
  * Errors that occur after content has started streaming remain visible and are not retried.
  * Improved handling of empty streams and other initial streaming errors.

* **Documentation**
  * Added guidance on context-window overflow behavior during streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->