### PR TITLE
fix(llm-client): follow only same-origin redirects to keep credentials on origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **Deployment credentials confined to the configured origin** — upstream
-  clients now follow only same-origin redirects, so a cross-origin 307/308
-  from the configured `base_url` is returned to the caller instead of being
-  followed, and `x-api-key`, `x-goog-api-key`, and forwarded caller
-  credentials can no longer reach another origin. Endpoints that answer with
-  a cross-origin redirect must be configured by their final origin. (#543)
+  clients, default and forwarded-auth alike, now follow only same-origin
+  redirects, so a cross-origin 307/308 from the configured `base_url` is
+  returned to the caller instead of being followed, and `x-api-key`,
+  `x-goog-api-key`, and forwarded caller credentials can no longer reach
+  another origin. Endpoints that answer with a cross-origin redirect must be
+  configured by their final origin. (#543)
 - **Reasoning order in mixed stream chunks** — the OpenAI Chat stream decoder
   emits reasoning deltas before content deltas from the same chunk, so
   interleaved reasoning is no longer reordered. (#387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Deployment credential leak on cross-origin redirect** — the default
-  upstream client no longer follows redirects, so a cross-origin 307/308 from
-  the configured `base_url` can no longer carry `x-api-key` or
-  `x-goog-api-key` to the redirect target; deployment credentials reach only
-  the configured origin, matching the forward-auth client. (#543)
+- **Deployment credentials confined to the configured origin** — upstream
+  clients now follow only same-origin redirects, so a cross-origin 307/308
+  from the configured `base_url` is returned to the caller instead of being
+  followed, and `x-api-key`, `x-goog-api-key`, and forwarded caller
+  credentials can no longer reach another origin. Endpoints that answer with
+  a cross-origin redirect must be configured by their final origin. (#543)
 - **Reasoning order in mixed stream chunks** — the OpenAI Chat stream decoder
   emits reasoning deltas before content deltas from the same chunk, so
   interleaved reasoning is no longer reordered. (#387)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Deployment credential leak on cross-origin redirect** — the default
+  upstream client no longer follows redirects, so a cross-origin 307/308 from
+  the configured `base_url` can no longer carry `x-api-key` or
+  `x-goog-api-key` to the redirect target; deployment credentials reach only
+  the configured origin, matching the forward-auth client. (#543)
 - **Reasoning order in mixed stream chunks** — the OpenAI Chat stream decoder
   emits reasoning deltas before content deltas from the same chunk, so
   interleaved reasoning is no longer reordered. (#387)

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -1317,6 +1317,98 @@ mod tests {
         Ok(())
     }
 
+    // A cross-origin redirect must not carry the deployment credential to the
+    // redirect target. The default client serves non-forward-auth backends and
+    // refuses to follow redirects, so the sink origin never receives x-api-key.
+    #[tokio::test]
+    async fn default_client_does_not_follow_cross_origin_redirect_with_credential()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::mpsc;
+        use std::time::Instant;
+
+        // The sink stands in for the redirect target on a different origin. It
+        // reports whether any request reached it carrying the credential.
+        let sink = std::net::TcpListener::bind("127.0.0.1:0")?;
+        sink.set_nonblocking(true)?;
+        let sink_addr = sink.local_addr()?;
+        let (sink_tx, sink_rx) = mpsc::channel::<bool>();
+        let sink_handle = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(500);
+            while Instant::now() < deadline {
+                match sink.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = [0_u8; 2048];
+                        let read = stream.read(&mut request).unwrap_or(0);
+                        let seen = String::from_utf8_lossy(&request[..read]).to_lowercase();
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                              Content-Length: 2\r\nConnection: close\r\n\r\n{}",
+                        );
+                        let _ = sink_tx.send(seen.contains("x-api-key"));
+                        return;
+                    }
+                    Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+
+        // The origin is the configured base_url. It sees the credential (allowed)
+        // and replies with a cross-origin redirect to the sink.
+        let origin = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let origin_addr = origin.local_addr()?;
+        let (origin_tx, origin_rx) = mpsc::channel::<bool>();
+        let origin_handle = std::thread::spawn(move || -> std::io::Result<()> {
+            let (mut stream, _) = origin.accept()?;
+            let mut request = [0_u8; 2048];
+            let read = stream.read(&mut request)?;
+            let seen = String::from_utf8_lossy(&request[..read]).to_lowercase();
+            let _ = origin_tx.send(seen.contains("x-api-key"));
+            let response = format!(
+                "HTTP/1.1 307 Temporary Redirect\r\n\
+                 Location: http://{sink_addr}/v1/messages\r\n\
+                 Content-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes())?;
+            Ok(())
+        });
+
+        let base_url = format!("http://{origin_addr}/v1");
+        let client = TranslatingLlmClient::new(&anthropic_map(&base_url))?;
+        // With redirects disabled the 307 surfaces as an upstream error rather than
+        // being followed; the call outcome is irrelevant, only where the key went.
+        let _ = client
+            .call_rewrite_model(request_for(Some("claude"), false), None)
+            .await;
+
+        let origin_saw_key = origin_rx
+            .recv_timeout(Duration::from_millis(500))
+            .expect("the configured origin should receive the request");
+        assert!(
+            origin_saw_key,
+            "the configured origin should receive the deployment credential"
+        );
+
+        // The redirect target must never receive the credential. With the redirect
+        // refused it is not contacted at all, so the channel disconnects unused.
+        if let Ok(sink_saw_key) = sink_rx.recv_timeout(Duration::from_millis(700)) {
+            assert!(
+                !sink_saw_key,
+                "redirect target received x-api-key: the deployment credential leaked across origins"
+            );
+        }
+
+        sink_handle
+            .join()
+            .map_err(|_| std::io::Error::other("sink server thread panicked"))?;
+        origin_handle
+            .join()
+            .map_err(|_| std::io::Error::other("origin server thread panicked"))??;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn rewrites_model_to_resolved_upstream_id()
     -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -115,9 +115,9 @@ impl TranslatingLlmClient {
         // clients follow only same-origin redirects, so deployment and forwarded
         // credentials are re-sent exclusively within the configured origin.
         let client =
-            build_client(reqwest::Client::builder().redirect(restricted_redirect_policy()))?;
+            build_client(reqwest::Client::builder().redirect(same_origin_redirect_policy()))?;
         let forward_auth_client =
-            build_client(reqwest::Client::builder().redirect(restricted_redirect_policy()))?;
+            build_client(reqwest::Client::builder().redirect(same_origin_redirect_policy()))?;
         let model_to_config = model_configs
             .iter()
             .map(|config| (config.model_name.clone(), config.clone()))
@@ -645,7 +645,7 @@ fn record_gen_ai_request(url: &str, model: &str, streaming: bool) {
 // is followed only while it stays on the origin the request was first sent to,
 // so deployment or forwarded credentials never reach another origin. A refused
 // redirect is returned to the caller untouched instead of being followed.
-fn restricted_redirect_policy() -> reqwest::redirect::Policy {
+fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
     reqwest::redirect::Policy::custom(|attempt| {
         let stays_on_origin = attempt
             .previous()
@@ -1343,7 +1343,9 @@ mod tests {
     }
 
     // Reads until the end of an HTTP request head, so a TCP segment boundary
-    // cannot split the headers a later assertion matches against.
+    // cannot split the headers a later assertion matches against. Test requests
+    // sit far below the buffer size; exceeding it is a loud error, never a
+    // silent truncation.
     fn read_request_head(
         stream: &mut std::net::TcpStream,
         buffer: &mut [u8],
@@ -1352,8 +1354,21 @@ mod tests {
         loop {
             let read = stream.read(&mut buffer[total..])?;
             total += read;
-            if read == 0 || buffer[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+            let head_complete = buffer[..total].windows(4).any(|w| w == b"\r\n\r\n");
+            if read == 0 && !head_complete {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed before the request head was complete",
+                ));
+            }
+            if head_complete {
                 return Ok(total);
+            }
+            if total == buffer.len() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "request head exceeded the read buffer",
+                ));
             }
         }
     }
@@ -1471,25 +1486,20 @@ mod tests {
         Ok(())
     }
 
-    // Same-origin redirects are still followed: the credential rides each hop
-    // that stays within the configured origin, so gateways that redirect on
-    // their own origin keep working without credentials ever leaving it.
-    #[tokio::test]
-    async fn same_origin_redirect_is_followed_within_the_configured_origin()
-    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+    // Serves two sequential responses from one origin and returns the lowercase
+    // request heads it received, so tests can pin what rode each hop.
+    fn two_hop_origin_server(
+        build_responses: impl FnOnce(&str) -> [String; 2] + Send + 'static,
+    ) -> std::io::Result<(
+        String,
+        std::thread::JoinHandle<std::io::Result<Vec<String>>>,
+    )> {
         let origin = std::net::TcpListener::bind("127.0.0.1:0")?;
         let origin_addr = origin.local_addr()?;
         let origin_url = format!("http://{origin_addr}");
-        let server_url = origin_url.clone();
-        let server = std::thread::spawn(move || -> std::io::Result<Vec<String>> {
-            let mut responses = [
-                format!(
-                    "HTTP/1.1 307 Temporary Redirect\r\n\
-                     Location: {server_url}/chat/completions\r\n\
-                     Content-Length: 0\r\nConnection: close\r\n\r\n"
-                ),
-                raw_chat_success_response(),
-            ];
+        let responses = build_responses(&origin_url);
+        let handle = std::thread::spawn(move || -> std::io::Result<Vec<String>> {
+            let mut responses = responses;
             let mut requests = Vec::with_capacity(responses.len());
             for response in &mut responses {
                 let (mut stream, _) = origin.accept()?;
@@ -1500,6 +1510,25 @@ mod tests {
             }
             Ok(requests)
         });
+        Ok((origin_url, handle))
+    }
+
+    // Same-origin redirects are still followed: the credential rides each hop
+    // that stays within the configured origin, so gateways that redirect on
+    // their own origin keep working without credentials ever leaving it.
+    #[tokio::test]
+    async fn same_origin_redirect_is_followed_within_the_configured_origin()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let (origin_url, server) = two_hop_origin_server(|origin_url| {
+            [
+                format!(
+                    "HTTP/1.1 307 Temporary Redirect\r\n\
+                     Location: {origin_url}/chat/completions\r\n\
+                     Content-Length: 0\r\nConnection: close\r\n\r\n"
+                ),
+                raw_chat_success_response(),
+            ]
+        })?;
 
         let client = TranslatingLlmClient::new(&chat_map(&format!("{origin_url}/v1")))?;
         let response = client
@@ -1519,6 +1548,63 @@ mod tests {
                 .iter()
                 .all(|request| request.contains("authorization:")),
             "the credential must ride every same-origin hop"
+        );
+        Ok(())
+    }
+
+    // The forwarded-auth client serves caller credentials and previously refused
+    // every redirect outright. Same-origin redirects must work there too, with
+    // the caller's own credential riding both hops without ever leaving the
+    // configured origin.
+    #[tokio::test]
+    async fn forward_auth_client_follows_same_origin_redirect_with_credential()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let (origin_url, server) = two_hop_origin_server(|origin_url| {
+            [
+                format!(
+                    "HTTP/1.1 307 Temporary Redirect\r\n\
+                     Location: {origin_url}/chat/completions\r\n\
+                     Content-Length: 0\r\nConnection: close\r\n\r\n"
+                ),
+                raw_chat_success_response(),
+            ]
+        })?;
+
+        let mut backend = config(&format!("{origin_url}/v1"));
+        backend.api_key = None;
+        backend.forward_auth = true;
+        let model_configs = vec![ModelConfig::new("gpt", Backend::OpenAiChat(backend), None)];
+        let client = TranslatingLlmClient::new(&model_configs)?;
+
+        // The caller's credential arrives as forwarded metadata, not as
+        // configured auth.
+        let request = Request {
+            llm_request: text_request(Some("gpt".to_string()), "hi"),
+            raw_request: None,
+            metadata: Some(Metadata {
+                http_headers: Some(HeaderMap::from_iter([(
+                    reqwest::header::AUTHORIZATION,
+                    reqwest::header::HeaderValue::from_static("Bearer caller-canary"),
+                )])),
+                wire_format: Some(WireFormat::OpenAiChat),
+                ..Default::default()
+            }),
+        };
+        let response = client.call_rewrite_model(request, None).await?;
+        assert_eq!(
+            completion_text(&response.llm_response.into_agg().await?),
+            "recovered"
+        );
+
+        let requests = server
+            .join()
+            .map_err(|_| std::io::Error::other("forward-auth redirect server panicked"))??;
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests.iter().all(|request| {
+                request.contains("authorization:") && request.contains("caller-canary")
+            }),
+            "the caller credential must ride every same-origin hop"
         );
         Ok(())
     }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -111,9 +111,11 @@ impl TranslatingLlmClient {
                 source: Box::new(error),
             })
         };
-        let client = build_client(reqwest::Client::builder())?;
         // A redirect could move provider-specific headers to another origin.
-        // Forwarded credentials are sent only to the configured URL.
+        // Deployment credentials are sent only to the configured URL, so neither
+        // client follows redirects.
+        let client =
+            build_client(reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()))?;
         let forward_auth_client =
             build_client(reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()))?;
         let model_to_config = model_configs

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -111,13 +111,13 @@ impl TranslatingLlmClient {
                 source: Box::new(error),
             })
         };
-        // A redirect could move provider-specific headers to another origin.
-        // Deployment credentials are sent only to the configured URL, so neither
-        // client follows redirects.
+        // A redirect could move provider-specific headers to another origin. Both
+        // clients follow only same-origin redirects, so deployment and forwarded
+        // credentials are re-sent exclusively within the configured origin.
         let client =
-            build_client(reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()))?;
+            build_client(reqwest::Client::builder().redirect(restricted_redirect_policy()))?;
         let forward_auth_client =
-            build_client(reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()))?;
+            build_client(reqwest::Client::builder().redirect(restricted_redirect_policy()))?;
         let model_to_config = model_configs
             .iter()
             .map(|config| (config.model_name.clone(), config.clone()))
@@ -639,6 +639,31 @@ fn record_gen_ai_request(url: &str, model: &str, streaming: bool) {
             span.record("server.port", i64::from(port));
         }
     }
+}
+
+// Builds every upstream client with the same redirect confinement: a redirect
+// is followed only while it stays on the origin the request was first sent to,
+// so deployment or forwarded credentials never reach another origin. A refused
+// redirect is returned to the caller untouched instead of being followed.
+fn restricted_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        let stays_on_origin = attempt
+            .previous()
+            .first()
+            .is_some_and(|first_url| is_same_origin(first_url, attempt.url()));
+        if stays_on_origin {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+// Whether two URLs share a scheme, host, and effective port.
+fn is_same_origin(left: &reqwest::Url, right: &reqwest::Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
 }
 
 fn convert_reqwest_error(error: reqwest::Error) -> LlmClientError {
@@ -1317,34 +1342,53 @@ mod tests {
         Ok(())
     }
 
-    // A cross-origin redirect must not carry the deployment credential to the
-    // redirect target. The default client serves non-forward-auth backends and
-    // refuses to follow redirects, so the sink origin never receives x-api-key.
+    // Reads until the end of an HTTP request head, so a TCP segment boundary
+    // cannot split the headers a later assertion matches against.
+    fn read_request_head(
+        stream: &mut std::net::TcpStream,
+        buffer: &mut [u8],
+    ) -> std::io::Result<usize> {
+        let mut total = 0;
+        loop {
+            let read = stream.read(&mut buffer[total..])?;
+            total += read;
+            if read == 0 || buffer[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+                return Ok(total);
+            }
+        }
+    }
+
+    // A cross-origin redirect must not carry deployment credentials to the
+    // redirect target, whichever transport carries them: the anthropic
+    // `api_key` (`x-api-key`) or `extra_headers` (`x-goog-api-key`). The client
+    // refuses to leave the configured origin, so the sink origin is never
+    // contacted at all and the refused 307 surfaces as an upstream error.
     #[tokio::test]
-    async fn default_client_does_not_follow_cross_origin_redirect_with_credential()
+    async fn cross_origin_redirect_never_carries_deployment_credentials()
     -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         use std::sync::mpsc;
         use std::time::Instant;
 
         // The sink stands in for the redirect target on a different origin. It
-        // reports whether any request reached it carrying the credential.
+        // reports whether any request reached it at all.
         let sink = std::net::TcpListener::bind("127.0.0.1:0")?;
         sink.set_nonblocking(true)?;
         let sink_addr = sink.local_addr()?;
         let (sink_tx, sink_rx) = mpsc::channel::<bool>();
         let sink_handle = std::thread::spawn(move || {
-            let deadline = Instant::now() + Duration::from_millis(500);
+            let deadline = Instant::now() + Duration::from_millis(750);
             while Instant::now() < deadline {
                 match sink.accept() {
                     Ok((mut stream, _)) => {
+                        let _ = stream.set_nonblocking(false);
                         let mut request = [0_u8; 2048];
-                        let read = stream.read(&mut request).unwrap_or(0);
+                        let read = read_request_head(&mut stream, &mut request).unwrap_or(0);
                         let seen = String::from_utf8_lossy(&request[..read]).to_lowercase();
                         let _ = stream.write_all(
                             b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
                               Content-Length: 2\r\nConnection: close\r\n\r\n{}",
                         );
-                        let _ = sink_tx.send(seen.contains("x-api-key"));
+                        let _ = sink_tx.send(!seen.is_empty());
                         return;
                     }
                     Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1355,17 +1399,17 @@ mod tests {
             }
         });
 
-        // The origin is the configured base_url. It sees the credential (allowed)
-        // and replies with a cross-origin redirect to the sink.
+        // The origin is the configured base_url. It sees both credentials
+        // (allowed) and replies with a cross-origin redirect to the sink.
         let origin = std::net::TcpListener::bind("127.0.0.1:0")?;
         let origin_addr = origin.local_addr()?;
         let (origin_tx, origin_rx) = mpsc::channel::<bool>();
         let origin_handle = std::thread::spawn(move || -> std::io::Result<()> {
             let (mut stream, _) = origin.accept()?;
             let mut request = [0_u8; 2048];
-            let read = stream.read(&mut request)?;
+            let read = read_request_head(&mut stream, &mut request)?;
             let seen = String::from_utf8_lossy(&request[..read]).to_lowercase();
-            let _ = origin_tx.send(seen.contains("x-api-key"));
+            let _ = origin_tx.send(seen.contains("x-api-key") && seen.contains("x-goog-api-key"));
             let response = format!(
                 "HTTP/1.1 307 Temporary Redirect\r\n\
                  Location: http://{sink_addr}/v1/messages\r\n\
@@ -1375,29 +1419,47 @@ mod tests {
             Ok(())
         });
 
+        // The anthropic backend carries `x-api-key` from `api_key`; the extra
+        // header adds the gemini-style transport on the same request.
         let base_url = format!("http://{origin_addr}/v1");
-        let client = TranslatingLlmClient::new(&anthropic_map(&base_url))?;
-        // With redirects disabled the 307 surfaces as an upstream error rather than
-        // being followed; the call outcome is irrelevant, only where the key went.
-        let _ = client
+        let mut backend_config = config(&base_url);
+        backend_config
+            .extra_headers
+            .insert("x-goog-api-key".to_string(), "gemini-canary".to_string());
+        let model_configs = vec![ModelConfig::new(
+            "claude",
+            Backend::Anthropic(backend_config),
+            None,
+        )];
+        let client = TranslatingLlmClient::new(&model_configs)?;
+
+        let result = client
             .call_rewrite_model(request_for(Some("claude"), false), None)
             .await;
+        let Err(error) = result else {
+            panic!("expected the cross-origin redirect to be refused");
+        };
+        assert!(
+            matches!(
+                error,
+                LlmClientError::UpstreamHttp { status, .. } if status.as_u16() == 307
+            ),
+            "expected the refused redirect to surface as upstream HTTP 307, got {error}"
+        );
 
         let origin_saw_key = origin_rx
-            .recv_timeout(Duration::from_millis(500))
+            .recv_timeout(Duration::from_secs(2))
             .expect("the configured origin should receive the request");
         assert!(
             origin_saw_key,
-            "the configured origin should receive the deployment credential"
+            "the configured origin should receive both deployment credentials"
         );
 
-        // The redirect target must never receive the credential. With the redirect
-        // refused it is not contacted at all, so the channel disconnects unused.
-        if let Ok(sink_saw_key) = sink_rx.recv_timeout(Duration::from_millis(700)) {
-            assert!(
-                !sink_saw_key,
-                "redirect target received x-api-key: the deployment credential leaked across origins"
-            );
+        // The redirect target must never be contacted: no connection within the
+        // window is the success case, any accepted connection fails the test.
+        match sink_rx.recv_timeout(Duration::from_millis(1500)) {
+            Ok(_) => panic!("redirect target was contacted during the redirect"),
+            Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => {}
         }
 
         sink_handle
@@ -1406,6 +1468,58 @@ mod tests {
         origin_handle
             .join()
             .map_err(|_| std::io::Error::other("origin server thread panicked"))??;
+        Ok(())
+    }
+
+    // Same-origin redirects are still followed: the credential rides each hop
+    // that stays within the configured origin, so gateways that redirect on
+    // their own origin keep working without credentials ever leaving it.
+    #[tokio::test]
+    async fn same_origin_redirect_is_followed_within_the_configured_origin()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let origin = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let origin_addr = origin.local_addr()?;
+        let origin_url = format!("http://{origin_addr}");
+        let server_url = origin_url.clone();
+        let server = std::thread::spawn(move || -> std::io::Result<Vec<String>> {
+            let mut responses = [
+                format!(
+                    "HTTP/1.1 307 Temporary Redirect\r\n\
+                     Location: {server_url}/chat/completions\r\n\
+                     Content-Length: 0\r\nConnection: close\r\n\r\n"
+                ),
+                raw_chat_success_response(),
+            ];
+            let mut requests = Vec::with_capacity(responses.len());
+            for response in &mut responses {
+                let (mut stream, _) = origin.accept()?;
+                let mut request = [0_u8; 2048];
+                let read = read_request_head(&mut stream, &mut request)?;
+                requests.push(String::from_utf8_lossy(&request[..read]).to_lowercase());
+                stream.write_all(response.as_bytes())?;
+            }
+            Ok(requests)
+        });
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{origin_url}/v1")))?;
+        let response = client
+            .call_rewrite_model(request_for(Some("gpt"), false), None)
+            .await?;
+        assert_eq!(
+            completion_text(&response.llm_response.into_agg().await?),
+            "recovered"
+        );
+
+        let requests = server
+            .join()
+            .map_err(|_| std::io::Error::other("redirect server thread panicked"))??;
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.contains("authorization:")),
+            "the credential must ride every same-origin hop"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## The bug

`TranslatingLlmClient::new` built the default upstream client with a plain
`reqwest::Client::builder()`, which follows redirects (up to ten). Only
`forward_auth_client` disabled them. `send_once` uses the default client for every
non-forward-auth backend, i.e. deployments configured via `api_key_env` /
`extra_headers`. reqwest strips `Authorization` on a cross-origin redirect but not
arbitrary headers, so a cross-origin 307/308 from the configured `base_url` re-sends
Anthropic `x-api-key` (and Gemini `x-goog-api-key`) to the redirect target origin.
OpenAI (bearer/Authorization) was only accidentally safe.

## The fix

Both upstream clients now share one redirect policy: a redirect is followed only
while it stays on the origin the request was first sent to. A cross-origin
redirect is refused and returned to the caller untouched, so deployment
credentials (`x-api-key`, `x-goog-api-key` via `extra_headers`) and forwarded
caller credentials never leave the configured origin — while same-origin
redirects (Azure-style LB 307s, path normalization) keep working with the
credential riding every hop. This supersedes the earlier all-redirects-refused
approach from the first push: refusing same-origin redirects broke legitimate
endpoints without adding any security.

## Review follow-ups addressed (52d0d9f8)

- Same-origin redirects are followed again; only cross-origin hops are refused.
- The sink assertion now fails on **any** contact with the redirect target;
  timeout/disconnect is the asserted success case (contact-without-key used to pass).
- Request heads are read to the header terminator, so TCP segmentation cannot
  split the headers the assertions match against.
- The refused redirect is pinned as an upstream HTTP 307 error.
- The cross-origin test exercises both credential transports on one request:
  `x-api-key` (`api_key_env`) and `x-goog-api-key` (`extra_headers`).
- New test proves same-origin redirects are followed with the credential
  present on every hop.
- CHANGELOG states the operator-facing behavior change explicitly: endpoints
  answering with a cross-origin redirect must be configured by their final origin.

## Testing

Test contract (locked before the code): deployment credentials reach only the
configured origin; same-origin redirects are followed, cross-origin targets are
never contacted.

- `cross_origin_redirect_never_carries_deployment_credentials`: hermetic
  two-`TcpListener` pair; the origin returns a cross-origin 307 while carrying
  both credential transports; the sink must receive nothing at all.
  Mutation-checked: the test fails if the policy wrongly follows cross-origin
  redirects.
- `same_origin_redirect_is_followed_within_the_configured_origin`: a 307 to the
  same origin is followed end-to-end; both hops carry `authorization`.
- `cargo test -p switchyard-llm-client` green (56 lib + 12 integration).
- `cargo fmt --check` and `cargo clippy --tests -D warnings` clean for the crate.

Closes #543

## Second review round addressed (716cbfeb)

- Dedicated test for the forwarded-auth client: a same-origin 307 is followed
  and the caller-provided `Authorization` rides both hops without leaving the
  configured origin. Its redirect policy was loosened from refuse-all in the
  first push, so this pins the new behavior explicitly.
- `read_request_head` now errors loudly on EOF-before-head-complete or buffer
  exhaustion instead of silently truncating oversized request heads.
- Both same-origin tests share one two-hop server harness; the policy helper
  is renamed to `same_origin_redirect_policy`; the CHANGELOG names both client
  paths (default and forwarded-auth) explicitly.
- Retitled: redirects are confined to the configured origin, not disabled.
  Gates re-run green: fmt --check, clippy --tests -D warnings, 57 lib + 12
  integration tests.
