### PR TITLE
feat(runner): load deployment from TOML source

### DIFF
--- a/crates/switchyard-runner/src/config.rs
+++ b/crates/switchyard-runner/src/config.rs
@@ -43,7 +43,7 @@ pub(crate) fn load_runner(path: impl AsRef<Path>) -> RunnerResult<Runner> {
     })
 }
 
-fn runner_from_toml(source: &str) -> RunnerResult<Runner> {
+pub(crate) fn runner_from_toml(source: &str) -> RunnerResult<Runner> {
     let config: DeploymentConfig = toml::from_str(source).map_err(|error| {
         RunnerError::configuration_source(format!("failed to parse TOML: {error}"), error)
     })?;
@@ -583,6 +583,15 @@ id = "switchyard/passthrough"
 type = "passthrough"
 target = "weak"
 "#;
+
+    #[test]
+    fn public_runner_from_toml_builds_a_deployment() -> RunnerResult<()> {
+        let runner = Runner::from_toml(VALID_CONFIG)?;
+
+        assert!(runner.route("switchyard/classifier").is_some());
+        assert!(runner.route("switchyard/passthrough").is_some());
+        Ok(())
+    }
 
     fn error_message(toml: &str) -> String {
         match runner_from_toml(toml) {

--- a/crates/switchyard-runner/src/runner.rs
+++ b/crates/switchyard-runner/src/runner.rs
@@ -47,6 +47,13 @@ impl Runner {
         config::load_runner(path)
     }
 
+    /// Loads and validates a version-1 deployment TOML document.
+    ///
+    /// Use [`Self::load`] when the deployment is stored in a file.
+    pub fn from_toml(source: &str) -> Result<Self, RunnerError> {
+        config::runner_from_toml(source)
+    }
+
     /// Builds a runner from named routes in caller-provided order.
     /// Pre-condition: There must be at least one route.
     pub fn new(routes: Vec<(ModelId, Route)>) -> Self {


### PR DESCRIPTION
## What

Adds `Runner::from_toml(&str)` as the in-memory counterpart to `Runner::load(path)`. Both entry points use the same version-1 deployment parser and validation path.

## Why

Enables hosts that already own deployment text to build a configured runner without writing a temporary file. This is the runner-side foundation for a future Relay inline Switchyard deployment configuration.

Relates to #537.

## How tested

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p switchyard-runner --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/ -q` green
- [x] Manual smoke: built the existing V1 multi-route deployment through `Runner::from_toml` and verified both routes register.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class.
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. Not applicable: this is a Rust crate API.
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. Not applicable: Rustdoc documents the new library method; no CLI or README behavior changed.
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

The implementation intentionally exposes the existing parser instead of adding another deployment representation or duplicating any configuration-building logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating a deployment runner directly from TOML configuration text.
  - TOML configurations are parsed and validated before routes are built.
  - Existing file-based configuration loading remains available.

- **Tests**
  - Added coverage confirming valid deployment configurations successfully create routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->