### PR TITLE
refactor(libsy): decide stage-router picker on score-as-probability

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -994,7 +994,7 @@ async fn stage_router_records_algorithm_owned_metrics() -> switchyard_libsy::Res
         Some(1)
     );
     for name in [
-        "switchyard.stage_router.score",
+        "switchyard.stage_router.probability",
         "switchyard.stage_router.confidence",
         "switchyard.stage_router.severity",
         "switchyard.stage_router.spinning",

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -624,7 +624,7 @@ impl Classifier<State> for StageClassifier {
                 tier,
                 source,
                 score,
-                ..
+                confidence,
             } => {
                 let target = self.targets.name(tier);
                 record_decision_source(state, source);
@@ -633,7 +633,10 @@ impl Classifier<State> for StageClassifier {
                 // is the only branch whose tier the signals actually chose — an
                 // ambiguous turn is decided further down the cascade.
                 self.apply_handoff_note(request, tier, source);
-                let conf = score.abs();
+                // Use the confidence pick_tier already computed (e.g. `1.0` for
+                // an Override) rather than re-deriving it from `score`, which is
+                // `0.0` on both hard-rule paths and would understate them.
+                let conf = confidence.unwrap_or(score.abs());
                 Ok((
                     Classification::Scores(vec![Score {
                         target: target.clone(),
@@ -858,6 +861,8 @@ mod tests {
             Classification::Scores(scores) => {
                 assert_eq!(scores.len(), 1);
                 assert_eq!(scores[0].target, "strong");
+                // An override is maximally certain, not `score.abs() == 0.0`.
+                assert_eq!(scores[0].confidence, 1.0);
             }
             _ => panic!("expected a definite classification"),
         }

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -710,92 +710,17 @@ mod tests {
     }
 
     #[test]
-    fn probability_remaps_the_score_brackets_onto_zero_point_five_plus_or_minus_half_threshold() {
-        assert_eq!(
-            ScoreResult {
-                score: -1.0,
-                confidence: 1.0
-            }
-            .probability(),
-            0.0
-        );
-        assert_eq!(
-            ScoreResult {
-                score: 0.0,
-                confidence: 0.0
-            }
-            .probability(),
-            0.5
-        );
-        assert_eq!(
-            ScoreResult {
-                score: 1.0,
-                confidence: 1.0
-            }
-            .probability(),
-            1.0
-        );
-        let t = 0.5;
-        assert_eq!(
-            ScoreResult {
-                score: t,
-                confidence: t
-            }
-            .probability(),
-            0.5 + t / 2.0
-        );
-        assert_eq!(
-            ScoreResult {
-                score: -t,
-                confidence: t
-            }
-            .probability(),
-            0.5 - t / 2.0
-        );
-    }
-
-    #[test]
-    fn pick_tier_agrees_with_the_pre_probability_score_based_decision_off_the_boundary() {
-        // Away from the exact `score == ±threshold` boundary, deciding on the
-        // probability `p = (score+1)/2` against `0.5 ± t/2` must pick the same
-        // tier as the original `confidence >= threshold` check on `score`.
-        for score_millis in -999..=999 {
-            let score = score_millis as f64 / 1000.0;
-            for threshold_millis in (0..=1000).step_by(50) {
-                let threshold = threshold_millis as f64 / 1000.0;
-                let confidence = score.abs();
-                if (confidence - threshold).abs() < 1e-9 {
-                    continue; // exact boundary: deliberately reclassified, see above.
-                }
-                let old_decisive = confidence >= threshold;
-                let old_tier = if score > 0.0 {
-                    Tier::Capable
-                } else {
-                    Tier::Efficient
-                };
-
-                let probability = (score + 1.0) / 2.0;
-                let half_threshold = threshold / 2.0;
-                let new_decisive =
-                    probability > 0.5 + half_threshold || probability < 0.5 - half_threshold;
-                let new_tier = if probability > 0.5 {
-                    Tier::Capable
-                } else {
-                    Tier::Efficient
-                };
-
-                assert_eq!(
-                    old_decisive, new_decisive,
-                    "decisiveness disagreement at score={score} threshold={threshold}"
-                );
-                if old_decisive {
-                    assert_eq!(
-                        old_tier, new_tier,
-                        "tier disagreement at score={score} threshold={threshold}"
-                    );
-                }
-            }
-        }
+    fn pick_tier_treats_the_exact_threshold_score_as_ambiguous() {
+        // score == threshold maps to p == 0.5 + t/2 exactly, the closed
+        // ambiguous-band endpoint — a deliberate boundary reclassification
+        // from the old `confidence >= threshold` framing.
+        let mut signal = signal_from(json!([{"role": "user", "content": "hi"}]));
+        signal.severity = HARD_SEVERITY as f32;
+        let threshold = score_signal(&signal).confidence;
+        assert!(matches!(
+            pick_tier(&signal, PickerMode::EfficientFirst, threshold),
+            PickOutcome::ConsultClassifier { .. }
+        ));
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -50,8 +50,8 @@ const SEVERITY_CRITICAL: f32 = 1.0;
 /// Counts final stage-router choices by decision source and semantic target.
 const ROUTING_DECISIONS_METRIC: &str = "switchyard.stage_router.routing_decisions";
 
-/// Distribution of the stage scorer's signed routing score.
-const SCORE_METRIC: &str = "switchyard.stage_router.score";
+/// Distribution of the picker's capable-tier probability.
+const PROBABILITY_METRIC: &str = "switchyard.stage_router.probability";
 /// Distribution of the confidence used to resolve or defer a turn.
 const CONFIDENCE_METRIC: &str = "switchyard.stage_router.confidence";
 /// Distribution of detected tool-failure severity.
@@ -65,7 +65,7 @@ const PRODUCTION_INTENSITY_METRIC: &str = "switchyard.stage_router.production_in
 
 // Histogram boundaries live with the instruments so every host exports the
 // same stage-router distributions without duplicating algorithm knowledge.
-const SCORE_BUCKETS: &[f64] = &[-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0];
+const PROBABILITY_BUCKETS: &[f64] = &[0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0];
 const UNIT_BUCKETS: &[f64] = &[0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0];
 
 /// The two tiers a turn can route to.
@@ -247,11 +247,7 @@ pub struct ScoreResult {
 }
 
 impl ScoreResult {
-    /// `score` remapped from `(-1, +1)` onto a `(0, 1)` capable-tier
-    /// probability: `p = (score + 1) / 2`. Strictly increasing, so it carries
-    /// the picker's `[-1, -t], (-t, t), [t, 1]` score brackets onto
-    /// `[0, 0.5 - t/2], (0.5 - t/2, 0.5 + t/2), [0.5 + t/2, 1]` without
-    /// changing which bracket any given turn falls into.
+    /// `score` remapped from `(-1, +1)` onto a `(0, 1)` capable-tier probability.
     fn probability(self) -> f64 {
         (self.score + 1.0) / 2.0
     }
@@ -280,16 +276,17 @@ pub enum PickOutcome {
         tier: Tier,
         /// What produced it.
         source: DecisionSource,
-        /// Signed scorer value (`0.0` for override / tests-passed).
-        score: f64,
+        /// Capable-tier probability in `(0, 1)`; `0.5` (neutral) for the
+        /// hard-rule paths, which bypass the scorer.
+        probability: f64,
         /// Scorer confidence (`None` where the scorer did not run).
         confidence: Option<f64>,
     },
     /// The scorer was below threshold. The caller runs its classifier; if it
     /// has none (or it fails), fall open to `default_tier`.
     ConsultClassifier {
-        /// Signed scorer value, for logging.
-        score: f64,
+        /// Capable-tier probability, for logging.
+        probability: f64,
         /// Scorer confidence, for logging.
         confidence: f64,
         /// Tier to fall open to when no classifier resolves it.
@@ -335,18 +332,26 @@ pub(crate) fn record_routing_decision(source: DecisionSource, target_name: &str)
 
 /// Records the scorer's bounded inputs and output as six explicit histograms.
 fn record_score_metrics(signal: &ToolSignals, outcome: &PickOutcome) {
-    let (score, confidence) = match outcome {
+    let (probability, confidence) = match outcome {
         PickOutcome::Resolved {
-            score, confidence, ..
-        } => (*score, confidence.unwrap_or(score.abs())),
+            probability,
+            confidence,
+            ..
+        } => (
+            *probability,
+            // Distance from 0.5, doubled onto [0, 1] — probability's `score.abs()`.
+            confidence.unwrap_or_else(|| 2.0 * (probability - 0.5).abs()),
+        ),
         PickOutcome::ConsultClassifier {
-            score, confidence, ..
-        } => (*score, *confidence),
+            probability,
+            confidence,
+            ..
+        } => (*probability, *confidence),
     };
     let dimensions = dimensions_from_signal(signal);
     let meter = meter();
     for (name, value, boundaries) in [
-        (SCORE_METRIC, score, SCORE_BUCKETS),
+        (PROBABILITY_METRIC, probability, PROBABILITY_BUCKETS),
         (CONFIDENCE_METRIC, confidence, UNIT_BUCKETS),
         (SEVERITY_METRIC, dimensions.severity, UNIT_BUCKETS),
         (SPINNING_METRIC, dimensions.spinning, UNIT_BUCKETS),
@@ -424,20 +429,16 @@ fn should_deescalate(signal: &ToolSignals) -> bool {
 pub fn pick_tier(signal: &ToolSignals, mode: PickerMode, confidence_threshold: f64) -> PickOutcome {
     // 1. Escalate — a hard reason to go capable, ahead of everything else.
     if should_escalate(signal) {
-        return resolved(Tier::Capable, DecisionSource::Override, 0.0, Some(1.0));
+        return resolved(Tier::Capable, DecisionSource::Override, 0.5, Some(1.0));
     }
 
     // 2. De-escalate — a hard reason to go cheap (the turn is winding down).
     if should_deescalate(signal) {
-        return resolved(Tier::Efficient, DecisionSource::TestsPassed, 0.0, None);
+        return resolved(Tier::Efficient, DecisionSource::TestsPassed, 0.5, None);
     }
 
-    // 3. Scorer — no hard reason either way, so weigh error vs production. Read
-    //    the score as a capable-tier probability `p`; outside the closed
-    //    ambiguous band `[0.5 - t/2, 0.5 + t/2]`, follow which side of 0.5 it
-    //    lands on. The band's endpoints count as ambiguous (strict `>`/`<`),
-    //    a one-point boundary flip from the old `confidence >= threshold`
-    //    framing that only bites at floating-point equality.
+    // 3. Scorer — no hard reason either way, so weigh error vs production.
+    //    Resolve outside the closed ambiguous band [0.5 - t/2, 0.5 + t/2].
     let scored = score_signal(signal);
     let probability = scored.probability();
     let half_threshold = confidence_threshold / 2.0;
@@ -450,7 +451,7 @@ pub fn pick_tier(signal: &ToolSignals, mode: PickerMode, confidence_threshold: f
         return resolved(
             tier,
             DecisionSource::Dimensions,
-            scored.score,
+            probability,
             Some(scored.confidence),
         );
     }
@@ -458,7 +459,7 @@ pub fn pick_tier(signal: &ToolSignals, mode: PickerMode, confidence_threshold: f
     // 4. Fall open — the signals didn't corroborate enough to be sure. Hand off
     //    to the caller's classifier; with none, land on the picker's default.
     PickOutcome::ConsultClassifier {
-        score: scored.score,
+        probability,
         confidence: scored.confidence,
         default_tier: mode.default_tier(),
     }
@@ -468,13 +469,13 @@ pub fn pick_tier(signal: &ToolSignals, mode: PickerMode, confidence_threshold: f
 fn resolved(
     tier: Tier,
     source: DecisionSource,
-    score: f64,
+    probability: f64,
     confidence: Option<f64>,
 ) -> PickOutcome {
     PickOutcome::Resolved {
         tier,
         source,
-        score,
+        probability,
         confidence,
     }
 }
@@ -623,7 +624,7 @@ impl Classifier<State> for StageClassifier {
             PickOutcome::Resolved {
                 tier,
                 source,
-                score,
+                probability,
                 confidence,
             } => {
                 let target = self.targets.name(tier);
@@ -633,10 +634,9 @@ impl Classifier<State> for StageClassifier {
                 // is the only branch whose tier the signals actually chose — an
                 // ambiguous turn is decided further down the cascade.
                 self.apply_handoff_note(request, tier, source);
-                // Use the confidence pick_tier already computed (e.g. `1.0` for
-                // an Override) rather than re-deriving it from `score`, which is
-                // `0.0` on both hard-rule paths and would understate them.
-                let conf = confidence.unwrap_or(score.abs());
+                // Prefer pick_tier's own confidence (e.g. 1.0 for an Override)
+                // over re-deriving it from the neutral 0.5 placeholder.
+                let conf = confidence.unwrap_or_else(|| 2.0 * (probability - 0.5).abs());
                 Ok((
                     Classification::Scores(vec![Score {
                         target: target.clone(),

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -246,6 +246,17 @@ pub struct ScoreResult {
     pub confidence: f64,
 }
 
+impl ScoreResult {
+    /// `score` remapped from `(-1, +1)` onto a `(0, 1)` capable-tier
+    /// probability: `p = (score + 1) / 2`. Strictly increasing, so it carries
+    /// the picker's `[-1, -t], (-t, t), [t, 1]` score brackets onto
+    /// `[0, 0.5 - t/2], (0.5 - t/2, 0.5 + t/2), [0.5 + t/2, 1]` without
+    /// changing which bracket any given turn falls into.
+    fn probability(self) -> f64 {
+        (self.score + 1.0) / 2.0
+    }
+}
+
 /// The two-axis feature view of a single [`ToolSignals`].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CodingAgentDimensions {
@@ -421,11 +432,17 @@ pub fn pick_tier(signal: &ToolSignals, mode: PickerMode, confidence_threshold: f
         return resolved(Tier::Efficient, DecisionSource::TestsPassed, 0.0, None);
     }
 
-    // 3. Scorer — no hard reason either way, so weigh error vs production. If
-    //    confident enough, follow the sign: positive → capable, negative → efficient.
+    // 3. Scorer — no hard reason either way, so weigh error vs production. Read
+    //    the score as a capable-tier probability `p`; outside the closed
+    //    ambiguous band `[0.5 - t/2, 0.5 + t/2]`, follow which side of 0.5 it
+    //    lands on. The band's endpoints count as ambiguous (strict `>`/`<`),
+    //    a one-point boundary flip from the old `confidence >= threshold`
+    //    framing that only bites at floating-point equality.
     let scored = score_signal(signal);
-    if scored.confidence >= confidence_threshold {
-        let tier = if scored.score > 0.0 {
+    let probability = scored.probability();
+    let half_threshold = confidence_threshold / 2.0;
+    if probability > 0.5 + half_threshold || probability < 0.5 - half_threshold {
+        let tier = if probability > 0.5 {
             Tier::Capable
         } else {
             Tier::Efficient
@@ -687,6 +704,95 @@ mod tests {
             scored.confidence < 0.5,
             "one signal should not clear 0.5: {scored:?}"
         );
+    }
+
+    #[test]
+    fn probability_remaps_the_score_brackets_onto_zero_point_five_plus_or_minus_half_threshold() {
+        assert_eq!(
+            ScoreResult {
+                score: -1.0,
+                confidence: 1.0
+            }
+            .probability(),
+            0.0
+        );
+        assert_eq!(
+            ScoreResult {
+                score: 0.0,
+                confidence: 0.0
+            }
+            .probability(),
+            0.5
+        );
+        assert_eq!(
+            ScoreResult {
+                score: 1.0,
+                confidence: 1.0
+            }
+            .probability(),
+            1.0
+        );
+        let t = 0.5;
+        assert_eq!(
+            ScoreResult {
+                score: t,
+                confidence: t
+            }
+            .probability(),
+            0.5 + t / 2.0
+        );
+        assert_eq!(
+            ScoreResult {
+                score: -t,
+                confidence: t
+            }
+            .probability(),
+            0.5 - t / 2.0
+        );
+    }
+
+    #[test]
+    fn pick_tier_agrees_with_the_pre_probability_score_based_decision_off_the_boundary() {
+        // Away from the exact `score == ±threshold` boundary, deciding on the
+        // probability `p = (score+1)/2` against `0.5 ± t/2` must pick the same
+        // tier as the original `confidence >= threshold` check on `score`.
+        for score_millis in -999..=999 {
+            let score = score_millis as f64 / 1000.0;
+            for threshold_millis in (0..=1000).step_by(50) {
+                let threshold = threshold_millis as f64 / 1000.0;
+                let confidence = score.abs();
+                if (confidence - threshold).abs() < 1e-9 {
+                    continue; // exact boundary: deliberately reclassified, see above.
+                }
+                let old_decisive = confidence >= threshold;
+                let old_tier = if score > 0.0 {
+                    Tier::Capable
+                } else {
+                    Tier::Efficient
+                };
+
+                let probability = (score + 1.0) / 2.0;
+                let half_threshold = threshold / 2.0;
+                let new_decisive =
+                    probability > 0.5 + half_threshold || probability < 0.5 - half_threshold;
+                let new_tier = if probability > 0.5 {
+                    Tier::Capable
+                } else {
+                    Tier::Efficient
+                };
+
+                assert_eq!(
+                    old_decisive, new_decisive,
+                    "decisiveness disagreement at score={score} threshold={threshold}"
+                );
+                if old_decisive {
+                    assert_eq!(
+                        old_tier, new_tier,
+                        "tier disagreement at score={score} threshold={threshold}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/switchyard-server/src/stats/algorithms/stage_router.rs
+++ b/crates/switchyard-server/src/stats/algorithms/stage_router.rs
@@ -9,7 +9,7 @@ use prometheus::proto::{Metric, MetricFamily};
 use serde::Serialize;
 
 const ROUTING_DECISIONS_METRIC: &str = "switchyard_stage_router_routing_decisions_total";
-const SCORE_METRIC: &str = "switchyard_stage_router_score";
+const PROBABILITY_METRIC: &str = "switchyard_stage_router_probability";
 const CONFIDENCE_METRIC: &str = "switchyard_stage_router_confidence";
 const SEVERITY_METRIC: &str = "switchyard_stage_router_severity";
 const SPINNING_METRIC: &str = "switchyard_stage_router_spinning";
@@ -19,7 +19,7 @@ const PRODUCTION_INTENSITY_METRIC: &str = "switchyard_stage_router_production_in
 #[derive(Clone, Debug, Default)]
 pub(super) struct StageRouterCumulative {
     decisions: BTreeMap<DecisionKey, u64>,
-    score: HistogramTotal,
+    probability: HistogramTotal,
     confidence: HistogramTotal,
     severity: HistogramTotal,
     spinning: HistogramTotal,
@@ -56,7 +56,7 @@ pub(crate) struct DecisionStatsSnapshot {
 /// Stage scorer output and input-dimension summaries.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub(crate) struct ScoringStatsSnapshot {
-    pub score: MetricSummary,
+    pub probability: MetricSummary,
     pub confidence: MetricSummary,
     pub dimensions: DimensionStatsSnapshot,
 }
@@ -81,7 +81,7 @@ impl StageRouterCumulative {
     pub(super) fn collect(families: &[MetricFamily]) -> Self {
         Self {
             decisions: collect_decisions(families),
-            score: collect_histogram(families, SCORE_METRIC),
+            probability: collect_histogram(families, PROBABILITY_METRIC),
             confidence: collect_histogram(families, CONFIDENCE_METRIC),
             severity: collect_histogram(families, SEVERITY_METRIC),
             spinning: collect_histogram(families, SPINNING_METRIC),
@@ -104,7 +104,7 @@ impl StageRouterCumulative {
         StageRouterStatsSnapshot {
             routing_decisions,
             scoring: ScoringStatsSnapshot {
-                score: self.score.delta(baseline.score),
+                probability: self.probability.delta(baseline.probability),
                 confidence: self.confidence.delta(baseline.confidence),
                 dimensions: DimensionStatsSnapshot {
                     severity: self.severity.delta(baseline.severity),
@@ -231,9 +231,9 @@ mod tests {
                     KeyValue::new("target_name", "model/capable"),
                 ],
             );
-        for value in [0.5, -0.25] {
+        for value in [0.5, 0.25] {
             meter
-                .f64_histogram("switchyard.stage_router.score")
+                .f64_histogram("switchyard.stage_router.probability")
                 .build()
                 .record(value, &[]);
         }
@@ -251,8 +251,8 @@ mod tests {
         assert_eq!(dimensions.total, 3);
         assert_eq!(dimensions.targets["model/efficient"], 2);
         assert_eq!(dimensions.targets["model/capable"], 1);
-        assert_eq!(stage.scoring.score.count, 2);
-        assert_eq!(stage.scoring.score.mean, 0.125);
+        assert_eq!(stage.scoring.probability.count, 2);
+        assert_eq!(stage.scoring.probability.mean, 0.375);
         assert_eq!(stage.scoring.confidence.mean, 0.75);
 
         stats.reset();


### PR DESCRIPTION
Switches the stage-router picker to think in probability instead of raw score.

Today it scores a turn as a signed value in `(-1, 1)` and checks `|score|` against a threshold. This maps that onto a `(0, 1)` probability with `p = (score + 1) / 2`: above `0.5 + t/2` goes capable, below `0.5 - t/2` goes efficient, in between is ambiguous. Same decisions as before, just relabeled — the one edge case is the exact boundary (`score == threshold`), which now reads ambiguous instead of resolving, but that basically never happens.

`probability` carries all the way out: renamed the field on `PickOutcome`, the exported metric (`...stage_router.score` -> `...stage_router.probability`, buckets now `0..1`), and its stats/Prometheus projection in `switchyard-server`. Hard-rule decisions (override, tests-passed) report a neutral `0.5` instead of the old `0.0` placeholder.

Also fixed a bug I found while tracing this: the classifier was reporting confidence as `score.abs()` instead of the confidence the picker already computed, which silently zeroed out confidence on override/tests-passed decisions that should've been maximally confident.

Dashboard heads up: `switchyard_stage_router_score` is renamed to `..._probability` and its buckets move from `[-1,1]` to `[0,1]`.