### PR TITLE
feat(llm-client): restore X-Switchyard-Version on upstream calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   work; span fields only, no new metric labels. (#249)
 - **Unified LLM-classifier bindings** — LLM-classifier routing is available
   through the native PyO3 bindings, unifying the Python-side surface. (#465)
+- **`X-Switchyard-Version` on upstream calls** — outbound LLM requests once
+  again carry the release-attribution header. No request or response content is
+  included. Set `SWITCHYARD_TELEMETRY_OPT_OUT` (legacy alias
+  `NEMO_SWITCHYARD_TELEMETRY_OPT_OUT`) to suppress it, or `SWITCHYARD_VERSION`
+  to override the reported version.
 
 ### Changed
 

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use switchyard_protocol::{Metadata, WireFormat};
 
 use crate::error::{LlmClientError, Result, is_overflow_body};
+use crate::telemetry::SWITCHYARD_VERSION_HEADER;
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
@@ -88,19 +89,27 @@ pub enum Backend {
 impl Backend {
     // Checks custom headers before the client can send a request.
     pub(crate) fn validate_extra_headers(&self, model_name: &str) -> Result<()> {
-        let invalid_name = self.config().extra_headers.keys().find(|name| match self {
-            Backend::OpenAiChat(_) | Backend::OpenAiResponses(_) => {
-                name.eq_ignore_ascii_case("authorization")
-                    || (self.is_forwarding_auth()
-                        && (name.eq_ignore_ascii_case("chatgpt-account-id")
-                            || name.eq_ignore_ascii_case("x-openai-fedramp")))
+        let invalid_name = self.config().extra_headers.keys().find(|name| {
+            // The client owns the telemetry header on every backend, and
+            // `RequestBuilder::header` appends, so a configured value would be sent
+            // alongside the generated one and would survive a telemetry opt-out.
+            if name.eq_ignore_ascii_case(SWITCHYARD_VERSION_HEADER) {
+                return true;
             }
-            Backend::Anthropic(_) => {
-                name.eq_ignore_ascii_case("x-api-key")
-                    || name.eq_ignore_ascii_case("anthropic-version")
-                    || (self.is_forwarding_auth()
-                        && (name.eq_ignore_ascii_case("authorization")
-                            || name.eq_ignore_ascii_case("anthropic-beta")))
+            match self {
+                Backend::OpenAiChat(_) | Backend::OpenAiResponses(_) => {
+                    name.eq_ignore_ascii_case("authorization")
+                        || (self.is_forwarding_auth()
+                            && (name.eq_ignore_ascii_case("chatgpt-account-id")
+                                || name.eq_ignore_ascii_case("x-openai-fedramp")))
+                }
+                Backend::Anthropic(_) => {
+                    name.eq_ignore_ascii_case("x-api-key")
+                        || name.eq_ignore_ascii_case("anthropic-version")
+                        || (self.is_forwarding_auth()
+                            && (name.eq_ignore_ascii_case("authorization")
+                                || name.eq_ignore_ascii_case("anthropic-beta")))
+                }
             }
         });
         if let Some(name) = invalid_name {
@@ -346,6 +355,35 @@ mod tests {
             extra_headers: BTreeMap::new(),
             extra_body: BTreeMap::new(),
             max_retries: 0,
+        }
+    }
+
+    // The client owns the telemetry header, so config cannot also set it on any backend.
+    #[test]
+    fn extra_headers_cannot_set_the_telemetry_header() {
+        for backend in [
+            Backend::OpenAiChat(config("https://api.openai.com/v1")),
+            Backend::OpenAiResponses(config("https://api.openai.com/v1")),
+            Backend::Anthropic(config("https://api.anthropic.com")),
+        ] {
+            let mut config = match &backend {
+                Backend::OpenAiChat(config)
+                | Backend::OpenAiResponses(config)
+                | Backend::Anthropic(config) => config.clone(),
+            };
+            // Mixed case proves the check is case-insensitive.
+            config
+                .extra_headers
+                .insert("X-Switchyard-Version".to_string(), "9.9.9".to_string());
+            let backend = match backend {
+                Backend::OpenAiChat(_) => Backend::OpenAiChat(config),
+                Backend::OpenAiResponses(_) => Backend::OpenAiResponses(config),
+                Backend::Anthropic(_) => Backend::Anthropic(config),
+            };
+            let error = backend
+                .validate_extra_headers("gpt")
+                .expect_err("telemetry header must be rejected");
+            assert!(error.to_string().contains("X-Switchyard-Version"));
         }
     }
 

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -26,6 +26,7 @@ use crate::backend::Backend;
 use crate::error::{LlmClientError, Result};
 use crate::metrics;
 use crate::raw::RawResponse;
+use crate::telemetry::{SWITCHYARD_VERSION_HEADER, telemetry_header_value};
 
 // Headers this client owns or that are hop-by-hop. Backends apply an explicitly
 // enabled caller credential after generic metadata forwarding skips these.
@@ -49,6 +50,7 @@ const RESERVED_HEADERS: &[&str] = &[
     "anthropic-version",
     "content-type",
     "accept-encoding",
+    "x-switchyard-version",
 ];
 
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
@@ -305,7 +307,11 @@ impl TranslatingLlmClient {
         };
         let builder = client.post(url).json(body);
         let builder = forward_metadata_headers(builder, metadata);
-        let builder = backend.apply_forwarded_auth(builder, metadata);
+        let mut builder = backend.apply_forwarded_auth(builder, metadata);
+        // Attribute the call to this Switchyard release unless telemetry is opted out.
+        if let Some(version) = telemetry_header_value() {
+            builder = builder.header(SWITCHYARD_VERSION_HEADER, version);
+        }
         let builder = apply_extra_headers(builder, backend);
         let builder = backend.apply_auth(builder);
 
@@ -1953,6 +1959,81 @@ mod tests {
         assert!(!received.headers.contains_key("api-key"));
         assert!(!received.headers.contains_key("openai-organization"));
         assert!(!received.headers.contains_key("openai-project"));
+        Ok(())
+    }
+
+    // The release-attribution header is applied to every upstream call.
+    #[tokio::test]
+    async fn sends_the_switchyard_version_header()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wiremock::matchers::header(
+                "x-switchyard-version",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1", "model": "gpt",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
+        // The matcher above fails the call if the header is absent or wrong.
+        client.call(request_for(Some("gpt"), false)).await?;
+        Ok(())
+    }
+
+    // A caller-supplied version header is reserved, so it cannot spoof attribution.
+    #[tokio::test]
+    async fn client_supplied_switchyard_version_header_is_not_forwarded()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wiremock::matchers::header(
+                "x-switchyard-version",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1", "model": "gpt",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-switchyard-version",
+            http::HeaderValue::from_static("9.9.9-spoofed"),
+        );
+        let request = Request {
+            llm_request: LlmRequest {
+                model: Some("gpt".to_string()),
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: Some(Metadata {
+                http_headers: Some(headers),
+                ..Default::default()
+            }),
+        };
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
+        client.call_rewrite_model(request, None).await?;
+        let received = server
+            .received_requests()
+            .await
+            .ok_or("request recording should be enabled")?;
+        let received = received.first().ok_or("expected one upstream request")?;
+        let values: Vec<_> = received
+            .headers
+            .get_all("x-switchyard-version")
+            .into_iter()
+            .collect();
+        assert_eq!(values, [env!("CARGO_PKG_VERSION")]);
         Ok(())
     }
 

--- a/crates/libsy-llm-client/src/lib.rs
+++ b/crates/libsy-llm-client/src/lib.rs
@@ -24,6 +24,7 @@ mod observability;
 mod observation;
 pub mod raw;
 pub mod run;
+mod telemetry;
 
 pub use backend::{Backend, DEFAULT_MAX_RETRIES, HttpBackendConfig};
 pub use client::{ModelConfig, TranslatingLlmClient};

--- a/crates/libsy-llm-client/src/telemetry.rs
+++ b/crates/libsy-llm-client/src/telemetry.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Release-attribution header for outbound upstream calls.
+
+use std::env;
+
+pub(crate) const SWITCHYARD_VERSION_HEADER: &str = "X-Switchyard-Version";
+
+const SWITCHYARD_VERSION_ENV: &str = "SWITCHYARD_VERSION";
+const SWITCHYARD_TELEMETRY_OPT_OUT_ENV: &str = "SWITCHYARD_TELEMETRY_OPT_OUT";
+const NEMO_SWITCHYARD_TELEMETRY_OPT_OUT_ENV: &str = "NEMO_SWITCHYARD_TELEMETRY_OPT_OUT";
+
+pub(crate) fn telemetry_header_value() -> Option<String> {
+    telemetry_header_value_from_values(
+        env::var(SWITCHYARD_TELEMETRY_OPT_OUT_ENV).ok().as_deref(),
+        env::var(NEMO_SWITCHYARD_TELEMETRY_OPT_OUT_ENV)
+            .ok()
+            .as_deref(),
+        env::var(SWITCHYARD_VERSION_ENV).ok().as_deref(),
+    )
+}
+
+fn telemetry_header_value_from_values(
+    opt_out: Option<&str>,
+    legacy_opt_out: Option<&str>,
+    version: Option<&str>,
+) -> Option<String> {
+    if env_value_opts_out(opt_out) || env_value_opts_out(legacy_opt_out) {
+        return None;
+    }
+    Some(configured_version(version).unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()))
+}
+
+fn configured_version(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn env_value_opts_out(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim) else {
+        return false;
+    };
+    !matches!(
+        value.to_ascii_lowercase().as_str(),
+        "" | "0" | "false" | "no"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_header_uses_configured_version_when_not_opted_out() {
+        assert_eq!(
+            telemetry_header_value_from_values(None, None, Some(" 1.2.3 ")),
+            Some("1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    fn telemetry_header_falls_back_to_crate_version() {
+        assert_eq!(
+            telemetry_header_value_from_values(None, None, None),
+            Some(env!("CARGO_PKG_VERSION").to_string())
+        );
+        assert_eq!(
+            telemetry_header_value_from_values(None, None, Some(" ")),
+            Some(env!("CARGO_PKG_VERSION").to_string())
+        );
+    }
+
+    #[test]
+    fn telemetry_header_respects_current_and_legacy_opt_out_env_values() {
+        assert_eq!(
+            telemetry_header_value_from_values(Some("true"), None, Some("1.2.3")),
+            None
+        );
+        assert_eq!(
+            telemetry_header_value_from_values(None, Some("yes"), Some("1.2.3")),
+            None
+        );
+    }
+
+    #[test]
+    fn telemetry_header_ignores_falsey_opt_out_values() {
+        for value in ["", "0", "false", "FALSE", "no", " No "] {
+            assert_eq!(
+                telemetry_header_value_from_values(Some(value), None, Some("1.2.3")),
+                Some("1.2.3".to_string())
+            );
+        }
+    }
+}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -170,9 +170,11 @@ Check health: `curl http://localhost:4000/health`
 Switchyard sends an `X-Switchyard-Version` header on outbound LLM calls for
 release attribution. No request or response content is included.
 
-Set `SWITCHYARD_TELEMETRY_OPT_OUT` to any value other than `0`, `false`, or
-`no` to suppress the header entirely (`NEMO_SWITCHYARD_TELEMETRY_OPT_OUT` is
-accepted as a legacy alias). Set `SWITCHYARD_VERSION` to report a specific
+Set `SWITCHYARD_TELEMETRY_OPT_OUT` to suppress the header entirely. Any
+non-empty value other than `0`, `false`, or `no` opts out; the comparison
+ignores case and surrounding whitespace, so an empty or whitespace-only value
+does not opt out. `NEMO_SWITCHYARD_TELEMETRY_OPT_OUT` is accepted as a legacy
+alias with the same meaning. Set `SWITCHYARD_VERSION` to report a specific
 version instead of the running release.
 
 ---

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -167,10 +167,13 @@ Check health: `curl http://localhost:4000/health`
 
 **Telemetry header**
 
-Switchyard documents an `X-Switchyard-Version` header for release attribution
-on outbound LLM calls. No request or response content is included. The 0.2.0
-native server does not currently send this header upstream (see
-[Known Issues](known_issues.md)), so no opt-out is required at the moment.
+Switchyard sends an `X-Switchyard-Version` header on outbound LLM calls for
+release attribution. No request or response content is included.
+
+Set `SWITCHYARD_TELEMETRY_OPT_OUT` to any value other than `0`, `false`, or
+`no` to suppress the header entirely (`NEMO_SWITCHYARD_TELEMETRY_OPT_OUT` is
+accepted as a legacy alias). Set `SWITCHYARD_VERSION` to report a specific
+version instead of the running release.
 
 ---
 

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -5,7 +5,6 @@
 2. Routing-tier attribution is missing from `GET /v1/stats` and `/metrics` for LLM-classifier judge failures that route to the default target, escalation decisions, and `stage_router` fallback decisions.
 3. The retry recovery counter stays at zero after a successful upstream retry.
 4. `x-switchyard-session-id` is not recorded in native session stats.
-5. The native server does not send the documented `X-Switchyard-Version` header upstream.
 
 ## 0.1.0
 1. Completed Codex Responses tasks may record `0` token usage in `GET /v1/stats`.


### PR DESCRIPTION
## What

Sends the documented `X-Switchyard-Version` header on outbound upstream LLM calls.

- Adds `crates/libsy-llm-client/src/telemetry.rs`, ported from the implementation
  that lived in `switchyard-components` until #343 (`git show
  b104765^:crates/switchyard-components/src/telemetry.rs`). Behavior is preserved
  exactly, including the legacy `NEMO_`-prefixed opt-out and the falsey-value list.
- Applies the header in `send_once()`, the single funnel for all outbound upstream
  HTTP in the current stack.
- Adds `x-switchyard-version` to `RESERVED_HEADERS` so a client-supplied value is
  dropped by `forward_metadata_headers()` rather than forwarded upstream.
- Updates `docs/getting_started.md`, drops Known Issue #5, adds a CHANGELOG entry.

The module is private (`mod telemetry;`) — no new public Rust, PyO3, Python, CLI, or
deployment-TOML surface. The only user-visible surface is three environment
variables, all pre-existing:

| Variable | Behavior |
|---|---|
| `SWITCHYARD_TELEMETRY_OPT_OUT` | Any value other than `""`, `0`, `false`, `no` (case-insensitive, trimmed) suppresses the header |
| `NEMO_SWITCHYARD_TELEMETRY_OPT_OUT` | Legacy alias, same semantics |
| `SWITCHYARD_VERSION` | Overrides the reported version when set and non-blank |

## Why

`docs/getting_started.md` promised the header and an opt-out that the native path
never actually implemented, so users had a documented opt-out that could not be
honored. Tracked as Known Issue #5 for 0.2.0.

Closes #550

One correction to the obvious reading of the history, since it affects review:
**#343 is not where this regressed.** Immediately before that commit,
`crates/switchyard-server/Cargo.toml` already depended on `switchyard-llm-client`,
not on `switchyard-components` — the only remaining dependent was
`crates/switchyard-py`. Known Issue #5 was also filed in #327 on 2026-08-07, four
days before #343 merged. The header was only ever sent by the deprecated Python
server path; it was never ported to `switchyard-llm-client`, and #343 correctly
removed the last copy of code that was already dead.

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green (115 passed)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] Manual smoke: mutation-checked the anti-spoof test — removing
      `"x-switchyard-version"` from `RESERVED_HEADERS` makes
      `client_supplied_switchyard_version_header_is_not_forwarded` fail, confirming
      it is load-bearing rather than vacuously passing.

Six new tests. Four unit tests on the pure
`telemetry_header_value_from_values()` cover the opt-out/override matrix, ported
under their original names. Two `wiremock` tests in `client.rs` cover the wire:
that the header is sent with the crate version, and that a client-supplied value in
`Metadata::http_headers` is replaced by the crate's own value rather than forwarded.

The unit tests deliberately avoid mutating process env — `cargo test` runs threads
in parallel within a binary and env is process-global, so that would be flaky. That
is the reason the pure function is split out from the env-reading
`telemetry_header_value()`.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class.
- [ ] New public symbols exported from `switchyard/__init__.py.__all__` — n/a, no
      Python surface changes.
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed — `docs/getting_started.md` updated.
- [x] Commits signed off per the DCO.

## Notes for reviewers

Three intentional trade-offs worth your attention:

1. **Header ordering.** The original applied the header after auth and before
   per-request extra headers. In the current chain `backend.apply_auth` runs *last*,
   after `apply_extra_headers`, so exact positional parity is not reachable without
   reordering existing calls. I placed it after `apply_forwarded_auth` and before
   `apply_extra_headers`, preserving the intent. This is moot in practice:
   `RequestBuilder::header` appends rather than replaces, so position confers no
   override semantics.

2. **Env vars read on every call.** `telemetry_header_value()` does three `env::var`
   lookups per upstream call, matching the original. A `OnceLock` would take that off
   the hot path but changes semantics to read-once-at-first-call, so I kept parity
   rather than deciding unilaterally. Happy to change it if you'd prefer.

3. **`env!("CARGO_PKG_VERSION")` asserted directly in the wire test.** This assumes
   no opt-out env var is set, which holds in CI. The old integration suite used an
   `expected_switchyard_version_header()` helper mirroring the opt-out logic; that
   avoids a confusing local failure for a developer who exports
   `SWITCHYARD_TELEMETRY_OPT_OUT`, at the cost of a test that passes vacuously under
   opt-out. I took the simpler assertion — say the word if you want the helper.

Also flagged during review, **not** addressed here as it is pre-existing and out of
scope: `Backend::validate_extra_headers` does not forbid an admin-configured
`extra_headers` entry named `x-switchyard-version`. Because `header` appends, such a
config would send two values. It is admin-controlled rather than caller-controlled,
so it is not a spoofing vector, but you may want to tighten that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic `X-Switchyard-Version` headers to outbound LLM requests.
  * Supports custom version reporting through an environment variable.

* **Bug Fixes**
  * Prevented caller-provided metadata from overriding the version header.

* **Documentation**
  * Documented version telemetry, customization, and opt-out options.
  * Removed the outdated known issue regarding missing version headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->