### PR TITLE
fix(translation): map anthropic metadata.user_id to Chat user

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -932,7 +932,6 @@ fn copy_openai_chat_request_extensions(
     extensions: &Map<String, Value>,
 ) {
     for field in [
-        "metadata",
         "parallel_tool_calls",
         "prompt_cache_key",
         "prompt_cache_retention",
@@ -947,6 +946,20 @@ fn copy_openai_chat_request_extensions(
             body.entry(field.to_string())
                 .or_insert_with(|| value.clone());
         }
+    }
+    match extensions.get("metadata") {
+        // Anthropic {"user_id": ...} metadata causes some endpoints to reject
+        // as an invalid parameter. Translate this to Chat's `user`
+        Some(Value::Object(map)) if !map.is_empty() && map.keys().all(|k| k == "user_id") => {
+            if let Some(user) = map.get("user_id") {
+                body.entry("user").or_insert_with(|| user.clone());
+            }
+        }
+        Some(value) => {
+            body.entry("metadata".to_string())
+                .or_insert_with(|| value.clone());
+        }
+        None => {}
     }
     if let Some(stop_sequences) = extensions.get("stop_sequences") {
         body.entry("stop").or_insert_with(|| stop_sequences.clone());

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -575,7 +575,8 @@ fn anthropic_tool_without_name_is_dropped_before_openai_chat() -> TestResult {
     Ok(())
 }
 
-// Verifies OpenAI-compatible Anthropic extension fields are preserved.
+// Verifies Anthropic extension fields translate to their Chat equivalents:
+// metadata.user_id becomes Chat's `user` (some endpoints reject user_id).
 #[test]
 fn anthropic_openai_compatible_extensions_are_preserved_for_openai_chat() -> TestResult {
     let engine = TranslationEngine::default();
@@ -597,7 +598,8 @@ fn anthropic_openai_compatible_extensions_are_preserved_for_openai_chat() -> Tes
         )?
         .body;
 
-    assert_eq!(output["metadata"], json!({"user_id": "u123"}));
+    assert_eq!(output["user"], json!("u123"));
+    assert!(output.get("metadata").is_none());
     assert_eq!(output["stop"], json!(["END"]));
     assert!(output.get("thinking").is_none());
     Ok(())


### PR DESCRIPTION
## What

Translates Anthropic `metadata.user_id` to Chat's `user` field in the openai_chat request codec instead of passing `metadata` through untouched. Anthropic metadata is a different shape than Chat metadata (a string map attached to stored completions), and some endpoints reject the unknown shape. Other metadata objects continue to pass through.

## Why

Anthropic clients attach `metadata.user_id` to requests, so pointing one at certain Chat upstreams through Switchyard fails on the first call:

```
curl -s https://opencode.ai/zen/v1/chat/completions \
    -H "Authorization: Bearer $OPENCODE_API_KEY" -H "Content-Type: application/json" \
    -d '{"model":"big-pickle","max_tokens":16,
         "metadata":{"user_id":"user_abc123"},
         "messages":[{"role":"user","content":"hi"}]}'
{"error":{"type":"server_error","message":"Error from provider (Console): Upstream request failed: [1210] Invalid API parameter, please check the documentation."}}
```

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green
- [x] `cargo fmt --all --check` clean; `cargo clippy -p switchyard-translation --all-targets -- -D warnings` clean
- [x] `cargo test -p switchyard-translation` green — 145 tests
- [x] Manual smoke: the failing curl above, re-sent as the translated shape (`"user":"user_abc123"`, no `metadata`), returns a completion from `big-pickle`. Have also tested long Claude Agent SDK -> Switchyard -> opencode sessions on a wheel built from this branch (without the fix every session dies on its first request).

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. (Rust-only change)
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. (n/a)
- [x] Unit tests added for new components / bug fixes. (`anthropic_openai_compatible_extensions_are_preserved_for_openai_chat` now asserts the mapping)
- [x] README / `--help` updated if customer-facing surface changed. (n/a)
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

`user` is set with `or_insert`, so an explicit `user` already on the request wins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation of chat request metadata.
  - When metadata contains only a user ID, it is now correctly represented in the request’s user field.
  - Other metadata continues to be preserved as metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->