### PR TITLE
chore: Remove routing_tier

### DIFF
--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -1436,39 +1436,3 @@ async fn classifier_fail_open_records_each_failure_stage() -> switchyard_libsy::
     }
     Ok(())
 }
-
-/// A decision made by the cascade fallback still names its routing tier.
-///
-/// The judge call fails, so `TaskClassifier` fails open and `DefaultTarget`
-/// decides. That decider defines no tier of its own, so without the cascade
-/// lookup the selection logs `tier: None` while a judged decision to the same
-/// target logs its tier. `AffinityRouter` reuse takes the same path.
-#[tokio::test]
-async fn fallback_decision_logs_the_routing_tier() -> switchyard_libsy::Result<()> {
-    let _guard = serialize_test().lock().await;
-    let (store, _, _, _, _) = telemetry();
-
-    let client = Arc::new(JudgeClient {
-        judge_model: "ft-judge".into(),
-        outcome: JudgeOutcome::CallFailure,
-    }) as Arc<dyn RoutedLlmClient>;
-    run(
-        classifier_router("ft-judge", "ft-weak", "ft-strong")?,
-        client,
-        classifier_request(),
-    )
-    .await?;
-
-    let events = store.events();
-    assert!(
-        events.iter().any(|event| {
-            event.fields.get("target").map(String::as_str) == Some("ft-strong")
-                && event
-                    .fields
-                    .get("tier")
-                    .is_some_and(|tier| tier.contains("strong"))
-        }),
-        "fallback selection logged without its routing tier: {events:?}"
-    );
-    Ok(())
-}

--- a/crates/libsy/src/algorithms/escalation.rs
+++ b/crates/libsy/src/algorithms/escalation.rs
@@ -78,18 +78,6 @@ pub(super) fn build_classifier(
 
 #[async_trait]
 impl Classifier<State> for EscalationClassifier {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        if self.capable == self.efficient {
-            None
-        } else if *selected_model_id == self.capable {
-            Some("strong")
-        } else if *selected_model_id == self.efficient {
-            Some("weak")
-        } else {
-            None
-        }
-    }
-
     async fn score(
         &self,
         state: &mut State,

--- a/crates/libsy/src/algorithms/fall_through.rs
+++ b/crates/libsy/src/algorithms/fall_through.rs
@@ -256,11 +256,11 @@ where
             if let Some(score) = scores.argmax(false)? {
                 // Only the deciding classifier's response answers the turn; an abstaining
                 // classifier selected nothing for it to be the answer to.
-                routed = Some((score, Arc::clone(classifier), response));
+                routed = Some((score, response));
                 break;
             }
         }
-        let Some((score, deciding, served)) = routed else {
+        let Some((score, served)) = routed else {
             return Err(LibsyError::AlgorithmError {
                 message: "every classifier abstained".to_string(),
             });
@@ -269,14 +269,7 @@ where
         // 3. Resolve the target and log the choice.
         algorithm::ensure_model_is_target(&self.targets, &score.target)?;
         let target = score.target.clone();
-        // A fallback or affinity-reuse decider carries no tier of its own, so
-        // resolve it across the cascade rather than logging it as None.
-        let tier = deciding.routing_tier(&target).or_else(|| {
-            self.classifiers
-                .iter()
-                .find_map(|c| c.routing_tier(&target))
-        });
-        tracing::info!(algorithm=self.name, target=%score.target, confidence=score.confidence, tier = ?tier, "Model selected");
+        tracing::info!(algorithm=self.name, target=%score.target, confidence=score.confidence, "Model selected");
 
         // 4. Post-decision replay: every processor sees the selection so stateful ones
         //    can bind it, and may rewrite the outbound request (e.g. add a target prompt).

--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -462,7 +462,6 @@ impl JudgePolicy for CustomPolicyRuntime {
 
 struct TaskClassifier {
     classifier: JudgeClassifier<CapabilityJudge, TaskClassifierPolicy>,
-    efficient_target: ModelId,
     capable_target: ModelId,
 }
 
@@ -607,7 +606,6 @@ impl LlmTaskClassifier {
                     &config,
                 ),
             ),
-            efficient_target: efficient_target.clone(),
             capable_target: capable_target.clone(),
         });
         let inner: Arc<dyn Classifier<State>> = classifier.clone();
@@ -773,18 +771,6 @@ impl LlmTaskClassifier {
 
 #[async_trait]
 impl Classifier<State> for TaskClassifier {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        if self.efficient_target == self.capable_target {
-            None
-        } else if *selected_model_id == self.efficient_target {
-            Some("weak")
-        } else if *selected_model_id == self.capable_target {
-            Some("strong")
-        } else {
-            None
-        }
-    }
-
     async fn score(
         &self,
         state: &mut State,
@@ -797,10 +783,6 @@ impl Classifier<State> for TaskClassifier {
 
 #[async_trait]
 impl Classifier<State> for LlmTaskClassifier {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        self.inner.routing_tier(selected_model_id)
-    }
-
     async fn score(
         &self,
         state: &mut State,

--- a/crates/libsy/src/algorithms/stage.rs
+++ b/crates/libsy/src/algorithms/stage.rs
@@ -45,10 +45,6 @@ struct SourceStamp {
 
 #[async_trait]
 impl Classifier<State> for SourceStamp {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        self.inner.routing_tier(selected_model_id)
-    }
-
     async fn score(
         &self,
         state: &mut State,

--- a/crates/libsy/src/algorithms/util/stage.rs
+++ b/crates/libsy/src/algorithms/util/stage.rs
@@ -78,10 +78,9 @@ pub enum Tier {
 }
 
 impl Tier {
-    /// Stable label for stats and the [`routing_tier`](Classifier::routing_tier)
-    /// hook, independent of what the tiers' targets are called. These are the
-    /// strings the capability route reports too, so a deployment running both
-    /// sees one tier vocabulary. Also the encoding a default-tier override is
+    /// Stable label for stats, independent of what the tiers' targets are called.
+    /// These are the strings the capability route reports too, so a deployment running
+    /// both sees one tier vocabulary. Also the encoding a default-tier override is
     /// stored under, so changing these strings invalidates one.
     pub(crate) fn label(self) -> &'static str {
         match self {
@@ -601,10 +600,6 @@ impl StageClassifier {
 
 #[async_trait]
 impl Classifier<State> for StageClassifier {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        self.targets.label_for(selected_model_id)
-    }
-
     async fn score(
         &self,
         state: &mut State,

--- a/crates/libsy/src/algorithms/util/subagent.rs
+++ b/crates/libsy/src/algorithms/util/subagent.rs
@@ -74,10 +74,6 @@ impl<S> Classifier<S> for SubagentGate<S>
 where
     S: Send + 'static,
 {
-    fn routing_tier(&self, selected_model_id: &ModelId) -> Option<&'static str> {
-        self.inner.routing_tier(selected_model_id)
-    }
-
     async fn score(
         &self,
         state: &mut S,

--- a/crates/libsy/src/core/classifier.rs
+++ b/crates/libsy/src/core/classifier.rs
@@ -71,11 +71,6 @@ fn argmax(scores: &[Score]) -> Result<Option<Score>> {
 /// Scores targets from the current request and the composition's state.
 #[async_trait]
 pub trait Classifier<S = ()>: Send + Sync {
-    /// Stable tier represented by `selected_model_id`, when this classifier defines one.
-    fn routing_tier(&self, _selected_model_id: &ModelId) -> Option<&'static str> {
-        None
-    }
-
     /// Score the classifier's targets given the current state and request.
     ///
     /// When present, `driver` lets a classifier offload model calls. It is `None`


### PR DESCRIPTION
We're moving away from the binary weak/strong tier system to a probability
distribution over a vector of models.

Ref https://github.com/NVIDIA-NeMo/Switchyard/pull/546

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified classifier routing by removing routing-tier metadata and related delegation.
  * Streamlined fallback and selection logging to record scores and responses without classifier-derived tier labels.
  * Removed unused target configuration fields from task classification.
* **Tests**
  * Removed an integration test covering routing-tier logging during fallback selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->