### PR TITLE
build: Add Community Gardener notes and tools

### DIFF
--- a/scripts/community_gardener/README
+++ b/scripts/community_gardener/README
@@ -1,0 +1,33 @@
+# Community Gardener Notes
+
+(Don't turn this file into a full description of the role and never use AI on it. It's just some notes. Please update them and add yours.)
+
+The Community Gardener handles externally contributed Issues and PRs:
+
+- Merge the good PRs that are ready, close the bad ones, and help the others become good ones.
+- Help contributors prepare their work so that someone on our dev team can review it: Explain CI failures, ensure they address Code Rabbit issues, and trigger the test suite (see Security).
+
+Every GitHub Issue is synced to Linear in "Switchyard GitHub" under Triage: https://linear.app/nvidia/team/SYGH/triage . Once a PR is ready assign it to the relevant person for review. The Community Gardener can review, but you are not the everything-reviewer. You garden.
+
+If an Issue looks important comment that it is accepted, and ask if the author wants to take it. If not move it to our Backlog. If it's urgent find someone to take it.
+
+## Security checklist
+
+Do not trust external PRs. They do not trigger full CI in case they do something bad.
+
+1. Always wait for the Code Rabbit review to complete or ask local agent of a review.
+2. Does the PR change anything under `.github/`? That's a big red flag.
+3. Check for `Cargo.lock` and `uv.lock` changes. The AI review does not check dependencies. Supply chain attacks are common.
+
+If all the above looks good click "Approve workflows to run".
+
+## Close these ones
+
+Abandoned: PRs that have been idle for 7 days can be closed as abandoned, with a note to re-open if necessary.
+
+Slop:
+ - If you read the first sentence of the description three times and still don't understand it that usually means it's slop. Close it with a note asking the author to re-write the description.
+ - Our CONTRIBUTING guide says "Using AI tools to write code is fine, but you must understand and be able to explain every change in your PR.". If you feel that's not the case close it with that quote.
+
+Out of scope: Attempts to productionize the demo server (Kubernetes, authentication). Tools that should live outside our repo, such as dashboard and CLIs. And really anything not directly related to routing.
+

--- a/scripts/community_gardener/github_last_night.sh
+++ b/scripts/community_gardener/github_last_night.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# New activity on the repo over a configurable overnight period.
+
+usage() {
+ printf 'Usage: %s [hours]\n' "${0##*/}"
+}
+
+if (( $# > 1 )); then
+ usage >&2
+ exit 2
+fi
+
+if [[ ${1:-} == --help ]]; then
+ usage
+ exit 0
+fi
+
+hours="${1:-16}"
+if [[ ! $hours =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+ printf 'Error: hours must be a non-negative number.\n' >&2
+ usage >&2
+ exit 2
+fi
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+since="$(date -u -d "$hours hours ago" +%Y-%m-%dT%H:%M:%SZ)"
+
+printf 'Overnight activity on %s. Last %s hours.\n\n' "$repo" "$hours"
+
+{
+ printf 'WHEN\tKIND\tACTOR\tURL\tTEXT\n'
+
+ # Newly created Issues and PRs
+ gh api --paginate -X GET "repos/$repo/issues" \
+ -f state=all -f since="$since" -f sort=updated -f direction=asc -f per_page=100 |
+ jq -r --arg since "$since" '
+ .[]
+ | select(.created_at >= $since)
+ | select(.user.login | endswith("[bot]") | not)
+ | [.created_at,
+ (if .pull_request then "NEW PR" else "NEW ISSUE" end),
+ .user.login, .html_url, .title]
+ | @tsv '
+
+ # New regular comments on Issues and PR conversations
+ gh api --paginate -X GET "repos/$repo/issues/comments" \
+ -f since="$since" -f per_page=100 |
+ jq -r --arg since "$since" '
+ .[]
+ | select(.created_at >= $since)
+ | select(.user.login | endswith("[bot]") | not)
+ | [.created_at, "ISSUE/PR COMMENT", .user.login, .html_url,
+ (.body | split("\n")[0] | gsub("\t"; " "))]
+ | @tsv '
+
+ # New inline PR review comments
+ gh api --paginate -X GET "repos/$repo/pulls/comments" \
+ -f since="$since" -f per_page=100 |
+ jq -r --arg since "$since" '
+ .[]
+ | select(.created_at >= $since)
+ | select(.user.login | endswith("[bot]") | not)
+ | [.created_at, "PR REVIEW COMMENT", .user.login, .html_url,
+ (.body | split("\n")[0] | gsub("\t"; " "))]
+ | @tsv '
+} | column -ts $'\t'

--- a/scripts/community_gardener/issues_prompt.txt
+++ b/scripts/community_gardener/issues_prompt.txt
@@ -1,0 +1,7 @@
+I am the maintainer / "community gardener" for Switchyard this week. Repo is https://github.com/NVIDIA-NeMo/Switchyard . It is checked out in the current folder.
+
+1. Look at all the Issues on GitHub. Do categories emerge? Write all of the issues by category into `ISSUES_BY_CATEGORY.md` in the current directory. If natural categories do not emerge invent ones that would be useful to an open source maintainer.
+2. Identify any Issues that can be closed right now: Noise, Spam, overly AI generated slop, or outdated ones. Write those to `ISSUES_TO_CLOSE.md`.
+3. Identify the 5 - 10 key Issues I should look at today. Write those to `ISSUES_TODAY.md`
+
+At all times write at a high-school reading level in short, simple sentences. Avoid jargon and metaphors.

--- a/scripts/community_gardener/prs_prompt.txt
+++ b/scripts/community_gardener/prs_prompt.txt
@@ -1,0 +1,8 @@
+I am the maintainer / "community gardener" for Switchyard this week. Repo is https://github.com/NVIDIA-NeMo/Switchyard . It is checked out in the current folder.
+
+1. Look at all the pull requests on GitHub. Do categories emerge? Write all the pull requests by category into `BY_CATEGORY.md` in the current directory. If natural categories do not emerge invent ones that would be useful to an open source
+maintainer.
+2. Identify the five to ten PRs I should look at today. Those should be as ready to merge as possible. Write those to `BEST_PRS.md`.
+3. Review each one of those PRs, using sub-agents if appropriate. Do you recommend it be merged? Write your review and assessment to one file per PR identified by the PR number, e.g. `600.md`. Include a clear explanation of what the PR does and why it matters.
+
+At all times write at a high-school reading level in short, simple sentences. Avoid jargon and metaphors


### PR DESCRIPTION
Things that were useful to me this week. Hopefully this will be a living
folder, changing with each new person as we pass the baton.

- A script to show overnight changes on github: New PRs, new Issues, and new non-bot comments.
- A prompt to fetch and categorize PRs, and review 5-10 of the most mergeable ones.
- A prompt to fetch and categorize Issues, and recommend those that can be closed.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tools**
  - Added a command-line report for reviewing recent, non-automated GitHub activity, including issues, pull requests, and review comments.
  - Added configurable time-window support, repository detection, help text, validation, and formatted results.

- **Documentation**
  - Added community gardener guidance for triage, contributor support, security checks, workflow approvals, and handling inactive or unsuitable contributions.
  - Added structured prompts for categorizing issues and pull requests, selecting items for review, and recording recommendations in Markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->