### PR TITLE
docs(known-issues): remove the X-Switchyard-Version entry

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -165,30 +165,12 @@ references, and route construction without starting the server.
 
 Check health: `curl http://localhost:4000/health`
 
-**Telemetry**
+**Telemetry header**
 
-Switchyard does not phone home. No attribution header is added to outbound LLM
-calls, and no request content, response content, or version information is sent
-to NVIDIA or any third party. There is no vendor telemetry to opt out of.
-
-Switchyard does emit OpenTelemetry data, but only where you point it. The
-server always maintains a Prometheus registry and serves it at `/metrics`, and
-it additionally exports OTLP traces and metrics when
-`OTEL_EXPORTER_OTLP_ENDPOINT` is set. Set `OTEL_SDK_DISABLED=true` to disable
-OTLP export.
-
-Spans and metrics carry request parameters, model ids, token usage, and the
-running version. Two paths can also surface model text in your own logs and
-traces: a failed upstream call records the upstream error body verbatim, which
-some providers fill with the request, and an `advisor` route logs the first 160
-characters of the advisor model's reply at `info`. Both stay on infrastructure
-you control.
-
-Earlier documentation described an `X-Switchyard-Version` header. That header
-is not sent, and it is not planned: Switchyard is a library, so identifying the
-caller to an upstream provider belongs to the integration that embeds it. An
-integration that wants to report itself (Relay, LiteLLM, or your own
-application) should add its own header to the calls it makes.
+Switchyard documents an `X-Switchyard-Version` header for release attribution
+on outbound LLM calls. No request or response content is included. The 0.2.0
+native server does not currently send this header upstream (see
+[Known Issues](known_issues.md)), so no opt-out is required at the moment.
 
 ---
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -165,12 +165,17 @@ references, and route construction without starting the server.
 
 Check health: `curl http://localhost:4000/health`
 
-**Telemetry header**
+**Telemetry**
 
-Switchyard documents an `X-Switchyard-Version` header for release attribution
-on outbound LLM calls. No request or response content is included. The 0.2.0
-native server does not currently send this header upstream (see
-[Known Issues](known_issues.md)), so no opt-out is required at the moment.
+Switchyard sends no telemetry. It adds no attribution header to outbound LLM
+calls, and no request or response content is reported anywhere. There is
+nothing to opt out of.
+
+Earlier documentation described an `X-Switchyard-Version` header. That header
+is not sent, and it is not planned: Switchyard is a library, so identifying the
+caller to an upstream provider belongs to the integration that embeds it. An
+integration that wants to report itself (Relay, LiteLLM, or your own
+application) should add its own header to the calls it makes.
 
 ---
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -167,9 +167,16 @@ Check health: `curl http://localhost:4000/health`
 
 **Telemetry**
 
-Switchyard sends no telemetry. It adds no attribution header to outbound LLM
-calls, and no request or response content is reported anywhere. There is
-nothing to opt out of.
+Switchyard does not phone home. No attribution header is added to outbound LLM
+calls, and no request content, response content, or version information is sent
+to NVIDIA or any third party. There is no vendor telemetry to opt out of.
+
+Switchyard does emit OpenTelemetry data, but only where you point it. The
+server always maintains a Prometheus registry and serves it at `/metrics`, and
+it additionally exports OTLP traces and metrics when
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set. Spans carry request parameters, model
+ids, and token usage, never prompt or completion content. Set
+`OTEL_SDK_DISABLED=true` to disable OTLP export.
 
 Earlier documentation described an `X-Switchyard-Version` header. That header
 is not sent, and it is not planned: Switchyard is a library, so identifying the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -174,9 +174,15 @@ to NVIDIA or any third party. There is no vendor telemetry to opt out of.
 Switchyard does emit OpenTelemetry data, but only where you point it. The
 server always maintains a Prometheus registry and serves it at `/metrics`, and
 it additionally exports OTLP traces and metrics when
-`OTEL_EXPORTER_OTLP_ENDPOINT` is set. Spans carry request parameters, model
-ids, and token usage, never prompt or completion content. Set
-`OTEL_SDK_DISABLED=true` to disable OTLP export.
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set. Set `OTEL_SDK_DISABLED=true` to disable
+OTLP export.
+
+Spans and metrics carry request parameters, model ids, token usage, and the
+running version. Two paths can also surface model text in your own logs and
+traces: a failed upstream call records the upstream error body verbatim, which
+some providers fill with the request, and an `advisor` route logs the first 160
+characters of the advisor model's reply at `info`. Both stay on infrastructure
+you control.
 
 Earlier documentation described an `X-Switchyard-Version` header. That header
 is not sent, and it is not planned: Switchyard is a library, so identifying the

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -5,7 +5,6 @@
 2. Routing-tier attribution is missing from `GET /v1/stats` and `/metrics` for LLM-classifier judge failures that route to the default target, escalation decisions, and `stage_router` fallback decisions.
 3. The retry recovery counter stays at zero after a successful upstream retry.
 4. `x-switchyard-session-id` is not recorded in native session stats.
-5. The native server does not send the documented `X-Switchyard-Version` header upstream.
 
 ## 0.1.0
 1. Completed Codex Responses tasks may record `0` token usage in `GET /v1/stats`.


### PR DESCRIPTION
## What

Removes item 5 from the 0.2.0 list in `docs/known_issues.md`:

> 5. The native server does not send the documented `X-Switchyard-Version` header upstream.

One line, no code changes.

## Why

The header is not a defect and is not planned. Per maintainer direction on #550,
Switchyard is a library, and the integration that embeds it (Relay, LiteLLM, Ramp) is
what should identify itself upstream if it wants to. A deliberate non-behavior does not
belong in Known Issues.

Closes #550. Supersedes #551, which restored the header in `switchyard-llm-client` and
was closed in favor of documenting the stance.

An earlier revision of this PR also rewrote the "Telemetry header" section of
`docs/getting_started.md`. That has been reverted at maintainer request: we do not need
to list what we do not do.

## How tested

- [x] `uv run ruff check .` clean
- [x] `uv run mypy switchyard` clean
- [x] `uv run pytest tests/` green (115 passed)
- [x] Manual smoke: `uv run --group docs mkdocs build --strict` exits 0

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. n/a, docs only.
- [ ] New public symbols exported from `switchyard/__init__.py.__all__`. n/a.
- [ ] Unit tests added. n/a, no behavior change.
- [ ] README / `--help` updated. n/a.
- [x] Commits signed off per the DCO.

## Notes for reviewers

The branch carries the reverted `getting_started.md` commits in its history; the net diff
against `main` is the single deleted line above. Squash-merging collapses them.

One leftover to flag, not changed here since it is outside what was asked for.
`docs/getting_started.md` still reads:

> The 0.2.0 native server does not currently send this header upstream (see
> [Known Issues](known_issues.md)), so no opt-out is required at the moment.

With item 5 gone that cross-reference points at a page which no longer mentions the
header, and the surrounding text still describes the header as documented for release
attribution. Say the word and I will delete that section in a follow-up, which also
looks like the "do not list what we do not do" cleanup.
