### PR TITLE
fix(libsy): make tool signals readable from codex traffic

### DIFF
--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -124,6 +124,9 @@ static BASH_WRITE_PATTERNS: &[&str] = &[
     "<<eof",
     "<<'eof'",
     "<< eof",
+    "write_text(",
+    "writelines(",
+    ".write(",
 ];
 
 static BASH_EDIT_PATTERNS: &[&str] = &[
@@ -161,6 +164,7 @@ static BASH_TOOL_NAMES: &[&str] = &[
     "shell",
     "local_shell_call",
     "terminal",
+    "exec_command", // codex
 ];
 
 // Prefer false negatives: tests_passed routes the picker to EFFICIENT, so a false
@@ -389,10 +393,34 @@ const COMPACTION_MARKER: &str = "session is being continued";
 /// The shell command a tool call carries, when it has one. Harnesses name the
 /// field `command`; anything else is a tool whose category comes from its name.
 fn command_of(arguments: &Value) -> Option<String> {
-    arguments
-        .get("command")
-        .and_then(Value::as_str)
-        .map(str::to_lowercase)
+    // The Responses wire format carries tool arguments as a JSON-encoded string
+    // rather than an object, so decode that before looking for the command.
+    let decoded = arguments
+        .as_str()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+    let object = decoded.as_ref().unwrap_or(arguments);
+
+    ["command", "cmd", "input"]
+        .iter()
+        .filter_map(|key| object.get(*key))
+        .find_map(command_text)
+}
+
+/// One command field as lowercase text, whether the harness sent a string or an
+/// argv array.
+fn command_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.to_lowercase()),
+        Value::Array(parts) => {
+            let joined = parts
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!joined.is_empty()).then(|| joined.to_lowercase())
+        }
+        _ => None,
+    }
 }
 
 /// Text carried by a content block, ignoring the non-textual kinds.
@@ -796,6 +824,58 @@ mod tests {
         assert_eq!(sig.edit_count, 1);
         assert_eq!(sig.recent_write_count, 2);
         assert_eq!(sig.recent_edit_count, 1);
+    }
+
+    // codex issues every shell action as `exec_command`, and the Responses wire
+    // format hands the arguments over as a JSON-encoded string.
+    fn exec_command(arguments: Value) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolCall(ToolCall {
+                id: String::new(),
+                name: "exec_command".to_string(),
+                arguments,
+            })],
+        }
+    }
+
+    #[test]
+    fn codex_exec_command_carries_its_command_under_cmd() {
+        for arguments in [
+            json!({"command": "sed -i s/a/b/ src/lib.rs"}),
+            json!({"cmd": "sed -i s/a/b/ src/lib.rs"}),
+            json!({"cmd": ["bash", "-lc", "sed -i s/a/b/ src/lib.rs"]}),
+        ] {
+            let request = with_messages(vec![exec_command(arguments.clone()), tr("ok")]);
+            let signal = ToolSignals::from_request(&request, None);
+            assert_eq!(signal.recent_edit_count, 1, "edit count for {arguments}");
+        }
+    }
+
+    #[test]
+    fn responses_format_json_string_arguments_are_decoded() {
+        let request = with_messages(vec![
+            exec_command(json!(
+                r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#
+            )),
+            tr("ok"),
+        ]);
+        assert_eq!(
+            ToolSignals::from_request(&request, None).recent_edit_count,
+            1
+        );
+    }
+
+    #[test]
+    fn interpreter_heredoc_that_writes_a_file_counts_as_a_write() {
+        let request = with_messages(vec![
+            exec_command(json!({"cmd": "python3 - <<'PY'\np.write_text(s)\nPY"})),
+            tr("ok"),
+        ]);
+        assert_eq!(
+            ToolSignals::from_request(&request, None).recent_write_count,
+            1
+        );
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -428,10 +428,14 @@ fn text_of(block: &ContentBlock) -> Option<&str> {
     }
 }
 
-/// Whether every command in a tool result exited zero. A successful `grep`
-/// prints whatever the file holds, error words included.
-fn reports_success_exit(text: &str) -> bool {
+/// Whether a tool result reports a status that rules out failure: a zero exit, or
+/// a command still running. A successful `grep` prints whatever the file holds,
+/// error words included, and a command that has not finished has not failed yet.
+fn reports_no_failure(text: &str) -> bool {
     let lower = text.to_lowercase();
+    if lower.contains("process running with session id") {
+        return true;
+    }
     let mut saw_zero = false;
     for marker in ["exited with code ", "exit code: "] {
         for tail in lower.split(marker).skip(1) {
@@ -460,7 +464,7 @@ fn build_signal(
     let sev_start = tool_texts.len().saturating_sub(recent_window.max(1));
     let mut severity = 0.0f32;
     for text in &tool_texts[sev_start..] {
-        if reports_success_exit(text) {
+        if reports_no_failure(text) {
             continue;
         }
         let (sev, _patterns) = classify_text(text);
@@ -877,6 +881,18 @@ mod tests {
         let request = with_messages(vec![
             exec_command(json!({"cmd": "sed -n 1,40p tool_signals.rs"})),
             tr(&format!("Process exited with code 0\nOutput: {source}")),
+        ]);
+        assert_eq!(ToolSignals::from_request(&request, None).severity, 0.0);
+    }
+
+    #[test]
+    fn streaming_chunk_is_not_a_failure() {
+        // a chunk from a command still running echoes the diff being written
+        let request = with_messages(vec![
+            exec_command(json!({"cmd": "python3 - <<'PY'"})),
+            tr(
+                "Process running with session ID 14028\nOutput:\n+ tr(\"Traceback (most recent call last)\"),",
+            ),
         ]);
         assert_eq!(ToolSignals::from_request(&request, None).severity, 0.0);
     }

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -872,7 +872,7 @@ mod tests {
     }
 
     #[test]
-    fn a_command_that_exited_zero_is_not_an_error() {
+    fn exit_zero_is_not_an_error() {
         let source = "static CRITICAL: &[&str] = &[\"out of memory\", \"connection refused\"];";
         let request = with_messages(vec![
             exec_command(json!({"cmd": "sed -n 1,40p tool_signals.rs"})),
@@ -882,7 +882,7 @@ mod tests {
     }
 
     #[test]
-    fn a_rust_module_path_is_not_a_failure_marker() {
+    fn rust_path_is_not_a_failure() {
         let passing = "test error::tests::preserves_source ... ok\n\
                        test result: ok. 268 passed; 0 failed; 0 ignored";
         let request = with_messages(vec![
@@ -893,7 +893,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_exec_command_carries_its_command_under_cmd() {
+    fn exec_command_arg_shapes() {
         for arguments in [
             json!({"command": "sed -i s/a/b/ src/lib.rs"}),
             json!({"cmd": "sed -i s/a/b/ src/lib.rs"}),
@@ -907,7 +907,7 @@ mod tests {
     }
 
     #[test]
-    fn interpreter_heredoc_that_writes_a_file_counts_as_a_write() {
+    fn heredoc_script_is_a_write() {
         let request = with_messages(vec![
             exec_command(json!({"cmd": "python3 - <<'PY'\np.write_text(s)\nPY"})),
             tr("ok"),

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -431,6 +431,28 @@ fn text_of(block: &ContentBlock) -> Option<&str> {
     }
 }
 
+/// Whether a tool result explicitly reports that every command in it exited zero.
+///
+/// Harnesses that report an exit status make pattern matching unnecessary and
+/// actively misleading: a successful `grep` or `sed` prints whatever the file
+/// contains, including words like "connection refused", and that is not an error
+/// the agent hit. Only trust this when no non-zero status appears in the same text.
+fn reports_success_exit(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    let mut saw_zero = false;
+    for marker in ["exited with code ", "exit code: "] {
+        for tail in lower.split(marker).skip(1) {
+            let code: String = tail.chars().take_while(char::is_ascii_digit).collect();
+            match code.as_str() {
+                "" => {}
+                "0" => saw_zero = true,
+                _ => return false,
+            }
+        }
+    }
+    saw_zero
+}
+
 fn build_signal(
     tool_texts: Vec<String>,
     tool_calls: Vec<ObservedToolCall>,
@@ -445,6 +467,9 @@ fn build_signal(
     let sev_start = tool_texts.len().saturating_sub(recent_window.max(1));
     let mut severity = 0.0f32;
     for text in &tool_texts[sev_start..] {
+        if reports_success_exit(text) {
+            continue;
+        }
         let (sev, _patterns) = classify_text(text);
         if sev > severity {
             severity = sev;
@@ -581,12 +606,30 @@ fn compute_no_error_streak(tool_texts: &[String]) -> u32 {
     streak
 }
 
+/// Whether a tool result carries a literal failure marker.
+///
+/// A marker ending in `:` must not match a Rust path such as `error::tests::…`,
+/// which every passing test in a module named `error` prints.
+fn contains_failure_literal(lower: &str) -> bool {
+    TEST_FAILURE_LITERAL.iter().any(|literal| {
+        let mut cursor = 0usize;
+        while let Some(rel) = lower[cursor..].find(literal) {
+            let end = cursor + rel + literal.len();
+            if !lower[end..].starts_with(':') {
+                return true;
+            }
+            cursor = end;
+        }
+        false
+    })
+}
+
 fn detect_tests_passed(tool_texts: &[String], recent_window: usize) -> bool {
     let start = tool_texts.len().saturating_sub(recent_window.max(1));
     tool_texts[start..].iter().any(|text| {
         let lower = text.to_lowercase();
         TEST_PASS_PHRASES.iter().any(|p| lower.contains(p))
-            && !TEST_FAILURE_LITERAL.iter().any(|p| lower.contains(p))
+            && !contains_failure_literal(&lower)
             && !has_nonzero_failure_count(&lower)
     })
 }
@@ -837,6 +880,30 @@ mod tests {
                 arguments,
             })],
         }
+    }
+
+    #[test]
+    fn a_command_that_exited_zero_is_not_an_error() {
+        // reading a source file prints whatever it contains, including the words
+        // this module matches on. a zero exit status says nothing went wrong.
+        let source = "static CRITICAL: &[&str] = &[\"out of memory\", \"connection refused\"];";
+        let request = with_messages(vec![
+            exec_command(json!({"cmd": "sed -n 1,40p tool_signals.rs"})),
+            tr(&format!("Process exited with code 0\nOutput: {source}")),
+        ]);
+        assert_eq!(ToolSignals::from_request(&request, None).severity, 0.0);
+    }
+
+    #[test]
+    fn a_rust_module_path_is_not_a_failure_marker() {
+        // every passing test in a module named `error` prints `error::…`
+        let passing = "test error::tests::preserves_source ... ok\n\
+                       test result: ok. 268 passed; 0 failed; 0 ignored";
+        let request = with_messages(vec![
+            exec_command(json!({"cmd": "cargo test"})),
+            tr(passing),
+        ]);
+        assert!(ToolSignals::from_request(&request, None).tests_passed);
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -393,8 +393,6 @@ const COMPACTION_MARKER: &str = "session is being continued";
 /// The shell command a tool call carries, when it has one. Harnesses name the
 /// field `command`; anything else is a tool whose category comes from its name.
 fn command_of(arguments: &Value) -> Option<String> {
-    // The Responses wire format carries tool arguments as a JSON-encoded string
-    // rather than an object, so decode that before looking for the command.
     let decoded = arguments
         .as_str()
         .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
@@ -406,8 +404,7 @@ fn command_of(arguments: &Value) -> Option<String> {
         .find_map(command_text)
 }
 
-/// One command field as lowercase text, whether the harness sent a string or an
-/// argv array.
+/// A command field as lowercase text, from a string or an argv array.
 fn command_text(value: &Value) -> Option<String> {
     match value {
         Value::String(text) => Some(text.to_lowercase()),
@@ -431,12 +428,8 @@ fn text_of(block: &ContentBlock) -> Option<&str> {
     }
 }
 
-/// Whether a tool result explicitly reports that every command in it exited zero.
-///
-/// Harnesses that report an exit status make pattern matching unnecessary and
-/// actively misleading: a successful `grep` or `sed` prints whatever the file
-/// contains, including words like "connection refused", and that is not an error
-/// the agent hit. Only trust this when no non-zero status appears in the same text.
+/// Whether every command in a tool result exited zero. A successful `grep`
+/// prints whatever the file holds, error words included.
 fn reports_success_exit(text: &str) -> bool {
     let lower = text.to_lowercase();
     let mut saw_zero = false;
@@ -606,10 +599,8 @@ fn compute_no_error_streak(tool_texts: &[String]) -> u32 {
     streak
 }
 
-/// Whether a tool result carries a literal failure marker.
-///
-/// A marker ending in `:` must not match a Rust path such as `error::tests::…`,
-/// which every passing test in a module named `error` prints.
+/// Whether a tool result carries a failure marker. `error:` must not match the
+/// path `error::`, which passing tests print.
 fn contains_failure_literal(lower: &str) -> bool {
     TEST_FAILURE_LITERAL.iter().any(|literal| {
         let mut cursor = 0usize;
@@ -869,8 +860,6 @@ mod tests {
         assert_eq!(sig.recent_edit_count, 1);
     }
 
-    // codex issues every shell action as `exec_command`, and the Responses wire
-    // format hands the arguments over as a JSON-encoded string.
     fn exec_command(arguments: Value) -> Message {
         Message {
             role: Role::Assistant,
@@ -884,8 +873,6 @@ mod tests {
 
     #[test]
     fn a_command_that_exited_zero_is_not_an_error() {
-        // reading a source file prints whatever it contains, including the words
-        // this module matches on. a zero exit status says nothing went wrong.
         let source = "static CRITICAL: &[&str] = &[\"out of memory\", \"connection refused\"];";
         let request = with_messages(vec![
             exec_command(json!({"cmd": "sed -n 1,40p tool_signals.rs"})),
@@ -896,7 +883,6 @@ mod tests {
 
     #[test]
     fn a_rust_module_path_is_not_a_failure_marker() {
-        // every passing test in a module named `error` prints `error::…`
         let passing = "test error::tests::preserves_source ... ok\n\
                        test result: ok. 268 passed; 0 failed; 0 ignored";
         let request = with_messages(vec![
@@ -912,25 +898,12 @@ mod tests {
             json!({"command": "sed -i s/a/b/ src/lib.rs"}),
             json!({"cmd": "sed -i s/a/b/ src/lib.rs"}),
             json!({"cmd": ["bash", "-lc", "sed -i s/a/b/ src/lib.rs"]}),
+            json!(r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#),
         ] {
             let request = with_messages(vec![exec_command(arguments.clone()), tr("ok")]);
             let signal = ToolSignals::from_request(&request, None);
             assert_eq!(signal.recent_edit_count, 1, "edit count for {arguments}");
         }
-    }
-
-    #[test]
-    fn responses_format_json_string_arguments_are_decoded() {
-        let request = with_messages(vec![
-            exec_command(json!(
-                r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#
-            )),
-            tr("ok"),
-        ]);
-        assert_eq!(
-            ToolSignals::from_request(&request, None).recent_edit_count,
-            1
-        );
     }
 
     #[test]


### PR DESCRIPTION
**Background:** Stage routing reads an agent's tool calls and output to pick the capable or efficient tier. Those signals were calibrated against Claude Code. Codex reports its tools differently, and three pattern matches fire on text that is not an error.

Under Codex the tier only ever moves toward capable. Replaying a recorded session through `stage_router`, `efficient_first` went capable on the third request and never returned, `capable_first` never left capable.

**What:** All in `crates/libsy/src/algorithms/util/tool_signals.rs`.

- `command_of` decodes arguments sent as a JSON string, and accepts `command`, `cmd`, or an argv array. Responses sends a string, so the lookup always came back empty.
- `exec_command` joins the shell tools. Codex runs every shell action through it.
- `write_text(`, `writelines(`, `.write(` join the bash write patterns. Codex edits by piping a Python snippet to an interpreter.
- New `reports_no_failure` skips severity scoring when a tool result reports exit 0, or reports the command is still running. Opening a file containing "out of memory" scored as a critical failure, and a streaming chunk echoing a diff scored on whatever that diff contained. Neither is an error the agent hit.
- New `contains_failure_literal` stops `error:` matching the path `error::`. `libsy` has a module named `error`, so passing tests print `test error::tests::...` and a green `cargo test` was never seen as green.

**Why:** The first three make Codex traffic legible. Before them, zero of 39 real `exec_command` calls registered as an edit or write.

The last two are not Codex-specific and matter more. Any agent that reads or writes source code can trip the severity match, and any repo with an `error` module breaks pass detection. Both fail silently: 200s all the way, the cheap tier just stops being used.

Related to #264. Scorer confidence topped out at 0.46 against the 0.5 default, so the tests-passed shortcut was the only route down, and these bugs broke exactly that. Thresholds alone would not have fixed it.

Verified by replaying recorded Codex sessions through a live server: on a passing test run the tier now moves capable to efficient, where before it could not. No claim here about turns or cost, run-to-run variance across a handful of live Codex runs was larger than any difference between routes.

Five tests, each fails without its fix.