### PR TITLE
docs(changelog): note composite rename, picker rework, and fixes since #549's coverage in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Runner deployment from TOML source** — `Runner::from_toml(&str)` builds a
   configured runner from in-memory deployment text through the same
   version-1 parser and validation path as `Runner::load(path)`. (#545)
-- **Hierarchical routing** — libsy adds hierarchical routing, with stages
-  delegating to their own sub-router; a hierarchical stage router that
-  carries its own judge is rejected. (#533)
+- **Composite routing** — libsy adds composite routing (introduced as
+  "hierarchical" and renamed before release), with stages delegating to their
+  own sub-router; a composite stage router that carries its own judge is
+  rejected. (#533, #548)
 
 ### Changed
 
@@ -73,6 +74,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **LiteLLM integration replaced by a routing plugin** — the client
   integration becomes a routing plugin, and its example moves out of
   `experimental`. (#532)
+- **Stage-router picker decides on score-as-probability** — the picker
+  interprets the scorer's signed score remapped onto a `(0, 1)` capable-tier
+  probability and resolves a tier when it falls outside a threshold-derived
+  ambiguous band around `0.5`, instead of gating on the scorer's separate
+  confidence value (an exact-threshold score now defers to the classifier);
+  hard-rule overrides report the picker's confidence instead of
+  `score.abs()`, and the metric `switchyard.stage_router.score` is renamed
+  to `switchyard.stage_router.probability` with probability-space histogram
+  buckets. (#546)
+- **Hierarchical routing renamed to composite** — the route type string,
+  Rust types (`HierarchicalRouter`/`HierarchicalRouterConfig` and their
+  re-exports), docs, and TOML schema all move to the `composite` name; TOML
+  routes using `type = "hierarchical"` must switch to
+  `type = "composite"`. (#548)
 
 ### Removed
 
@@ -86,6 +101,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Packaging extras `[server]`, `[gpu]`, `[all]`, and `[cli]`** — dropped
   together with the deprecated Python server stack and launcher CLI. Install
   server functionality via the standalone `switchyard-server` binary instead.
+- **`routing_tier` classifier hook** — the `Classifier::routing_tier` method
+  and the `tier` field on the "Model selected" log event are removed, as
+  routing moves away from the binary weak/strong tier model toward a
+  probability distribution over a vector of models. (#554)
 
 ### Fixed
 
@@ -143,6 +162,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `message_stop` (optional `[DONE]` stays compatible for OpenAI Chat and
   Responses), and a duplicate EOF error is no longer appended after a decoded
   in-band provider error. (#425)
+- **Streaming context-overflow fallback** — a streaming request whose first
+  SSE event is an in-band context-overflow error (as SGLang delivers with
+  HTTP 200) now fails the call before anything reaches the client and falls
+  through to the next candidate in the ordered loop; an overflow that
+  arrives mid-stream after delivered content still surfaces without retry.
+  (#542)
+- **Codex `apply_patch` counted as an edit signal** — the stage router's
+  tool-signal classifier recognizes Codex's `apply_patch` edit tool, so its
+  calls count toward edit and recent-edit signals. (#558)
 
 ## [0.2.0]
 


### PR DESCRIPTION
## Summary

Follow-up to #549 (merged): the upstream `main` gained six more commits since #549's coverage ended at c6651746 (2026-08-25 20:07 UTC). This PR records the notable changes in the `Unreleased` section, per the coverage promise left in #549.

## Coverage

Commits after c6651746, newest first:

| Commit | PR | Recorded as |
|---|---|---|
| 2c7cbfa fix(libsy): classify codex apply_patch as an edit signal | #558 | Fixed |
| ed24a6e build: Add Community Gardener notes and tools | #556 | skipped — repo gardening/meta, no user-facing behavior |
| 1500191 chore: Remove routing_tier | #554 | Removed |
| 21f6951 fix(llm-client): fall back when the first stream event is a context overflow | #542 | Fixed |
| 479cbcbb refactor(libsy): decide stage-router picker on score-as-probability | #546 | Changed |
| 22a5503 docs: Update the README warning | #552 | skipped — docs-only README wording, no changelog precedent for this class |
| 7d1380b refactor(libsy): rename hierarchical routing to composite | #548 | Changed + the existing #533 Added entry updated to the shipped "Composite routing" name (both still unreleased) |

## Entry notes

- **#548 rename**: the existing Unreleased entry for hierarchical routing (#533) still advertised the old name, so it is updated to "Composite routing" and now references both PRs; a separate Changed entry spells out the migration-relevant bits (TOML `type = "hierarchical"` → `type = "composite"`, Rust type renames).
- **#546**: although labeled `refactor`, it changes observable behavior — the picker now decides on the score remapped to a `(0, 1)` capable-tier probability with a closed ambiguous band around `0.5`, exact-threshold scores defer to the classifier, overrides report confidence `1.0` instead of `score.abs()`, and the `switchyard.stage_router.score` metric is renamed to `..._probability` with probability-space buckets. Recorded under Changed with the metric rename spelled out for scrapers.
- **#554**: the `routing_tier` hook (and the `tier` field on the "Model selected" log event) is user-observable telemetry removal, recorded under Removed with the maintainer's stated direction (probability distribution over a model vector) as rationale.
- **#542**: first-event in-band overflow (SGLang-style HTTP 200) now fails before delivery and falls through to the next candidate; mid-stream overflow after delivered content still surfaces un-retried — both halves captured in the entry.
- **#558**: `apply_patch` joins `EDIT_TOOL_NAMES`, counting toward edit/recent-edit signals.

## Testing

- `CHANGELOG.md` only; no code paths touched.
- Verified each entry against the corresponding commit diff (files + patch) on upstream `main` at 2c7cbfa.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more reliable model-selection decisions using probability-based scoring and confidence thresholds.
  - Added a fallback for streaming responses when context limits are exceeded.
  - Improved detection of edit signals from Codex patch operations.

- **Improvements**
  - Updated routing terminology from “hierarchical” to “composite” throughout the product and configuration experience.
  - Simplified model-selection event details for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->