### PR TITLE
feat(runner): let a route declare image input so Codex stops omitting images

### DIFF
--- a/crates/switchyard-runner/src/config.rs
+++ b/crates/switchyard-runner/src/config.rs
@@ -67,6 +67,7 @@ struct RouteConfig {
     context_window: Option<u32>,
     tool_calling: Option<bool>,
     reasoning: Option<bool>,
+    vision: Option<bool>,
     algorithm: AlgorithmSpec,
 }
 
@@ -80,6 +81,7 @@ impl<'de> Deserialize<'de> for RouteConfig {
         let context_window = take_optional(&mut table, "context_window")?;
         let tool_calling = take_optional(&mut table, "tool_calling")?;
         let reasoning = take_optional(&mut table, "reasoning")?;
+        let vision = take_optional(&mut table, "vision")?;
         let algorithm = AlgorithmSpec::deserialize(toml::Value::Table(table))
             .map_err(serde::de::Error::custom)?;
         Ok(Self {
@@ -87,6 +89,7 @@ impl<'de> Deserialize<'de> for RouteConfig {
             context_window,
             tool_calling,
             reasoning,
+            vision,
             algorithm,
         })
     }
@@ -118,6 +121,7 @@ impl RouteConfig {
             context_window: self.context_window,
             tool_calling: self.tool_calling,
             reasoning: self.reasoning,
+            vision: self.vision,
         }
     }
 

--- a/crates/switchyard-runner/src/route.rs
+++ b/crates/switchyard-runner/src/route.rs
@@ -26,6 +26,16 @@ pub struct ModelCapabilities {
     /// probe this, so a route opts in via config; undeclared routes advertise as
     /// non-reasoning to Codex (fail closed).
     pub reasoning: Option<bool>,
+    /// Whether the routed model accepts image input. Declared per route for the same
+    /// reason as `reasoning`, and failing closed matters more here: a route may
+    /// resolve to a target with no vision at all.
+    ///
+    /// This is not cosmetic metadata. Codex reads `input_modalities` from the model
+    /// card and, when it reads text-only, replaces an attached image with the literal
+    /// text `image content omitted because you do not support image input` *before
+    /// sending*. An undeclared vision-capable route therefore loses the image in the
+    /// client, and the proxy never receives one to forward.
+    pub vision: Option<bool>,
 }
 
 /// Caller credential family required by a forwarded-auth route.

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -1478,6 +1478,7 @@ fn model_entry_json(model: &str, capabilities: ModelCapabilities) -> Value {
         "capabilities": {
             "streaming": true,
             "tool_calling": capabilities.tool_calling,
+            "vision": capabilities.vision,
             "context_window": capabilities.context_window,
             "supported_inbound_formats": [
                 "openai-chat-completions",
@@ -1543,7 +1544,13 @@ fn codex_model_entry_json(model: &str, capabilities: ModelCapabilities, priority
         "max_context_window": capabilities.context_window,
         "effective_context_window_percent": 95,
         "experimental_supported_tools": [],
-        "input_modalities": ["text"],
+        // Codex omits an attached image client-side when this says text-only, so a
+        // route whose target can see must declare `vision = true`. Fails closed.
+        "input_modalities": if capabilities.vision.unwrap_or(false) {
+            json!(["text", "image"])
+        } else {
+            json!(["text"])
+        },
         "supports_search_tool": false,
     })
 }

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -3474,3 +3474,75 @@ async fn responses_round_trips_codex_tool_namespaces() -> TestResult {
     assert_eq!(completed["response"]["output"][0]["namespace"], "mcp__b");
     Ok(())
 }
+
+// Verifies a route declaring `vision = true` advertises image input, and that an
+// undeclared route still fails closed to text-only.
+//
+// This is not cosmetic metadata. Codex reads `input_modalities` from the model card
+// and, when it reads text-only, replaces an attached image with the literal text
+// "image content omitted because you do not support image input" before sending — so
+// a route whose target can see but which does not say so loses the image in the
+// client, and Switchyard never receives one to forward.
+#[tokio::test]
+async fn models_endpoint_advertises_image_input_only_for_vision_routes() -> TestResult {
+    const CONFIG: &str = r#"
+schema_version = 1
+
+[llm_clients.shared]
+format = "openai_responses"
+base_url = "http://127.0.0.1:1/v1"
+
+[targets.shared]
+id = "shared-model"
+llm_client = "shared"
+
+[routes.sees]
+id = "sees"
+type = "passthrough"
+target = "shared"
+vision = true
+
+[routes.blind]
+id = "blind"
+type = "passthrough"
+target = "shared"
+"#;
+    let app = build_switchyard_router(load_test_config(CONFIG)?);
+    let models = send(&app, "GET", "/v1/models", None).await?;
+    assert_eq!(models.status, StatusCode::OK);
+    let body = models.json()?;
+
+    let codex_metadata = body["models"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|entry| {
+            entry["slug"]
+                .as_str()
+                .map(|slug| (slug.to_string(), entry.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(
+        codex_metadata["sees"]["input_modalities"],
+        json!(["text", "image"])
+    );
+    assert_eq!(codex_metadata["blind"]["input_modalities"], json!(["text"]));
+
+    // The OpenAI `data` entry reports the raw Option, so an undeclared route stays
+    // distinguishable from one that declared `false`.
+    let capabilities = body["data"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|entry| {
+            entry["id"]
+                .as_str()
+                .map(|id| (id.to_string(), entry["capabilities"].clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(capabilities["sees"]["vision"], json!(true));
+    assert_eq!(capabilities["blind"]["vision"], json!(null));
+    Ok(())
+}

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -101,6 +101,7 @@ Every route takes the common keys below, plus the keys for its type.
 | `context_window` | No | unset | Positive token count advertised for this route by `GET /v1/models`. Unset values appear as `null`. This does not enforce a request limit. |
 | `tool_calling` | No | unset | Whether `GET /v1/models` advertises tool-calling support for this route. Unset values appear as `null`. |
 | `reasoning` | No | unset | Whether `GET /v1/models` advertises reasoning support to Codex direct-provider discovery. Unset routes are advertised as non-reasoning. |
+| `vision` | No | unset | Whether `GET /v1/models` advertises **image input** to Codex direct-provider discovery. Unset routes are advertised as text-only. This is not cosmetic: Codex reads `input_modalities` from the model card and, when it reads text-only, replaces an attached image with the text `image content omitted because you do not support image input` **before sending**, so a route whose target can see but which does not declare `vision = true` loses the image in the client. Declare it only when every target the route can select accepts images. |
 
 ### `noop`
 


### PR DESCRIPTION
## What

Adds a `vision` route capability, so `GET /v1/models` can advertise image input instead of always declaring `input_modalities: ["text"]`.

## Why

The hardcoded declaration is not cosmetic metadata. Codex reads `input_modalities` from the model card and, when it reads text-only, replaces an attached image with the literal text

```
image content omitted because you do not support image input
```

**before it sends**. So routing a vision-capable model through Switchyard loses the image *in the client*, and the proxy never receives one to forward. The response is `200`, nothing is logged, and the only other signal is a smaller prompt-token count — the model simply answers that it was given no image.

Measured at the wire against a stand-in upstream that logs the request body, driving real `codex exec -i <file>` through a one-route passthrough:

| Run | Outbound body | Last user-message content |
|---|---|---|
| Codex → upstream, no proxy (control) | 759,745 B | `input_image` (543,102-char data URI) |
| Codex → Switchyard, `["text"]` | **248,385 B** | 60-char placeholder |
| Codex → Switchyard, `["text","image"]` | **739,155 B** | `input_image`, same as control |

Closes #563

## How

`vision: Option<bool>` beside the existing `tool_calling` and `reasoning`, with the same rationale — a serving surface cannot probe it, so a route opts in via config:

```toml
[routes.sees]
id = "sees"
type = "passthrough"
target = "hosted-vision-model"
vision = true
```

⭐ **Failing closed matters more here than for the other two capabilities.** A route may resolve to a target with no vision at all, and declaring image support for such a target sends an image the backend cannot read. So an undeclared route stays text-only, and the documentation says to declare `vision = true` only when *every* target the route can select accepts images.

The OpenAI `data` entry reports the raw `Option`, so an undeclared route stays distinguishable from one that declared `false`.

## How tested

- [x] `cargo test --workspace` green (33 suites, 0 failures)
- [x] `cargo fmt --check` clean
- [x] Added `models_endpoint_advertises_image_input_only_for_vision_routes`: a `vision = true` route advertises `["text","image"]`, an undeclared route stays `["text"]`, and the `data` entry reports `true` vs `null`.
- [x] Manual smoke: real `codex exec -i <png>` through a locally built `switchyard-server` into a request-logging upstream, before and after declaring `vision = true` — the table above.
- [ ] `uv run ruff check .` / `mypy` / `pytest` — n/a, no Python touched

## Notes for reviewers

- ⚠ **DCO sign-off is not yet on the commit.** Happy to `git rebase --signoff` and force-push on request; I did not want to add the attestation line unasked.
- This does **not** address the neighbouring hardcoded fields on the same model card. `supports_image_detail_original` is still `false`, and `base_instructions` / `default_reasoning_level` / `truncation_policy` are still constants — the `base_instructions` one has a larger consequence and is filed separately as #565.
- The existing `codex_model_entry_json` comment already flags this class of problem, with a TODO about sourcing capabilities from the backend rather than route config. This change follows the current convention (declare in config, fail closed) rather than pre-empting that refactor; if you would rather `input_modalities` be derived from a backend probe where one exists, I am glad to rework it that way.
- Found together with #564 (Responses image encode shape, PR #566). They are independent defects: #564 is unreachable on a same-format route, and fixing it does not make images work, which is why both exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yveJruskBHpt3EXehSuwo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-route vision capability configuration.
  * Model listings now indicate whether routes support image inputs.
  * Vision-capable routes advertise both text and image input support.

* **Documentation**
  * Documented the new `vision` route option and its behavior when omitted.

* **Bug Fixes**
  * Improved image-input handling by accurately reporting route capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->