### PR TITLE
fix(libsy): read tool signals from codex exec_command traffic

### DIFF
--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -836,44 +836,47 @@ mod tests {
         assert_eq!(sig.recent_edit_count, 1);
     }
 
-    fn exec_command(arguments: Value) -> Message {
+    fn exec_command(cmd: Value) -> Message {
         Message {
             role: Role::Assistant,
             content: vec![ContentBlock::ToolCall(ToolCall {
                 id: String::new(),
                 name: "exec_command".to_string(),
-                arguments,
+                arguments: cmd,
             })],
         }
     }
 
     #[test]
-    fn exec_command_arg_shapes() {
-        for arguments in [
-            json!({"command": "sed -i s/a/b/ src/lib.rs"}),
-            json!({"cmd": "sed -i s/a/b/ src/lib.rs"}),
-            json!({"cmd": ["bash", "-lc", "sed -i s/a/b/ src/lib.rs"]}),
-            json!(r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#),
-        ] {
-            let request = with_messages(vec![exec_command(arguments.clone()), tr("ok")]);
-            let signal = ToolSignals::from_request(&request, None);
-            assert_eq!(signal.recent_edit_count, 1, "edit count for {arguments}");
-        }
+    fn codex_exec_command_is_classified() {
+        // arguments arrive as a JSON string, with the command under `cmd`
+        let args = json!(r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#);
+        let request = with_messages(vec![exec_command(args), tr("ok")]);
+        assert_eq!(
+            ToolSignals::from_request(&request, None).recent_edit_count,
+            1
+        );
     }
 
     #[test]
     fn python_write_expressions_need_a_python_command() {
-        // (command, expected writes, expected reads)
-        for (cmd, writes, reads) in [
-            ("python3 - <<'PY'\np.write_text(s)\nPY", 1, 0),
-            ("grep -R '.write(' src", 0, 1),
-            ("grep -R 'write_text(' src", 0, 1),
-        ] {
-            let request = with_messages(vec![exec_command(json!({"cmd": cmd})), tr("ok")]);
-            let signal = ToolSignals::from_request(&request, None);
-            assert_eq!(signal.recent_write_count, writes, "writes for {cmd}");
-            assert_eq!(signal.recent_read_count, reads, "reads for {cmd}");
-        }
+        let write = with_messages(vec![
+            exec_command(json!({"cmd": "python3 - <<'PY'\np.write_text(s)\nPY"})),
+            tr("ok"),
+        ]);
+        assert_eq!(
+            ToolSignals::from_request(&write, None).recent_write_count,
+            1
+        );
+
+        let search = with_messages(vec![
+            exec_command(json!({"cmd": "grep -R '.write(' src"})),
+            tr("ok"),
+        ]);
+        assert_eq!(
+            ToolSignals::from_request(&search, None).recent_write_count,
+            0
+        );
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -124,6 +124,9 @@ static BASH_WRITE_PATTERNS: &[&str] = &[
     "<<eof",
     "<<'eof'",
     "<< eof",
+    "write_text(",
+    "writelines(",
+    ".write(",
 ];
 
 static BASH_EDIT_PATTERNS: &[&str] = &[
@@ -161,6 +164,7 @@ static BASH_TOOL_NAMES: &[&str] = &[
     "shell",
     "local_shell_call",
     "terminal",
+    "exec_command", // codex
 ];
 
 // Prefer false negatives: tests_passed routes the picker to EFFICIENT, so a false
@@ -389,10 +393,32 @@ const COMPACTION_MARKER: &str = "session is being continued";
 /// The shell command a tool call carries, when it has one. Harnesses name the
 /// field `command`; anything else is a tool whose category comes from its name.
 fn command_of(arguments: &Value) -> Option<String> {
-    arguments
-        .get("command")
-        .and_then(Value::as_str)
-        .map(str::to_lowercase)
+    // the Responses wire format sends arguments as a JSON string, not an object
+    let decoded = arguments
+        .as_str()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+    let object = decoded.as_ref().unwrap_or(arguments);
+
+    ["command", "cmd", "input"]
+        .iter()
+        .filter_map(|key| object.get(*key))
+        .find_map(command_text)
+}
+
+/// A command field as lowercase text, from a string or an argv array.
+fn command_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.to_lowercase()),
+        Value::Array(parts) => {
+            let joined = parts
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!joined.is_empty()).then(|| joined.to_lowercase())
+        }
+        _ => None,
+    }
 }
 
 /// Text carried by a content block, ignoring the non-textual kinds.
@@ -804,6 +830,43 @@ mod tests {
         let sig = ToolSignals::from_request(&request, None);
         assert_eq!(sig.edit_count, 1);
         assert_eq!(sig.recent_edit_count, 1);
+    }
+
+    fn exec_command(arguments: Value) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolCall(ToolCall {
+                id: String::new(),
+                name: "exec_command".to_string(),
+                arguments,
+            })],
+        }
+    }
+
+    #[test]
+    fn exec_command_arg_shapes() {
+        for arguments in [
+            json!({"command": "sed -i s/a/b/ src/lib.rs"}),
+            json!({"cmd": "sed -i s/a/b/ src/lib.rs"}),
+            json!({"cmd": ["bash", "-lc", "sed -i s/a/b/ src/lib.rs"]}),
+            json!(r#"{"cmd":"sed -i s/a/b/ src/lib.rs","workdir":"/x"}"#),
+        ] {
+            let request = with_messages(vec![exec_command(arguments.clone()), tr("ok")]);
+            let signal = ToolSignals::from_request(&request, None);
+            assert_eq!(signal.recent_edit_count, 1, "edit count for {arguments}");
+        }
+    }
+
+    #[test]
+    fn heredoc_script_is_a_write() {
+        let request = with_messages(vec![
+            exec_command(json!({"cmd": "python3 - <<'PY'\np.write_text(s)\nPY"})),
+            tr("ok"),
+        ]);
+        assert_eq!(
+            ToolSignals::from_request(&request, None).recent_write_count,
+            1
+        );
     }
 
     #[test]

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -124,9 +124,11 @@ static BASH_WRITE_PATTERNS: &[&str] = &[
     "<<eof",
     "<<'eof'",
     "<< eof",
-    "write_text(",
-    ".write(",
 ];
+
+/// Python file-write expressions, which only indicate a write when an
+/// interpreter is running them rather than a search looking for them.
+static PYTHON_WRITE_PATTERNS: &[&str] = &["write_text(", "writelines(", ".write("];
 
 static BASH_EDIT_PATTERNS: &[&str] = &[
     "sed -i",
@@ -322,6 +324,9 @@ fn classify_tool_call(name: &str, command: Option<&str>) -> ToolCategory {
     {
         // Write/edit redirection trumps read-like operands.
         if BASH_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
+            return ToolCategory::Write;
+        }
+        if cmd.contains("python") && PYTHON_WRITE_PATTERNS.iter().any(|p| cmd.contains(p)) {
             return ToolCategory::Write;
         }
         if BASH_EDIT_PATTERNS.iter().any(|p| cmd.contains(p)) {
@@ -853,6 +858,16 @@ mod tests {
             let request = with_messages(vec![exec_command(arguments.clone()), tr("ok")]);
             let signal = ToolSignals::from_request(&request, None);
             assert_eq!(signal.recent_edit_count, 1, "edit count for {arguments}");
+        }
+    }
+
+    #[test]
+    fn searching_for_a_write_expression_is_a_read() {
+        for cmd in ["grep -R '.write(' src", "grep -R 'write_text(' src"] {
+            let request = with_messages(vec![exec_command(json!({"cmd": cmd})), tr("ok")]);
+            let signal = ToolSignals::from_request(&request, None);
+            assert_eq!(signal.recent_write_count, 0, "write count for {cmd}");
+            assert_eq!(signal.recent_read_count, 1, "read count for {cmd}");
         }
     }
 

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -125,7 +125,6 @@ static BASH_WRITE_PATTERNS: &[&str] = &[
     "<<'eof'",
     "<< eof",
     "write_text(",
-    "writelines(",
     ".write(",
 ];
 

--- a/crates/libsy/src/algorithms/util/tool_signals.rs
+++ b/crates/libsy/src/algorithms/util/tool_signals.rs
@@ -862,25 +862,18 @@ mod tests {
     }
 
     #[test]
-    fn searching_for_a_write_expression_is_a_read() {
-        for cmd in ["grep -R '.write(' src", "grep -R 'write_text(' src"] {
+    fn python_write_expressions_need_a_python_command() {
+        // (command, expected writes, expected reads)
+        for (cmd, writes, reads) in [
+            ("python3 - <<'PY'\np.write_text(s)\nPY", 1, 0),
+            ("grep -R '.write(' src", 0, 1),
+            ("grep -R 'write_text(' src", 0, 1),
+        ] {
             let request = with_messages(vec![exec_command(json!({"cmd": cmd})), tr("ok")]);
             let signal = ToolSignals::from_request(&request, None);
-            assert_eq!(signal.recent_write_count, 0, "write count for {cmd}");
-            assert_eq!(signal.recent_read_count, 1, "read count for {cmd}");
+            assert_eq!(signal.recent_write_count, writes, "writes for {cmd}");
+            assert_eq!(signal.recent_read_count, reads, "reads for {cmd}");
         }
-    }
-
-    #[test]
-    fn heredoc_script_is_a_write() {
-        let request = with_messages(vec![
-            exec_command(json!({"cmd": "python3 - <<'PY'\np.write_text(s)\nPY"})),
-            tr("ok"),
-        ]);
-        assert_eq!(
-            ToolSignals::from_request(&request, None).recent_write_count,
-            1
-        );
     }
 
     #[test]


### PR DESCRIPTION
**Background:** Tool signals are extracted from a tool call's name and its command. Codex reports both differently from Claude Code, so no tool use activity is classified as a read, write, or edit. This matters for routing algorithms in switchyard such as `stage` which rely on tool signals.

Sampled from 146 tool calls across 20 local codex-cli 0.149.1 sessions:

- Tool names used: `exec_command` (110), `write_stdin` (18), `update_plan` (18). No `bash`, `shell`, `terminal` or `local_shell_call`, so every shell action fell through to `Other`.
- Responses sends `arguments` as a JSON string rather than an object, so `arguments.get("command")` never resolved. This affects any Responses client.
- The command is under `cmd`.
- Codex rewrites whole files with `python3 - <<'PY' ... p.write_text(...)` in which case the write is only visible in the command text.

Each `exec_command` call carries the shell text it ran. Since Codex runs every shell action through that one tool, the text is the only way to tell a read from a write. When the arguments cannot be parsed it is unreachable, so nothing gets classified.

**What:** All in `crates/libsy/src/algorithms/util/tool_signals.rs`.

- `command_of` decodes `arguments` sent as a JSON string, and accepts `cmd` and `input` as well as `command`. New `command_text` handles an argv array as well as a string.
- `exec_command` joins the known shell tool names.
- `write_text(` and `.write(` join the bash write patterns, matching 18 and 3 commands in the sample, all of which modified a file.

Across the 110 sampled `exec_command` calls this moves classification from 100% `Other` to 41 reads, 21 writes, 48 other.

OpenAI ref: https://developers.openai.com/api/docs/guides/function-calling#handling-function-calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection of file-writing commands in Python-style code, including `write_text` and `.write()` calls.
  * Added support for recognizing `exec_command` as a shell-like tool.
  * Enhanced command extraction from JSON arguments, including string and argument-array formats.

* **Bug Fixes**
  * Improved handling of heredoc-based file writes and varied command input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->