### PR TITLE
chore: Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,25 +4,9 @@ Short summary of what this PR changes.
 
 ## Why
 
-The motivation — what problem does this solve, or which ticket does it close?
-
-Closes #
-
-## How tested
-
-- [ ] `uv run ruff check .` clean
-- [ ] `uv run mypy switchyard` clean
-- [ ] `uv run pytest tests/` green
-- [ ] Manual smoke (describe what was run)
-
-## Checklist
-
-- [ ] One class per file; filename = `snake_case` of the primary class.
-- [ ] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use.
-- [ ] Unit tests added for new components / bug fixes.
-- [ ] README / `--help` updated if customer-facing surface changed.
-- [ ] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.
+The motivation — what problem does this solve? Link the Issue if you have one.
 
 ## Notes for reviewers
 
-Anything reviewers should pay extra attention to — risky paths, follow-up tickets, intentional trade-offs.
+Where should the reviewer start? Help us help you land this.
+


### PR DESCRIPTION
Remove the Python checklist.

In general if it's important CI should enforce it. The checklist is
unnecessary.

Signed-off-by: Graham King <grahamk@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template to request motivation, issue links, and reviewer starting points.
  * Simplified the template by removing testing, checklist, and extended reviewer-guidance sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->