### PR TITLE
feat(protocol): add typed request context

### DIFF
--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -101,6 +101,11 @@ assert_eq!(request.llm_request.tools[0].name, "lookup_metric");
 
 ## Trusted in-process context
 
+This API is unreleased and must ship in the next breaking `switchyard-protocol` release. Adding a
+field to public `Metadata` is source-incompatible for downstream exhaustive struct literals. Such
+callers must add `..Metadata::default()` (or set `typed_context`) before upgrading. The `v0.2.0`
+setup dependency above does not contain this API.
+
 Hosts can attach cloneable, typed values to [`Metadata::typed_context`] without
 encoding trusted state into client-controlled headers or serialized protocol
 payloads:

--- a/crates/protocol/README.md
+++ b/crates/protocol/README.md
@@ -99,6 +99,35 @@ let request = Request {
 assert_eq!(request.llm_request.tools[0].name, "lookup_metric");
 ```
 
+## Trusted in-process context
+
+Hosts can attach cloneable, typed values to [`Metadata::typed_context`] without
+encoding trusted state into client-controlled headers or serialized protocol
+payloads:
+
+```rust
+use switchyard_protocol::Metadata;
+
+#[derive(Clone, Debug, PartialEq)]
+struct TenantId(String);
+
+let mut metadata = Metadata::default();
+metadata
+    .typed_context
+    .insert(TenantId("tenant-42".to_string()));
+
+let cloned = metadata.clone();
+assert_eq!(
+    cloned.typed_context.get::<TenantId>(),
+    Some(&TenantId("tenant-42".to_string()))
+);
+```
+
+Values in `typed_context` are host-owned and remain in process: Switchyard does
+not populate them from HTTP headers, serialize them, log them, or forward them
+to providers. Applications remain responsible for inserting only safe,
+cloneable types and for enforcing their own authorization boundaries.
+
 ## Response forms
 
 [`LlmResponse`] contains either a completed [`AggLlmResponse`] or a

--- a/crates/protocol/src/metadata.rs
+++ b/crates/protocol/src/metadata.rs
@@ -155,7 +155,8 @@ const HEADER_CONFIG: &HeaderConfig = &[
 /// are present (e.g. to key per-session state or emit correlated telemetry). The
 /// agent-lineage fields (`parent_agent_id`, `is_subagent`, `agent_kind`, `agent_role`,
 /// `task_kind`, `turn_id`, `session_final`) are populated for requests from a coding
-/// agent. `extra_metadata` is a free-form escape hatch for host-specific keys.
+/// agent. `extra_metadata` is a free-form escape hatch for observable host-specific
+/// keys; `typed_context` carries host-owned values that must stay in process.
 #[derive(Clone, Default)]
 pub struct Metadata {
     /// Stable id for a multi-request session/conversation.
@@ -188,6 +189,12 @@ pub struct Metadata {
     pub correlation_id: Option<String>,
     /// Switchyard target that successfully served a response.
     pub served_model: Option<ModelId>,
+    /// Cloneable host-owned context carried in process with the request.
+    ///
+    /// Values are never populated from HTTP headers, serialized, logged, or forwarded
+    /// by the protocol crate. Hosts may use this for trusted typed data that algorithms
+    /// or clients need without reducing it to string metadata.
+    pub typed_context: http::Extensions,
     /// Arbitrary host-defined key/value metadata.
     pub extra_metadata: Option<BTreeMap<String, String>>,
     /// HTTP headers to attach when forwarding the request/response, if any.
@@ -375,11 +382,38 @@ pub fn slice_to_header_map(sl: &[(&str, &str)]) -> http::HeaderMap {
 mod tests {
     use super::*;
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct HostAuthorization {
+        tenant: &'static str,
+    }
+
     /// Header carrying Codex's structured turn metadata as a JSON object.
     const CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
 
     fn metadata(headers: &[(&str, &str)]) -> Metadata {
         Metadata::from_headers(&slice_to_header_map(headers))
+    }
+
+    #[test]
+    fn typed_context_survives_metadata_clone() {
+        let mut metadata = Metadata::default();
+        metadata
+            .typed_context
+            .insert(HostAuthorization { tenant: "tenant-a" });
+
+        let cloned = metadata.clone();
+
+        assert_eq!(
+            cloned.typed_context.get::<HostAuthorization>(),
+            Some(&HostAuthorization { tenant: "tenant-a" })
+        );
+    }
+
+    #[test]
+    fn headers_cannot_populate_typed_context() {
+        let metadata = metadata(&[("x-switchyard-typed-context", "untrusted")]);
+
+        assert!(metadata.typed_context.is_empty());
     }
 
     #[test]

--- a/crates/protocol/src/metadata.rs
+++ b/crates/protocol/src/metadata.rs
@@ -394,6 +394,7 @@ mod tests {
         Metadata::from_headers(&slice_to_header_map(headers))
     }
 
+    // Cloning metadata must preserve cloneable, host-owned typed context.
     #[test]
     fn typed_context_survives_metadata_clone() {
         let mut metadata = Metadata::default();
@@ -409,10 +410,12 @@ mod tests {
         );
     }
 
+    // Even recognized HTTP metadata headers must never populate trusted typed context.
     #[test]
     fn headers_cannot_populate_typed_context() {
-        let metadata = metadata(&[("x-switchyard-typed-context", "untrusted")]);
+        let metadata = metadata(&[(SWITCHYARD_SESSION_ID_HEADER, "untrusted")]);
 
+        assert_eq!(metadata.session_id.as_deref(), Some("untrusted"));
         assert!(metadata.typed_context.is_empty());
     }
 


### PR DESCRIPTION
## Status and dependencies

**Draft.** This proposal is blocked on the request-context ownership decision in #583 and on the next breaking protocol release. It is independent of #579 and #586. I will not advance the implementation until the community agrees on the context boundary and public API shape.

## What

Adds a cloneable, typed, in-process context to protocol Metadata using http::Extensions.

The new field is documented and covered by clone and untrusted-header tests. It is not populated from headers, serialized, logged, or forwarded by the protocol crate.

## Why

Rust hosts embedding Switchyard need to carry trusted authorization and tenant context across request clones without reducing it to client-controlled string metadata.

## Notes for reviewers

Start with crates/protocol/src/metadata.rs. The field preserves runtime defaults but is source-incompatible for downstream exhaustive Metadata struct literals. It must ship in the next breaking switchyard-protocol release; callers should migrate to struct update syntax with Metadata::default() or initialize typed_context explicitly.

Validated with workspace Rust tests, strict clippy, rustdoc warnings-as-errors, Ruff, and all 115 Python tests including the Docker e2e.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing cloneable, typed application context in metadata.
  * Typed context is preserved when metadata is cloned and remains available for local processing.

* **Documentation**
  * Added guidance and examples for inserting and retrieving typed context.
  * Clarified that typed context is process-local and is not serialized, logged, forwarded, or populated from HTTP headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->