### PR TITLE
fix(translation): preserve Anthropic tool strictness

### DIFF
--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -701,7 +701,7 @@ fn decode_anthropic_tools(value: Option<&Value>) -> Vec<ToolDefinition> {
                     .get("input_schema")
                     .cloned()
                     .unwrap_or_else(|| json!({})),
-                strict: None,
+                strict: tool.get("strict").and_then(Value::as_bool),
             })
         })
         .collect()

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -654,6 +654,47 @@ fn anthropic_tool_without_name_is_dropped_before_openai_chat() -> TestResult {
     Ok(())
 }
 
+// Verifies Anthropic tool strictness survives translation into both OpenAI formats.
+#[test]
+fn anthropic_tool_strictness_is_preserved_for_openai_formats() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet-4-20250514",
+        "messages": [{"role": "user", "content": "Use a tool."}],
+        "max_tokens": 100,
+        "tools": [
+            {"name": "strict_tool", "input_schema": {}, "strict": true},
+            {"name": "non_strict_tool", "input_schema": {}, "strict": false},
+            {"name": "unspecified_tool", "input_schema": {}}
+        ]
+    });
+
+    let chat = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    let responses = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(chat["tools"][0]["function"]["strict"], true);
+    assert_eq!(chat["tools"][1]["function"]["strict"], false);
+    assert!(chat["tools"][2]["function"].get("strict").is_none());
+    assert_eq!(responses["tools"][0]["strict"], true);
+    assert_eq!(responses["tools"][1]["strict"], false);
+    assert!(responses["tools"][2].get("strict").is_none());
+    Ok(())
+}
+
 // Verifies OpenAI-compatible Anthropic extension fields are preserved.
 #[test]
 fn anthropic_openai_compatible_extensions_are_preserved_for_openai_chat() -> TestResult {


### PR DESCRIPTION
## What

Preserve top-level `tools[].strict` when decoding Anthropic Messages requests so explicit strictness reaches OpenAI Chat and Responses targets.

Add regression coverage for `true`, `false`, and omitted strictness across both translated formats.

## Why

The Anthropic decoder previously replaced every tool's strictness with an absent value, silently disabling schema enforcement after translation.

Closes #577.

## Notes for reviewers

Start with `decode_anthropic_tools`; the runtime change is one expression. The request-translation test exercises the complete decoder/encoder path for both destination formats.

Local validation:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --locked --offline -p switchyard-translation`
- `cargo test --workspace`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy switchyard`
- Hermetic Python suite: 113 passed, 2 deselected
- Loopback proxy capture confirmed `function.strict: true` in the forwarded request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic tool definitions now correctly preserve the optional `strict` setting during translation.
  - Both enabled and disabled values are retained, while unspecified settings remain absent.

- **Tests**
  - Added coverage confirming `strict` values translate correctly to OpenAI Chat and Responses formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->