### PR TITLE
fix(translation): decode flat Responses input_file payloads

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -588,6 +588,11 @@ pub(crate) fn decode_image_source(block: &Map<String, Value>) -> Option<ImageSou
 }
 
 /// Decodes OpenAI file block shapes into normalized file sources.
+///
+/// Accepts both the Chat shape, which nests the payload under a `file` object,
+/// and the Responses shape, which carries `file_id`/`file_data`/`filename`
+/// directly on the block. Returns `FileSource::Raw` when neither shape carries a
+/// field this can normalize.
 pub(crate) fn decode_file_source(block: &Map<String, Value>) -> FileSource {
     if let Some(file) = block.get("file").and_then(Value::as_object) {
         if let Some(file_id) = file.get("file_id").and_then(Value::as_str) {
@@ -604,8 +609,19 @@ pub(crate) fn decode_file_source(block: &Map<String, Value>) -> FileSource {
         }
         return FileSource::Raw(Value::Object(file.clone()));
     }
+    // A Chat block never reaches here with these keys, having matched the nested
+    // branch above.
     if let Some(file_id) = block.get("file_id").and_then(Value::as_str) {
         return FileSource::FileId(file_id.to_string());
+    }
+    if let Some(file_data) = block.get("file_data").and_then(Value::as_str) {
+        return FileSource::FileData {
+            data: file_data.to_string(),
+            filename: block
+                .get("filename")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+        };
     }
     FileSource::Raw(Value::Object(block.clone()))
 }

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -2301,3 +2301,50 @@ fn anthropic_thinking_is_dropped_from_responses_input() -> TestResult {
     );
     Ok(())
 }
+
+// Verifies a flat Responses `input_file` decodes instead of being dropped.
+//
+// The Responses wire carries `file_data`/`filename` directly on the block, while
+// `decode_file_source` read a direct `file_id` but not a direct `file_data`, so a
+// Responses file fell through to `FileSource::Raw`. Chat's raw file encoder maps
+// only Anthropic `document` blocks and returns `None` otherwise -- so the file did
+// not merely lose its filename, it vanished from the request entirely.
+#[test]
+fn responses_flat_file_data_survives_into_chat() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5.4-mini",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "read this"},
+                {
+                    "type": "input_file",
+                    "file_data": "JVBERi0xLjQK",
+                    "filename": "report.pdf"
+                }
+            ]
+        }]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiResponses,
+            WireFormat::OpenAiChat,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    let content = output["messages"][0]["content"]
+        .as_array()
+        .ok_or("Chat content should be an array")?;
+    let file = content
+        .iter()
+        .find(|block| block["type"] == "file")
+        .ok_or("the file must survive into Chat, not be dropped as unmappable raw")?;
+    assert_eq!(file["file"]["file_data"], "JVBERi0xLjQK");
+    assert_eq!(file["file"]["filename"], "report.pdf");
+    Ok(())
+}


### PR DESCRIPTION
## What

`decode_file_source` now reads an `input_file` payload carried directly on the
content block, not only nested under a `file` object.

## Why

The Responses wire puts `file_data`/`filename` directly on the block, while
OpenAI Chat nests them under `file`. The nested shape decoded both `file_id`
and `file_data`, but the flat shape read only `file_id` — so a flat
`file_data` fell through to `FileSource::Raw`.

That is not a cosmetic loss. Chat's raw file encoder maps only Anthropic
`document` blocks and returns `None` for anything else, so the block is then
dropped: a Responses request carrying base64 file content loses the file
entirely en route to a Chat backend, silently and with no diagnostic.

The new test fails on `main` with

```
the file must survive into Chat, not be dropped as unmappable raw
```

and passes with this change.

## Notes for reviewers

Decode path only: one branch in `decode_file_source`, plus one test. A Chat
block cannot reach that branch, having matched the nested one above, so the
existing shapes decode unchanged.

Independent of #530, which fixes the Responses *encoder* for image and file
content and explicitly scoped this reverse-path case out. This applies to
`main` as-is and does not touch `responses/buffered.rs`, so the two do not
conflict and neither blocks the other.

Split out at reviewer request from #566, which was closed as overlapping #530.

- `cargo test --workspace`: 678 passed, 0 failed
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Commit carries the DCO sign-off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI Responses-style file inputs.
  * File data and filenames provided directly on file input blocks are now preserved during translation.
  * Existing nested file formats and raw fallback behavior remain supported.

* **Tests**
  * Added regression coverage to verify file content is translated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->