### PR TITLE
fix(translation): preserve OpenAI tool strictness for Anthropic

### DIFF
--- a/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/anthropic/buffered.rs
@@ -1044,11 +1044,15 @@ fn encode_anthropic_tools(tools: &[ToolDefinition]) -> Value {
         tools
             .iter()
             .map(|tool| {
-                json!({
+                let mut item = json!({
                     "name": tool.name,
                     "description": tool.description.clone().unwrap_or_default(),
                     "input_schema": tool.parameters,
-                })
+                });
+                if let Some(strict) = tool.strict {
+                    item["strict"] = Value::Bool(strict);
+                }
+                item
             })
             .collect(),
     )

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -1853,6 +1853,44 @@ fn openai_schema_constraints_are_removed_from_anthropic_output_format() -> TestR
     Ok(())
 }
 
+// Verifies OpenAI tool strictness survives translation to Anthropic.
+#[test]
+fn openai_tool_strictness_is_preserved_for_anthropic() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "Use a tool."}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "strict", "parameters": {}, "strict": true}
+            },
+            {
+                "type": "function",
+                "function": {"name": "non_strict", "parameters": {}, "strict": false}
+            },
+            {
+                "type": "function",
+                "function": {"name": "unspecified", "parameters": {}}
+            }
+        ]
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::OpenAiChat,
+            WireFormat::AnthropicMessages,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(output["tools"][0]["strict"], true);
+    assert_eq!(output["tools"][1]["strict"], false);
+    assert!(output["tools"][2].get("strict").is_none());
+    Ok(())
+}
+
 // Verifies Anthropic-bound OpenAI requests get the required max_tokens fallback.
 #[test]
 fn openai_request_to_anthropic_adds_required_default_max_tokens() -> TestResult {


### PR DESCRIPTION
## What

Preserve `ToolDefinition.strict` when Switchyard encodes an Anthropic Messages tool definition.

The field is written for `true` and `false`, and left out when it was not set.

## Why

OpenAI Chat already decodes function strictness into the shared request type, but the Anthropic encoder was dropping it. That silently turned a strict tool into a normal tool before the upstream request was sent.

This is the reverse direction of #585.

Closes #599.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p switchyard-translation`
- Live OpenAI Chat to Switchyard to Anthropic capture: the outbound tool contained `strict: true` and Anthropic returned HTTP 200 with the forced tool call.

No public API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tool definitions translated to Anthropic format now preserve explicitly configured strictness settings.
  - Unspecified strictness remains unchanged during translation.

- **Tests**
  - Added coverage for strict, non-strict, and unspecified tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->