### PR TITLE
feat(server): gate OTLP export behind telemetry opt-in

### DIFF
--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -171,6 +171,9 @@ containing `opus`, `sonnet`, then `haiku`. Other ties preserve the route's targe
 ## Metrics
 
 `GET /metrics` exposes Prometheus text from the server's process-wide OpenTelemetry provider.
+Outbound OTLP export is disabled unless `SWITCHYARD_TELEMETRY` is explicitly enabled with a truthy
+value such as `1` or `true`; configuring `OTEL_EXPORTER_OTLP_*` alone is not treated as telemetry
+opt-in. The local `/metrics` endpoint remains available either way.
 Routed-call compatibility metrics are:
 
 | Metric | Type | Labels | Meaning |

--- a/crates/switchyard-server/src/observability.rs
+++ b/crates/switchyard-server/src/observability.rs
@@ -21,6 +21,7 @@ use crate::{ServerError, ServerResult, metrics};
 
 const DEFAULT_LOG_FILTER: &str = "info,opentelemetry=warn";
 const DEFAULT_SERVICE_NAME: &str = "switchyard-server";
+const SWITCHYARD_TELEMETRY_ENV: &str = "SWITCHYARD_TELEMETRY";
 
 struct Observability {
     tracer_provider: Option<SdkTracerProvider>,
@@ -74,6 +75,9 @@ impl Extractor for HeaderExtractor<'_> {
 
 pub(crate) fn otlp_enabled(signal: &str) -> bool {
     if env_var_is_true("OTEL_SDK_DISABLED") {
+        return false;
+    }
+    if !env_var_is_true(SWITCHYARD_TELEMETRY_ENV) {
         return false;
     }
     if env::var(format!("OTEL_{signal}_EXPORTER"))


### PR DESCRIPTION
## What

- Add a `SWITCHYARD_TELEMETRY` env gate in `switchyard-server` before OTLP trace/metric exporters are installed.
- Keep local Prometheus `/metrics` available regardless of the opt-in flag.
- Document that `OTEL_EXPORTER_OTLP_*` configures the transport, but does not by itself opt users into outbound Switchyard telemetry.

## Why

This implements the narrow opt-in gate from SWITCH-1381 under SWITCH-1297. libsy remains instrumentation-only; the server owns exporter setup, so the opt-in check belongs at the server OTLP initialization boundary.

## How

`otlp_enabled(signal)` now returns false unless:

- `OTEL_SDK_DISABLED` is not set truthy,
- `SWITCHYARD_TELEMETRY` is set truthy,
- and the relevant OTLP endpoint/exporter env vars are configured.

## Validation

- Not run, per request.
- Commit hook ran `cargo fmt` and `cargo clippy` successfully.

Linear: SWITCH-1381
Parent: SWITCH-1297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Outbound OTLP telemetry is now disabled unless `SWITCHYARD_TELEMETRY` is explicitly enabled.
  * Setting `OTEL_EXPORTER_OTLP_*` variables alone no longer activates outbound telemetry.
  * The local `/metrics` endpoint remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->