### PR TITLE
feat(relay): add schemas to routing marks

### DIFF
--- a/crates/switchyard-nemo-relay-plugin/README.md
+++ b/crates/switchyard-nemo-relay-plugin/README.md
@@ -110,6 +110,19 @@ attributes. `target_model` comes from the configured Switchyard target set,
 rather than arbitrary caller input, keeping the metric cardinality bounded by
 the deployment.
 
+Every non-metric mark sets `data_schema.name` to the mark name and
+`data_schema.version` to `1`. Consumers should tolerate unknown fields and
+values. Removing or renaming fields, changing their type, or changing their
+meaning requires a new schema version.
+
+| Mark | Data fields |
+| --- | --- |
+| `switchyard.routing.requested` | `algorithm` |
+| `switchyard.routing.llm_call` | `call_index`, `selected_model`, `call_role`, `outcome`, `latency_ms` |
+| `switchyard.routing.overhead` | `latency_ms` |
+| `switchyard.routing.decision` | `algorithm`, `selected_model` |
+| `switchyard.routing.error` | `failure_kind`; optional `category`, `phase`, `upstream_status`, and `target` |
+
 ## Failure policy
 
 `switchyard-llm-client` owns provider retry and route-candidate fallback

--- a/crates/switchyard-nemo-relay-plugin/src/runtime.rs
+++ b/crates/switchyard-nemo-relay-plugin/src/runtime.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use futures_util::{Stream, StreamExt};
 use http::StatusCode;
 use nemo_relay_plugin::{
-    Json, LlmRequest as RelayRequest, LogSeverity, MetricKind, MetricMeasurement, MetricValueType,
-    PluginRuntime,
+    DataSchema, Json, LlmRequest as RelayRequest, LogSeverity, MetricKind, MetricMeasurement,
+    MetricValueType, PluginRuntime,
 };
 use serde_json::{Map, json};
 use switchyard_llm_client::{LlmCallObservation, RunObservation, RunObserver};
@@ -22,12 +22,23 @@ use switchyard_translation::{TranslationEngine, encode_stream_with_extensions};
 use crate::config::SwitchyardConfig;
 use crate::translation;
 
+const ROUTING_MARK_SCHEMA_VERSION: &str = "1";
+
 #[derive(Debug)]
 pub(crate) struct RoutingMark {
     pub(crate) name: String,
     pub(crate) data: Json,
     pub(crate) metadata: Json,
     pub(crate) severity: Option<LogSeverity>,
+}
+
+impl RoutingMark {
+    fn data_schema(&self) -> DataSchema {
+        DataSchema {
+            name: self.name.clone(),
+            version: ROUTING_MARK_SCHEMA_VERSION.into(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -324,15 +335,18 @@ pub(crate) fn emit_events(runtime: &PluginRuntime, events: Vec<RoutingEvent>) {
 
 pub(crate) fn emit_event(runtime: &PluginRuntime, event: RoutingEvent) {
     let result = match event {
-        RoutingEvent::Mark(mark) => runtime
-            .emit_mark_with_options(
-                &mark.name,
-                Some(&mark.data),
-                Some(&mark.metadata),
-                None,
-                mark.severity,
-            )
-            .map_err(|error| ("routing mark", mark.name, error)),
+        RoutingEvent::Mark(mark) => {
+            let data_schema = mark.data_schema();
+            runtime
+                .emit_mark_with_options(
+                    &mark.name,
+                    Some(&mark.data),
+                    Some(&mark.metadata),
+                    Some(&data_schema),
+                    mark.severity,
+                )
+                .map_err(|error| ("routing mark", mark.name, error))
+        }
         RoutingEvent::Metric(metric) => runtime
             .emit_metric(&metric.name, metric.measurements, Some(&metric.metadata))
             .map_err(|error| ("routing metric", metric.name, error)),
@@ -980,6 +994,8 @@ mod tests {
         assert_eq!(mark.data["target"], "weak");
         assert_eq!(mark.data["upstream_status"], Json::Null);
         assert_eq!(mark.severity, Some(LogSeverity::Error));
+        assert_eq!(mark.data_schema().name, "switchyard.routing.error");
+        assert_eq!(mark.data_schema().version, "1");
         assert!(!mark.data.to_string().contains(secret));
     }
 


### PR DESCRIPTION
## What

Adds a Relay `DataSchema` to each non-metric mark emitted by the native Switchyard plugin.

The schema name matches the existing mark name and starts at version `1`. The mark payloads, metrics, and routing behavior do not change.

Follow-up to [#528](https://github.com/NVIDIA-NeMo/Switchyard/pull/528), which landed the native Relay plugin.

## Why

The plugin emits routing decisions, routing-model calls, overhead, and failures as structured JSON. Relay subscribers can identify those events by their mark names today, but `data_schema` is unset, so there is no version attached to the JSON shape they consume.

That becomes a problem once a dashboard or subscriber depends on fields such as `selected_model`, `outcome`, or `latency_ms`. Without a schema version, a future rename, type change, or change in meaning is indistinguishable from the existing contract and can silently break the consumer.

Relay already provides the schema name and version fields needed to make that boundary explicit. This PR starts using them before downstream integrations depend on the unversioned payloads.

## Before and after

Relevant fields from a routing-decision mark before this change:

```json
{
  "name": "switchyard.routing.decision",
  "data": {
    "algorithm": "stage_router",
    "selected_model": "capable"
  },
  "data_schema": null
}
```

After this change:

```json
{
  "name": "switchyard.routing.decision",
  "data": {
    "algorithm": "stage_router",
    "selected_model": "capable"
  },
  "data_schema": {
    "name": "switchyard.routing.decision",
    "version": "1"
  }
}
```

The `data` object is unchanged. The same name-and-version rule applies to `requested`, `llm_call`, `overhead`, and `error` marks. Relay-owned metric marks keep their existing metric schema.

Consumers should tolerate new fields and values within version `1`. Removing or renaming a field, changing its type, or changing its meaning requires a new version.

## Notes for reviewers

Start with `RoutingMark::data_schema` and `emit_event` in `crates/switchyard-nemo-relay-plugin/src/runtime.rs`. The README records the payload fields covered by version `1`.

This PR intentionally excludes answer-candidate, served-model, and fallback reporting. Those are separate behavior changes.

No public Rust, Python, TOML, or Relay API changes.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `git diff --check`
