### PR TITLE
fix(libsy): drop reasoning from task classifier history

### DIFF
--- a/crates/libsy/src/algorithms/llm_class.rs
+++ b/crates/libsy/src/algorithms/llm_class.rs
@@ -173,6 +173,16 @@ impl ClassifierInput for TaskInput {
             Some(window) => trim_messages(&request.llm_request.messages, window),
             None => task_messages(&request.llm_request.messages),
         };
+        // Reasoning is provider-private and not required to classify the task. Some
+        // upstreams also reject an unsigned reasoning item replayed without the
+        // opaque state it was issued with, so it cannot travel through a windowed
+        // classifier request as ordinary history.
+        for message in &mut messages {
+            message
+                .content
+                .retain(|block| !matches!(block, ContentBlock::Reasoning { .. }));
+        }
+        messages.retain(|message| !message.content.is_empty());
         // Only the windowed path carries assistant turns and tool traffic for the judge
         // to be distracted by. The default path is user task messages only — the anchor
         // and the latest follow-up — so there is nothing there to outrank.
@@ -1465,6 +1475,74 @@ mod tests {
             Some(TRAILING_ROUTING_INSTRUCTION)
         );
         Ok(())
+    }
+
+    /// Reasoning is provider-private and some upstreams reject it replayed without the
+    /// opaque state it was issued with, so it must not reach a windowed classifier
+    /// request. Visible assistant text and complete tool pairs still do, and a turn
+    /// whose only content was reasoning is dropped rather than left behind empty.
+    #[test]
+    fn a_window_drops_reasoning_but_keeps_visible_text_and_tool_pairs() {
+        let messages = vec![
+            Message::text(Role::System, "client instructions"),
+            Message::text(Role::User, "initial task"),
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Reasoning {
+                        text: "private chain of thought".to_string(),
+                        signature: None,
+                        details: Vec::new(),
+                    },
+                    ContentBlock::Text {
+                        text: "visible answer".to_string(),
+                    },
+                ],
+            },
+            tool_call("call-1"),
+            tool_result("call-1"),
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::Reasoning {
+                    text: "reasoning-only turn".to_string(),
+                    signature: None,
+                    details: Vec::new(),
+                }],
+            },
+            Message::text(Role::User, "follow-up"),
+        ];
+        let request = Request {
+            llm_request: LlmRequest {
+                messages,
+                ..LlmRequest::default()
+            },
+            raw_request: None,
+            metadata: None,
+        };
+
+        let built = TaskInput {
+            recent_turn_window: Some(10),
+        }
+        .build_messages(&State::default(), &request);
+
+        assert!(
+            !built
+                .iter()
+                .flat_map(|message| &message.content)
+                .any(|block| matches!(block, ContentBlock::Reasoning { .. })),
+            "{built:?}"
+        );
+        assert!(
+            built
+                .iter()
+                .any(|message| message.text_content("\n").as_deref() == Some("visible answer"))
+        );
+        assert!(built.contains(&tool_call("call-1")));
+        assert!(built.contains(&tool_result("call-1")));
+        // Six of the seven fixtures survive — the reasoning-only turn is gone entirely
+        // rather than left behind empty — plus the trailing routing instruction.
+        assert_eq!(built.len(), 7);
+        assert!(built.iter().all(|message| !message.content.is_empty()));
     }
 
     #[test]


### PR DESCRIPTION
## What

`TaskInput::build_messages` now removes `ContentBlock::Reasoning` from the history it
hands to an LLM task classifier, and drops a message that removal leaves empty. User
text, visible assistant text, tool calls and tool results are unchanged.

## Why

With `recent_turn_window` configured, the classifier sees recent assistant turns, and
those can carry a reasoning item that came from a Responses upstream. Such a block
always decodes with `signature: None` (`decode_responses_reasoning_item` never
populates `details`), and `encode_responses_special_input` re-emits it as:

```json
{"type": "reasoning", "content": [{"type": "reasoning_text", "text": "..."}], "summary": []}
```

which the upstream rejects:

```text
Invalid 'input[1].content': array too long. Expected an array with maximum
length 0, but got an array with length 1 instead.
```

The classifier fails open, so the user turn survives, but the routing decision is lost
and the warning repeats on every turn of the session.

Private model reasoning is not needed to classify the user's task, so the classifier
input is the right boundary for this. Filtering in the shared Responses codec instead
would change reasoning round-trip behavior for ordinary traffic, and reconstructing a
replayable provider reasoning item needs an explicit representation of the opaque
state — a larger change than the failure warrants.

Scope: both `build_capability` and `build_custom` construct `TaskInput`, so capability
and custom-schema classifiers are covered by the one change. Escalation classifiers use
`EscalationInput`, which flattens the conversation into a single user summary message,
so no structured reasoning block ever reaches the wire there.

Tool call/result pairing is unaffected: the window is still selected by `window_start`,
the filtering runs after selection, and a reasoning block never participates in a pair.

## Tests

Test in `crates/libsy/src/algorithms/llm_class.rs`:

- `a_window_drops_reasoning_but_keeps_visible_text_and_tool_pairs` — verifies that no
  reasoning block survives, visible assistant text and a complete tool call/result pair
  are preserved, and a reasoning-only assistant turn is removed entirely rather than left
  behind as an empty message.

Gates run locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace`, `uv run ruff check .`, `uv run mypy switchyard`, `uv run pytest tests/`.

Also verified against a live Responses-compatible upstream: before the change the
classifier call was rejected with the error above; after it the classifier request is
accepted.
