### PR TITLE
fix(llm-client): redact upstream body from client-call span

### DIFF
--- a/crates/libsy-llm-client/src/observability.rs
+++ b/crates/libsy-llm-client/src/observability.rs
@@ -66,7 +66,19 @@ pub(crate) fn observe_client_call(result: Result<Response>) -> Result<Response> 
         }
         Err(error) => {
             let error_type = client_call_error_type(&error);
-            record_client_error(&span, &error_type, &error);
+            match &error {
+                LibsyError::ClientCall {
+                    target,
+                    source: LlmClientError::UpstreamHttp { status, .. },
+                } => record_client_error(
+                    &span,
+                    &error_type,
+                    &format_args!(
+                        "client call to target {target:?} failed: upstream HTTP {status}"
+                    ),
+                ),
+                _ => record_client_error(&span, &error_type, &error),
+            }
             Err(error)
         }
     }

--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -413,6 +413,9 @@ impl RoutedLlmClient for ClassifierClient {
     }
 }
 
+// Conversation text that a provider may quote in an upstream error body.
+const LEAKED_CONTENT: &str = "patient name is Jane Doe";
+
 enum JudgeOutcome {
     CallFailure,
     Reply(&'static str),
@@ -440,7 +443,7 @@ impl RoutedLlmClient for JudgeClient {
         match &self.outcome {
             JudgeOutcome::CallFailure => Err(LlmClientError::UpstreamHttp {
                 status: http::StatusCode::INTERNAL_SERVER_ERROR,
-                body: "server error".to_string(),
+                body: format!(r#"{{"error":{{"message":"server error: {LEAKED_CONTENT}"}}}}"#),
             }),
             JudgeOutcome::Reply(text) => Ok(Response {
                 llm_response: LlmResponse::Agg(text_response(None, *text)),
@@ -1211,6 +1214,39 @@ async fn typed_client_failure_records_semantic_error_type() {
         client_span.fields.get("error.type").map(String::as_str),
         Some("timeout")
     );
+}
+
+/// Verifies that the client span retains the HTTP status without the upstream body.
+#[tokio::test]
+async fn upstream_body_is_redacted_from_the_client_call_span() -> switchyard_libsy::Result<()> {
+    let _guard = serialize_test().lock().await;
+    let (store, _, _, _, _) = telemetry();
+    const JUDGE: &str = "redaction-judge";
+    let client = Arc::new(JudgeClient {
+        judge_model: JUDGE.into(),
+        outcome: JudgeOutcome::CallFailure,
+    }) as Arc<dyn RoutedLlmClient>;
+    run(
+        classifier_router(JUDGE, "redaction-weak", "redaction-strong")?,
+        client,
+        classifier_request(),
+    )
+    .await?;
+
+    let spans = store.spans();
+    let client_span = find_span(&spans, "libsy.client_call", "selected_model", JUDGE);
+    assert_eq!(
+        client_span.fields.get("error.type").map(String::as_str),
+        Some("500")
+    );
+    let error = client_span
+        .fields
+        .get("error")
+        .map(String::as_str)
+        .unwrap_or("");
+    assert!(error.contains("upstream HTTP 500"), "{client_span:?}");
+    assert!(!error.contains(LEAKED_CONTENT), "{client_span:?}");
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

The `libsy.client_call` span recorded the full `Display` text of a failed client call. For `LlmClientError::UpstreamHttp`, that text includes the raw upstream response body, which may quote request content.

This was observed while reviewing #610. The broader cross-sink logging policy is tracked in #615.

## How

Only the buffered `LibsyError::ClientCall` / `LlmClientError::UpstreamHttp` path is changed. The span retains the target, HTTP status, and existing `error.type`, but does not record the upstream body. The original typed error is returned unchanged.

All other error telemetry keeps its existing behavior. The existing redaction helpers remain private; this PR adds no public API and does not change `libsy.run`, `libsy.llm_call`, Advisor, SSE, server, runner, Relay, or streaming error handling.

## Test

`upstream_body_is_redacted_from_the_client_call_span` drives a failing classifier client with an upstream body containing a content marker, then verifies that the `libsy.client_call` span preserves HTTP 500 classification without the marker.

Validated locally:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p switchyard-llm-client`