### PR TITLE
ci(release): publish switchyard-runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -477,6 +477,7 @@ jobs:
             switchyard-translation \
             switchyard-libsy \
             switchyard-llm-client \
+            switchyard-runner \
             switchyard-server; do
             crate_version="$(jq -r --arg crate "${crate}" \
               '.packages[] | select(.name == $crate) | .version' <<<"${metadata}")"
@@ -513,4 +514,5 @@ jobs:
           publish_crate switchyard-translation
           publish_crate switchyard-libsy
           publish_crate switchyard-llm-client
+          publish_crate switchyard-runner
           publish_crate switchyard-server

--- a/docs/internal/release_workflow.md
+++ b/docs/internal/release_workflow.md
@@ -90,13 +90,14 @@ ready.
 The same tag publishes these crates to crates.io in dependency order:
 
 1. `switchyard-protocol`
-2. `switchyard-libsy`
-3. `switchyard-translation`
+2. `switchyard-translation`
+3. `switchyard-libsy`
 4. `switchyard-llm-client`
-5. `switchyard-server`
+5. `switchyard-runner`
+6. `switchyard-server`
 
 Add a repository Actions secret named `CARGO_REGISTRY_TOKEN` containing a crates.io API token that
-can publish all five crates and create new crates. The job waits for each version to reach the
+can publish all six crates and create new crates. The job waits for each version to reach the
 crates.io index before publishing its dependents. If publication stops partway through, use
 GitHub's **Re-run failed jobs** action so successful crate jobs are not repeated.
 


### PR DESCRIPTION
## Summary
- publish `switchyard-runner` to crates.io on tagged releases
- validate its version alongside the other released Rust crates
- document the dependency-ordered release sequence

## Validation
- `cargo package --allow-dirty --list --package switchyard-runner`
- YAML parse of `.github/workflows/publish.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release process to validate and publish the runner package before the server package.
  - Expanded release checks to cover all published crates.

- **Documentation**
  - Updated release documentation to reflect the current crate publication order.
  - Clarified that the registry token must have permission to publish all six crates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->