### PR TITLE
feat(server): configure prefill routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures-util",
+ "prefill-router",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/switchyard-runner/Cargo.toml
+++ b/crates/switchyard-runner/Cargo.toml
@@ -13,8 +13,12 @@ repository.workspace = true
 rust-version.workspace = true
 publish = ["crates-io"]
 
+[features]
+prefill-router = ["dep:prefill-router"]
+
 [dependencies]
 libsy = { package = "switchyard-libsy", path = "../libsy", version = "0.2.0" }
+prefill-router = { path = "../prefill-router", version = "0.2.0", optional = true }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/switchyard-runner/src/algorithm.rs
+++ b/crates/switchyard-runner/src/algorithm.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use libsy::{
@@ -311,6 +312,22 @@ pub enum AlgorithmSpec {
         #[serde(default = "default_fail_open")]
         fail_open: bool,
     },
+    /// Routes using a checkpoint-backed prefill classifier.
+    PrefillRouter {
+        /// Target names in checkpoint output order.
+        targets: Vec<String>,
+        /// Tensor-only router checkpoint path.
+        checkpoint: PathBuf,
+        /// PyTorch device used for encoder inference, such as `cpu`, `cuda`, or
+        /// `cuda:0`. Auto-detected when omitted.
+        device: Option<String>,
+        /// Directory where Hugging Face caches the downloaded encoder and tokenizer.
+        cache_dir: Option<PathBuf>,
+        /// Maximum tokenized encoder input length; longer prompts are truncated.
+        max_length: Option<usize>,
+        /// Maximum prompts per encoder forward pass.
+        batch_size: Option<usize>,
+    },
 }
 
 /// What fires an advisor route's review.
@@ -471,6 +488,7 @@ impl AlgorithmSpec {
             Self::Advisor {
                 executor_target, ..
             } => vec![executor_target],
+            Self::PrefillRouter { targets, .. } => targets.iter().map(String::as_str).collect(),
         }
     }
 
@@ -1071,6 +1089,46 @@ fn build_algorithm(
                 )
             })?;
             Ok(Arc::new(algorithm))
+        }
+        AlgorithmSpec::PrefillRouter {
+            targets: names,
+            checkpoint,
+            device,
+            cache_dir,
+            max_length,
+            batch_size,
+        } => {
+            #[cfg(feature = "prefill-router")]
+            {
+                let targets =
+                    resolve_targets(route_name, names.iter().map(String::as_str), targets)?;
+                let mut config = prefill_router::PrefillRouterConfig::new(targets, checkpoint);
+                config.device.clone_from(device);
+                config.cache_dir.clone_from(cache_dir);
+                if let Some(max_length) = max_length {
+                    config.max_length = *max_length;
+                }
+                if let Some(batch_size) = batch_size {
+                    config.batch_size = *batch_size;
+                }
+                let algorithm = config.build().map_err(|error| {
+                    AlgorithmConfigError::with_source(
+                        format!("prefill_router route {route_name}: {error}"),
+                        error,
+                    )
+                })?;
+                Ok(Arc::new(algorithm))
+            }
+
+            #[cfg(not(feature = "prefill-router"))]
+            {
+                let _ = (
+                    names, checkpoint, device, cache_dir, max_length, batch_size, targets,
+                );
+                Err(AlgorithmConfigError::new(format!(
+                    "prefill_router route {route_name} requires the `prefill-router` Cargo feature"
+                )))
+            }
         }
     }
 }

--- a/crates/switchyard-runner/tests/route.rs
+++ b/crates/switchyard-runner/tests/route.rs
@@ -163,3 +163,37 @@ fn algorithm_build_reports_unknown_configured_target() {
         "route plugin references unknown target missing"
     );
 }
+
+// Preserve checkpoint target order and explicit TOML overrides.
+#[test]
+fn prefill_router_config_preserves_target_order_and_overrides() {
+    let spec: AlgorithmSpec = toml::from_str(
+        r#"
+type = "prefill_router"
+targets = ["fast", "strong"]
+checkpoint = "/models/router.pt"
+device = "cuda:1"
+max_length = 4096
+batch_size = 8
+"#,
+    )
+    .expect("prefill router config should parse");
+
+    let AlgorithmSpec::PrefillRouter {
+        targets,
+        checkpoint,
+        device,
+        cache_dir,
+        max_length,
+        batch_size,
+    } = spec
+    else {
+        panic!("expected prefill router config");
+    };
+    assert_eq!(targets, ["fast", "strong"]);
+    assert_eq!(checkpoint.to_string_lossy(), "/models/router.pt");
+    assert_eq!(device.as_deref(), Some("cuda:1"));
+    assert_eq!(cache_dir, None);
+    assert_eq!(max_length, Some(4096));
+    assert_eq!(batch_size, Some(8));
+}

--- a/crates/switchyard-server/Cargo.toml
+++ b/crates/switchyard-server/Cargo.toml
@@ -16,6 +16,9 @@ documentation = "https://docs.rs/switchyard-server"
 keywords = ["llm", "proxy", "routing", "openai", "anthropic"]
 publish = ["crates-io"]
 
+[features]
+prefill-router = ["switchyard-runner/prefill-router"]
+
 [dependencies]
 async-stream.workspace = true
 async-trait.workspace = true

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -73,8 +73,9 @@ upstream, and a route's `id` is the model clients send to select that algorithm.
 Each target references an entry under `llm_clients`. All configured clients use
 `TranslatingLlmClient`; supported formats are `openai_chat`, `openai_responses`, and
 `anthropic_messages`. Supported algorithms are `noop`, `random`, `passthrough`,
-`llm_classifier`, and `stage_router`. An `api_key_env` value names an environment variable; the TOML
-never contains the secret itself. If omitted, the client sends no authentication.
+`llm_classifier`, and `stage_router`. The optional `prefill-router` feature also enables
+`prefill_router`. An `api_key_env` value names an environment variable; the TOML never contains the
+secret itself. If omitted, the client sends no authentication.
 A client can set `forward_auth = true` instead of `api_key_env` to send the
 caller's credential to the configured upstream. OpenAI clients forward
 `authorization`, `chatgpt-account-id`, and `x-openai-fedramp`. Anthropic clients

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -141,6 +141,29 @@ Splits traffic across targets. See
 | `weights` | No | equal | Finite, non-negative relative weights in `targets` order, with at least one positive value. Invalid weights are rejected at load time. |
 | `seed` | No | unset | Reproduces the selection sequence. |
 
+### `prefill_router`
+
+Routes the latest non-empty user message with a checkpoint-backed prefill classifier. Build
+`switchyard-server` with `--features prefill-router` and make the prefill router's Python
+dependencies available in the active virtual environment.
+
+| Key | Required | Default | Meaning |
+|---|:---:|---|---|
+| `targets` | Yes | — | Target names in the exact order expected by the checkpoint outputs. |
+| `checkpoint` | Yes | — | Path to the tensor-only router checkpoint. Relative paths use the server's working directory. |
+| `device` | No | auto | PyTorch device used for encoder inference, such as `cpu`, `cuda`, or `cuda:0`. |
+| `cache_dir` | No | unset | Directory where Hugging Face caches the downloaded encoder and tokenizer. |
+| `max_length` | No | `2048` | Maximum tokenized encoder input length; longer prompts are truncated. |
+| `batch_size` | No | `32` | Maximum prompts per encoder forward pass. |
+
+```toml
+[routes.prefill]
+id = "switchyard/prefill"
+type = "prefill_router"
+targets = ["fast", "strong"]
+checkpoint = "/models/router.pt"
+```
+
 ### `llm_classifier`
 
 Runs one of three judge-backed modes: `capability`, `escalation`, or `custom`.


### PR DESCRIPTION
## What

- adds an opt-in `prefill-router` feature to `switchyard-server`, forwarded through `switchyard-runner`
- adds `type = "prefill_router"` to the stable route schema and constructs it when the feature is enabled
- returns a focused configuration error when a prefill route is loaded by a binary built without the feature
- resolves configured target names in checkpoint output order and builds `PrefillRouterConfig` with its existing defaults
- documents the TOML fields and adds one focused parsing test

## Why

This completes [SWITCH-1281](https://linear.app/nvidia/issue/SWITCH-1281/expose-prefill-router-in-switchyard-server-through-config), the server/configuration step of the prefill-router parent issue. The HTTP server already executes arbitrary libsy algorithms through `switchyard-runner`; this change exposes the merged `PrefillRouterAlgo` through that existing construction path without adding a separate server path.

Keeping the route schema independent of Cargo features also confines conditional compilation to the optional construction path. A binary without the feature can still deserialize the configuration and report exactly which feature is required.

## Configuration

```toml
[routes.prefill]
id = "switchyard/prefill"
type = "prefill_router"
targets = ["qwen", "gemma", "opus", "nano"]
checkpoint = "/models/router.pt"

# Optional overrides:
# device = "cuda"
# cache_dir = "/models/cache"
# max_length = 2048
# batch_size = 32
```

`targets` is ordered and must match the checkpoint output order. `device`, `cache_dir`, `max_length`, and `batch_size` retain the defaults from `PrefillRouterConfig` when omitted.

Build the server with:

```bash
cargo build -p switchyard-server --features prefill-router
```

## What to review

- the server feature only forwards the runner feature and remains disabled by default
- the route schema and target introspection are feature-independent; only construction is conditionally compiled
- the runner preserves configured target order before constructing `PrefillRouterConfig`
- optional TOML values override the existing algorithm defaults without duplicating them
- no HTTP handlers, routing behavior, telemetry, or Python implementation changed

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p switchyard-runner --features prefill-router`
- `cargo clippy -p switchyard-server --all-targets --features prefill-router -- -D warnings`
- strict MkDocs build
- live server request using the supplied PinchBench checkpoint and its Qwen 35B encoder across two GPUs; the route selected `claude-opus-4-8`, forwarded that model to a local OpenAI-compatible mock, and returned HTTP 200

No external model endpoint was called. Publishing the standalone `prefill-router` crate is intentionally deferred to the planned 0.3.0 release work.
