### PR TITLE
fix(llm-client): canonical reasoning representation + target reasoning-pin precedence

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -256,8 +256,18 @@ impl TranslatingLlmClient {
         if matches!(backend, Backend::Anthropic(_)) {
             enable_anthropic_prompt_caching(&mut body);
         }
+        // Target-pinned reasoning policy is canonical on both OpenAI leg formats:
+        // when the target pins a nested `reasoning` policy (e.g. an NT lane's
+        // `reasoning = { effort = "none" }` or `enabled = false` pin via
+        // extra_body), it overrides any caller-supplied reasoning representation.
+        // merge_extra_body only fills absent keys (or_insert), so the target pin
+        // must be re-asserted here; without it, a caller's own `reasoning` object
+        // would silently displace the target's policy.
         if matches!(backend, Backend::OpenAiChat(_)) {
+            canonicalize_reasoning_effort(&mut body, backend.extra_body().get("reasoning"));
             ensure_openai_stream_usage(&mut body);
+        } else if matches!(backend, Backend::OpenAiResponses(_)) {
+            canonicalize_reasoning_effort(&mut body, backend.extra_body().get("reasoning"));
         }
         let streaming = endpoint.allows_streaming()
             && body.get("stream").and_then(Value::as_bool).unwrap_or(false);
@@ -826,6 +836,46 @@ fn merge_extra_body(body: &mut Value, extra_body: &BTreeMap<String, Value>) {
     };
     for (key, value) in extra_body {
         object.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+}
+
+// Enforces exactly ONE canonical reasoning representation per upstream request,
+// and makes the TARGET's reasoning pin (route-author policy via extra_body)
+// authoritative over caller-supplied reasoning.
+//
+// Two rules, applied AFTER `merge_extra_body` (or_insert - caller values win -
+// so the target pin must be re-asserted here):
+//
+// 1. Target reasoning pin (e.g. `reasoning = { effort = "none" }` on an NT
+//    lane, or `reasoning = { enabled = false }`): the target pin REPLACES the
+//    caller's nested `reasoning` object (if any) and the flat `reasoning_effort`
+//    is dropped. Without this, a caller-supplied `reasoning` object displaces
+//    the target's policy through or_insert merge precedence, and an NT lane
+//    would run reasoning its route author disabled.
+// 2. No target pin: OpenRouter rejects the dual representation when the nested
+//    `reasoning` object carries an effort value AND the caller's flat
+//    `reasoning_effort` rides along with a conflicting value
+//    ("reasoning_effort and reasoning.effort are both provided with conflicting
+//    values"). The nested object is canonical; the flat field is dropped.
+fn canonicalize_reasoning_effort(body: &mut Value, reasoning_pin: Option<&Value>) {
+    let Value::Object(object) = body else {
+        return;
+    };
+    if let Some(pin) = reasoning_pin {
+        // Rule 1: target policy pin is canonical - replaces any caller reasoning.
+        object.insert("reasoning".to_string(), pin.clone());
+        object.remove("reasoning_effort");
+        return;
+    }
+    // Rule 2: no target pin - avoid the conflicting dual representation.
+    if object
+        .get("reasoning")
+        .and_then(Value::as_object)
+        .and_then(|reasoning| reasoning.get("effort"))
+        .and_then(Value::as_str)
+        .is_some()
+    {
+        object.remove("reasoning_effort");
     }
 }
 
@@ -2276,4 +2326,208 @@ mod tests {
             .await?;
         Ok(())
     }
+    // A target that pins its thinking policy as a nested `reasoning` object must
+    // not be displaced by a caller-supplied nested `reasoning` object: the merge
+    // only fills absent keys, so the target pin is re-asserted after it. An NT
+    // lane must reliably remain non-thinking regardless of caller parameters.
+    #[tokio::test]
+    async fn target_reasoning_pin_overrides_caller_nested_reasoning()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/effort").and_then(Value::as_str) == Some("none")
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1",
+                "model": "gpt",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let extra_body = BTreeMap::from([(
+            "reasoning".to_string(),
+            json!({"effort": "none"}),
+        )]);
+        let client = TranslatingLlmClient::new(&chat_map_with_extra_body(
+            &format!("{}/v1", server.uri()),
+            extra_body,
+        ))?;
+        let raw = json!({
+            "model": "client-facing",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"effort": "high"},
+            "reasoning_effort": "high",
+            "max_tokens": 16
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("none"),
+            "target NT pin must replace the caller's nested reasoning object"
+        );
+        assert!(
+            seen_body.get("reasoning_effort").is_none(),
+            "flat reasoning_effort must be dropped when the target pins its policy"
+        );
+        Ok(())
+    }
+
+    // A target pinning `reasoning.enabled = false` must likewise override a
+    // caller-supplied nested reasoning object.
+    #[tokio::test]
+    async fn target_enabled_false_pin_overrides_caller_reasoning()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/enabled") == Some(&Value::Bool(false))
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1",
+                "model": "gpt",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let extra_body = BTreeMap::from([(
+            "reasoning".to_string(),
+            json!({"enabled": false}),
+        )]);
+        let client = TranslatingLlmClient::new(&chat_map_with_extra_body(
+            &format!("{}/v1", server.uri()),
+            extra_body,
+        ))?;
+        let raw = json!({
+            "model": "client-facing",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"effort": "medium"},
+            "max_tokens": 16
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen_body.pointer("/reasoning/enabled"),
+            Some(&Value::Bool(false)),
+            "target enabled=false pin must replace the caller's reasoning object"
+        );
+        assert!(
+            seen_body.pointer("/reasoning/effort").is_none(),
+            "caller effort must not ride alongside the target's enabled=false pin"
+        );
+        Ok(())
+    }
+
+    // Without a target pin, a nested `reasoning.effort` plus a caller flat
+    // `reasoning_effort` with a conflicting value is rejected by OpenRouter
+    // (dual representation). The nested object is canonical; the flat field is
+    // dropped.
+    #[tokio::test]
+    async fn target_pinned_reasoning_effort_suppresses_flat_reasoning_effort()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/effort").and_then(Value::as_str) == Some("low")
+                    && body.get("reasoning_effort").is_none()
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1",
+                "model": "gpt",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let extra_body = BTreeMap::from([(
+            "reasoning".to_string(),
+            json!({"enabled": true, "effort": "low"}),
+        )]);
+        let client = TranslatingLlmClient::new(&chat_map_with_extra_body(
+            &format!("{}/v1", server.uri()),
+            extra_body,
+        ))?;
+        let raw = json!({
+            "model": "client-facing",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "medium",
+            "max_tokens": 16
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert!(
+            seen_body.get("reasoning_effort").is_none(),
+            "flat reasoning_effort must be suppressed when the body pins nested reasoning.effort"
+        );
+        assert_eq!(
+            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("low"),
+            "nested reasoning.effort must reach the upstream"
+        );
+        Ok(())
+    }
+
 }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -855,10 +855,11 @@ fn merge_extra_body(body: &mut Value, extra_body: &BTreeMap<String, Value>) {
 //    the target's policy through or_insert merge precedence, and an NT lane
 //    would run reasoning its route author disabled.
 // 2. No target pin: OpenRouter rejects the dual representation when the nested
-//    `reasoning` object carries an effort value AND the caller's flat
-//    `reasoning_effort` rides along with a conflicting value
-//    ("reasoning_effort and reasoning.effort are both provided with conflicting
-//    values"). The nested object is canonical; the flat field is dropped.
+//    `reasoning` object AND the caller's flat `reasoning_effort` ride along
+//    together ("reasoning_effort and reasoning.effort are both provided with
+//    conflicting values"). ANY object-valued `reasoning` is canonical - not
+//    only one carrying a string `effort` (e.g. `{"enabled": false}` must also
+//    suppress the flat field, or the conflicting dual representation ships).
 fn canonicalize_reasoning_effort(body: &mut Value, reasoning_pin: Option<&Value>) {
     let Value::Object(object) = body else {
         return;
@@ -870,13 +871,9 @@ fn canonicalize_reasoning_effort(body: &mut Value, reasoning_pin: Option<&Value>
         return;
     }
     // Rule 2: no target pin - avoid the conflicting dual representation.
-    if object
-        .get("reasoning")
-        .and_then(Value::as_object)
-        .and_then(|reasoning| reasoning.get("effort"))
-        .and_then(Value::as_str)
-        .is_some()
-    {
+    // Any object-valued `reasoning` is canonical; the flat field is dropped
+    // regardless of whether the object carries a string `effort`.
+    if object.get("reasoning").and_then(Value::as_object).is_some() {
         object.remove("reasoning_effort");
     }
 }
@@ -2591,6 +2588,69 @@ mod tests {
         assert!(
             seen_body.get("reasoning_effort").is_none(),
             "conflicting flat reasoning_effort must be dropped without a target pin"
+        );
+        Ok(())
+    }
+
+    // No target pin: a nested `reasoning` object WITHOUT a string `effort`
+    // (e.g. `{"enabled": false}`) is still canonical - the flat
+    // `reasoning_effort` must be dropped so the upstream never sees the
+    // conflicting dual representation.
+    #[tokio::test]
+    async fn no_pin_object_reasoning_without_effort_suppresses_flat_reasoning_effort()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/enabled") == Some(&Value::Bool(false))
+                    && body.get("reasoning_effort").is_none()
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1",
+                "model": "gpt",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
+        let raw = json!({
+            "model": "client-facing",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"enabled": false},
+            "reasoning_effort": "high",
+            "max_tokens": 16
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen_body.pointer("/reasoning/enabled"),
+            Some(&Value::Bool(false)),
+            "object-valued reasoning without effort must reach the upstream"
+        );
+        assert!(
+            seen_body.get("reasoning_effort").is_none(),
+            "flat reasoning_effort must be dropped when any object-valued reasoning is present"
         );
         Ok(())
     }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -839,9 +839,11 @@ fn merge_extra_body(body: &mut Value, extra_body: &BTreeMap<String, Value>) {
     }
 }
 
-// Enforces exactly ONE canonical reasoning representation per upstream request,
-// and makes the TARGET's reasoning pin (route-author policy via extra_body)
-// authoritative over caller-supplied reasoning.
+// Enforces exactly ONE canonical reasoning representation per upstream request
+// on OpenAI-family backends (OpenAI Chat and OpenAI Responses; Anthropic has a
+// separate thinking contract), and makes the TARGET's reasoning pin
+// (route-author policy via extra_body) authoritative over caller-supplied
+// reasoning.
 //
 // Two rules, applied AFTER `merge_extra_body` (or_insert - caller values win -
 // so the target pin must be re-asserted here):
@@ -2461,12 +2463,12 @@ mod tests {
         Ok(())
     }
 
-    // Without a target pin, a nested `reasoning.effort` plus a caller flat
+    // A target pinning nested `reasoning.effort` plus a caller flat
     // `reasoning_effort` with a conflicting value is rejected by OpenRouter
-    // (dual representation). The nested object is canonical; the flat field is
-    // dropped.
+    // (dual representation). The target's nested object is canonical; the flat
+    // field is dropped.
     #[tokio::test]
-    async fn target_pinned_reasoning_effort_suppresses_flat_reasoning_effort()
+    async fn body_nested_reasoning_effort_suppresses_conflicting_flat_reasoning_effort()
     -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
         use std::sync::Mutex as StdMutex;
         let server = MockServer::start().await;
@@ -2526,6 +2528,134 @@ mod tests {
             seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
             Some("low"),
             "nested reasoning.effort must reach the upstream"
+        );
+        Ok(())
+    }
+
+    // No target pin: a caller body carrying BOTH a nested `reasoning.effort`
+    // and a flat `reasoning_effort` with a conflicting value must not ship the
+    // dual representation to the upstream (OpenRouter rejects it). The nested
+    // object wins; the flat field is dropped.
+    #[tokio::test]
+    async fn no_pin_nested_reasoning_effort_suppresses_conflicting_flat_reasoning_effort()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/effort").and_then(Value::as_str) == Some("medium")
+                    && body.get("reasoning_effort").is_none()
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "1",
+                "model": "gpt",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&chat_map(&format!("{}/v1", server.uri())))?;
+        let raw = json!({
+            "model": "client-facing",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"effort": "medium"},
+            "reasoning_effort": "high",
+            "max_tokens": 16
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("medium"),
+            "nested reasoning.effort must reach the upstream"
+        );
+        assert!(
+            seen_body.get("reasoning_effort").is_none(),
+            "conflicting flat reasoning_effort must be dropped without a target pin"
+        );
+        Ok(())
+    }
+
+    // OpenAI Responses backend: a target `reasoning = { effort = "none" }` pin
+    // must replace the caller's nested reasoning object on the Responses wire.
+    #[tokio::test]
+    async fn responses_target_reasoning_pin_overrides_caller_nested_reasoning()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        use std::sync::Mutex as StdMutex;
+        let server = MockServer::start().await;
+        let seen: Arc<StdMutex<Value>> = Arc::new(StdMutex::new(Value::Null));
+        let seen_for_assert = Arc::clone(&seen);
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                *seen_for_assert.lock().unwrap() = body.clone();
+                body.pointer("/reasoning/effort").and_then(Value::as_str) == Some("none")
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "resp_1",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt",
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&server)
+            .await;
+
+        let extra_body = BTreeMap::from([(
+            "reasoning".to_string(),
+            json!({"effort": "none"}),
+        )]);
+        // Responses backend with a reasoning pin; the caller's nested reasoning
+        // object arrives via the raw Responses body.
+        let mut backend = config(&format!("{}/v1", server.uri()));
+        backend.extra_body = extra_body;
+        let client = TranslatingLlmClient::new(&vec![ModelConfig::new(
+            "gpt",
+            Backend::OpenAiResponses(backend),
+            None,
+        )])?;
+        let raw = json!({
+            "model": "client-facing",
+            "reasoning": {"effort": "high"},
+            "input": "hi"
+        });
+
+        client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiResponses,
+            )
+            .await?;
+
+        let seen_body = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            Some("none"),
+            "Responses-leg target NT pin must replace the caller's nested reasoning"
         );
         Ok(())
     }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -2356,10 +2356,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let extra_body = BTreeMap::from([(
-            "reasoning".to_string(),
-            json!({"effort": "none"}),
-        )]);
+        let extra_body = BTreeMap::from([("reasoning".to_string(), json!({"effort": "none"}))]);
         let client = TranslatingLlmClient::new(&chat_map_with_extra_body(
             &format!("{}/v1", server.uri()),
             extra_body,
@@ -2383,7 +2380,9 @@ mod tests {
 
         let seen_body = seen.lock().unwrap().clone();
         assert_eq!(
-            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            seen_body
+                .pointer("/reasoning/effort")
+                .and_then(Value::as_str),
             Some("none"),
             "target NT pin must replace the caller's nested reasoning object"
         );
@@ -2423,10 +2422,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let extra_body = BTreeMap::from([(
-            "reasoning".to_string(),
-            json!({"enabled": false}),
-        )]);
+        let extra_body = BTreeMap::from([("reasoning".to_string(), json!({"enabled": false}))]);
         let client = TranslatingLlmClient::new(&chat_map_with_extra_body(
             &format!("{}/v1", server.uri()),
             extra_body,
@@ -2522,7 +2518,9 @@ mod tests {
             "flat reasoning_effort must be suppressed when the body pins nested reasoning.effort"
         );
         assert_eq!(
-            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            seen_body
+                .pointer("/reasoning/effort")
+                .and_then(Value::as_str),
             Some("low"),
             "nested reasoning.effort must reach the upstream"
         );
@@ -2581,7 +2579,9 @@ mod tests {
 
         let seen_body = seen.lock().unwrap().clone();
         assert_eq!(
-            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            seen_body
+                .pointer("/reasoning/effort")
+                .and_then(Value::as_str),
             Some("medium"),
             "nested reasoning.effort must reach the upstream"
         );
@@ -2683,10 +2683,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let extra_body = BTreeMap::from([(
-            "reasoning".to_string(),
-            json!({"effort": "none"}),
-        )]);
+        let extra_body = BTreeMap::from([("reasoning".to_string(), json!({"effort": "none"}))]);
         // Responses backend with a reasoning pin; the caller's nested reasoning
         // object arrives via the raw Responses body.
         let mut backend = config(&format!("{}/v1", server.uri()));
@@ -2713,11 +2710,12 @@ mod tests {
 
         let seen_body = seen.lock().unwrap().clone();
         assert_eq!(
-            seen_body.pointer("/reasoning/effort").and_then(Value::as_str),
+            seen_body
+                .pointer("/reasoning/effort")
+                .and_then(Value::as_str),
             Some("none"),
             "Responses-leg target NT pin must replace the caller's nested reasoning"
         );
         Ok(())
     }
-
 }


### PR DESCRIPTION
OpenAI-family targets pin their thinking policy via `extra_body` (for example a non-thinking lane carrying `reasoning = { effort = "none" }`, or `reasoning = { enabled = false }`). Because `merge_extra_body` only fills absent keys (or_insert semantics), a caller that supplies its own nested `reasoning` object silently displaces the target's policy: a non-thinking lane would run reasoning its route author disabled.

This series re-asserts the target's reasoning pin after merge (replacing any caller-supplied nested `reasoning` object and dropping the flat `reasoning_effort`), on OpenAI Chat and Responses backends. It also fixes the conflicting dual representation OpenRouter rejects ("reasoning_effort and reasoning.effort are both provided with conflicting values"): with no target pin, a body carrying both a nested `reasoning.effort` and a conflicting flat `reasoning_effort` now drops the flat field and keeps the nested object, which is the canonical form.

Regression tests cover: target NT-pin precedence (Chat and Responses legs), `enabled = false` pins, and dual-representation suppression with and without a target pin. Anthropic's separate thinking contract is explicitly out of scope.

DCO signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of reasoning settings for OpenAI Chat and Responses requests.
  - Backend-provided reasoning defaults now take precedence when explicitly configured.
  - Conflicting reasoning options are resolved consistently, preventing duplicate or contradictory settings from being sent.
  - Reasoning behavior is now more predictable across supported OpenAI request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->