### PR TITLE
fix(llm-client): strip max_output_tokens for ChatGPT Codex Responses backends

### DIFF
--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -136,7 +136,17 @@ impl Backend {
     /// than normal OpenAI `/v1/responses` endpoints.
     pub fn is_codex(&self) -> bool {
         matches!(self, Backend::OpenAiResponses(_))
-            && self.config().base_url.contains("/backend-api/codex")
+            && self
+                .config()
+                .base_url
+                // Path-boundary match, not a substring match: strip query and
+                // fragment, then require the path to END with /backend-api/codex.
+                // Near-matches (e.g. https://proxy.example/backend-api/codex-compat
+                // or https://proxy.example/not-backend-api/codex) are NOT Codex.
+                .split(['?', '#'])
+                .next()
+                .map(|rest| rest.trim_end_matches('/').ends_with("/backend-api/codex"))
+                .unwrap_or(false)
     }
 
     /// The fully resolved upstream URL for this backend's endpoint.

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -135,17 +135,16 @@ impl Backend {
     /// (`chatgpt.com/backend-api/codex`), which applies stricter wire rules
     /// than normal OpenAI `/v1/responses` endpoints.
     pub fn is_codex(&self) -> bool {
-        matches!(self, Backend::OpenAiResponses(_))
-            && {
-                // Path-boundary match, not a substring match: the base URL is
-                // normalized ONCE (query and fragment stripped by
-                // `split_base_url`, shared with `url()`) and the path must END
-                // with /backend-api/codex. Near-matches (e.g.
-                // https://proxy.example/backend-api/codex-compat or
-                // https://proxy.example/not-backend-api/codex) are NOT Codex.
-                let (base, _, _) = split_base_url(&self.config().base_url);
-                base.ends_with("/backend-api/codex")
-            }
+        matches!(self, Backend::OpenAiResponses(_)) && {
+            // Path-boundary match, not a substring match: the base URL is
+            // normalized ONCE (query and fragment stripped by
+            // `split_base_url`, shared with `url()`) and the path must END
+            // with /backend-api/codex. Near-matches (e.g.
+            // https://proxy.example/backend-api/codex-compat or
+            // https://proxy.example/not-backend-api/codex) are NOT Codex.
+            let (base, _, _) = split_base_url(&self.config().base_url);
+            base.ends_with("/backend-api/codex")
+        }
     }
 
     /// The fully resolved upstream URL for this backend's endpoint.
@@ -427,14 +426,13 @@ mod tests {
 
     #[test]
     fn codex_near_matches_with_query_remain_non_codex() {
-        assert!(!Backend::OpenAiResponses(
-            config("https://host/backend-api/codex-compat?v=1")
-        )
-        .is_codex());
-        assert!(!Backend::OpenAiResponses(
-            config("https://host/not-backend-api/codex?x=1")
-        )
-        .is_codex());
+        assert!(
+            !Backend::OpenAiResponses(config("https://host/backend-api/codex-compat?v=1"))
+                .is_codex()
+        );
+        assert!(
+            !Backend::OpenAiResponses(config("https://host/not-backend-api/codex?x=1")).is_codex()
+        );
     }
 
     #[test]

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -136,29 +136,39 @@ impl Backend {
     /// than normal OpenAI `/v1/responses` endpoints.
     pub fn is_codex(&self) -> bool {
         matches!(self, Backend::OpenAiResponses(_))
-            && self
-                .config()
-                .base_url
-                // Path-boundary match, not a substring match: strip query and
-                // fragment, then require the path to END with /backend-api/codex.
-                // Near-matches (e.g. https://proxy.example/backend-api/codex-compat
-                // or https://proxy.example/not-backend-api/codex) are NOT Codex.
-                .split(['?', '#'])
-                .next()
-                .map(|rest| rest.trim_end_matches('/').ends_with("/backend-api/codex"))
-                .unwrap_or(false)
+            && {
+                // Path-boundary match, not a substring match: the base URL is
+                // normalized ONCE (query and fragment stripped by
+                // `split_base_url`, shared with `url()`) and the path must END
+                // with /backend-api/codex. Near-matches (e.g.
+                // https://proxy.example/backend-api/codex-compat or
+                // https://proxy.example/not-backend-api/codex) are NOT Codex.
+                let (base, _, _) = split_base_url(&self.config().base_url);
+                base.ends_with("/backend-api/codex")
+            }
     }
 
     /// The fully resolved upstream URL for this backend's endpoint.
     ///
     /// Tolerates base URLs that already include the provider path (or a bare
-    /// `/v1`), matching the join rules of the existing native backends.
+    /// `/v1`), matching the join rules of the existing native backends. The
+    /// endpoint path is appended BEFORE any query or fragment of the
+    /// configured base URL (one shared normalization with `is_codex`), so a
+    /// base like `https://host/backend-api/codex?route=x` resolves to
+    /// `https://host/backend-api/codex/responses?route=x` — never
+    /// `...codex?route=x/responses`.
     pub fn url(&self) -> String {
-        let base_url = self.config().base_url.trim_end_matches('/');
-        match self {
-            Backend::OpenAiChat(_) => openai_url(base_url, "/chat/completions"),
-            Backend::OpenAiResponses(_) => openai_url(base_url, "/responses"),
-            Backend::Anthropic(_) => anthropic_url(base_url),
+        let (base_url, query, fragment) = split_base_url(&self.config().base_url);
+        let endpoint = match self {
+            Backend::OpenAiChat(_) => openai_url(&base_url, "/chat/completions"),
+            Backend::OpenAiResponses(_) => openai_url(&base_url, "/responses"),
+            Backend::Anthropic(_) => anthropic_url(&base_url),
+        };
+        match (query, fragment) {
+            (Some(query), Some(fragment)) => format!("{endpoint}?{query}#{fragment}"),
+            (Some(query), None) => format!("{endpoint}?{query}"),
+            (None, Some(fragment)) => format!("{endpoint}#{fragment}"),
+            (None, None) => endpoint,
         }
     }
 
@@ -332,6 +342,24 @@ fn oauth_beta_header(value: &HeaderValue) -> Option<HeaderValue> {
     Some(value)
 }
 
+// Splits a configured base URL into (origin+path, query, fragment) so Codex
+// classification and endpoint construction share ONE normalization. An
+// endpoint path appended by `url()` must land BEFORE any query or fragment:
+// `https://h/codex?r=x` + `/responses` is `https://h/codex/responses?r=x`,
+// never `...codex?r=x/responses` (and a fragment must never swallow the
+// endpoint path entirely).
+fn split_base_url(base_url: &str) -> (String, Option<String>, Option<String>) {
+    let (without_fragment, fragment) = match base_url.split_once('#') {
+        Some((left, fragment)) => (left, Some(fragment.to_string())),
+        None => (base_url, None),
+    };
+    let (base, query) = match without_fragment.split_once('?') {
+        Some((left, query)) => (left, Some(query.to_string())),
+        None => (without_fragment, None),
+    };
+    (base.trim_end_matches('/').to_string(), query, fragment)
+}
+
 // Accept either a root `/v1` URL or an already-specific OpenAI endpoint URL.
 fn openai_url(base_url: &str, suffix: &str) -> String {
     let base_root = base_url
@@ -371,6 +399,49 @@ mod tests {
     fn openai_chat_url_joins_bare_v1() {
         let backend = Backend::OpenAiChat(config("https://api.openai.com/v1"));
         assert_eq!(backend.url(), "https://api.openai.com/v1/chat/completions");
+    }
+
+    // Codex classification and endpoint construction share ONE base-URL
+    // normalization (split_base_url): a base URL carrying a query is
+    // classified on its path and the endpoint path is appended BEFORE the
+    // query. CodeRabbit finding on PR #621.
+    #[test]
+    fn codex_base_url_with_query_appends_endpoint_before_query() {
+        let backend = Backend::OpenAiResponses(config("https://host/backend-api/codex?route=x"));
+        assert!(backend.is_codex());
+        assert_eq!(
+            backend.url(),
+            "https://host/backend-api/codex/responses?route=x"
+        );
+    }
+
+    #[test]
+    fn codex_base_url_with_fragment_keeps_the_endpoint_path() {
+        let backend = Backend::OpenAiResponses(config("https://host/backend-api/codex#frag"));
+        assert!(backend.is_codex());
+        assert_eq!(
+            backend.url(),
+            "https://host/backend-api/codex/responses#frag"
+        );
+    }
+
+    #[test]
+    fn codex_near_matches_with_query_remain_non_codex() {
+        assert!(!Backend::OpenAiResponses(
+            config("https://host/backend-api/codex-compat?v=1")
+        )
+        .is_codex());
+        assert!(!Backend::OpenAiResponses(
+            config("https://host/not-backend-api/codex?x=1")
+        )
+        .is_codex());
+    }
+
+    #[test]
+    fn normal_responses_base_url_is_unaffected_by_query_splitting() {
+        let backend = Backend::OpenAiResponses(config("https://api.openai.com/v1"));
+        assert!(!backend.is_codex());
+        assert_eq!(backend.url(), "https://api.openai.com/v1/responses");
     }
 
     #[test]

--- a/crates/libsy-llm-client/src/backend.rs
+++ b/crates/libsy-llm-client/src/backend.rs
@@ -131,6 +131,14 @@ impl Backend {
         }
     }
 
+    /// Whether this backend targets the ChatGPT Codex backend
+    /// (`chatgpt.com/backend-api/codex`), which applies stricter wire rules
+    /// than normal OpenAI `/v1/responses` endpoints.
+    pub fn is_codex(&self) -> bool {
+        matches!(self, Backend::OpenAiResponses(_))
+            && self.config().base_url.contains("/backend-api/codex")
+    }
+
     /// The fully resolved upstream URL for this backend's endpoint.
     ///
     /// Tolerates base URLs that already include the provider path (or a bare

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -989,6 +989,15 @@ mod tests {
         )]
     }
 
+    // A one-model config list: "gpt" served over OpenAI Responses at base_url.
+    fn responses_map(base_url: &str) -> Vec<ModelConfig> {
+        vec![ModelConfig::new(
+            "gpt",
+            Backend::OpenAiResponses(config(base_url)),
+            None,
+        )]
+    }
+
     fn chat_map_with_retries(base_url: &str, max_retries: u32) -> Vec<ModelConfig> {
         vec![ModelConfig::new(
             "gpt",
@@ -2291,4 +2300,158 @@ mod tests {
             .await?;
         Ok(())
     }
+    // The ChatGPT Codex Responses backend rejects `max_output_tokens` on every
+    // inbound path; a normal OpenAI `/v1/responses` endpoint keeps it. The
+    // strip must be Codex-specific, not a blanket Responses-format behavior.
+    #[tokio::test]
+    async fn codex_responses_requests_drop_max_output_tokens()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        let seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen_for_mock = seen.clone();
+        Mock::given(method("POST"))
+            .and(path("/backend-api/codex/responses"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                seen_for_mock.store(body.get("max_output_tokens").is_some(), Ordering::SeqCst);
+                true
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "resp_1",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt",
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&responses_map(
+            &format!("{}/backend-api/codex", server.uri()),
+        ))?;
+        let raw = json!({
+            "model": "client-facing",
+            "max_output_tokens": 4096,
+            "input": "hi"
+        });
+        let RawResponse::Buffered(body) = client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiResponses,
+            )
+            .await?
+        else {
+            panic!("expected a buffered response");
+        };
+        assert_eq!(body["status"], "completed");
+        // The parameter never reached the Codex-shaped upstream.
+        assert!(!seen.load(Ordering::SeqCst), "max_output_tokens leaked upstream");
+        Ok(())
+    }
+
+    // Chat requests routed to the Codex backend lose the translated
+    // `max_tokens -> max_output_tokens` field too.
+    #[tokio::test]
+    async fn codex_chat_requests_drop_translated_max_output_tokens()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        let seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen_for_mock = seen.clone();
+        Mock::given(method("POST"))
+            .and(path("/backend-api/codex/responses"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                seen_for_mock.store(body.get("max_output_tokens").is_some(), Ordering::SeqCst);
+                true
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "resp_1",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt",
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&responses_map(
+            &format!("{}/backend-api/codex", server.uri()),
+        ))?;
+        let raw = json!({
+            "model": "client-facing",
+            "max_tokens": 512,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        // Inbound chat -> internal -> outbound Responses.
+        let RawResponse::Buffered(body) = client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiChat,
+            )
+            .await?
+        else {
+            panic!("expected a buffered response");
+        };
+        // Inbound chat -> the raw response comes back chat-shaped.
+        assert_eq!(body["choices"][0]["message"]["content"], json!("ok"));
+        assert!(!seen.load(Ordering::SeqCst), "translated max_output_tokens leaked upstream");
+        Ok(())
+    }
+
+    // Non-Codex OpenAI Responses backends keep `max_output_tokens`.
+    #[tokio::test]
+    async fn openai_responses_requests_keep_max_output_tokens()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        let server = MockServer::start().await;
+        let seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let seen_for_mock = seen.clone();
+        Mock::given(method("POST"))
+            .and(path("/v1/responses"))
+            .and(move |request: &wiremock::Request| {
+                let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                seen_for_mock.store(body.get("max_output_tokens") == Some(&json!(4096)), Ordering::SeqCst);
+                true
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "resp_1",
+                "object": "response",
+                "status": "completed",
+                "model": "gpt",
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = TranslatingLlmClient::new(&responses_map(&format!("{}/v1", server.uri())))?;
+        let raw = json!({
+            "model": "client-facing",
+            "max_output_tokens": 4096,
+            "input": "hi"
+        });
+        let RawResponse::Buffered(body) = client
+            .call_rewrite_model_raw(
+                raw,
+                None,
+                Some(&ModelId::from("gpt")),
+                WireFormat::OpenAiResponses,
+            )
+            .await?
+        else {
+            panic!("expected a buffered response");
+        };
+        assert_eq!(body["status"], "completed");
+        assert!(seen.load(Ordering::SeqCst), "non-codex Responses backends keep max_output_tokens");
+        Ok(())
+    }
+
 }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -2454,4 +2454,61 @@ mod tests {
         Ok(())
     }
 
+    // Negative control: a URL that merely CONTAINS a codex-like path segment is
+    // not a Codex backend; the parameter must survive.
+    #[tokio::test]
+    async fn codex_near_match_urls_keep_max_output_tokens()
+    -> std::result::Result<(), Box<dyn Error + Sync + Send + 'static>> {
+        for near_path in ["/backend-api/codex-compat", "/not-backend-api/codex"] {
+            let server = MockServer::start().await;
+            let seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let seen_for_mock = seen.clone();
+            let path_suffix = if near_path == "/backend-api/codex-compat" {
+                "/backend-api/codex-compat/responses"
+            } else {
+                "/not-backend-api/codex/responses"
+            };
+            Mock::given(method("POST"))
+                .and(path(path_suffix))
+                .and(move |request: &wiremock::Request| {
+                    let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
+                    seen_for_mock.store(body.get("max_output_tokens") == Some(&json!(4096)), Ordering::SeqCst);
+                    true
+                })
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "id": "resp_1",
+                    "object": "response",
+                    "status": "completed",
+                    "model": "gpt",
+                    "output": [{"type": "message", "role": "assistant",
+                                "content": [{"type": "output_text", "text": "ok"}]}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+                })))
+                .mount(&server)
+                .await;
+
+            let base = format!("{}{}", server.uri(), near_path);
+            let client = TranslatingLlmClient::new(&responses_map(&base))?;
+            let raw = json!({
+                "model": "client-facing",
+                "max_output_tokens": 4096,
+                "input": "hi"
+            });
+            let RawResponse::Buffered(body) = client
+                .call_rewrite_model_raw(
+                    raw,
+                    None,
+                    Some(&ModelId::from("gpt")),
+                    WireFormat::OpenAiResponses,
+                )
+                .await?
+            else {
+                panic!("expected a buffered response");
+            };
+            assert_eq!(body["status"], "completed");
+            assert!(seen.load(Ordering::SeqCst), "near-match URL must not be treated as Codex");
+        }
+        Ok(())
+    }
+
 }

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -253,6 +253,14 @@ impl TranslatingLlmClient {
             strip_unsigned_thinking_blocks(&mut body);
         }
         merge_extra_body(&mut body, backend.extra_body());
+        // The ChatGPT Codex backend rejects `max_output_tokens` outright (2026-08
+        // API), on every inbound path - chat (`max_tokens`), Responses passthrough,
+        // and preserved same-format bodies alike. Strip AFTER `merge_extra_body`
+        // so no target `extra_body` can reinstate it. Normal OpenAI
+        // `/v1/responses` backends keep the parameter.
+        if backend.is_codex() {
+            strip_codex_incompatible_fields(&mut body);
+        }
         if matches!(backend, Backend::Anthropic(_)) {
             enable_anthropic_prompt_caching(&mut body);
         }
@@ -820,6 +828,13 @@ fn is_unsigned_thinking_block(block: &Value) -> bool {
 }
 
 // Applies target defaults without overriding fields supplied by the caller.
+// Removes fields the ChatGPT Codex Responses backend rejects outright.
+fn strip_codex_incompatible_fields(body: &mut Value) {
+    if let Value::Object(object) = body {
+        object.remove("max_output_tokens");
+    }
+}
+
 fn merge_extra_body(body: &mut Value, extra_body: &BTreeMap<String, Value>) {
     let Value::Object(object) = body else {
         return;

--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -2328,9 +2328,10 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = TranslatingLlmClient::new(&responses_map(
-            &format!("{}/backend-api/codex", server.uri()),
-        ))?;
+        let client = TranslatingLlmClient::new(&responses_map(&format!(
+            "{}/backend-api/codex",
+            server.uri()
+        )))?;
         let raw = json!({
             "model": "client-facing",
             "max_output_tokens": 4096,
@@ -2349,7 +2350,10 @@ mod tests {
         };
         assert_eq!(body["status"], "completed");
         // The parameter never reached the Codex-shaped upstream.
-        assert!(!seen.load(Ordering::SeqCst), "max_output_tokens leaked upstream");
+        assert!(
+            !seen.load(Ordering::SeqCst),
+            "max_output_tokens leaked upstream"
+        );
         Ok(())
     }
 
@@ -2380,9 +2384,10 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = TranslatingLlmClient::new(&responses_map(
-            &format!("{}/backend-api/codex", server.uri()),
-        ))?;
+        let client = TranslatingLlmClient::new(&responses_map(&format!(
+            "{}/backend-api/codex",
+            server.uri()
+        )))?;
         let raw = json!({
             "model": "client-facing",
             "max_tokens": 512,
@@ -2402,7 +2407,10 @@ mod tests {
         };
         // Inbound chat -> the raw response comes back chat-shaped.
         assert_eq!(body["choices"][0]["message"]["content"], json!("ok"));
-        assert!(!seen.load(Ordering::SeqCst), "translated max_output_tokens leaked upstream");
+        assert!(
+            !seen.load(Ordering::SeqCst),
+            "translated max_output_tokens leaked upstream"
+        );
         Ok(())
     }
 
@@ -2417,7 +2425,10 @@ mod tests {
             .and(path("/v1/responses"))
             .and(move |request: &wiremock::Request| {
                 let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
-                seen_for_mock.store(body.get("max_output_tokens") == Some(&json!(4096)), Ordering::SeqCst);
+                seen_for_mock.store(
+                    body.get("max_output_tokens") == Some(&json!(4096)),
+                    Ordering::SeqCst,
+                );
                 true
             })
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -2450,7 +2461,10 @@ mod tests {
             panic!("expected a buffered response");
         };
         assert_eq!(body["status"], "completed");
-        assert!(seen.load(Ordering::SeqCst), "non-codex Responses backends keep max_output_tokens");
+        assert!(
+            seen.load(Ordering::SeqCst),
+            "non-codex Responses backends keep max_output_tokens"
+        );
         Ok(())
     }
 
@@ -2472,7 +2486,10 @@ mod tests {
                 .and(path(path_suffix))
                 .and(move |request: &wiremock::Request| {
                     let body: Value = serde_json::from_slice(&request.body).unwrap_or(Value::Null);
-                    seen_for_mock.store(body.get("max_output_tokens") == Some(&json!(4096)), Ordering::SeqCst);
+                    seen_for_mock.store(
+                        body.get("max_output_tokens") == Some(&json!(4096)),
+                        Ordering::SeqCst,
+                    );
                     true
                 })
                 .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -2506,9 +2523,11 @@ mod tests {
                 panic!("expected a buffered response");
             };
             assert_eq!(body["status"], "completed");
-            assert!(seen.load(Ordering::SeqCst), "near-match URL must not be treated as Codex");
+            assert!(
+                seen.load(Ordering::SeqCst),
+                "near-match URL must not be treated as Codex"
+            );
         }
         Ok(())
     }
-
 }


### PR DESCRIPTION
The ChatGPT Codex Responses backend (`chatgpt.com/backend-api/codex`) rejects `max_output_tokens` outright on every inbound path - chat completions (`max_tokens` translated to `max_output_tokens`), Responses passthrough, and preserved same-format bodies alike. Normal OpenAI `/v1/responses` endpoints keep the parameter.

This series detects the Codex backend by its base-URL shape via a new `Backend::is_codex()` - a path-boundary match (query/fragment excluded; near-matches such as `/backend-api/codex-compat` or `/not-backend-api/codex` are explicitly not Codex) - and strips the field after `merge_extra_body`, so no target `extra_body` can reinstate it.

Regression tests cover: direct Codex Responses requests, chat-to-Responses translation, non-Codex preservation, and both near-match negative controls.

DCO signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying Codex-compatible OpenAI Responses endpoints, including URLs with trailing slashes, query parameters, or fragments.
  * Codex requests now automatically handle output limits in a way compatible with the Codex API.

* **Bug Fixes**
  * Improved handling of requests translated from chat format to Responses format for Codex endpoints.
  * Standard OpenAI Responses endpoints continue to preserve their configured output-token limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->