### PR TITLE
fix(translation): preserve OpenAI Chat refusal text

### DIFF
--- a/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/buffered.rs
@@ -284,6 +284,11 @@ impl FormatCodec for OpenAiChatCodec {
                 .and_then(Value::as_object)
                 .cloned()
                 .unwrap_or_default();
+            let content_is_null = message.get("content").is_none_or(Value::is_null);
+            let refusal = message
+                .get("refusal")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty());
             let mut content = decode_openai_content(
                 message.get("content").unwrap_or(&Value::Null),
                 WireFormat::OpenAiChat,
@@ -292,6 +297,18 @@ impl FormatCodec for OpenAiChatCodec {
                 "$.choices[0].message.content",
             )?;
             prepend_openai_reasoning_blocks(&mut content, &message);
+            if let Some(text) = refusal {
+                // Null content normally creates an empty placeholder, but the sibling refusal
+                // field is the actual assistant content for a structured refusal.
+                if content_is_null {
+                    content.retain(
+                        |block| !matches!(block, ContentBlock::Text { text } if text.is_empty()),
+                    );
+                }
+                content.push(ContentBlock::Refusal {
+                    text: text.to_string(),
+                });
+            }
             if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
                 for (index, tool_call) in tool_calls.iter().enumerate() {
                     if let Some(call) = decode_openai_tool_call(
@@ -303,12 +320,16 @@ impl FormatCodec for OpenAiChatCodec {
                     }
                 }
             }
+            let finish_reason = choice.get("finish_reason").and_then(Value::as_str);
+            let stop_reason = if refusal.is_some() && matches!(finish_reason, Some("stop") | None) {
+                StopReason::ContentFilter
+            } else {
+                map_openai_finish_reason(finish_reason)
+            };
             response.outputs.push(ResponseOutput {
                 role: Role::Assistant,
                 content,
-                stop_reason: Some(map_openai_finish_reason(
-                    choice.get("finish_reason").and_then(Value::as_str),
-                )),
+                stop_reason: Some(stop_reason),
             });
         }
 

--- a/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
+++ b/crates/switchyard-translation/src/codecs/openai_chat/stream.rs
@@ -134,6 +134,15 @@ fn decode_openai_chat_stream(
                     text: text.to_string(),
                 });
             }
+            if let Some(text) = delta.get("refusal").and_then(Value::as_str)
+                && !text.is_empty()
+            {
+                state.stop_reason = Some("content_filter".to_string());
+                out.push(LlmResponseChunk::TextDelta {
+                    index: 0,
+                    text: text.to_string(),
+                });
+            }
             if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
                 for tool_call in tool_calls {
                     if let Some(tool_call) = tool_call.as_object() {
@@ -159,6 +168,12 @@ fn decode_openai_chat_stream(
             }
         }
         if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
+            let reason =
+                if reason == "stop" && state.stop_reason.as_deref() == Some("content_filter") {
+                    "content_filter"
+                } else {
+                    reason
+                };
             out.push(LlmResponseChunk::MessageStop {
                 reason: Some(reason.to_string()),
             });

--- a/crates/switchyard-translation/tests/response_translation.rs
+++ b/crates/switchyard-translation/tests/response_translation.rs
@@ -7,7 +7,9 @@ pub mod common;
 
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use switchyard_translation::{TranslationEngine, TranslationPolicy, WireFormat};
+use switchyard_translation::{
+    ContentBlock, StopReason, TranslationEngine, TranslationPolicy, WireFormat,
+};
 
 use common::{
     REASONING_MODEL, normalized_policy, shell_tool_call, text_and_encrypted_reasoning_details,
@@ -50,6 +52,55 @@ fn openai_chat_response_translates_to_anthropic_message() -> TestResult {
     assert_eq!(
         output["usage"],
         json!({"input_tokens": 10, "output_tokens": 5})
+    );
+    Ok(())
+}
+
+// Verifies a Chat Completions refusal survives both neutral decoding and Anthropic encoding.
+#[test]
+fn openai_chat_refusal_decodes_and_translates_to_anthropic() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "id": "chatcmpl-refusal",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "refusal": "I cannot help with that request."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    });
+
+    let decoded =
+        engine.decode_response(WireFormat::OpenAiChat, &body, &TranslationPolicy::default())?;
+    let output = decoded.response.first_output().ok_or("missing output")?;
+    assert_eq!(
+        output.content,
+        vec![ContentBlock::Refusal {
+            text: "I cannot help with that request.".to_string()
+        }]
+    );
+    assert_eq!(output.stop_reason, Some(StopReason::ContentFilter));
+
+    let translated = engine
+        .encode_response(
+            WireFormat::AnthropicMessages,
+            &decoded.response,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+    assert_eq!(
+        translated["content"],
+        json!([{"type": "text", "text": "I cannot help with that request."}])
+    );
+    assert_eq!(translated["stop_reason"], "refusal");
+    assert_eq!(
+        translated["stop_details"],
+        json!({"type": "refusal", "category": null, "explanation": null})
     );
     Ok(())
 }

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -400,6 +400,63 @@ fn openai_chat_stream_event_translates_to_anthropic_message_events() -> TestResu
     Ok(())
 }
 
+// Verifies Chat Completions refusal deltas remain visible and terminate as refusals.
+#[test]
+fn openai_chat_refusal_stream_translates_to_anthropic() -> TestResult {
+    let engine = TranslationEngine::default();
+    let mut state =
+        StreamTranslationState::new(WireFormat::OpenAiChat, WireFormat::AnthropicMessages);
+    let refusal = json!({
+        "id": "chatcmpl-refusal",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "delta": {"refusal": "I cannot help with that request."},
+            "finish_reason": null
+        }]
+    });
+
+    let mut events = engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &refusal,
+    )?;
+    let text_delta = events
+        .iter()
+        .find(|event| event["type"] == "content_block_delta")
+        .ok_or("missing refusal text delta")?;
+    assert_eq!(
+        text_delta["delta"]["text"],
+        "I cannot help with that request."
+    );
+
+    let terminal = json!({
+        "id": "chatcmpl-refusal",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]
+    });
+    events.extend(engine.translate_event(
+        &mut state,
+        WireFormat::OpenAiChat,
+        WireFormat::AnthropicMessages,
+        &terminal,
+    )?);
+    events.extend(engine.finish_stream(&mut state, WireFormat::AnthropicMessages)?);
+    let message_delta = events
+        .iter()
+        .find(|event| event["type"] == "message_delta")
+        .ok_or("missing Anthropic terminal delta")?;
+    assert_eq!(message_delta["delta"]["stop_reason"], "refusal");
+    assert_eq!(
+        message_delta["delta"]["stop_details"],
+        json!({"type": "refusal", "category": null, "explanation": null})
+    );
+    Ok(())
+}
+
 // Restores Anthropic-safe IDs before emitting OpenAI tool-call deltas.
 #[test]
 fn anthropic_stream_tool_id_is_restored_for_openai_chat() -> TestResult {


### PR DESCRIPTION
## What

Preserve structured OpenAI Chat refusal responses across buffered and streaming translation.

- decode sibling `message.refusal` text into provider-neutral refusal content
- remove the synthetic empty text block when Chat content is null
- map refusal stops to Anthropic `stop_reason: "refusal"` and stop details
- retain streamed `delta.refusal` text and refusal semantics through the terminal chunk

## Why

OpenAI Chat refusals commonly use `content: null` with the explanation in `message.refusal`. Switchyard erased that explanation and returned an empty successful Anthropic turn.

Closes #622.

## End-to-end verification (before vs after)

Verified on 2026-09-04 with release builds of `switchyard-server` at the merge base `4022b677` (before) and this branch head `2765f469` (after), Rust 1.96.1, macOS arm64. The server was driven over `/v1/messages` (Anthropic ingress) with an `openai_chat` backend. Credentials were supplied only through the server's `api_key_env` mechanism and never appear in any capture.

Two evidence layers, both with real wire captures (auth redacted, leak-checked):

### 1. Live structured refusals from the real OpenAI API (the defect trigger)

Anthropic ingress with `output_config.format` json_schema over `/v1/messages`, translated by Switchyard to OpenAI `response_format` strict:true against `gpt-4o-2024-08-06` at `api.openai.com`. The upstream returned a real `message.refusal` with `content: null` and `finish_reason: stop` on every run (verified in the sanitized upstream captures, including `delta.refusal` on streams). This is OpenAI's documented Structured Outputs refusal shape.

Before (`4022b677`), 4/4 live structured refusals erased (2 buffered, 2 streaming), HTTP 200 with empty content, a silent success:

```json
{
  "content": [{"type": "text", "text": ""}],
  "stop_reason": "end_turn",
  "stop_details": null
}
```

After, 5/5 runs preserved the refusal text and surfaced the refusal stop:

```json
{
  "content": [{"type": "text", "text": "I'm sorry, but I can't assist with that request."}],
  "stop_reason": "refusal",
  "stop_details": {"type": "refusal", "category": null, "explanation": null}
}
```

Streaming before: zero refusal text delivered, terminal `end_turn`. Streaming after: refusal text delivered as content deltas, terminal `message_delta` with `stop_reason: "refusal"` and refusal stop details.

### 2. Supporting layers

Plain-prompt live refusals (no schema) against `gpt-4o` return refusal text in `content` with `refusal: null`; those passed 5/5 before and 5/5 after with text controls 4/4 on both, so no regression on ordinary refusal traffic. The deterministic replay of the exact #622 wire shape through both binaries also matches: 0/5 preserved before, 5/5 preserved after.

### Totals (live strict-schema + supporting)

| Scenario | before | after |
|---|---|---|
| Live structured refusal preserved (buffered) | 0/2 | 2/2 |
| Live structured refusal preserved (streaming) | 0/2 | 2/2 |
| Replay structured refusal preserved | 0/5 | 5/5 |
| Live plain-prompt refusals preserved | 5/5 | 5/5 |
| Text controls unchanged | 4/4 | 4/4 |

`cargo test -p switchyard-translation` on this head: 159 passed, including the two new refusal tests.

## Notes for reviewers

The buffered change is in the response handling of `decode_openai_chat`; the streaming change is in `decode_openai_chat_stream`. The two regression tests encode the before/after contract shown above.

Validation completed locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p switchyard-translation` re-run on this head on 2026-09-04
- `uv run ruff check .`
- `uv run mypy switchyard`
- `uv run pytest tests/ --ignore=tests/e2e -v` (115 passed, 2 subtests passed)

The full Python command was also attempted; its Docker E2E stopped before exercising Switchyard because the local Docker daemon is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI Chat refusals are now preserved when translating both complete and streaming responses.
  * Refusal text is correctly represented even when message content is null.
  * Responses with refusals now report the appropriate content-filter stop reason while preserving existing behavior for other finish reasons.

* **Tests**
  * Added coverage for buffered and streaming refusal translation to Anthropic-compatible responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

