### PR TITLE
docs(readme): make Relay and libsy quickstarts runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,20 @@ step 1, stop when you reach the result named under the heading.
 ### Path 1 — Load the NeMo Relay Plugin
 
 You finish with an existing NeMo Relay deployment routing through Switchyard.
-Requires NeMo Relay `>=0.8.1,<0.9.0`.
+Requires NeMo Relay `>=0.8.1,<0.9.0` and a Rust toolchain to build the plugin.
 
-**1. Build the plugin bundle.**
-
-```bash
-python crates/switchyard-nemo-relay-plugin/scripts/package_bundle.py
-```
+**1. Build, package, and enable the plugin.** Follow the
+[install steps in the plugin README](crates/switchyard-nemo-relay-plugin/README.md#install).
+They build the shared library, package it into a bundle with a digest-bearing
+`relay-plugin.toml`, and register and enable it with `nemo-relay plugins`.
 
 **2. Write the Switchyard deployment** to `/etc/switchyard/routes.toml` — the
 same version-1 TOML the proxy uses. Copy the file from step 2 of Path 3 below.
 
-**3. Point Relay at the generated manifest.** Use exactly one deployment
-source: a path, as here, or the config nested under `switchyard_config`.
+**3. Point the plugin at the deployment.** Add a `config` table to the
+`[[plugins.dynamic]]` entry that `nemo-relay plugins add` wrote. Use exactly one
+deployment source: a path, as here, or the config nested under
+`switchyard_config`.
 
 ```toml
 [[plugins.dynamic]]
@@ -131,27 +132,31 @@ switchyard_config_path = "/etc/switchyard/routes.toml"
 while Switchyard owns provider HTTP dispatch.
 
 Details: [`switchyard-nemo-relay-plugin`](crates/switchyard-nemo-relay-plugin/README.md)
-and the [server configuration guide](crates/switchyard-server/CONFIGURATION.md).
+and the [TOML schema reference](docs/reference/toml_schema.md).
 
 ### Path 2 — Embed the Library
 
 You finish with your own harness picking a model per request and still making
 every model call itself. Shown in Python; the Rust API has the same shape.
 
-**1. Install.**
+**1. Install.** The `Step` and `LlmResponse` API below is newer than the
+`nemo-switchyard` 0.2.0 release on PyPI, which exposes an older `LlmTarget`
+based interface. Until the next release, build from source (requires a Rust
+toolchain):
 
 ```bash
-pip install nemo-switchyard
+pip install git+https://github.com/NVIDIA-NeMo/Switchyard.git
 ```
 
-For Rust, add the crates to your `Cargo.toml` instead:
+For Rust, the `v0.2.0` tag has the older `run_stream` shape too, so depend on
+the repository's `main` branch and pin the `rev` you tested:
 
 ```toml
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-switchyard-libsy = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git", tag = "v0.2.0" }
-switchyard-protocol = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git", tag = "v0.2.0" }
+switchyard-libsy = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git", branch = "main" }
+switchyard-protocol = { git = "https://github.com/NVIDIA-NeMo/Switchyard.git", branch = "main" }
 tokio = { version = "1", features = ["macros", "rt"] }
 ```
 
@@ -171,33 +176,51 @@ algorithm = stage_router(
 )
 ```
 
-**3. Drive it.** `run_stream` takes an OpenAI-style request dict and yields
-steps. A `CallModel` step is a classifier or judge call — make it with your own
-client and hand the result back. `Done` carries the pick.
+**3. Drive it.** `run_stream` takes a normalized Switchyard request dict, not
+an OpenAI wire payload: the `Request` shape from
+[`switchyard-protocol`](crates/protocol/README.md), with `messages` whose
+`content` is a list of typed blocks. It yields steps. A `CallModel` step is a
+classifier or judge call — make it with your own client and hand back the
+normalized response wrapped in `LlmResponse.Agg`. `Done` carries the pick.
 
 ```python
-async def route(request: dict, clients: dict) -> tuple[str, dict]:
+async def call_with_fallback(request: dict, models: list[str], clients: dict) -> LlmResponse.Agg:
+    error: Exception | None = None
+    for model in models:
+        try:
+            return LlmResponse.Agg(await clients[model].call({**request, "model": model}))
+        except Exception as exc:
+            error = exc
+    raise error or RuntimeError("no candidate models")
+
+
+async def route(request: dict, clients: dict) -> LlmResponse.Agg | LlmResponse.Stream:
     async for step in algorithm.run_stream(request):
         match step:
             case Step.CallModel(call):
-                target = call.models[0]
                 try:
-                    response = await clients[target].call({**call.request, "model": target})
+                    call.respond(await call_with_fallback(call.request, call.models, clients))
                 except Exception as error:
                     call.fail(error)
-                else:
-                    call.respond(LlmResponse.Agg(response))
             case Step.Done(outcome):
-                return outcome.selected_model_ids[0], outcome.request
+                if outcome.response is not None:
+                    return outcome.response
+                return await call_with_fallback(
+                    outcome.request, outcome.selected_model_ids, clients
+                )
+    raise RuntimeError("algorithm ended without a decision")
 ```
 
-`clients` is your existing per-model client map. `call.models` lists fallbacks
-in order; `outcome.request` is the request to send, which may carry a rewrite
-the algorithm applied.
+`clients` maps each target name to your existing client; each `call` takes a
+normalized request dict and returns a normalized response dict. `call.models`
+and `outcome.selected_model_ids` list candidates in order, so the helper tries
+each one before giving up. `outcome.request` is the request to send, which may
+carry a rewrite the algorithm applied. When `outcome.response` is set, routing
+already produced the answer and no further call is needed.
 
-**4. Make the answer call** with the returned model and request, using your own
-HTTP client, retries, and credentials. If `outcome.response` is set, routing
-already produced the answer and you can return it directly.
+**4. Make the answer call** with your own HTTP client, retries, and
+credentials, as `call_with_fallback` does above. A complete runnable version,
+including streaming responses, is in [`examples/libsy.py`](examples/libsy.py).
 
 Type reference: [`switchyard-libsy`](crates/libsy/README.md) and
 [`switchyard-protocol`](crates/protocol/README.md). In Rust the loop is
@@ -246,8 +269,7 @@ confidence_threshold = 0.5
 TOML
 ```
 
-Every key is documented in the
-[server configuration guide](crates/switchyard-server/CONFIGURATION.md).
+Every key is documented in the [TOML schema reference](docs/reference/toml_schema.md).
 
 **3. Start it.** `--dry-run` loads the config, prints `server OK:` and the model
 IDs it exposes, then exits without starting the server.

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ step 1, stop when you reach the result named under the heading.
 You finish with an existing NeMo Relay deployment routing through Switchyard.
 Requires NeMo Relay `>=0.8.1,<0.9.0` and a Rust toolchain to build the plugin.
 
-**1. Build, package, and enable the plugin.** Follow the
-[install steps in the plugin README](crates/switchyard-nemo-relay-plugin/README.md#install).
+**1. Build, package, and register the plugin.** Follow steps 1–3 of the
+[install guide in the plugin README](crates/switchyard-nemo-relay-plugin/README.md#install).
 They build the shared library, package it into a bundle with a digest-bearing
-`relay-plugin.toml`, and register and enable it with `nemo-relay plugins`.
+`relay-plugin.toml`, and register it with `nemo-relay plugins add`.
 
 **2. Write the Switchyard deployment** to `/etc/switchyard/routes.toml` — the
 same version-1 TOML the proxy uses. Copy the file from step 2 of Path 3 below.
@@ -128,8 +128,15 @@ priority = 0
 switchyard_config_path = "/etc/switchyard/routes.toml"
 ```
 
-**4. Restart Relay.** It now runs any algorithm `switchyard-runner` supports,
-while Switchyard owns provider HTTP dispatch.
+**4. Enable, validate, and restart Relay.**
+
+```bash
+nemo-relay plugins enable nvidia.switchyard
+nemo-relay plugins validate nvidia.switchyard
+```
+
+Relay now runs any algorithm `switchyard-runner` supports, while Switchyard
+owns provider HTTP dispatch.
 
 Details: [`switchyard-nemo-relay-plugin`](crates/switchyard-nemo-relay-plugin/README.md)
 and the [TOML schema reference](docs/reference/toml_schema.md).

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ They build the shared library, package it into a bundle with a digest-bearing
 same version-1 TOML the proxy uses. Copy the file from step 2 of Path 3 below.
 
 **3. Point the plugin at the deployment.** Add a `config` table to the
-`[[plugins.dynamic]]` entry that `nemo-relay plugins add` wrote. Use exactly one
+`[[plugins.dynamic]]` entry that `nemo-relay plugins add` wrote, plus the
+policy override that lets Relay load the unsigned bundle. Use exactly one
 deployment source: a path, as here, or the config nested under
 `switchyard_config`.
 
@@ -126,6 +127,9 @@ manifest = "./plugins/switchyard/relay-plugin.toml"
 [plugins.dynamic.config]
 priority = 0
 switchyard_config_path = "/etc/switchyard/routes.toml"
+
+[plugins.policy.overrides."nvidia.switchyard"]
+attestation = "integrity_only"
 ```
 
 **4. Enable, validate, and restart Relay.**

--- a/crates/switchyard-nemo-relay-plugin/README.md
+++ b/crates/switchyard-nemo-relay-plugin/README.md
@@ -59,7 +59,8 @@ nemo-relay plugins add --user ./plugins/switchyard/relay-plugin.toml
 The plugin is not enabled yet; enabling before the deployment is configured
 fails validation because the plugin requires a Switchyard configuration.
 
-**4. Configure the deployment** as described in [Configure Relay](#configure-relay).
+**4. Configure the deployment and trust policy** in that `plugins.toml`, as
+described in [Configure Relay](#configure-relay).
 
 **5. Enable and validate the plugin**, then restart Relay. The manifest ships
 with `enabled = false`; Relay validates a disabled plugin but never loads it.
@@ -70,27 +71,14 @@ nemo-relay plugins validate nvidia.switchyard
 ```
 
 `validate` evaluates the manifest, the plugin configuration, the artifact
-digest, and the host trust policy. Native plugins run inside the Relay process
-without a sandbox, so treat the bundle as trusted host code. The generated
-manifest carries an integrity digest but no signature. If `validate` reports
-that the host policy requires a signature, either sign the artifact with an
-Ed25519 key listed in the host's `trusted_public_keys`, or relax the policy for
-this plugin in `plugins.toml`:
-
-```toml
-[plugins.policy.overrides."nvidia.switchyard"]
-attestation = "integrity_only"
-```
-
-See Relay's
-[discoverable plugins guide](https://github.com/NVIDIA/NeMo-Relay/blob/main/docs/configure-plugins/discoverable-plugins.mdx)
-for the policy keys.
+digest, and the host trust policy.
 
 ## Configure Relay
 
-Add the `config` table to the `[[plugins.dynamic]]` entry that `plugins add`
-wrote. Use exactly one Switchyard deployment source. To share an existing
-deployment file with `switchyard-server`, configure its path:
+Add a `config` table to the `[[plugins.dynamic]]` entry that `plugins add`
+wrote, and a policy override for the plugin. Use exactly one Switchyard
+deployment source. To share an existing deployment file with
+`switchyard-server`, configure its path:
 
 ```toml
 [[plugins.dynamic]]
@@ -99,7 +87,22 @@ manifest = "./plugins/switchyard/relay-plugin.toml"
 [plugins.dynamic.config]
 priority = 0
 switchyard_config_path = "/etc/switchyard/routes.toml"
+
+[plugins.policy.overrides."nvidia.switchyard"]
+attestation = "integrity_only"
 ```
+
+The policy override is required. The generated manifest carries a SHA-256
+digest but no signature, and Relay 0.8 refuses to activate an unsigned dynamic
+plugin at gateway start unless its host policy says otherwise; `plugins
+validate` still passes without the override, so the failure only shows up at
+startup as `requires integrity.signature under host policy`. Native plugins
+run inside the Relay process without a sandbox, so only install a bundle you
+built or obtained from a source you trust. To require a signature instead, sign
+the artifact with an Ed25519 key and list it in `trusted_public_keys`; see
+Relay's
+[discoverable plugins guide](https://github.com/NVIDIA/NeMo-Relay/blob/main/docs/configure-plugins/discoverable-plugins.mdx)
+for the policy keys.
 
 `switchyard_config_path` is a Switchyard version-1 TOML deployment, accepted by both
 `switchyard-server` and `switchyard-runner`. See the

--- a/crates/switchyard-nemo-relay-plugin/README.md
+++ b/crates/switchyard-nemo-relay-plugin/README.md
@@ -10,14 +10,59 @@ algorithm construction, retry policy, and route validation.
 
 ## Install
 
-Build the platform bundle with the package script, then configure Relay to load
-the generated `relay-plugin.toml` manifest. The plugin requires NeMo Relay
-`>=0.8.1,<0.9.0`.
+The plugin requires NeMo Relay `>=0.8.1,<0.9.0`, a Rust toolchain, and Python 3
+for the packaging script. Run every command from the repository root.
+
+**1. Build the shared library.**
+
+```bash
+cargo build --release -p switchyard-nemo-relay-plugin
+```
+
+The artifact is `target/release/libswitchyard_nemo_relay_plugin.so` on Linux
+and `target/release/libswitchyard_nemo_relay_plugin.dylib` on macOS.
+
+**2. Package the bundle.** The script copies the library, the config schema,
+and license files into an empty directory and writes a `relay-plugin.toml`
+manifest with the library name and its SHA-256 digest filled in. Relay verifies
+that digest before it loads the library, so rebuild the bundle after every
+rebuild of the library.
+
+```bash
+python crates/switchyard-nemo-relay-plugin/scripts/package_bundle.py \
+  --library target/release/libswitchyard_nemo_relay_plugin.so \
+  --output ./plugins/switchyard
+```
+
+Pass `--archive switchyard-plugin.tar.gz` (or `.zip`) to also produce an
+archive for distribution.
+
+**3. Register and enable the plugin.** The manifest ships with
+`enabled = false`; Relay validates a disabled plugin but never loads it.
+
+```bash
+nemo-relay plugins validate ./plugins/switchyard/relay-plugin.toml
+nemo-relay plugins add --user ./plugins/switchyard/relay-plugin.toml
+nemo-relay plugins enable nvidia.switchyard
+nemo-relay plugins validate nvidia.switchyard
+```
+
+`add` writes a `[[plugins.dynamic]]` entry to your `plugins.toml`; `enable`
+marks it active for the next gateway start. The final `validate` evaluates the
+manifest, the artifact digest, and the host trust policy. Native plugins run
+inside the Relay process without a sandbox, and Relay's default policy accepts
+integrity-only manifests. A host that sets
+`attestation = "signature_required"` under `[plugins.policy.defaults]` also
+needs an Ed25519 signature from a trusted key; see Relay's
+[discoverable plugins guide](https://github.com/NVIDIA/NeMo-Relay/blob/main/docs/configure-plugins/discoverable-plugins.mdx).
+
+**4. Configure the deployment** as shown below, then restart Relay.
 
 ## Configure Relay
 
-Use exactly one Switchyard deployment source. To share an existing deployment
-file with `switchyard-server`, configure its path:
+Add the `config` table to the `[[plugins.dynamic]]` entry that `plugins add`
+wrote. Use exactly one Switchyard deployment source. To share an existing
+deployment file with `switchyard-server`, configure its path:
 
 ```toml
 [[plugins.dynamic]]
@@ -30,8 +75,9 @@ switchyard_config_path = "/etc/switchyard/routes.toml"
 
 `switchyard_config_path` is a Switchyard version-1 TOML deployment, accepted by both
 `switchyard-server` and `switchyard-runner`. See the
-[server configuration guide](../switchyard-server/CONFIGURATION.md) for the
-deployment schema and routing algorithms.
+[TOML schema reference](../../docs/reference/toml_schema.md) for every key and
+the [routing overview](../../docs/routing_algorithms/overview.md) for the
+algorithms.
 
 To keep the deployment in the Relay configuration, nest the same version-1
 Switchyard configuration under `switchyard_config`:

--- a/crates/switchyard-nemo-relay-plugin/README.md
+++ b/crates/switchyard-nemo-relay-plugin/README.md
@@ -28,35 +28,63 @@ manifest with the library name and its SHA-256 digest filled in. Relay verifies
 that digest before it loads the library, so rebuild the bundle after every
 rebuild of the library.
 
+Linux:
+
 ```bash
 python crates/switchyard-nemo-relay-plugin/scripts/package_bundle.py \
   --library target/release/libswitchyard_nemo_relay_plugin.so \
   --output ./plugins/switchyard
 ```
 
+macOS:
+
+```bash
+python crates/switchyard-nemo-relay-plugin/scripts/package_bundle.py \
+  --library target/release/libswitchyard_nemo_relay_plugin.dylib \
+  --output ./plugins/switchyard
+```
+
 Pass `--archive switchyard-plugin.tar.gz` (or `.zip`) to also produce an
 archive for distribution.
 
-**3. Register and enable the plugin.** The manifest ships with
-`enabled = false`; Relay validates a disabled plugin but never loads it.
+**3. Register the plugin.**
 
 ```bash
 nemo-relay plugins validate ./plugins/switchyard/relay-plugin.toml
 nemo-relay plugins add --user ./plugins/switchyard/relay-plugin.toml
+```
+
+`add` writes a `[[plugins.dynamic]]` entry to your user `plugins.toml`
+(`~/.config/nemo-relay/plugins.toml` or `$XDG_CONFIG_HOME/nemo-relay/plugins.toml`).
+The plugin is not enabled yet; enabling before the deployment is configured
+fails validation because the plugin requires a Switchyard configuration.
+
+**4. Configure the deployment** as described in [Configure Relay](#configure-relay).
+
+**5. Enable and validate the plugin**, then restart Relay. The manifest ships
+with `enabled = false`; Relay validates a disabled plugin but never loads it.
+
+```bash
 nemo-relay plugins enable nvidia.switchyard
 nemo-relay plugins validate nvidia.switchyard
 ```
 
-`add` writes a `[[plugins.dynamic]]` entry to your `plugins.toml`; `enable`
-marks it active for the next gateway start. The final `validate` evaluates the
-manifest, the artifact digest, and the host trust policy. Native plugins run
-inside the Relay process without a sandbox, and Relay's default policy accepts
-integrity-only manifests. A host that sets
-`attestation = "signature_required"` under `[plugins.policy.defaults]` also
-needs an Ed25519 signature from a trusted key; see Relay's
-[discoverable plugins guide](https://github.com/NVIDIA/NeMo-Relay/blob/main/docs/configure-plugins/discoverable-plugins.mdx).
+`validate` evaluates the manifest, the plugin configuration, the artifact
+digest, and the host trust policy. Native plugins run inside the Relay process
+without a sandbox, so treat the bundle as trusted host code. The generated
+manifest carries an integrity digest but no signature. If `validate` reports
+that the host policy requires a signature, either sign the artifact with an
+Ed25519 key listed in the host's `trusted_public_keys`, or relax the policy for
+this plugin in `plugins.toml`:
 
-**4. Configure the deployment** as shown below, then restart Relay.
+```toml
+[plugins.policy.overrides."nvidia.switchyard"]
+attestation = "integrity_only"
+```
+
+See Relay's
+[discoverable plugins guide](https://github.com/NVIDIA/NeMo-Relay/blob/main/docs/configure-plugins/discoverable-plugins.mdx)
+for the policy keys.
 
 ## Configure Relay
 


### PR DESCRIPTION
Closes #624.

## What changed

- **Relay path**: the plugin README now has one install flow: `cargo build --release -p switchyard-nemo-relay-plugin`, `package_bundle.py --library ... --output ...`, then `nemo-relay plugins validate / add / enable / validate`. It explains the `enabled = false` manifest default, the artifact digest Relay verifies, and the optional signature policy. The root README Path 1 links to it instead of the incomplete `package_bundle.py` call.
- **Version**: Path 2 states that the `Step` / `LlmResponse` API is newer than `nemo-switchyard` 0.2.0 on PyPI and shows a source install. The Rust block depends on `main` instead of the `v0.2.0` tag, with a note to pin the tested `rev`.
- **Wording**: `run_stream` and `LlmResponse.Agg` are described as taking normalized Switchyard request and response dicts, linking to `switchyard-protocol` and `examples/libsy.py`.
- **Sample loop**: replaced with a `call_with_fallback` helper that walks `call.models` / `outcome.selected_model_ids` in order and returns `outcome.response` when routing already produced the answer.
- **TOML reference**: Path 1, Path 3, and the plugin README now link to `docs/reference/toml_schema.md` instead of the contributor guide.

## Checks

- Built the plugin in release mode and ran `package_bundle.py` with the documented arguments; the bundle contains the library, `config.schema.json`, licenses, and a manifest with the digest filled in. The `nemo-relay plugins` commands were not run locally (CLI not installed here); they follow Relay 0.8.1's discoverable-plugins guide.
- Ran the Path 2 Python blocks verbatim against `stage_router` with stub clients: efficient path served, and a failing efficient client fell back to capable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions for the Relay plugin, including building, packaging, registration, configuration, validation, and signature policies.
  * Documented deployment paths, generated manifests, and dynamic-plugin configuration.
  * Added guidance for installing Python components from the repository and pinning Rust dependencies to a repository revision.
  * Updated examples to use normalized protocol requests and responses.
  * Refreshed links to the TOML schema and routing documentation.
  * Documented ordered model fallbacks and algorithm-generated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->