### PR TITLE
fix(libsy): anchor every pre-reply user message for the escalation judge and log verdicts

### DIFF
--- a/crates/libsy/src/algorithms/util/escalation.rs
+++ b/crates/libsy/src/algorithms/util/escalation.rs
@@ -89,11 +89,14 @@ impl Default for EscalationJudgeConfig {
 }
 
 /// The judge's verdict. The schema also requires a `reason`, which makes the judge state its
-/// case and measurably sharpens the verdict — routing reads only the boolean, so it is
-/// deserialized away rather than carried.
+/// case and measurably sharpens the verdict. Routing reads only the boolean; the reason is
+/// kept solely so an operator can see why the judge held or escalated when the
+/// `switchyard_libsy::algorithms::util::escalation` target is enabled at `debug`.
 #[derive(Deserialize)]
 pub(crate) struct EscalationVerdict {
     escalate: bool,
+    #[serde(default)]
+    reason: String,
 }
 
 /// Builds the condensed trajectory presented to the escalation judge.
@@ -126,6 +129,13 @@ impl JudgePolicy for EscalationPolicy {
     type Verdict = EscalationVerdict;
 
     fn to_classification(&self, verdict: Option<&EscalationVerdict>) -> Classification {
+        if let Some(verdict) = verdict {
+            tracing::debug!(
+                escalate = verdict.escalate,
+                reason = %verdict.reason,
+                "escalation judge verdict"
+            );
+        }
         match verdict {
             Some(verdict) if verdict.escalate => Classification::Scores(vec![Score {
                 target: self.capable.clone(),

--- a/crates/libsy/src/algorithms/util/escalation.rs
+++ b/crates/libsy/src/algorithms/util/escalation.rs
@@ -34,8 +34,12 @@ const TRUNCATION_SUFFIX: &str = "...<truncated>";
 /// which coding-agent harnesses make very large.
 const SYSTEM_CHARS: usize = 1_000;
 
-/// Cap for the first user message — the task statement, so it gets the widest anchor budget.
-const FIRST_USER_CHARS: usize = 2_000;
+/// Per-message cap for task-framing user messages — every user message that precedes the first
+/// assistant reply. Coding-agent harnesses often send environment boilerplate as the first user
+/// message and the task itself as the second, so anchoring only the first would pin the
+/// boilerplate and let the task scroll out of the window. Feature specifications run to several
+/// thousand characters, so this gets the widest anchor budget.
+const TASK_CHARS: usize = 4_000;
 
 /// Backstop on the assembled transcript; the per-message caps normally bind first.
 const MAX_REQUEST_CHARS: usize = 18_000;
@@ -272,7 +276,7 @@ fn summarize_for_judge(
 ) -> String {
     let mut anchors: Vec<String> = Vec::new();
     let mut window: Vec<String> = Vec::new();
-    let mut first_user_seen = false;
+    let mut assistant_seen = false;
 
     for message in messages {
         let text = message_text(message);
@@ -282,18 +286,23 @@ fn summarize_for_judge(
                 role_label(message.role),
                 truncate_middle(&text, SYSTEM_CHARS)
             )),
-            Role::User if !first_user_seen => {
-                first_user_seen = true;
+            // Everything the user said before the agent first replied is task framing.
+            Role::User if !assistant_seen => {
                 anchors.push(format!(
                     "[user (task)] {}",
-                    truncate_middle(&text, FIRST_USER_CHARS)
+                    truncate_middle(&text, TASK_CHARS)
                 ));
             }
-            role => window.push(format!(
-                "[{}] {}",
-                role_label(role),
-                truncate_middle(&text, config.window_message_chars)
-            )),
+            role => {
+                if role == Role::Assistant {
+                    assistant_seen = true;
+                }
+                window.push(format!(
+                    "[{}] {}",
+                    role_label(role),
+                    truncate_middle(&text, config.window_message_chars)
+                ));
+            }
         }
     }
 
@@ -516,6 +525,49 @@ mod tests {
         assert!(summary.contains("step 9"), "{summary}");
         assert!(summary.contains("step 7"), "{summary}");
         assert!(!summary.contains("step 6"), "{summary}");
+    }
+
+    #[test]
+    fn summary_anchors_every_user_message_before_the_first_reply() {
+        // Codex sends environment boilerplate as the first user message and the task as the
+        // second. Both are framing; the task must stay visible after the window has moved on.
+        let mut messages = vec![
+            Message::text(
+                Role::Developer,
+                "<skills_instructions>...</skills_instructions>",
+            ),
+            Message::text(
+                Role::User,
+                "<environment_context><cwd>/app</cwd></environment_context>",
+            ),
+            Message::text(Role::User, "Implement RFC 5545 timezone interop in rrule."),
+        ];
+        for i in 0..40 {
+            messages.push(Message::text(Role::Assistant, format!("step {i}")));
+            messages.push(Message::text(Role::User, format!("later user note {i}")));
+        }
+        let config = EscalationJudgeConfig {
+            recent_turn_window: 3,
+            ..EscalationJudgeConfig::default()
+        };
+
+        let summary = summarize_for_judge(&messages, 40, &config);
+
+        assert!(
+            summary.contains("[user (task)] <environment_context>"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("[user (task)] Implement RFC 5545 timezone interop in rrule."),
+            "{summary}"
+        );
+        // User messages after the first reply are ordinary window entries, not anchors.
+        assert!(
+            !summary.contains("[user (task)] later user note"),
+            "{summary}"
+        );
+        assert!(summary.contains("[user] later user note 39"), "{summary}");
+        assert!(!summary.contains("later user note 0\n"), "{summary}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR now holds only the escalation-router-specific changes found while benchmarking the escalation mode of `llm_classifier` behind Codex 0.149.1 on DeepSWE-v1.1. The OpenAI Responses codec fixes that used to live here apply to any router that transforms traffic and have moved to #646; the two PRs are independent and can merge in either order.

## Problem

The trajectory summary handed to the escalation judge pinned the first user message as the task statement. Codex sends an environment context block (cwd, shell, date) as its first user message and the task as the second, so the judge read shell boilerplate as the task while the real specification sat in the rolling 28-message window, truncated to the per-message cap, and scrolled out after about thirty messages. On a real 485-message DeepSWE session the task was visible to the judge for the first thirty messages only. From then on every task-aware pattern in the rubric (drift, unverified completion, violated constraints) had nothing to compare against, and only friction patterns such as loops and environment fighting could fire. Measured over 64 tasks with the task made visible, the packaged rubric voted to escalate on 1.2 percent of turns, always as isolated votes, so the two-consecutive-votes gate produced zero latches.

Separately, the judge's verdict reason was parsed and discarded, so there was no way to see why sessions were held on the efficient tier without instrumenting a build by hand.

## Change

Every user message that precedes the first assistant reply is treated as task framing and anchored, with a wider per-message budget so a multi-thousand-character feature specification survives intact. This is harness-agnostic: for a client whose first user message is the task nothing changes, and for Codex the task is pinned alongside the environment block. A new test covers the Codex shape and checks that user messages after the first reply stay ordinary window entries.

The verdict now keeps its reason and emits one debug event per verdict under the `switchyard_libsy::algorithms::util::escalation` target. It is silent unless that target is enabled, and it made it possible to read, per session, which rubric pattern fired.

## Validation

libsy tests pass (283) and clippy is clean with `-D warnings`. Live, on a 64-task DeepSWE subset with verdict logging enabled, judge reasons after the change cite the specification ("early exploration of a large, cross-module feature", "verifying all required behaviors") where before they could only describe shell activity. The change does not by itself alter DeepSWE scores under the packaged rubric, because that rubric targets in-trajectory failure that DeepSWE tasks rarely show; the benchmark write-up covers that separately.
