### PR TITLE
fix(llm-client): drop upstream urls from transport errors

### DIFF
--- a/crates/libsy-llm-client/src/client.rs
+++ b/crates/libsy-llm-client/src/client.rs
@@ -464,17 +464,9 @@ impl TranslatingLlmClient {
                 // Adapt the reqwest body stream to plain bytes; the SSE-decode itself is
                 // transport-agnostic and lives in `switchyard-translation`.
                 let bytes = http_response.bytes_stream().map(|chunk| {
-                    chunk.map(|bytes| bytes.to_vec()).map_err(|error| {
-                        if error.is_timeout() {
-                            LlmClientError::Timeout {
-                                source: Box::new(error),
-                            }
-                        } else {
-                            LlmClientError::Transport {
-                                source: Box::new(error),
-                            }
-                        }
-                    })
+                    chunk
+                        .map(|bytes| bytes.to_vec())
+                        .map_err(convert_reqwest_error)
                 });
                 let mut chunks = decode_stream(bytes, wire_format)?;
                 // Providers reject an over-ceiling streaming request with an in-band
@@ -707,6 +699,7 @@ fn record_gen_ai_request(url: &str, model: &str, streaming: bool) {
 fn convert_reqwest_error(error: reqwest::Error) -> LlmClientError {
     // Reqwest labels truncated or otherwise unreadable response bodies as decode
     // errors, so distinguish them from serde JSON failures at the call site.
+    let error = error.without_url();
     if error.is_timeout() {
         LlmClientError::Timeout {
             source: Box::new(error),
@@ -1045,6 +1038,17 @@ mod tests {
             raw_request: None,
             metadata: None,
         }
+    }
+
+    #[tokio::test]
+    async fn transport_errors_drop_the_upstream_url() {
+        let error = reqwest::Client::new()
+            .post("http://127.0.0.1:1/v1?key=CANARY")
+            .send()
+            .await
+            .expect_err("closed port");
+
+        assert!(!convert_reqwest_error(error).to_string().contains("CANARY"));
     }
 
     #[test]

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -610,7 +610,7 @@ async fn proxy_unmatched(State(state): State<ServerState>, request: HttpRequest)
         }
         Err(error) => error_response(
             StatusCode::BAD_GATEWAY,
-            error.to_string(),
+            error.without_url().to_string(),
             "upstream_error",
             "upstream_error",
         ),

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -1997,6 +1997,60 @@ target = "weak"
 }
 
 #[tokio::test]
+async fn transport_errors_hide_credential_bearing_upstream_urls() -> TestResult {
+    const CANARY: &str = "CANARY_ADMIN_QUERY_KEY";
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let base_url = format!("http://{}/v1?key={CANARY}", listener.local_addr()?);
+    drop(listener);
+
+    let routed = build_switchyard_router(random_state(&base_url, &[(ROUTE_MODEL, &["model/a"])])?);
+    let routed_response = send(
+        &routed,
+        "POST",
+        "/v1/chat/completions",
+        Some(json!({
+            "model": ROUTE_MODEL,
+            "messages": [{"role": "user", "content": "hello"}]
+        })),
+    )
+    .await?;
+
+    let fallback = load_test_config(&format!(
+        r#"
+schema_version = 1
+fallback_client = "upstream"
+
+[llm_clients.upstream]
+format = "openai_chat"
+base_url = "{base_url}"
+
+[targets.model]
+id = "model/a"
+llm_client = "upstream"
+
+[routes.model]
+id = "switchyard/model"
+type = "passthrough"
+target = "model"
+"#
+    ))?;
+    let fallback = build_switchyard_router(fallback);
+    let fallback_response = send(&fallback, "POST", "/unmatched", None).await?;
+
+    for response in [routed_response, fallback_response] {
+        assert_eq!(response.status, StatusCode::BAD_GATEWAY);
+        let body = response.json()?;
+        let message = body["error"]["message"].as_str().unwrap_or_default();
+        assert!(
+            !message.contains(CANARY),
+            "credential leaked in {message:?}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn anthropic_client_forwards_oauth_when_configured() -> TestResult {
     let upstream = MockUpstream::start().await?;
     let state = load_test_config(&format!(


### PR DESCRIPTION
## What

Removes the upstream request URL from transport and timeout errors before they leave `switchyard-llm-client`.

The same conversion now covers buffered requests and streaming body failures. The server's raw fallback proxy applies the same protection because it sends requests without going through `switchyard-llm-client`.

## Why

Fixes [SYGH-64](https://linear.app/nvidia/issue/SYGH-64/bug-transport-502-echoes-base-url-including-key) and closes [#423](https://github.com/NVIDIA-NeMo/Switchyard/issues/423).

A failed upstream request currently returns the full reqwest URL in the client-visible 502. If a deployment uses a Gemini-style `base_url` containing `?key=...`, that response returns the configured key to the caller.

I reproduced this on untouched `main` with a closed local port:

```text
error sending request for url (http://127.0.0.1:1/v1?key=SYGH64_CANARY/chat/completions)
```

After this change, the response keeps the existing status, type, and code without the URL:

```json
{
  "error": {
    "message": "error sending request",
    "type": "upstream_error",
    "code": "upstream_error"
  }
}
```

## Behavior

- `LlmClientError::Transport` and `LlmClientError::Timeout` remain typed errors with their existing sources.
- The attached reqwest error no longer carries the upstream URL.
- HTTP status codes, error codes, retries, and fallback behavior are unchanged.
- No public APIs or dependencies change.

This uses the `reqwest::Error::without_url()` approach from Ryan's draft [#587](https://github.com/NVIDIA-NeMo/Switchyard/pull/587). The original server-side investigation is in [#428](https://github.com/NVIDIA-NeMo/Switchyard/pull/428).

## How tested

- [x] Live local reproduction for OpenAI Chat, streaming Chat, OpenAI Responses, Anthropic Messages, and the raw fallback proxy. Every request returned 502 without the canary.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `uv run ruff check .`
- [x] `uv run mypy switchyard`
- [x] `uv run pytest tests/` — 117 passed
- [x] Commit carries the required DCO sign-off.

## Notes for reviewers

The production change is five added lines across the shared reqwest error conversion and the raw fallback path. The remaining additions are regression coverage for both client-visible 502 paths.
