### PR TITLE
feat(routing): add auto algorithm type

### DIFF
--- a/crates/switchyard-runner/src/algorithm.rs
+++ b/crates/switchyard-runner/src/algorithm.rs
@@ -1012,6 +1012,11 @@ fn build_algorithm(
             subagents,
             ..
         } => {
+            let type_name = if matches!(config, AlgorithmSpec::Auto { .. }) {
+                "auto"
+            } else {
+                "stage_router"
+            };
             let StageTierConfig {
                 capable_target,
                 efficient_target,
@@ -1021,7 +1026,7 @@ fn build_algorithm(
             } = tiers;
             if matches!(picker, PickerMode::CapableFirst) {
                 tracing::warn!(
-                    "stage_router route {route_name} uses picker \"capable_first\", which is experimental: published thresholds and routing results all come from \"efficient_first\", so there is no calibrated confidence_threshold for it and no measured accuracy or cost. Use \"efficient_first\" unless you are running your own calibration."
+                    "{type_name} route {route_name} uses picker \"capable_first\", which is experimental: published thresholds and routing results all come from \"efficient_first\", so there is no calibrated confidence_threshold for it and no measured accuracy or cost. Use \"efficient_first\" unless you are running your own calibration."
                 );
             }
             let capable = resolve_target_model_id(route_name, capable_target, targets)?;
@@ -1044,7 +1049,7 @@ fn build_algorithm(
                 .transpose()?;
             let algorithm = StageRouter::new(capable, efficient, config).map_err(|error| {
                 AlgorithmConfigError::with_source(
-                    format!("stage_router route {route_name}: {error}"),
+                    format!("{type_name} route {route_name}: {error}"),
                     error,
                 )
             })?;

--- a/crates/switchyard-runner/src/algorithm.rs
+++ b/crates/switchyard-runner/src/algorithm.rs
@@ -258,17 +258,15 @@ pub enum AlgorithmSpec {
         #[serde(default)]
         subagents: Option<SubagentRouteConfig>,
     },
-    /// Picks a routing strategy automatically. Currently resolves to the same
-    /// behavior as `stage_router`; change the merged match arms below to
-    /// repoint it at a different algorithm.
+    /// Picks a routing strategy automatically, preset with recommended knobs.
+    /// Currently a `stage_router` with `picker = "efficient_first"` and
+    /// `confidence_threshold = 0.5`; change `build_algorithm`'s `Auto` arm to
+    /// repoint it at a different algorithm or preset.
     Auto {
-        #[serde(flatten)]
-        tiers: StageTierConfig,
-        picker: PickerMode,
-        #[serde(default)]
-        classifier: Option<StageClassifierConfig>,
-        #[serde(default)]
-        subagents: Option<SubagentRouteConfig>,
+        /// The capable tier.
+        capable_target: String,
+        /// The efficient tier.
+        efficient_target: String,
     },
     /// A judge picks the tier at each user turn; a stage router runs the turns within it.
     Composite {
@@ -466,9 +464,6 @@ impl AlgorithmSpec {
             }
             Self::StageRouter {
                 tiers, subagents, ..
-            }
-            | Self::Auto {
-                tiers, subagents, ..
             } => {
                 let mut names = vec![
                     tiers.capable_target.as_str(),
@@ -479,6 +474,10 @@ impl AlgorithmSpec {
                 }
                 names
             }
+            Self::Auto {
+                capable_target,
+                efficient_target,
+            } => vec![capable_target.as_str(), efficient_target.as_str()],
             Self::Composite {
                 stage, subagents, ..
             } => {
@@ -513,11 +512,6 @@ impl AlgorithmSpec {
                 ..
             } => names.extend(subagents.classifier_target_name()),
             Self::StageRouter {
-                classifier,
-                subagents,
-                ..
-            }
-            | Self::Auto {
                 classifier,
                 subagents,
                 ..
@@ -1004,19 +998,7 @@ fn build_algorithm(
             classifier,
             subagents,
             ..
-        }
-        | AlgorithmSpec::Auto {
-            tiers,
-            picker,
-            classifier,
-            subagents,
-            ..
         } => {
-            let type_name = if matches!(config, AlgorithmSpec::Auto { .. }) {
-                "auto"
-            } else {
-                "stage_router"
-            };
             let StageTierConfig {
                 capable_target,
                 efficient_target,
@@ -1026,7 +1008,7 @@ fn build_algorithm(
             } = tiers;
             if matches!(picker, PickerMode::CapableFirst) {
                 tracing::warn!(
-                    "{type_name} route {route_name} uses picker \"capable_first\", which is experimental: published thresholds and routing results all come from \"efficient_first\", so there is no calibrated confidence_threshold for it and no measured accuracy or cost. Use \"efficient_first\" unless you are running your own calibration."
+                    "stage_router route {route_name} uses picker \"capable_first\", which is experimental: published thresholds and routing results all come from \"efficient_first\", so there is no calibrated confidence_threshold for it and no measured accuracy or cost. Use \"efficient_first\" unless you are running your own calibration."
                 );
             }
             let capable = resolve_target_model_id(route_name, capable_target, targets)?;
@@ -1049,12 +1031,27 @@ fn build_algorithm(
                 .transpose()?;
             let algorithm = StageRouter::new(capable, efficient, config).map_err(|error| {
                 AlgorithmConfigError::with_source(
-                    format!("{type_name} route {route_name}: {error}"),
+                    format!("stage_router route {route_name}: {error}"),
                     error,
                 )
             })?;
             let parent: Arc<dyn Algorithm> = Arc::new(algorithm);
             attach_subagent_router(route_name, parent, subagents.as_ref(), targets)
+        }
+        AlgorithmSpec::Auto {
+            capable_target,
+            efficient_target,
+        } => {
+            let capable = resolve_target_model_id(route_name, capable_target, targets)?;
+            let efficient = resolve_target_model_id(route_name, efficient_target, targets)?;
+            let config = StageRouterConfig::new(PickerMode::EfficientFirst, 0.5);
+            let algorithm = StageRouter::new(capable, efficient, config).map_err(|error| {
+                AlgorithmConfigError::with_source(
+                    format!("auto route {route_name}: {error}"),
+                    error,
+                )
+            })?;
+            Ok(Arc::new(algorithm))
         }
         AlgorithmSpec::Composite {
             classifier,

--- a/crates/switchyard-runner/src/algorithm.rs
+++ b/crates/switchyard-runner/src/algorithm.rs
@@ -258,6 +258,18 @@ pub enum AlgorithmSpec {
         #[serde(default)]
         subagents: Option<SubagentRouteConfig>,
     },
+    /// Picks a routing strategy automatically. Currently resolves to the same
+    /// behavior as `stage_router`; change the merged match arms below to
+    /// repoint it at a different algorithm.
+    Auto {
+        #[serde(flatten)]
+        tiers: StageTierConfig,
+        picker: PickerMode,
+        #[serde(default)]
+        classifier: Option<StageClassifierConfig>,
+        #[serde(default)]
+        subagents: Option<SubagentRouteConfig>,
+    },
     /// A judge picks the tier at each user turn; a stage router runs the turns within it.
     Composite {
         /// Judge that picks the tier. Called through its own target.
@@ -454,6 +466,9 @@ impl AlgorithmSpec {
             }
             Self::StageRouter {
                 tiers, subagents, ..
+            }
+            | Self::Auto {
+                tiers, subagents, ..
             } => {
                 let mut names = vec![
                     tiers.capable_target.as_str(),
@@ -498,6 +513,11 @@ impl AlgorithmSpec {
                 ..
             } => names.extend(subagents.classifier_target_name()),
             Self::StageRouter {
+                classifier,
+                subagents,
+                ..
+            }
+            | Self::Auto {
                 classifier,
                 subagents,
                 ..
@@ -553,6 +573,7 @@ impl AlgorithmSpec {
             | Self::Passthrough { .. }
             | Self::LlmClassifier { .. }
             | Self::StageRouter { .. }
+            | Self::Auto { .. }
             | Self::Composite { .. }
             | Self::PrefillRouter { .. } => None,
         }
@@ -978,6 +999,13 @@ fn build_algorithm(
             Ok(Arc::new(algorithm))
         }
         AlgorithmSpec::StageRouter {
+            tiers,
+            picker,
+            classifier,
+            subagents,
+            ..
+        }
+        | AlgorithmSpec::Auto {
             tiers,
             picker,
             classifier,

--- a/crates/switchyard-runner/src/config.rs
+++ b/crates/switchyard-runner/src/config.rs
@@ -983,6 +983,14 @@ confidence_threshold = 0.5
     }
 
     #[test]
+    fn auto_builds_the_same_route_as_stage_router() -> RunnerResult<()> {
+        let config = stage_config().replace("type = \"stage_router\"", "type = \"auto\"");
+        let runner = runner_from_toml(&config)?;
+        assert!(runner.route("switchyard/stage").is_some());
+        Ok(())
+    }
+
+    #[test]
     fn composite_stage_block_rejects_an_unknown_field() {
         let config = composite_config().replace(
             "confidence_threshold = 0.5",

--- a/crates/switchyard-runner/src/config.rs
+++ b/crates/switchyard-runner/src/config.rs
@@ -983,10 +983,18 @@ confidence_threshold = 0.5
     }
 
     #[test]
-    fn auto_builds_the_same_route_as_stage_router() -> RunnerResult<()> {
-        let config = stage_config().replace("type = \"stage_router\"", "type = \"auto\"");
+    fn auto_route_builds_a_stage_router_with_no_extra_fields() -> RunnerResult<()> {
+        let config = format!(
+            r#"{VALID_CONFIG}
+[routes.auto]
+id = "switchyard/auto"
+type = "auto"
+capable_target = "strong"
+efficient_target = "weak"
+"#
+        );
         let runner = runner_from_toml(&config)?;
-        assert!(runner.route("switchyard/stage").is_some());
+        assert!(runner.route("switchyard/auto").is_some());
         Ok(())
     }
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,7 +64,7 @@ Cargo builds the release binary and installs it into `~/.cargo/bin` by default.
 
 The Rust server reads an explicit TOML file.
 
-Create `routes.toml` with an LLM-classifier route:
+Create `routes.toml` with an auto route:
 
 ```toml
 schema_version = 1
@@ -84,12 +84,9 @@ llm_client = "openrouter"
 
 [routes.smart]
 id = "switchyard"
-type = "llm_classifier"
-mode = "capability"
-classifier_target = "weak"
-strong_target = "strong"
-weak_target = "weak"
-base_threshold = 0.5
+type = "auto"
+capable_target = "strong"
+efficient_target = "weak"
 ```
 
 `format` selects the upstream protocol and must be `openai_chat`,
@@ -131,11 +128,12 @@ curl http://localhost:4000/v1/chat/completions \
 
 #### Choose a route type
 
-This guide uses `llm_classifier`, which asks a classifier target whether each
-request should use the weak or strong target. The Rust server also supports:
+This guide uses `auto`, which routes with Switchyard's recommended default
+settings. The Rust server also supports:
 
 | Algorithm | Use it when | Config |
 |---|---|---|
+| Auto | You want a recommended default instead of picking a strategy yourself. | `auto` |
 | [Random](routing_algorithms/random_routing.md) | You need a weighted split for A/B tests or baselines. | `random` |
 | [LLM classifier](routing_algorithms/llm_classifier_routing.md) | Request content should decide whether to use the weak or strong target. | `llm_classifier` |
 | [Stage router](routing_algorithms/stage_router_routing.md) | Tool-result and progress signals should select an efficient or capable target. | `stage_router` |

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -252,6 +252,11 @@ optional `handoff_notes` and `classifier` tables and for tuning.
 | `classifier.response_format_type` | No | `json_schema` | Structured-output mode for the optional classifier judge. Use `json_object` when the classifier provider does not support JSON Schema; Switchyard adds the schema to the prompt and validates the verdict locally. |
 | `subagents` | No | unset | Nested `passthrough` or custom `llm_classifier` policy used only for delegated sub-agent work. See [Sub-Agent-Aware Routing](../routing_algorithms/subagent_routing.md). |
 
+### `auto`
+
+Picks a routing strategy automatically. Currently resolves to `stage_router`
+and takes the same fields; the resolution may change in a future release.
+
 ### `composite`
 
 Composes other algorithms, letting one set another's

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -255,9 +255,17 @@ optional `handoff_notes` and `classifier` tables and for tuning.
 ### `auto`
 
 Uses Switchyard's recommended default routing strategy instead of one you pick
-yourself. See [Stage-Router Routing](../routing_algorithms/stage_router_routing.md)
-for a deeper dive on the current default, or the [strategy table](../routing_algorithms/overview.md#choose-a-strategy)
-to pick one manually.
+yourself: a `stage_router` preset with `picker = "efficient_first"` and
+`confidence_threshold = 0.5`, no classifier. See
+[Stage-Router Routing](../routing_algorithms/stage_router_routing.md) for a
+deeper dive on the current default, or the
+[strategy table](../routing_algorithms/overview.md#choose-a-strategy) to pick
+one manually.
+
+| Key | Required | Default | Meaning |
+|---|:---:|---|---|
+| `capable_target` | Yes | — | Capable tier. |
+| `efficient_target` | Yes | — | Efficient tier. |
 
 ### `composite`
 

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -254,8 +254,10 @@ optional `handoff_notes` and `classifier` tables and for tuning.
 
 ### `auto`
 
-Picks a routing strategy automatically. Currently resolves to `stage_router`
-and takes the same fields; the resolution may change in a future release.
+Uses Switchyard's recommended default routing strategy instead of one you pick
+yourself. See [Stage-Router Routing](../routing_algorithms/stage_router_routing.md)
+for a deeper dive on the current default, or the [strategy table](../routing_algorithms/overview.md#choose-a-strategy)
+to pick one manually.
 
 ### `composite`
 

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -16,6 +16,7 @@ configuration and tuning. For the vocabulary these pages use, see
 | [Random Routing](random_routing.md) | You need a fixed traffic split for A/B tests, baselines, or cost experiments. | `random` |
 | [LLM Classifier Routing](llm_classifier_routing.md) | Request content should decide whether a turn needs the weak or strong tier. | `llm_classifier` |
 | [Stage-Router Routing](stage_router_routing.md) | Tool-result and agent-progress signals should route most turns without an extra classifier call. | `stage_router` |
+| Auto Routing | You don't want to pick a strategy yet. Currently resolves to `stage_router`; the resolution may change. Takes the same fields as `stage_router`. | `auto` |
 | [Composite Routing](composite_routing.md) | Routing algorithms are composed, one setting the configuration of another before handing off. Today an LLM classifier sets a stage router's default tier. | `composite` |
 | [Escalation-Router Routing](escalation_router_routing.md) | Start every task on the weak tier and escalate to strong when an LLM judge detects trouble. | `llm_classifier` with `escalation` |
 | [Advisor-Gate Routing](advisor_gate_routing.md) | One model should serve every turn, with a stronger reviewer approving its "done" claims or sending back a redo plan. | `advisor` |

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -16,7 +16,7 @@ configuration and tuning. For the vocabulary these pages use, see
 | [Random Routing](random_routing.md) | You need a fixed traffic split for A/B tests, baselines, or cost experiments. | `random` |
 | [LLM Classifier Routing](llm_classifier_routing.md) | Request content should decide whether a turn needs the weak or strong tier. | `llm_classifier` |
 | [Stage-Router Routing](stage_router_routing.md) | Tool-result and agent-progress signals should route most turns without an extra classifier call. | `stage_router` |
-| Auto Routing | You don't want to pick a strategy yet. Currently resolves to `stage_router`; the resolution may change. Takes the same fields as `stage_router`. | `auto` |
+| Auto Routing | You want a recommended default instead of picking a strategy yourself. For a deeper dive on the current default, see [Stage-Router Routing](stage_router_routing.md); for full control, pick one of the strategies above instead. | `auto` |
 | [Composite Routing](composite_routing.md) | Routing algorithms are composed, one setting the configuration of another before handing off. Today an LLM classifier sets a stage router's default tier. | `composite` |
 | [Escalation-Router Routing](escalation_router_routing.md) | Start every task on the weak tier and escalate to strong when an LLM judge detects trouble. | `llm_classifier` with `escalation` |
 | [Advisor-Gate Routing](advisor_gate_routing.md) | One model should serve every turn, with a stronger reviewer approving its "done" claims or sending back a redo plan. | `advisor` |


### PR DESCRIPTION
Adds: a new `auto` algorithm type. Instead of picking a routing strategy just provide a `capable` and `efficient` model. Recommended settings are used out of the box.

Why: today setup requires a user to pick a strategy and fill in different thresholds people may not have an informed opinion about. This provides a simplified config that "just works".

Notes: 
- Resolves to stage router today but can be altered in future
- Designed so we can point auto at a new strategy or different defaults in future
- Also updated getting started guide to use auto