### PR TITLE
feat(routing): add ensemble response synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Most use an LLM as a judge. All of them pick between an **efficient** model and 
 | **[Advisor Gate](docs/routing_algorithms/advisor_gate_routing.md)** | One model serves every turn; a stronger advisor approves its plans and "done" claims, or sends it back. | `advisor` | lifts a weak executor 43.8% → 54.7% |
 | **[Sub-Agent-Aware](docs/routing_algorithms/subagent_routing.md)** | Delegated sub-agent traffic routes separately from the parent agent. | `subagents` on `passthrough` or `stage_router` | not yet benchmarked |
 | **[Custom](docs/routing_algorithms/llm_classifier_routing.md#custom-multi-target-routing)** | The first request is judged by an LLM against criteria you define, routing among 2+ of your own models. | `llm_classifier` + `target_selector` policy | not yet benchmarked |
+| **[Ensemble](docs/routing_algorithms/ensemble_routing.md)** | Several models answer concurrently; a synthesizer combines their responses. | `ensemble` | not yet benchmarked |
 | **[Random](docs/routing_algorithms/random_routing.md)** | Each request is routed at random, uniform or weighted. | `random` | baseline mechanism |
 
 Benchmarks are Terminal-Bench 2.1 against a $98.06 Opus 4.8 baseline at 76.0%.

--- a/benchmark/ensemble-inference-api-evidence.md
+++ b/benchmark/ensemble-inference-api-evidence.md
@@ -8,7 +8,7 @@ production endpoints and records the behavior that informed the initial defaults
 
 ## Setup
 
-- API: NVIDIA Inference API through OpenAI Responses format
+- API: OpenAI Responses through an authenticated model gateway (endpoint omitted)
 - Baseline: `azure/openai/gpt-6-astra`
 - Ensemble candidates: `azure/openai/gpt-5.6-sol` and
   `azure/anthropic/claude-opus-5`

--- a/benchmark/ensemble-inference-api-evidence.md
+++ b/benchmark/ensemble-inference-api-evidence.md
@@ -1,0 +1,146 @@
+# Ensemble exploratory evidence: SOL + Opus versus Astra
+
+Date: 2026-09-09
+
+This is a small live smoke comparison, not a statistically meaningful benchmark.
+It verifies that response-level ensemble routing works against heterogeneous
+production endpoints and records the behavior that informed the initial defaults.
+
+## Setup
+
+- API: NVIDIA Inference API through OpenAI Responses format
+- Baseline: `azure/openai/gpt-6-astra`
+- Ensemble candidates: `azure/openai/gpt-5.6-sol` and
+  `azure/anthropic/claude-opus-5`
+- Ensemble synthesizer: `azure/openai/gpt-5.6-sol`
+- Candidate cap: 2,048 output tokens
+- Required usable candidates: 2
+- Final cap: 1,024 output tokens
+- Reproduction config:
+  [`server-configs/inference-api-ensemble-sol-opus-vs-astra.toml`](server-configs/inference-api-ensemble-sol-opus-vs-astra.toml)
+
+Each comparison sent the same prompt to the `fusion` route first and the `astra`
+route second. Network load, backend load, model sampling, and cold starts were not
+controlled. Wall time was measured at the local HTTP client.
+
+## Initial smoke results
+
+| Case | Route | Status | Wall time | Visible words | Terminal response tokens |
+|---|---|:---:|---:|---:|---:|
+| First-success design | SOL + Opus → SOL | complete | 29.89 s | 209 | 612 |
+| First-success design | Astra | complete | 56.15 s | 214 | 945 |
+| Broken fan-out review | SOL + Opus → SOL | complete | 46.29 s | 201 | 740 |
+| Broken fan-out review | Astra | complete | 185.28 s | 209 | 925 |
+
+Both ensemble requests completed with `minimum_successful_candidates = 2`, so
+SOL and Opus each contributed usable output before synthesis. This prevents the
+comparison from silently degrading into a single-model answer. In these two
+uncontrolled observations, fusion was about 1.9x and 4.0x faster than Astra.
+
+### Quality assessment
+
+Both routes passed the same manual checklist: complete response, requested word
+limit, correct completion-order concurrency, loser cancellation without detached
+work, useful all-failed error handling, and implementation-level pseudocode. The
+fusion review explicitly caught insertion-order waiting, detached `JoinHandle`s,
+discarded backend and join errors, and showed `JoinSet::shutdown().await` to abort
+and join losers. Astra was also technically strong. These two samples support
+comparable quality with lower observed latency, not a claim that fusion is more
+capable than Astra. A quality-superiority claim needs a larger blinded rubric or
+task benchmark.
+
+## Expanded blinded quality comparison
+
+A follow-up comparison used six checkable cases spanning Rust concurrency,
+Python debugging, Bayesian arithmetic, Boolean logic, strict JSON formatting,
+and transactional-outbox design. For each case, the `fusion` and `astra` requests
+started together. Their answers were assigned alternating anonymous A/B labels
+and judged by `azure/openai/gpt-5.6-terra`, which was neither the baseline nor an
+ensemble candidate. The judge scored correctness, completeness, instruction
+following, and clarity from 1–5 against a case-specific rubric. Deterministic
+checks such as word counts and exact JSON took precedence over the model judge.
+
+| Case | Fusion time | Astra time | Fusion score | Astra score | Blind result |
+|---|---:|---:|---:|---:|:---:|
+| Tokio first-success review | 33.27 s | 125.30 s | 20/20 | 20/20 | tie |
+| Python LRU debugging | 12.46 s | 16.49 s | 20/20 | 20/20 | tie |
+| Two-test Bayesian posterior | 10.66 s | 10.27 s | 20/20 | 20/20 | tie |
+| Boolean truth-value derivation | 10.33 s | 19.85 s | 20/20 | 20/20 | tie |
+| Exact JSON sorting | 6.10 s | 3.72 s | 20/20 | 20/20 | tie |
+| Transactional outbox | 28.13 s | 46.92 s | 20/20 | 20/20 | tie |
+| **Arithmetic mean** | **16.83 s** | **37.09 s** | **20/20** | **20/20** | **6 ties** |
+| **Median** | **11.56 s** | **18.17 s** | — | — | — |
+
+Fusion was faster in four of six cases. Astra was slightly faster on the short
+Bayes calculation and the trivial exact-JSON transform, where three ensemble
+calls offer little benefit. All twelve final answers completed successfully.
+
+The quality pass exposed a defect that the judge missed: the first fusion outbox
+answer contained 224 whitespace-delimited words against a 220-word maximum.
+The default synthesis instruction was hardened to leave a safety margin below
+hard limits. Its rerun contained 219 words, preserved every rubric requirement,
+and again received a blind 20/20 tie. This corrected rerun is the row reported
+above.
+
+This remains an exploratory six-case comparison with one automated judge, not a
+statistically powered capability benchmark. It supports comparable quality on
+these cases and shows where ensemble overhead is wasteful; it does not establish
+general superiority over Astra. A release claim should use a larger randomized
+task set, multiple independent judges, repeated samples, and end-to-end cost
+accounting.
+
+The first-success answers covered concurrent polling, first observed success,
+loser cancellation, typed all-failed errors, structured task lifetime, replayable
+bodies, timeout policy, and simultaneous completions. The code-review answers
+both identified insertion-order waiting and detached Tokio tasks. The ensemble
+answer additionally showed `JoinSet::abort_all` followed by draining every task;
+the Astra answer used owned futures and explained that dropping local work cannot
+cancel remote side effects.
+
+`Terminal response tokens` is the usage returned for the final visible response.
+It excludes the two candidate calls, so it must not be used as an ensemble cost
+comparison. The ensemble makes three calls per request and should be assumed more
+expensive than the one-call Astra baseline until end-to-end candidate usage is
+captured.
+
+## Prompt 1: first-success design
+
+> In at most 220 words, explain how a Rust/Tokio gateway should send the same
+> request to three backends concurrently and return the first successful
+> response. Include concise implementation-level pseudocode. It must cancel
+> losing calls, preserve a useful typed error if every backend fails, and never
+> leave detached tasks. End with a short list of the key concurrency invariants
+> and edge cases. The answer must be complete and stay under 220 words.
+
+## Prompt 2: broken fan-out review
+
+> In at most 220 words, review this Rust/Tokio pseudocode against the requirement
+> “return the first successful backend response and cancel all losers without
+> detached work.” Identify the important correctness and lifecycle bugs, then
+> show a corrected pattern. The answer must be complete.
+
+The reviewed function spawned one task per backend, stored the handles in a
+vector, awaited them in insertion order, returned on the first successful await,
+and otherwise returned an untyped `AllFailed` error.
+
+## Hardening evidence
+
+An earlier configuration used Opus 5 as synthesizer and forwarded uncapped
+candidate outputs including reasoning. On the first-success prompt it repeatedly
+exhausted the 1,024-token cap and returned an incomplete or empty visible answer.
+Using SOL as synthesizer worked, and the implementation was then hardened to:
+
+- buffer internal candidate calls;
+- budget candidate output independently from the final response;
+- remove reasoning blocks before synthesis;
+- optionally require more than one usable candidate before synthesis;
+- leave margin below caller-specified hard length limits;
+- require concise, complete synthesis by default while allowing prompt override;
+- preserve the caller's final streaming and output settings.
+
+The relevant unit tests verify concurrent fan-out, partial candidate failure,
+all-candidate failure, candidate caps, reasoning removal, exact-replay
+invalidation, and configuration validation. A server integration test sends an
+ensemble request through the public OpenAI-compatible endpoint and verifies both
+candidate calls, independent candidate budgets, both drafts in the synthesis
+request, the final caller budget, and the synthesized response.

--- a/benchmark/server-configs/inference-api-ensemble-sol-opus-vs-astra.toml
+++ b/benchmark/server-configs/inference-api-ensemble-sol-opus-vs-astra.toml
@@ -1,0 +1,32 @@
+schema_version = 1
+
+[llm_clients.inference]
+format = "openai_responses"
+base_url = "https://inference-api.nvidia.com/v1"
+api_key_env = "NVIDIA_API_KEY"
+max_retries = 0
+
+[targets.sol]
+id = "azure/openai/gpt-5.6-sol"
+llm_client = "inference"
+
+[targets.opus]
+id = "azure/anthropic/claude-opus-5"
+llm_client = "inference"
+
+[targets.astra]
+id = "azure/openai/gpt-6-astra"
+llm_client = "inference"
+
+[routes.astra]
+id = "astra"
+type = "passthrough"
+target = "astra"
+
+[routes.fusion]
+id = "fusion"
+type = "ensemble"
+candidates = ["sol", "opus"]
+synthesizer_target = "sol"
+minimum_successful_candidates = 2
+candidate_max_output_tokens = 2048

--- a/benchmark/server-configs/inference-api-ensemble-sol-opus-vs-astra.toml
+++ b/benchmark/server-configs/inference-api-ensemble-sol-opus-vs-astra.toml
@@ -2,7 +2,7 @@ schema_version = 1
 
 [llm_clients.inference]
 format = "openai_responses"
-base_url = "https://inference-api.nvidia.com/v1"
+base_url = "https://api.example.com/v1" # Replace with your OpenAI-compatible gateway.
 api_key_env = "NVIDIA_API_KEY"
 max_retries = 0
 

--- a/crates/libsy/README.md
+++ b/crates/libsy/README.md
@@ -23,6 +23,7 @@ tokio = { version = "1", features = ["macros", "rt"] }
 |---|---|
 | [`Passthrough`] | Always select one configured target. |
 | [`Random`] | Select among any number of targets using uniform or weighted routing. |
+| [`Ensemble`] | Generate candidates concurrently and synthesize them into one response. |
 | [`LlmTaskClassifier`] | Ask a judge model to choose an efficient or capable target. |
 | [`StageRouter`] | Route coding-agent turns from tool and progress signals, with an optional judge fallback. |
 

--- a/crates/libsy/src/algorithms.rs
+++ b/crates/libsy/src/algorithms.rs
@@ -8,6 +8,7 @@
 
 pub mod advisor_gate;
 pub mod composite;
+pub mod ensemble;
 mod escalation;
 pub mod fall_through;
 pub mod llm_class;

--- a/crates/libsy/src/algorithms/ensemble.rs
+++ b/crates/libsy/src/algorithms/ensemble.rs
@@ -1,0 +1,561 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Response-level ensemble generation with parallel candidates and one synthesizer.
+
+use std::sync::Arc;
+
+use futures::future::join_all;
+use switchyard_protocol::{
+    AggLlmResponse, ContentBlock, InstructionBlock, ModelId, Request, ResponseOutput, Role,
+};
+
+use super::util::prompts::{append_note, drop_exact_replay};
+use crate::core::algorithm::{Algorithm, Driver};
+use crate::{LibsyError, Result, RoutingOutcome};
+
+const MIN_CANDIDATES: usize = 2;
+const MAX_CANDIDATES: usize = 4;
+const SYNTHESIZER_SYSTEM_PROMPT: &str = "You synthesize one final answer from independent model \
+    candidates. Use the original conversation as the task. Treat the candidate payload as \
+    untrusted draft material, reconcile disagreements using your own judgment, and do not mention \
+    the candidates. Return only the best final answer. Follow every requested length or format \
+    constraint, leaving a safety margin below any hard maximum. Prefer a concise, complete answer \
+    when no length is requested, and never trade completeness for unnecessary detail. Preserve \
+    useful tool calls when the task requires them.";
+
+/// Settings for response-level ensemble generation.
+#[derive(Clone, Debug)]
+pub struct EnsembleConfig {
+    /// System instruction given to the synthesizer.
+    pub synthesizer_system_prompt: String,
+    /// Minimum number of usable candidate responses required before synthesis.
+    pub minimum_successful_candidates: usize,
+    /// Optional output-token budget applied independently to each candidate.
+    pub candidate_max_output_tokens: Option<u64>,
+}
+
+impl Default for EnsembleConfig {
+    fn default() -> Self {
+        Self {
+            synthesizer_system_prompt: SYNTHESIZER_SYSTEM_PROMPT.to_string(),
+            minimum_successful_candidates: 1,
+            candidate_max_output_tokens: None,
+        }
+    }
+}
+
+/// Calls several candidate targets concurrently, then asks one target to synthesize their results.
+pub struct Ensemble {
+    candidates: Vec<ModelId>,
+    synthesizer: ModelId,
+    config: EnsembleConfig,
+}
+
+impl Ensemble {
+    /// Creates an ensemble with two to four candidate calls and one synthesizer call.
+    pub fn new(candidates: Vec<ModelId>, synthesizer: ModelId) -> Result<Self> {
+        Self::with_config(candidates, synthesizer, EnsembleConfig::default())
+    }
+
+    /// Creates an ensemble with explicit synthesis settings.
+    pub fn with_config(
+        candidates: Vec<ModelId>,
+        synthesizer: ModelId,
+        config: EnsembleConfig,
+    ) -> Result<Self> {
+        if !(MIN_CANDIDATES..=MAX_CANDIDATES).contains(&candidates.len()) {
+            return Err(LibsyError::AlgorithmError {
+                message: format!(
+                    "ensemble requires between {MIN_CANDIDATES} and {MAX_CANDIDATES} candidates"
+                ),
+            });
+        }
+        if config.synthesizer_system_prompt.trim().is_empty() {
+            return Err(LibsyError::AlgorithmError {
+                message: "ensemble synthesizer system prompt must not be empty".to_string(),
+            });
+        }
+        if config.candidate_max_output_tokens == Some(0) {
+            return Err(LibsyError::AlgorithmError {
+                message: "ensemble candidate_max_output_tokens must be greater than zero"
+                    .to_string(),
+            });
+        }
+        if !(1..=candidates.len()).contains(&config.minimum_successful_candidates) {
+            return Err(LibsyError::AlgorithmError {
+                message: format!(
+                    "ensemble minimum_successful_candidates must be between 1 and {}",
+                    candidates.len()
+                ),
+            });
+        }
+        Ok(Self {
+            candidates,
+            synthesizer,
+            config,
+        })
+    }
+
+    fn candidate_request(&self, mut request: Request) -> Request {
+        request.raw_request = None;
+        request.llm_request.stream = false;
+        if let Some(cap) = self.config.candidate_max_output_tokens {
+            request.llm_request.output.max_output_tokens = Some(cap);
+        }
+        drop_exact_replay(&mut request);
+        request
+    }
+
+    fn useful_outputs(response: &AggLlmResponse) -> Vec<ResponseOutput> {
+        response
+            .outputs
+            .iter()
+            .filter_map(|output| {
+                let content = output
+                    .content
+                    .iter()
+                    .filter(|block| match block {
+                        ContentBlock::Reasoning { .. } => false,
+                        ContentBlock::Text { text } | ContentBlock::Refusal { text } => {
+                            !text.trim().is_empty()
+                        }
+                        _ => true,
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                (!content.is_empty()).then(|| ResponseOutput {
+                    role: output.role,
+                    content,
+                    stop_reason: output.stop_reason,
+                })
+            })
+            .collect()
+    }
+
+    fn synthesis_request(
+        &self,
+        mut request: Request,
+        candidates: &[(ModelId, AggLlmResponse)],
+    ) -> Result<Request> {
+        let payload = candidates
+            .iter()
+            .filter_map(|(model, response)| {
+                let outputs = Self::useful_outputs(response);
+                if outputs.is_empty() {
+                    tracing::warn!(candidate = %model, "ensemble candidate had no usable output");
+                    return None;
+                }
+                Some(serde_json::json!({
+                    "model": model.as_str(),
+                    "outputs": outputs,
+                }))
+            })
+            .collect::<Vec<_>>();
+        if payload.len() < self.config.minimum_successful_candidates {
+            return Err(LibsyError::AlgorithmError {
+                message: format!(
+                    "ensemble requires {} usable candidate responses but received {}",
+                    self.config.minimum_successful_candidates,
+                    payload.len()
+                ),
+            });
+        }
+        let payload = serde_json::to_string(&payload)
+            .map_err(|error| LibsyError::external("serializing ensemble candidates", error))?;
+
+        request.raw_request = None;
+        request.llm_request.instructions.insert(
+            0,
+            InstructionBlock {
+                role: Role::System,
+                content: vec![ContentBlock::Text {
+                    text: self.config.synthesizer_system_prompt.clone(),
+                }],
+            },
+        );
+        append_note(
+            &mut request,
+            &format!("\n\n<ensemble_candidates>{payload}</ensemble_candidates>"),
+        );
+        Ok(request)
+    }
+}
+
+#[async_trait::async_trait]
+impl Algorithm for Ensemble {
+    fn name(&self) -> &str {
+        "ensemble"
+    }
+
+    async fn route(self: Arc<Self>, driver: Driver, request: Request) -> Result<RoutingOutcome> {
+        let calls = self.candidates.iter().cloned().map(|target| {
+            let driver = driver.clone();
+            let request = self.candidate_request(request.clone());
+            async move {
+                let result = async {
+                    let response = driver.call_model(request, vec![target.clone()]).await?;
+                    response
+                        .llm_response
+                        .into_agg()
+                        .await
+                        .map_err(|source| LibsyError::client_call(target.clone(), source))
+                }
+                .await;
+                (target, result)
+            }
+        });
+
+        let mut successful = Vec::with_capacity(self.candidates.len());
+        let mut first_error = None;
+        for (target, result) in join_all(calls).await {
+            match result {
+                Ok(response) => successful.push((target, response)),
+                Err(error) => {
+                    tracing::warn!(candidate = %target, "ensemble candidate failed");
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                }
+            }
+        }
+        if successful.is_empty() {
+            return match first_error {
+                Some(error) => Err(error),
+                None => Err(LibsyError::AlgorithmError {
+                    message: "ensemble produced no candidate results".to_string(),
+                }),
+            };
+        }
+
+        let synthesis_request = self.synthesis_request(request, &successful)?;
+        let response = driver
+            .call_model(synthesis_request.clone(), vec![self.synthesizer.clone()])
+            .await?;
+        Ok(RoutingOutcome::answered(
+            self.synthesizer.clone(),
+            synthesis_request,
+            response,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::Mutex;
+    use switchyard_protocol::{
+        ContentBlock, LlmClientError, LlmResponse, ModelId, Request, Response, completion_text,
+        text_request, text_response,
+    };
+    use tokio::sync::Barrier;
+    use tokio::time::{Duration, timeout};
+
+    use super::{Ensemble, EnsembleConfig};
+    use crate::core::algorithm::Algorithm;
+    use crate::core::testing::{reply, test_drive};
+
+    fn request() -> Request {
+        let mut llm_request = text_request(Some("ensemble-route".to_string()), "solve this");
+        llm_request.preservation.requests.insert(
+            "openai_chat".into(),
+            serde_json::json!({"model": "ensemble-route", "messages": []}),
+        );
+        Request {
+            llm_request,
+            raw_request: Some(serde_json::json!({"model": "ensemble-route"})),
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn fans_out_candidates_and_returns_the_synthesis() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::new(
+            vec![ModelId::from("candidate-a"), ModelId::from("candidate-b")],
+            ModelId::from("synthesizer"),
+        )?);
+        let synthesizer_request = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&synthesizer_request);
+
+        let (selected, response) = test_drive(
+            algorithm,
+            request(),
+            move |target: ModelId, request: Request| {
+                let captured = Arc::clone(&captured);
+                async move {
+                    match target.as_str() {
+                        "candidate-a" => Ok(reply("draft A")),
+                        "candidate-b" => Ok(reply("draft B")),
+                        "synthesizer" => {
+                            *captured.lock() = Some(request);
+                            Ok(reply("fused answer"))
+                        }
+                        other => Err(LlmClientError::General(format!(
+                            "unexpected target {other}"
+                        ))),
+                    }
+                }
+            },
+        )
+        .await?;
+
+        assert_eq!(selected, "synthesizer");
+        assert_eq!(
+            response.llm_response.as_agg().map(completion_text),
+            Some("fused answer".to_string())
+        );
+        let synthesis = synthesizer_request.lock().clone().ok_or_else(|| {
+            crate::LibsyError::AlgorithmError {
+                message: "synthesizer was not called".to_string(),
+            }
+        })?;
+        let prompt = synthesis
+            .llm_request
+            .messages
+            .last()
+            .and_then(|message| message.text_content(""))
+            .unwrap_or_default();
+        assert!(prompt.contains("draft A"));
+        assert!(prompt.contains("draft B"));
+        assert!(synthesis.raw_request.is_none());
+        assert!(synthesis.llm_request.preservation.requests.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn candidate_calls_run_concurrently() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::new(
+            vec![ModelId::from("candidate-a"), ModelId::from("candidate-b")],
+            ModelId::from("synthesizer"),
+        )?);
+        let barrier = Arc::new(Barrier::new(2));
+        let served = Arc::clone(&barrier);
+
+        let run = test_drive(
+            algorithm,
+            request(),
+            move |target: ModelId, _request: Request| {
+                let served = Arc::clone(&served);
+                async move {
+                    if target != "synthesizer" {
+                        served.wait().await;
+                    }
+                    Ok(reply(target.to_string()))
+                }
+            },
+        );
+        let result = timeout(Duration::from_secs(1), run)
+            .await
+            .map_err(|error| crate::LibsyError::external("waiting for candidate fan-out", error))?;
+        result?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn candidate_calls_are_buffered_capped_and_hide_reasoning() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::with_config(
+            vec![ModelId::from("candidate-a"), ModelId::from("candidate-b")],
+            ModelId::from("synthesizer"),
+            EnsembleConfig {
+                candidate_max_output_tokens: Some(64),
+                ..EnsembleConfig::default()
+            },
+        )?);
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let requests = Arc::clone(&captured);
+        let mut input = request();
+        input.llm_request.stream = true;
+        input.llm_request.output.max_output_tokens = Some(32);
+
+        test_drive(
+            algorithm,
+            input,
+            move |target: ModelId, request: Request| {
+                let requests = Arc::clone(&requests);
+                async move {
+                    requests.lock().push((target.clone(), request));
+                    if target == "candidate-a" {
+                        let mut response = text_response(None, "visible draft");
+                        response.outputs[0].content.insert(
+                            0,
+                            ContentBlock::Reasoning {
+                                text: "private chain of thought".to_string(),
+                                signature: None,
+                                details: Vec::new(),
+                            },
+                        );
+                        Ok(Response {
+                            llm_response: LlmResponse::Agg(response),
+                            metadata: None,
+                        })
+                    } else {
+                        Ok(reply(target.to_string()))
+                    }
+                }
+            },
+        )
+        .await?;
+
+        let requests = captured.lock();
+        let candidates = requests
+            .iter()
+            .filter(|(target, _)| target != "synthesizer")
+            .collect::<Vec<_>>();
+        assert_eq!(candidates.len(), 2);
+        for (_, request) in candidates {
+            assert!(!request.llm_request.stream);
+            assert_eq!(request.llm_request.output.max_output_tokens, Some(64));
+            assert!(request.raw_request.is_none());
+            assert!(request.llm_request.preservation.requests.is_empty());
+        }
+        let synthesis = requests
+            .iter()
+            .find(|(target, _)| target == "synthesizer")
+            .map(|(_, request)| request)
+            .ok_or_else(|| crate::LibsyError::AlgorithmError {
+                message: "synthesizer was not called".to_string(),
+            })?;
+        let prompt = synthesis
+            .llm_request
+            .messages
+            .last()
+            .and_then(|message| message.text_content(""))
+            .unwrap_or_default();
+        assert!(prompt.contains("visible draft"));
+        assert!(!prompt.contains("private chain of thought"));
+        assert!(synthesis.llm_request.stream);
+        assert_eq!(synthesis.llm_request.output.max_output_tokens, Some(32));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn continues_when_one_candidate_fails() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::new(
+            vec![ModelId::from("failed"), ModelId::from("successful")],
+            ModelId::from("synthesizer"),
+        )?);
+
+        let (_, response) = test_drive(
+            algorithm,
+            request(),
+            |target: ModelId, _request: Request| async move {
+                match target.as_str() {
+                    "failed" => Err(LlmClientError::General("candidate failed".to_string())),
+                    "successful" => Ok(reply("only draft")),
+                    "synthesizer" => Ok(reply("recovered synthesis")),
+                    other => Err(LlmClientError::General(format!(
+                        "unexpected target {other}"
+                    ))),
+                }
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            response.llm_response.as_agg().map(completion_text),
+            Some("recovered synthesis".to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn can_require_every_candidate_to_produce_usable_output() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::with_config(
+            vec![ModelId::from("empty"), ModelId::from("successful")],
+            ModelId::from("synthesizer"),
+            EnsembleConfig {
+                minimum_successful_candidates: 2,
+                ..EnsembleConfig::default()
+            },
+        )?);
+
+        let error = match test_drive(
+            algorithm,
+            request(),
+            |target: ModelId, _request: Request| async move {
+                if target == "empty" {
+                    Ok(reply(""))
+                } else {
+                    Ok(reply("usable draft"))
+                }
+            },
+        )
+        .await
+        {
+            Ok(_) => panic!("an ensemble below its success threshold must fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("requires 2 usable"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fails_when_every_candidate_fails() -> crate::Result<()> {
+        let algorithm: Arc<dyn Algorithm> = Arc::new(Ensemble::new(
+            vec![ModelId::from("failed-a"), ModelId::from("failed-b")],
+            ModelId::from("synthesizer"),
+        )?);
+
+        let error = match test_drive(
+            algorithm,
+            request(),
+            |_target: ModelId, _request: Request| async move {
+                Err(LlmClientError::General("candidate failed".to_string()))
+            },
+        )
+        .await
+        {
+            Ok(_) => panic!("an ensemble without candidates must fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("failed-a"));
+        Ok(())
+    }
+
+    #[test]
+    fn requires_two_to_four_candidates() {
+        for count in [0, 1, 5] {
+            let candidates = (0..count)
+                .map(|index| ModelId::from(format!("candidate-{index}")))
+                .collect();
+            assert!(Ensemble::new(candidates, ModelId::from("synthesizer")).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_configuration() {
+        let candidates = || vec![ModelId::from("candidate-a"), ModelId::from("candidate-b")];
+        let invalid_prompt = EnsembleConfig {
+            synthesizer_system_prompt: "  ".to_string(),
+            ..EnsembleConfig::default()
+        };
+        assert!(
+            Ensemble::with_config(candidates(), ModelId::from("synthesizer"), invalid_prompt)
+                .is_err()
+        );
+
+        let zero_cap = EnsembleConfig {
+            candidate_max_output_tokens: Some(0),
+            ..EnsembleConfig::default()
+        };
+        assert!(
+            Ensemble::with_config(candidates(), ModelId::from("synthesizer"), zero_cap).is_err()
+        );
+
+        let excessive_minimum = EnsembleConfig {
+            minimum_successful_candidates: 3,
+            ..EnsembleConfig::default()
+        };
+        assert!(
+            Ensemble::with_config(
+                candidates(),
+                ModelId::from("synthesizer"),
+                excessive_minimum
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/libsy/src/lib.rs
+++ b/crates/libsy/src/lib.rs
@@ -17,6 +17,7 @@ pub use error::{DriverError, LibsyError, Result};
 mod algorithms;
 pub use algorithms::advisor_gate::{AdvisorGate, AdvisorGateConfig, GateTrigger};
 pub use algorithms::composite::{CompositeRouter, CompositeRouterConfig};
+pub use algorithms::ensemble::{Ensemble, EnsembleConfig};
 pub use algorithms::llm_class::{
     CustomClassifierConfig, CustomClassifierPolicy, LlmClassifierConfig, LlmTaskClassifier,
     TaskClassifierConfig,

--- a/crates/switchyard-runner/src/algorithm.rs
+++ b/crates/switchyard-runner/src/algorithm.rs
@@ -12,9 +12,10 @@ use std::sync::Arc;
 use libsy::{
     AdvisorGate, AdvisorGateConfig, Algorithm, ClassifierContractConfig, ClassifierResponseFormat,
     ClassifyTrigger, CompositeRouter, CompositeRouterConfig, CustomClassifierConfig,
-    CustomClassifierPolicy, EscalationJudgeConfig, GateTrigger, HandoffNoteConfig,
-    LlmClassifierConfig, LlmFallback, LlmTaskClassifier, Noop, Passthrough, PickerMode, Random,
-    StageRouter, StageRouterConfig, SubagentRouter, SubagentRouterConfig, TaskClassifierConfig,
+    CustomClassifierPolicy, Ensemble, EnsembleConfig, EscalationJudgeConfig, GateTrigger,
+    HandoffNoteConfig, LlmClassifierConfig, LlmFallback, LlmTaskClassifier, Noop, Passthrough,
+    PickerMode, Random, StageRouter, StageRouterConfig, SubagentRouter, SubagentRouterConfig,
+    TaskClassifierConfig,
 };
 use serde::Deserialize;
 use switchyard_protocol::ModelId;
@@ -268,6 +269,22 @@ pub enum AlgorithmSpec {
         #[serde(default)]
         subagents: Option<SubagentRouteConfig>,
     },
+    /// Generates independent candidate answers and synthesizes them into one response.
+    Ensemble {
+        /// Targets called concurrently to produce candidate answers.
+        candidates: Vec<String>,
+        /// Target that synthesizes the successful candidate answers.
+        synthesizer_target: String,
+        /// Replaces the built-in synthesis instruction.
+        #[serde(default)]
+        synthesizer_system_prompt: Option<String>,
+        /// Minimum number of usable candidate responses required before synthesis.
+        #[serde(default = "default_minimum_successful_candidates")]
+        minimum_successful_candidates: usize,
+        /// Optional output-token cap for each candidate call.
+        #[serde(default)]
+        candidate_max_output_tokens: Option<u64>,
+    },
     /// Serves every turn from one target, and has a second model review some of
     /// those turns before the caller sees them.
     Advisor {
@@ -476,6 +493,15 @@ impl AlgorithmSpec {
                 }
                 names
             }
+            Self::Ensemble {
+                candidates,
+                synthesizer_target,
+                ..
+            } => candidates
+                .iter()
+                .map(String::as_str)
+                .chain(std::iter::once(synthesizer_target.as_str()))
+                .collect(),
             // The advisor is judge-only: reviews go through its own client,
             // so it is not a completion (or count_tokens) destination.
             Self::Advisor {
@@ -550,6 +576,7 @@ impl AlgorithmSpec {
             } => Some((executor_target, advisor_target)),
             Self::Noop { .. }
             | Self::Random { .. }
+            | Self::Ensemble { .. }
             | Self::Passthrough { .. }
             | Self::LlmClassifier { .. }
             | Self::StageRouter { .. }
@@ -1049,6 +1076,31 @@ fn build_algorithm(
             let parent: Arc<dyn Algorithm> = Arc::new(algorithm);
             attach_subagent_router(route_name, parent, subagents.as_ref(), targets)
         }
+        AlgorithmSpec::Ensemble {
+            candidates,
+            synthesizer_target,
+            synthesizer_system_prompt,
+            minimum_successful_candidates,
+            candidate_max_output_tokens,
+        } => {
+            let candidates =
+                resolve_targets(route_name, candidates.iter().map(String::as_str), targets)?;
+            let synthesizer = resolve_target_model_id(route_name, synthesizer_target, targets)?;
+            let mut config = EnsembleConfig::default();
+            if let Some(prompt) = synthesizer_system_prompt {
+                config.synthesizer_system_prompt = prompt.clone();
+            }
+            config.minimum_successful_candidates = *minimum_successful_candidates;
+            config.candidate_max_output_tokens = *candidate_max_output_tokens;
+            let algorithm =
+                Ensemble::with_config(candidates, synthesizer, config).map_err(|error| {
+                    AlgorithmConfigError::with_source(
+                        format!("ensemble route {route_name}: {error}"),
+                        error,
+                    )
+                })?;
+            Ok(Arc::new(algorithm))
+        }
         AlgorithmSpec::Advisor {
             executor_target,
             advisor_target,
@@ -1170,6 +1222,10 @@ fn classifier_contract(prompt: Option<&str>) -> ClassifierContractConfig {
 
 fn default_classifier_max_output_tokens() -> u64 {
     TaskClassifierConfig::default().max_output_tokens
+}
+
+const fn default_minimum_successful_candidates() -> usize {
+    1
 }
 
 fn resolve_targets<'a>(

--- a/crates/switchyard-runner/src/config.rs
+++ b/crates/switchyard-runner/src/config.rs
@@ -778,6 +778,76 @@ confidence_threshold = 0.5
         )
     }
 
+    fn ensemble_config() -> String {
+        format!(
+            r#"{VALID_CONFIG}
+[routes.ensemble]
+id = "switchyard/ensemble"
+type = "ensemble"
+candidates = ["strong", "weak"]
+synthesizer_target = "classifier"
+"#
+        )
+    }
+
+    #[test]
+    fn ensemble_route_builds_with_candidates_and_synthesizer() -> RunnerResult<()> {
+        let runner = runner_from_toml(&ensemble_config())?;
+        assert!(
+            runner
+                .models()
+                .any(|model| model.id.as_str() == "switchyard/ensemble")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ensemble_route_requires_two_to_four_candidates() {
+        for candidates in [
+            "[]",
+            "[\"strong\"]",
+            "[\"strong\", \"weak\", \"strong\", \"weak\", \"strong\"]",
+        ] {
+            let config = ensemble_config().replace(
+                "candidates = [\"strong\", \"weak\"]",
+                &format!("candidates = {candidates}"),
+            );
+            assert!(
+                error_message(&config).contains("requires between 2 and 4 candidates"),
+                "{candidates}"
+            );
+        }
+    }
+
+    #[test]
+    fn ensemble_route_accepts_synthesis_settings() -> RunnerResult<()> {
+        let config = ensemble_config().replace(
+            "synthesizer_target = \"classifier\"",
+            "synthesizer_target = \"classifier\"\n\
+             synthesizer_system_prompt = \"Reconcile the drafts concisely.\"\n\
+             minimum_successful_candidates = 2\n\
+             candidate_max_output_tokens = 512",
+        );
+        runner_from_toml(&config)?;
+        Ok(())
+    }
+
+    #[test]
+    fn ensemble_route_rejects_invalid_synthesis_settings() {
+        for setting in [
+            "synthesizer_system_prompt = \" \"",
+            "minimum_successful_candidates = 0",
+            "minimum_successful_candidates = 3",
+            "candidate_max_output_tokens = 0",
+        ] {
+            let config = ensemble_config().replace(
+                "synthesizer_target = \"classifier\"",
+                &format!("synthesizer_target = \"classifier\"\n{setting}"),
+            );
+            assert!(error_message(&config).contains("ensemble"), "{setting}");
+        }
+    }
+
     #[test]
     fn composite_route_builds_and_claims_both_tiers_and_its_judge() -> RunnerResult<()> {
         let runner = runner_from_toml(&composite_config())?;

--- a/crates/switchyard-server/README.md
+++ b/crates/switchyard-server/README.md
@@ -73,7 +73,7 @@ upstream, and a route's `id` is the model clients send to select that algorithm.
 
 Each target references an entry under `llm_clients`. All configured clients use
 `TranslatingLlmClient`; supported formats are `openai_chat`, `openai_responses`, and
-`anthropic_messages`. Supported algorithms are `noop`, `random`, `passthrough`,
+`anthropic_messages`. Supported algorithms are `noop`, `random`, `ensemble`, `passthrough`,
 `llm_classifier`, and `stage_router`. The optional `prefill-router` feature also enables
 `prefill_router`. An `api_key_env` value names an environment variable; the TOML never contains the
 secret itself. If omitted, the client sends no authentication.

--- a/crates/switchyard-server/tests/server.rs
+++ b/crates/switchyard-server/tests/server.rs
@@ -301,7 +301,18 @@ async fn upstream_chat(
                 .is_some_and(|content| content.contains("schema-invalid verdict"))
         })
     });
-    let content = if model == "model/classifier" && custom_target_schema {
+    let content = if model == "model/ensemble-a" {
+        "draft A"
+    } else if model == "model/ensemble-b" {
+        "draft B"
+    } else if model == "model/ensemble-synthesizer" {
+        let messages = body["messages"].to_string();
+        if messages.contains("draft A") && messages.contains("draft B") {
+            "fused answer"
+        } else {
+            "missing candidate"
+        }
+    } else if model == "model/classifier" && custom_target_schema {
         if requests_invalid_verdict {
             r#"{"decision":{"target":"unknown"}}"#
         } else {
@@ -1316,6 +1327,85 @@ confidence_threshold = 0.5
         stats["algorithm_stats"]["stage_router"]["routing_decisions"]["override"]["targets"]["model/stats-strong"],
         1
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn ensemble_route_fans_out_and_synthesizes_through_the_public_api() -> TestResult {
+    let upstream = MockUpstream::start().await?;
+    let state = load_test_config(&format!(
+        r#"
+schema_version = 1
+
+[llm_clients.upstream]
+format = "openai_chat"
+base_url = "{base_url}"
+
+[targets.candidate_a]
+id = "model/ensemble-a"
+llm_client = "upstream"
+
+[targets.candidate_b]
+id = "model/ensemble-b"
+llm_client = "upstream"
+
+[targets.synthesizer]
+id = "model/ensemble-synthesizer"
+llm_client = "upstream"
+
+[routes.ensemble]
+id = "switchyard/ensemble"
+type = "ensemble"
+candidates = ["candidate_a", "candidate_b"]
+synthesizer_target = "synthesizer"
+minimum_successful_candidates = 2
+candidate_max_output_tokens = 64
+"#,
+        base_url = upstream.base_url
+    ))?;
+    let app = build_switchyard_router(state);
+
+    let response = send(
+        &app,
+        "POST",
+        "/v1/chat/completions",
+        Some(json!({
+            "model": "switchyard/ensemble",
+            "messages": [{"role": "user", "content": "solve this"}],
+            "max_completion_tokens": 32
+        })),
+    )
+    .await?;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(
+        response.json()?["choices"][0]["message"]["content"],
+        "fused answer"
+    );
+    assert_eq!(
+        response
+            .headers
+            .get("x-model-router-selected-model")
+            .and_then(|value| value.to_str().ok()),
+        Some("model/ensemble-synthesizer")
+    );
+
+    let calls = upstream.calls.lock().await;
+    assert_eq!(calls.len(), 3);
+    let mut candidate_models = calls[..2]
+        .iter()
+        .filter_map(|call| call["model"].as_str())
+        .collect::<Vec<_>>();
+    candidate_models.sort_unstable();
+    assert_eq!(candidate_models, ["model/ensemble-a", "model/ensemble-b"]);
+    for candidate in &calls[..2] {
+        assert!(!candidate["stream"].as_bool().unwrap_or(false));
+        assert_eq!(candidate["max_completion_tokens"], 64);
+    }
+    assert_eq!(calls[2]["model"], "model/ensemble-synthesizer");
+    assert_eq!(calls[2]["max_completion_tokens"], 32);
+    assert!(calls[2]["messages"].to_string().contains("draft A"));
+    assert!(calls[2]["messages"].to_string().contains("draft B"));
     Ok(())
 }
 

--- a/dev-server/config.toml
+++ b/dev-server/config.toml
@@ -4,7 +4,7 @@ schema_version = 1
 
 [llm_clients.inference_hub]
 format = "openai_responses"
-base_url = "https://inference-api.nvidia.com/v1"
+base_url = "https://api.example.com/v1" # Replace with your OpenAI-compatible gateway.
 api_key_env = "NVIDIA_API_KEY"
 
 # The two models our algos use
@@ -73,4 +73,3 @@ advisor_target = "capable"
 max_reviews = 3
 gate_stall_turns = 30
 gate_min_tool_results = 3
-

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -77,6 +77,7 @@ route types:
 |---|---|
 | `passthrough` | Sends every request to one target. |
 | `random` | Selects among targets using optional relative weights. |
+| `ensemble` | Calls several targets concurrently and synthesizes their responses. |
 | `llm_classifier` | Uses a classifier target to choose between weak and strong targets. |
 | `stage_router` | Uses tool-result and progress signals to choose an efficient or capable target. |
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -137,6 +137,7 @@ request should use the weak or strong target. The Rust server also supports:
 | Algorithm | Use it when | Config |
 |---|---|---|
 | [Random](routing_algorithms/random_routing.md) | You need a weighted split for A/B tests or baselines. | `random` |
+| [Ensemble](routing_algorithms/ensemble_routing.md) | Several independent answers should be synthesized into one response. | `ensemble` |
 | [LLM classifier](routing_algorithms/llm_classifier_routing.md) | Request content should decide whether to use the weak or strong target. | `llm_classifier` |
 | [Stage router](routing_algorithms/stage_router_routing.md) | Tool-result and progress signals should select an efficient or capable target. | `stage_router` |
 
@@ -199,6 +200,7 @@ tokio = { version = "1", features = ["macros", "rt"] }
 | `StageRouter` | Route from signals already in the conversation, such as tool results and errors, with an optional judge fallback. |
 | `LlmTaskClassifier` with escalation | Every turn runs on the efficient target first, and a judge reads that answer to decide whether to send the same request to the capable target. |
 | `Random` | Select among any number of targets, uniform or weighted. |
+| `Ensemble` | Generate two to four candidates concurrently and synthesize their responses. |
 
 These are the same strategies the server exposes as route types, so a deployment
 can move between the server and library paths without changing routing

--- a/docs/reference/toml_schema.md
+++ b/docs/reference/toml_schema.md
@@ -154,6 +154,20 @@ Splits traffic across targets. See
 | `weights` | No | equal | Finite, non-negative relative weights in `targets` order, with at least one positive value. Invalid weights are rejected at load time. |
 | `seed` | No | unset | Reproduces the selection sequence. |
 
+### `ensemble`
+
+Calls several targets concurrently, then asks a synthesizer target to combine
+their successful responses. See
+[Ensemble Routing](../routing_algorithms/ensemble_routing.md).
+
+| Key | Required | Default | Meaning |
+|---|:---:|---|---|
+| `candidates` | Yes | — | Two to four target names called concurrently. |
+| `synthesizer_target` | Yes | — | Target that receives the original conversation and successful candidate outputs, then produces the final response. |
+| `synthesizer_system_prompt` | No | packaged prompt | Replaces the synthesis instruction. Must be non-empty. |
+| `minimum_successful_candidates` | No | `1` | Usable candidate responses required before synthesis, from one through the configured candidate count. |
+| `candidate_max_output_tokens` | No | caller's cap | Positive output-token budget applied independently to each candidate. |
+
 ### `prefill_router`
 
 Routes the latest non-empty user message with a checkpoint-backed prefill classifier. Build

--- a/docs/routing_algorithms/ensemble_routing.md
+++ b/docs/routing_algorithms/ensemble_routing.md
@@ -1,0 +1,75 @@
+# Ensemble Routing
+
+Ensemble routing calls two to four candidate targets concurrently, buffers the
+successful responses, and asks a synthesizer target to produce one final answer.
+It is response-level fusion: Switchyard does not merge model weights or logits.
+
+Use it when answer quality can justify several candidate calls plus synthesis.
+Compared with ordinary routing, every request costs at least three model calls
+and waits for every candidate call to finish before synthesis begins.
+
+## Configure an ensemble
+
+Declare every candidate and the synthesizer as normal targets, then reference
+their target names from the route:
+
+```toml
+schema_version = 1
+
+[llm_clients.openrouter]
+format = "openai_chat"
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+
+[targets.fast]
+id = "provider/fast-model"
+llm_client = "openrouter"
+
+[targets.reasoning]
+id = "provider/reasoning-model"
+llm_client = "openrouter"
+
+[targets.synthesizer]
+id = "provider/synthesis-model"
+llm_client = "openrouter"
+
+[routes.fused]
+id = "fused"
+type = "ensemble"
+candidates = ["fast", "reasoning"]
+synthesizer_target = "synthesizer"
+minimum_successful_candidates = 2
+candidate_max_output_tokens = 2048
+```
+
+Clients send `fused` as the model ID. Switchyard sends the original request to
+both candidates. The synthesizer then receives the original conversation plus
+the normalized outputs of every successful candidate. Internal reasoning blocks
+are removed before synthesis; final text, refusals, and tool calls are retained.
+
+Candidate calls are always buffered because their partial tokens are not sent to
+the caller. `candidate_max_output_tokens` gives each internal candidate an
+independent budget, which may be higher or lower than the final response budget.
+The final synthesis keeps the caller's original streaming and output settings.
+
+The packaged synthesis prompt asks for a concise, complete answer that follows
+the caller's length and format constraints. Set `synthesizer_system_prompt` when
+the application needs a domain-specific rubric or output style.
+
+## Failure behavior
+
+A failed or empty candidate is omitted from synthesis. By default the route
+continues when at least one candidate produces usable output. Set
+`minimum_successful_candidates` to require more contributors; synthesis fails
+when fewer usable candidates remain. A synthesizer failure fails the request
+normally.
+
+Candidate responses must finish before synthesis, so callers do not receive
+candidate tokens as they arrive. When the original request asks for streaming,
+the synthesizer's final response can still stream to the caller.
+
+## Limits
+
+- Configure between two and four candidates.
+- Candidate ordering does not express priority; calls run concurrently.
+- Tool definitions from the original request remain available to the synthesizer.

--- a/docs/routing_algorithms/ensemble_routing.md
+++ b/docs/routing_algorithms/ensemble_routing.md
@@ -5,8 +5,10 @@ successful responses, and asks a synthesizer target to produce one final answer.
 It is response-level fusion: Switchyard does not merge model weights or logits.
 
 Use it when answer quality can justify several candidate calls plus synthesis.
-Compared with ordinary routing, every request costs at least three model calls
-and waits for every candidate call to finish before synthesis begins.
+Requests that reach synthesis make at least three model calls and wait for every
+candidate call to finish before synthesis begins. If fewer than
+`minimum_successful_candidates` candidates produce usable output, the request
+fails after the candidate calls without calling the synthesizer.
 
 ## Configure an ensemble
 

--- a/docs/routing_algorithms/overview.md
+++ b/docs/routing_algorithms/overview.md
@@ -14,6 +14,7 @@ configuration and tuning. For the vocabulary these pages use, see
 |---|---|---|
 | [Sub-Agent-Aware Routing](subagent_routing.md) | Delegated sub-agents should use a separate routing policy from the parent agent. | `passthrough` or `stage_router` with `subagents` |
 | [Random Routing](random_routing.md) | You need a fixed traffic split for A/B tests, baselines, or cost experiments. | `random` |
+| [Ensemble Routing](ensemble_routing.md) | Several independent answers should be combined into one model-generated response. | `ensemble` |
 | [LLM Classifier Routing](llm_classifier_routing.md) | Request content should decide whether a turn needs the weak or strong tier. | `llm_classifier` |
 | [Stage-Router Routing](stage_router_routing.md) | Tool-result and agent-progress signals should route most turns without an extra classifier call. | `stage_router` |
 | [Composite Routing](composite_routing.md) | Routing algorithms are composed, one setting the configuration of another before handing off. Today an LLM classifier sets a stage router's default tier. | `composite` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Overview: routing_algorithms/overview.md
       - Sub-Agent-Aware Routing: routing_algorithms/subagent_routing.md
       - Random Routing: routing_algorithms/random_routing.md
+      - Ensemble Routing: routing_algorithms/ensemble_routing.md
       - LLM Classifier Routing: routing_algorithms/llm_classifier_routing.md
       - Stage-Router Routing: routing_algorithms/stage_router_routing.md
       - Composite Routing: routing_algorithms/composite_routing.md

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -190,9 +190,9 @@ def test_cli_write_records_direct_upstream_mode_without_routing_stats(tmp_path: 
             "--server-config-json",
             '{"mode":"direct","upstream_api_key_env":"NVIDIA_API_KEY"}',
             "--harbor-base-url",
-            "https://inference-api.nvidia.com/v1",
+            "https://api.example.com/v1",
             "--upstream-base-url",
-            "https://inference-api.nvidia.com/v1",
+            "https://api.example.com/v1",
             "--upstream-api-key-env",
             "NVIDIA_API_KEY",
             "--harbor-path",
@@ -224,7 +224,7 @@ def test_cli_write_records_direct_upstream_mode_without_routing_stats(tmp_path: 
     manifest = json.loads(out.read_text())
     assert manifest["server"]["preset"] == "direct"
     assert manifest["server"]["mode"] == "direct"
-    assert manifest["server"]["upstream_base_url"] == "https://inference-api.nvidia.com/v1"
+    assert manifest["server"]["upstream_base_url"] == "https://api.example.com/v1"
     assert manifest["server"]["upstream_api_key_env"] == "NVIDIA_API_KEY"
     assert manifest["server"]["server_config"] is None
     assert manifest["outcomes"]["routing_stats_json_status"] == "not-requested"


### PR DESCRIPTION
## What

Adds an `ensemble` route: two to four targets generate drafts concurrently, then a configured synthesizer returns one answer. Supports independent candidate token budgets, a minimum usable-candidate threshold, and a synthesis prompt override. Internal drafts are buffered and reasoning blocks excluded; the final response retains the caller's streaming and output settings.

## Why

Allows applications to explore whether multiple smaller models can produce useful answers at lower latency than a stronger single model. The included deployment compares SOL + Opus → SOL against Astra, with both candidates required to contribute.

## Benchmarks

Exploratory live evaluation on September 9, 2026 through an authenticated OpenAI-compatible gateway (endpoint omitted):

- Baseline: `azure/openai/gpt-6-astra`.
- Candidates: `azure/openai/gpt-5.6-sol` and `azure/anthropic/claude-opus-5`; synthesizer: SOL. Three upstream calls per ensemble request.
- Budgets: 2,048 output tokens per candidate; 1,024 for the final answer. Both candidates must return usable output.
- Six manually selected tasks. Baseline and ensemble requests started together in the initial run.
- Judge: `azure/openai/gpt-5.6-terra`, with anonymous A/B answers and alternating order. Scores are correctness, completeness, instruction following, and clarity, each out of five.

| Case | SOL + Opus → SOL | Astra | Judge score, fusion / Astra |
|---|---:|---:|---:|
| Tokio first-success review | 33.27 s | 125.30 s | 20 / 20 |
| Python LRU debugging | 12.46 s | 16.49 s | 20 / 20 |
| Two-test Bayesian posterior | 10.66 s | 10.27 s | 20 / 20 |
| Boolean truth-value derivation | 10.33 s | 19.85 s | 20 / 20 |
| Exact JSON sorting | 6.10 s | 3.72 s | 20 / 20 |
| Transactional outbox, original run | 35.62 s | 46.92 s | 20 / 20 |
| Transactional outbox, fusion-only rerun | 28.13 s | — | 20 / 20 against saved Astra answer |

Fusion was faster on four of six initial cases; Astra was faster on Bayes and JSON sorting. The committed report's mean of 16.83 s versus 37.09 s and median of 11.56 s versus 18.17 s substitute the outbox rerun for its original result, so they combine two prompt versions and should not be treated as a controlled benchmark.

All six pairs received ties from the single model judge, but these small tasks, development-time prompt tuning limit the conclusion. This does not establish general quality superiority or equivalence. There are no repeated samples, confidence intervals, or independent held-out evaluation. Returned terminal usage excludes candidate usage, so no cost advantage is claimed.

### Evidence and configuration

- [Committed benchmark report](https://github.com/pst2154/Switchyard/blob/1cf7dcfa/benchmark/ensemble-inference-api-evidence.md)
- [Secret-free deployment configuration](https://github.com/pst2154/Switchyard/blob/1cf7dcfa/benchmark/server-configs/inference-api-ensemble-sol-opus-vs-astra.toml)
- [Ensemble configuration and behavior documentation](https://github.com/pst2154/Switchyard/blob/1cf7dcfa/docs/routing_algorithms/ensemble_routing.md)

## Validation

- Full Rust workspace tests passed after rebasing onto upstream `main`.
- Eight ensemble unit tests cover concurrent calls, candidate failure, minimum usable results, token budgets, reasoning removal, and configuration validation.
- Four runner configuration tests cover construction and invalid settings.
- Public HTTP integration test verifies both candidate calls, both drafts reaching synthesis, separate candidate/final budgets, and the returned synthesized answer.
- Earlier Clippy, Ruff, mypy, strict docs build, and 115 Python tests passed. The Docker integration file containing two tests was excluded because the Docker daemon was unavailable; the full Python suite was not green.

## Notes for reviewers

Start with `crates/libsy/src/algorithms/ensemble.rs`, then the runner configuration and HTTP integration test. Candidate failures can be tolerated up to the configured threshold; all-candidate failures retain a typed error. Candidate generation waits for all candidates before synthesis, and the final response usage does not aggregate internal call costs.
