### PR TITLE
fix(translation): encode Responses image URLs

### DIFF
--- a/crates/switchyard-translation/src/codecs/responses/buffered.rs
+++ b/crates/switchyard-translation/src/codecs/responses/buffered.rs
@@ -19,9 +19,9 @@ use crate::diagnostic::TranslationDiagnostic;
 use crate::error::{Result, TranslationError};
 use crate::format::{FormatId, WireFormat};
 use crate::llm::{
-    AggLlmResponse, ContentBlock, InstructionBlock, LlmRequest, MediaSource, Message, OutputParams,
-    ProviderExtensions, ReasoningParams, ResponseOutput, Role, SamplingParams, StopReason,
-    ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
+    AggLlmResponse, ContentBlock, ImageSource, InstructionBlock, LlmRequest, MediaSource, Message,
+    OutputParams, ProviderExtensions, ReasoningParams, ResponseOutput, Role, SamplingParams,
+    StopReason, ToolCall, ToolChoice, ToolDefinition, ToolResult, Usage,
 };
 use crate::policy::{DeterministicIdPolicy, TranslationPolicy};
 use crate::util::{
@@ -1137,6 +1137,53 @@ fn encode_responses_reasoning_input(text: &str, details: &[Value]) -> Option<Val
     }))
 }
 
+// Maps a normalized image source to the scalar URL required by OpenAI Responses.
+fn response_image_url(source: &ImageSource) -> Option<String> {
+    match source {
+        ImageSource::Url { url, .. } => Some(url.clone()),
+        ImageSource::Base64 { media_type, data } => Some(format!(
+            "data:{};base64,{}",
+            media_type.as_deref().unwrap_or("application/octet-stream"),
+            data
+        )),
+        ImageSource::Raw(raw) => {
+            let object = raw.as_object();
+            let object = if object
+                .and_then(|object| object.get("type"))
+                .and_then(Value::as_str)
+                == Some("image")
+            {
+                object
+                    .and_then(|object| object.get("source"))
+                    .and_then(Value::as_object)
+            } else {
+                object
+            };
+            let object = object?;
+            if let Some(url) = object.get("url").and_then(Value::as_str) {
+                return Some(url.to_string());
+            }
+            if let Some(url) = object.get("image_url").and_then(Value::as_str) {
+                return Some(url.to_string());
+            }
+            if let Some(url) = object
+                .get("image_url")
+                .and_then(Value::as_object)
+                .and_then(|image_url| image_url.get("url"))
+                .and_then(Value::as_str)
+            {
+                return Some(url.to_string());
+            }
+            let data = object.get("data").and_then(Value::as_str)?;
+            let media_type = object
+                .get("media_type")
+                .and_then(Value::as_str)
+                .unwrap_or("application/octet-stream");
+            Some(format!("data:{media_type};base64,{data}"))
+        }
+    }
+}
+
 // Maps normalized roles back to Responses role strings.
 fn role_to_responses(role: Role) -> &'static str {
     match role {
@@ -1172,7 +1219,15 @@ fn encode_responses_content(
                 blocks.push(json!({"type": "refusal", "refusal": text}));
             }
             ContentBlock::Image { source } => {
-                blocks.push(json!({"type": "input_image", "image_url": source}));
+                if let Some(image_url) = response_image_url(source) {
+                    blocks.push(json!({"type": "input_image", "image_url": image_url}));
+                } else {
+                    push_lossy(
+                        diagnostics,
+                        policy,
+                        "Responses codec could not map image content",
+                    )?;
+                }
             }
             ContentBlock::Audio { source } => blocks.push(match source {
                 MediaSource::Raw(raw) => json!({"type": "input_text", "text": json_string(raw)}),

--- a/crates/switchyard-translation/tests/request_translation.rs
+++ b/crates/switchyard-translation/tests/request_translation.rs
@@ -355,6 +355,89 @@ fn anthropic_unknown_content_does_not_leak_into_responses_request_blocks() -> Te
     Ok(())
 }
 
+// Verifies Anthropic base64 images become the scalar data URL Responses requires.
+#[test]
+fn anthropic_base64_image_becomes_responses_data_url() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet-4-20250514",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image."},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "aGVsbG8="
+                    }
+                }
+            ]
+        }],
+        "max_tokens": 1024
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["input"][0]["content"][1],
+        json!({
+            "type": "input_image",
+            "image_url": "data:image/png;base64,aGVsbG8="
+        })
+    );
+    Ok(())
+}
+
+// Verifies Anthropic URL images become the scalar URL Responses requires.
+#[test]
+fn anthropic_url_image_becomes_responses_image_url() -> TestResult {
+    let engine = TranslationEngine::default();
+    let body = json!({
+        "model": "claude-sonnet-4-20250514",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image."},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "url",
+                        "url": "https://example.test/image.png"
+                    }
+                }
+            ]
+        }],
+        "max_tokens": 1024
+    });
+
+    let output = engine
+        .translate_request(
+            WireFormat::AnthropicMessages,
+            WireFormat::OpenAiResponses,
+            &body,
+            &TranslationPolicy::default(),
+        )?
+        .body;
+
+    assert_eq!(
+        output["input"][0]["content"][1],
+        json!({
+            "type": "input_image",
+            "image_url": "https://example.test/image.png"
+        })
+    );
+    Ok(())
+}
+
 // Verifies Anthropic mixed tool-result and text content splits into valid OpenAI messages.
 #[test]
 fn anthropic_tool_result_followup_text_splits_to_openai_messages() -> TestResult {


### PR DESCRIPTION
Hey! Just writing here to show that a human is behind this PR. I required this patch (patching it using a Nix overlay) to avoid issues with mixing the different provider APIs via switchyard.

## What

Fix OpenAI Responses request encoding for normalized image content.

The buffered Responses codec previously serialized the internal tagged `ImageSource` enum directly into `input_image.image_url`. That produces an object such as `{ "type": "raw", "data": ... }`, while the Responses API requires `image_url` to be the scalar URL/data URL.

This change maps normalized image sources to the wire form Responses accepts:

- URL sources become scalar URLs.
- Base64 sources become `data:<media-type>;base64,<payload>` data URLs.
- Common raw Anthropic/OpenAI image shapes are recovered to their URL or data URL.
- Unmappable raw image shapes go through the existing lossy-translation diagnostic path.

Regression tests cover Anthropic URL and base64 image blocks translated into OpenAI Responses.

## Why

Image-bearing Anthropic requests routed through Switchyard to an OpenAI Responses backend currently emit a malformed `input_image` block. The route can then fail with an upstream schema error instead of preserving the image.

## How tested

TDD: added the two regression tests first and confirmed both failed before the codec change with the internal tagged `ImageSource` object in `image_url`; both pass after the fix.

- [ ] `uv run ruff check .` clean — not run; no Python files changed
- [ ] `uv run mypy switchyard` clean — not run; no Python files changed
- [ ] `uv run pytest tests/` green — not run; no Python tests changed
- [x] Manual smoke (describe what was run)

Rust checks run:

```text
cargo fmt --all -- --check
cargo clippy -p switchyard-translation --all-targets -- -D warnings
cargo test -p switchyard-translation
cargo test -p switchyard-translation --test request_translation
```

Results: formatting clean; clippy clean; translation suite green, including all 59 request-translation tests.

## Checklist

- [x] One class per file; filename = `snake_case` of the primary class. — N/A; Rust codec change only
- [x] New public symbols exported from `switchyard/__init__.py.__all__` if intended for downstream use. — N/A; no public Python symbols
- [x] Unit tests added for new components / bug fixes.
- [x] README / `--help` updated if customer-facing surface changed. — N/A; bug fix only
- [x] Commits signed off (`Signed-off-by: Your Name <email>`) per the DCO.

## Notes for reviewers

This intentionally preserves the current scalar `image_url` output shape and does not add support for a Responses `detail` field. Unmappable raw image sources report lossy conversion through the existing policy hook rather than serializing a malformed internal enum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image handling in Responses translations, including URL, base64, and raw image sources.
  * Base64-encoded images are converted into compatible data URLs with media types.

* **Bug Fixes**
  * Image sources that cannot be converted now produce a diagnostic instead of failing direct serialization.

* **Tests**
  * Added coverage for translating Anthropic image blocks into OpenAI Responses image inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->