### PR TITLE
fix(translation): open a reasoning summary part only when text streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Encrypted-only reasoning items open no summary part** — the Responses
+  stream encoder opened a `reasoning_summary_part` for every reasoning item and
+  closed it only when text had streamed, so an encrypted-only item left a part
+  open with no `done`. The part now opens on the first text delta. (#671)
 - **Responses reasoning through transforming routes** — reasoning that a route
   buffers or re-encodes now reaches the client in the standard `summary_text`
   shape with `reasoning_summary_*` events, encrypted-only and done-only

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -823,10 +823,27 @@ fn ensure_responses_reasoning_started(
             "summary": [],
         },
     }));
+    out
+}
+
+// Opens the item's single summary part the first time text streams for it. Encrypted-only
+// reasoning never streams text, so it never opens a part; the item closes with an empty
+// `summary`, matching what `finish_responses_stream` emits for it.
+fn ensure_responses_reasoning_summary_started(
+    state: &mut StreamTranslationState,
+    index: usize,
+) -> Vec<Value> {
+    let mut out = ensure_responses_reasoning_started(state, index);
+    let item_id = responses_reasoning_item_id(state, index);
+    let item = state.response_reasoning.entry(index).or_default();
+    if item.summary_started {
+        return out;
+    }
+    item.summary_started = true;
     out.push(json!({
         "type": "response.reasoning_summary_part.added",
         "item_id": item_id,
-        "output_index": output_index,
+        "output_index": item.output_index.unwrap_or(0),
         "summary_index": 0,
         "part": {"type": "summary_text", "text": ""},
     }));
@@ -839,7 +856,7 @@ fn encode_responses_reasoning_delta(
     index: usize,
     text: String,
 ) -> Vec<Value> {
-    let mut out = ensure_responses_reasoning_started(state, index);
+    let mut out = ensure_responses_reasoning_summary_started(state, index);
     let item = state.response_reasoning.entry(index).or_default();
     item.text.push_str(&text);
     let output_index = item.output_index.unwrap_or(0);

--- a/crates/switchyard-translation/src/codecs/responses/stream.rs
+++ b/crates/switchyard-translation/src/codecs/responses/stream.rs
@@ -856,6 +856,10 @@ fn encode_responses_reasoning_delta(
     index: usize,
     text: String,
 ) -> Vec<Value> {
+    // An empty delta carries nothing to show and must not open a part that would never close.
+    if text.is_empty() {
+        return ensure_responses_reasoning_started(state, index);
+    }
     let mut out = ensure_responses_reasoning_summary_started(state, index);
     let item = state.response_reasoning.entry(index).or_default();
     item.text.push_str(&text);

--- a/crates/switchyard-translation/src/codecs/stream.rs
+++ b/crates/switchyard-translation/src/codecs/stream.rs
@@ -78,8 +78,11 @@ pub struct StreamTranslationState {
 // One Responses reasoning output item under construction by the encoder.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ResponseReasoningState {
-    /// Set once the item's `added` events were emitted.
+    /// Set once the item's `added` event was emitted.
     pub(crate) started: bool,
+    /// Set once the item's summary part opened, which happens on the first text delta. An
+    /// encrypted-only item never opens one, so it never has to close one either.
+    pub(crate) summary_started: bool,
     pub(crate) output_index: Option<usize>,
     /// Provider item id the encrypted reasoning was issued under. Used as the emitted item id
     /// so the client's replay verifies upstream; `None` falls back to a synthesized id.

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -2245,3 +2245,45 @@ fn responses_stream_encrypted_only_reasoning_opens_no_summary_part() -> TestResu
     assert_eq!(done["item"]["summary"], json!([]));
     Ok(())
 }
+
+// An empty reasoning delta opens the item but not a summary part, so a provider that sends a
+// blank first delta does not leave the client with an unclosed part.
+#[test]
+fn responses_stream_empty_reasoning_delta_opens_no_summary_part() -> TestResult {
+    let engine = TranslationEngine::default();
+    let format = WireFormat::OpenAiResponses;
+    let mut state = StreamTranslationState::new(format, format);
+    let chunks = vec![
+        LlmResponseChunk::MessageStart {
+            id: Some("resp_1".into()),
+            model: Some(REASONING_MODEL.into()),
+        },
+        LlmResponseChunk::ReasoningDelta {
+            index: 0,
+            text: String::new(),
+        },
+        LlmResponseChunk::TextDelta {
+            index: 1,
+            text: "done".into(),
+        },
+        LlmResponseChunk::MessageStop { reason: None },
+    ];
+    let mut events = Vec::new();
+    for chunk in chunks {
+        events.extend(engine.encode_stream_event(
+            &mut state,
+            format,
+            LlmResponseStreamEvent::new(vec![chunk]),
+        )?);
+    }
+    events.extend(engine.finish_stream(&mut state, format)?);
+    let types: Vec<&str> = events.iter().filter_map(|e| e["type"].as_str()).collect();
+    assert!(
+        !types
+            .iter()
+            .any(|t| t.starts_with("response.reasoning_summary")),
+        "{types:?}"
+    );
+    assert!(types.contains(&"response.output_item.added"), "{types:?}");
+    Ok(())
+}

--- a/crates/switchyard-translation/tests/stream_translation.rs
+++ b/crates/switchyard-translation/tests/stream_translation.rs
@@ -2194,3 +2194,54 @@ fn responses_stream_opens_reasoning_under_provider_id_before_payload_arrives() -
     assert_eq!(done["item"]["summary"][0]["text"], "plan");
     Ok(())
 }
+
+// An encrypted-only reasoning item streams no text, so it must not open a summary part it can
+// never close; the client should see the item open, then close with an empty `summary` and the
+// encrypted payload attached.
+#[test]
+fn responses_stream_encrypted_only_reasoning_opens_no_summary_part() -> TestResult {
+    let engine = TranslationEngine::default();
+    let format = WireFormat::OpenAiResponses;
+    let mut state = StreamTranslationState::new(format, format);
+    let chunks = vec![
+        LlmResponseChunk::MessageStart {
+            id: Some("resp_1".into()),
+            model: Some(REASONING_MODEL.into()),
+        },
+        LlmResponseChunk::ReasoningDetailsDelta {
+            index: 0,
+            details: vec![json!({"type": "reasoning.encrypted", "data": "opaque", "id": "rs_1"})],
+            text: String::new(),
+        },
+        LlmResponseChunk::TextDelta {
+            index: 1,
+            text: "done".into(),
+        },
+        LlmResponseChunk::MessageStop { reason: None },
+    ];
+    let mut events = Vec::new();
+    for chunk in chunks {
+        events.extend(engine.encode_stream_event(
+            &mut state,
+            format,
+            LlmResponseStreamEvent::new(vec![chunk]),
+        )?);
+    }
+    events.extend(engine.finish_stream(&mut state, format)?);
+    let types: Vec<&str> = events.iter().filter_map(|e| e["type"].as_str()).collect();
+
+    assert!(
+        !types
+            .iter()
+            .any(|t| t.starts_with("response.reasoning_summary")),
+        "{types:?}"
+    );
+    let done = events
+        .iter()
+        .find(|e| e["type"] == "response.output_item.done" && e["item"]["type"] == "reasoning")
+        .ok_or("expected the reasoning item to close")?;
+    assert_eq!(done["item"]["id"], "rs_1");
+    assert_eq!(done["item"]["encrypted_content"], "opaque");
+    assert_eq!(done["item"]["summary"], json!([]));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The Responses stream encoder opened a `reasoning_summary_part` for every reasoning item as soon as the item opened, and closed it only when text had streamed. An encrypted-only reasoning item, which GPT-5 models return on every turn behind a route that re-streams a buffered reply, therefore left the client with a `response.reasoning_summary_part.added` and no matching `done`, while the completed item carried an empty `summary`. Clients tolerate it today, but it contradicts the shape the encoder itself emits for the completed item. Surfaced by review on #639 against an earlier revision of the codec; the condition still held on main after #646.

## Change

The summary part opens on the first non-empty text delta for the item instead of at item start. Encrypted-only items, and items whose provider sends an empty first delta, open, carry their payload, and close with an empty `summary` and no part events. Items with text see exactly the events they saw before: `output_item.added`, `reasoning_summary_part.added`, `reasoning_summary_text.delta`, `reasoning_summary_text.done`, `reasoning_summary_part.done`, `output_item.done`.

Implementation: the per-item encoder state gains a `summary_started` flag; `ensure_responses_reasoning_started` now emits only the item's `added` event, and a new `ensure_responses_reasoning_summary_started` emits the part's `added` event once, called from the text-delta path. An empty delta only opens the item.

## Tests

Two new stream tests: an encrypted-only reasoning detail produces no summary events and closes with the provider id, the payload, and an empty summary; an empty reasoning delta opens the item and no part. The existing summary-text test still sees its part open and close. Translation suite 185 tests, clippy clean with `-D warnings`. Changelog entry under Unreleased.
