### PR TITLE
ci: skip project builds for static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
           python-version: "3.12"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv sync --locked
+      - run: uv sync --locked --no-install-project
       - name: ruff check
-        run: uv run ruff check .
+        run: uv run --no-sync ruff check .
 
   # SPDX headers are a hard gate — every Python file must carry the exact
   # NVIDIA OSRB-required two-line form (SPDX-FileCopyrightText with the
@@ -128,9 +128,9 @@ jobs:
           python-version: "3.12"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - run: uv sync --locked
+      - run: uv sync --locked --no-install-project
       - name: mypy
-        run: uv run mypy switchyard
+        run: uv run --no-sync mypy switchyard
 
   # Unit tests on supported Python versions. Integration/e2e tests are
   # intentionally deselected here because they may need Docker, live provider


### PR DESCRIPTION
## What

Updates the Ruff and mypy jobs to install the locked development dependencies without installing the local Switchyard project. Both tools then run without synchronizing the environment a second time.

## Why

Ruff and mypy inspect the source tree and do not need the installed Switchyard package. The existing setup builds the local Maturin/PyO3 project before each check. In a clean local control run with dependencies cached, that build took about two minutes.

[`--no-install-project`](https://docs.astral.sh/uv/concepts/projects/sync/#partial-installations) skips the local project while retaining its dependencies. [`--no-sync`](https://docs.astral.sh/uv/concepts/projects/sync/#automatic-lock-and-sync) prevents `uv run` from synchronizing again and installing the project anyway. Relay uses the same pairing.

## How tested

- [x] `UV_PYTHON=3.12 uv sync --locked --no-install-project`
- [x] `UV_PYTHON=3.12 uv run --no-sync ruff check .`
- [x] `UV_PYTHON=3.12 uv run --no-sync mypy switchyard`
- [x] Confirmed `nemo-switchyard` remained uninstalled after both checks
- [x] Parsed `.github/workflows/ci.yml` as YAML
- [x] `git diff --check`

No live provider tests were run because this only changes setup for static-analysis jobs.

## Notes for reviewers

This changes four workflow lines. The Python test, Rust, and package smoke-test jobs continue to install Switchyard normally. No product code, dependencies, lockfile, or public APIs change.
