### PR TITLE
ci: bound package portability runs

### DIFF
--- a/.github/workflows/package-portability.yml
+++ b/.github/workflows/package-portability.yml
@@ -24,6 +24,11 @@ on:
       - "switchyard_rust/**"
   workflow_dispatch:
 
+# Cancel superseded PR runs; keep push and manual runs independent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -37,6 +42,7 @@ jobs:
   wheel:
     name: Wheel (linux-x86_64)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## What

- Cancel superseded package-portability runs when a pull request is updated.
- Keep `main` pushes and manual runs independent.
- Stop the wheel job if it runs longer than 30 minutes.

## Why

The portability job currently keeps running after a pull request receives a newer commit. Those outdated wheel builds overlap with the current run and use the same CI capacity.

The concurrency key is shared only by runs for the same pull request. Push and manual runs use their unique run ID, so they are not serialized or dropped.

Recent successful wheel jobs take about four minutes, with a maximum of roughly four minutes and 20 seconds across the latest 100 runs. Thirty minutes leaves substantial headroom while avoiding GitHub's six-hour default if the build hangs.

## How tested

- [x] `actionlint .github/workflows/package-portability.yml`
- [x] YAML parse
- [x] `git diff --check`
- [x] Live GitHub check: the [superseded run](https://github.com/NVIDIA-NeMo/Switchyard/actions/runs/34527176557) was canceled and its [replacement](https://github.com/NVIDIA-NeMo/Switchyard/actions/runs/34527366504) passed in 4m 2s
- [x] GitHub CI passed
- [x] Commit carries the required DCO sign-off

## Notes for reviewers

This changes only workflow run control. The package matrix, build commands, release workflow, artifacts, and publishing behavior are unchanged.

The timeout applies after a runner starts the job. It does not affect time spent waiting for a runner or approval.
