### PR TITLE
ci: enforce complete Python type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -130,7 +129,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - run: uv sync --locked
       - name: mypy
-        run: uv run mypy switchyard
+        run: uv run mypy
 
   # Unit tests on supported Python versions. Integration/e2e tests are
   # intentionally deselected here because they may need Docker, live provider


### PR DESCRIPTION
## What

Makes CI type-check both shipped Python packages and treats mypy failures as blocking.

The workflow now uses the roots already configured in `pyproject.toml` instead of overriding them with only `switchyard`.

## Why

The mypy configuration includes both `switchyard` and `switchyard_rust`, but CI currently passes `switchyard` explicitly and leaves the Rust binding facade unchecked. The job also uses `continue-on-error`, so type errors do not block a PR.

Both packages already pass under the existing strict configuration.

## How tested

- `uv sync --locked`
- `uv run mypy` — no issues in 7 source files
- Added a temporary type error under `switchyard_rust`, confirmed mypy failed, removed it, and confirmed mypy passed again
- `uv run ruff check .`
- `uv run pytest tests/ -v -m "not integration"` — 117 passed, 2 deselected

No runtime behavior, public APIs, dependencies, packaging, or release behavior change.
