### PR TITLE
ci: lock Rust checks and test prefill feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,13 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all --check
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - name: cargo clippy (prefill-router)
+        run: cargo clippy -p switchyard-server --all-targets --features prefill-router --locked -- -D warnings
       - name: cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace --locked
+      - name: cargo test (prefill-router)
+        run: cargo test -p switchyard-runner --features prefill-router --locked
 
   typecheck:
     name: Typecheck (mypy)


### PR DESCRIPTION
## What

- Run the existing Rust Clippy and test commands with `--locked`.
- Add focused Clippy and test coverage for the optional `prefill-router` integration.

## Why

The current Rust job does not fail when the Cargo manifests and committed lockfile disagree.

Cargo documents [`--locked`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#option-cargo-test---locked) as requiring the dependency versions recorded in `Cargo.lock` to remain unchanged. It exits with an error if the lockfile is missing or dependency resolution would update it.

It also tests the standalone `prefill-router` workspace crate without enabling the optional integration in `switchyard-runner` or the feature forwarded by `switchyard-server`.

The existing default checks stay in place because they compile the feature-disabled runner path. The two new steps cover the enabled path without rerunning every workspace test with `--all-features`.

## Notes for reviewers

This changes one workflow file (`+6/-2`). It does not change runtime behavior, public APIs, dependencies, packages, or release workflows.

## How tested

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo clippy -p switchyard-server --all-targets --features prefill-router --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo test -p switchyard-runner --features prefill-router --locked`
- [x] `git diff --check`

No live provider test was run because this only changes the Cargo commands used by CI.
