### PR TITLE
ci: lint GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   # ruff is a hard gate — the codebase passes today, keep it that way.
   lint:
-    name: Lint (ruff)
+    name: Lint
     needs: changes
     if: needs.changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
@@ -52,6 +52,8 @@ jobs:
           python-version: "3.12"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+      - name: actionlint
+        run: uvx --from pre-commit==4.5.0 pre-commit run actionlint --all-files
       - run: uv sync --locked --no-install-project
       - name: ruff check
         run: uv run --no-sync ruff check .

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -142,13 +142,13 @@ jobs:
           type = "passthrough"
           target = "mock"
           TOML
-          target/release/switchyard-server --config bench.toml --port $PROXY_PORT &
+          target/release/switchyard-server --config bench.toml --port "$PROXY_PORT" &
           echo "PROXY_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for proxy to be ready
         run: |
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:$PROXY_PORT/health > /dev/null 2>&1; then
+            if curl -sf "http://localhost:${PROXY_PORT}/health" > /dev/null 2>&1; then
               echo "Proxy is up after ${i}s"
               exit 0
             fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,11 @@ repos:
         additional_dependencies:
           - "@commitlint/config-conventional@20.4.1"
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: spdx-headers


### PR DESCRIPTION
## What

Adds `actionlint` to pre-commit and runs the same pinned hook in the existing CI lint job.

The first GitHub run also found two unquoted variables in `perf.yml`; those are quoted so the current workflow set starts clean.

## Why

Workflow YAML can parse successfully while still containing invalid GitHub expressions, contexts, matrix references, job dependencies, or embedded shell. This catches those errors before a workflow is merged.

## How tested

- [x] `uvx --from pre-commit==4.5.0 pre-commit validate-config`
- [x] `uvx --from pre-commit==4.5.0 pre-commit run actionlint --all-files` — all 9 workflows passed
- [x] GitHub Actions `Lint` job — actionlint, `uv sync`, and Ruff passed on Ubuntu 24.04
- [x] `git diff --check`
- [x] Commit carries the required DCO sign-off

## Notes for reviewers

This uses the same `actionlint` hook and version as NeMo Relay without copying its larger pre-commit CI setup. It adds no new GitHub `uses:` reference, public API, dependency lock change, packaging, or release behavior.
