### PR TITLE
ci: trial main-owned Rust caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust components
         run: rustup component add rustfmt clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: cargo fmt
         run: cargo fmt --all --check
       - name: cargo clippy


### PR DESCRIPTION
## What

Adds `Swatinem/rust-cache` to the existing Rust CI job.

Pull requests can restore the cache, but only `main` saves it. `cache-bin: false` keeps Cargo-installed binaries out. This follows the same pinned-action and main-writes pattern used by [NeMo Relay's Rust CI](https://github.com/NVIDIA/NeMo-Relay/blob/1ec3c63521b2323f939f1813c90d431121a74eaa/.github/workflows/ci_rust.yml#L116-L122), introduced as part of [NVIDIA/NeMo-Relay#46](https://github.com/NVIDIA/NeMo-Relay/pull/46).

## Why

Starts the trial described in [#669](https://github.com/NVIDIA-NeMo/Switchyard/issues/669).

Recent successful runs spend a median of 3m30s in the Rust job. Python currently takes longer, so I do not expect this to shorten the full workflow yet. It should reduce repeated Rust compilation and return Rust results sooner.

This is intentionally experimental. The first `main` run will seed the cache, then we can compare 5-10 warm runs and inspect cache size, restore time, and Rust job duration. If the savings are not meaningful or the cache churn is too high, we should revert it.

## Scope

- Only the core Rust job is cached.
- No custom cache keys or workspace-crate caching.
- Python, docs, portability, performance, publishing, and release workflows are unchanged.
- No public API, runtime dependency, package, or release behavior changes.

## How tested

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run ruff check .`
- `uv run mypy switchyard`
- `env -u OPENROUTER_API_KEY -u NVIDIA_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY uv run pytest tests/ -v -m "not integration"` - 117 passed, 2 deselected

No live provider calls were made.

## Notes for reviewers

The production diff is four YAML lines. A cache miss falls back to the normal Cargo build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Rust CI caching to reduce unnecessary cache storage and limit cache updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->