### PR TITLE
feat(relay): report routing outcome evidence

### DIFF
--- a/crates/libsy-llm-client/src/observation.rs
+++ b/crates/libsy-llm-client/src/observation.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use switchyard_libsy::OutcomeMetadata;
 use switchyard_protocol::{ModelId, Usage};
 
 /// One completed model call observed while serving an algorithm run.
@@ -24,6 +25,8 @@ pub struct LlmCallObservation {
 /// One request-scoped observation emitted by the algorithm runner.
 #[derive(Clone, Debug)]
 pub enum RunObservation {
+    /// Metadata attached to the completed routing outcome.
+    Outcome(OutcomeMetadata),
     /// A completed model call requested by the algorithm for routing work.
     LlmCall(LlmCallObservation),
     /// A completed terminal model call made from the routing outcome.

--- a/crates/libsy-llm-client/src/run.rs
+++ b/crates/libsy-llm-client/src/run.rs
@@ -33,7 +33,8 @@ use crate::{metrics, observability};
 /// Run one request to completion, serving every offloaded model call with `client`.
 ///
 /// Returns the model selected by the algorithm and the final [`Response`]. `observer`, when
-/// present, receives each completed routing or answer call and the routing overhead.
+/// present, receives metadata for the routing outcome, each completed routing or answer call,
+/// and the routing overhead.
 ///
 /// `clients` resolves each offloaded call to the client for the target the algorithm
 /// selected — an algorithm may route among targets served by different providers, so this is
@@ -71,6 +72,11 @@ pub async fn run(
     metrics::record_routing_overhead(&algorithm_name, overhead);
 
     let selected_model_id = outcome.selected_model_id()?.clone();
+    if let Some(observer) = &observer
+        && let Some(metadata) = outcome.metadata
+    {
+        observer(RunObservation::Outcome(metadata));
+    }
     let (result, answer_duration) = if let Some(response) = outcome.response {
         (Ok(response), None)
     } else {
@@ -659,9 +665,13 @@ mod tests {
         assert!(matches!(observations[0], RunObservation::AnswerCall(_)));
         assert!(matches!(
             observations[1],
+            RunObservation::Outcome(ref metadata) if metadata.algorithm == "answered_test"
+        ));
+        assert!(matches!(
+            observations[2],
             RunObservation::RoutingOverhead(_)
         ));
-        assert_eq!(observations.len(), 2);
+        assert_eq!(observations.len(), 3);
         Ok(())
     }
 

--- a/crates/libsy-llm-client/tests/observability.rs
+++ b/crates/libsy-llm-client/tests/observability.rs
@@ -1211,15 +1211,19 @@ async fn observed_run_reports_one_successful_routed_call() -> switchyard_libsy::
         Some(Some(MODEL))
     );
     let observations = observations.lock();
-    assert_eq!(observations.len(), 2);
-    let RunObservation::AnswerCall(observation) = &observations[0] else {
+    assert_eq!(observations.len(), 3);
+    let RunObservation::Outcome(metadata) = &observations[0] else {
+        return Err(test_error("expected an outcome observation"));
+    };
+    assert_eq!(metadata.algorithm, ALGO);
+    let RunObservation::AnswerCall(observation) = &observations[1] else {
         return Err(test_error("expected an answer-call observation"));
     };
     assert_eq!(observation.selected_model, MODEL);
     assert!(observation.is_success);
     assert!(observation.usage.is_some());
     assert!(matches!(
-        observations[1],
+        observations[2],
         RunObservation::RoutingOverhead(_)
     ));
     Ok(())

--- a/crates/switchyard-nemo-relay-plugin/README.md
+++ b/crates/switchyard-nemo-relay-plugin/README.md
@@ -198,10 +198,12 @@ meaning requires a new schema version.
 | `switchyard.routing.requested` | `algorithm` |
 | `switchyard.routing.llm_call` | `call_index`, `selected_model`, `call_role`, `outcome`, `latency_ms` |
 | `switchyard.routing.overhead` | `latency_ms` |
-| `switchyard.routing.decision` | `algorithm`, `selected_model`, nullable `served_model`, nullable `fallback_used` |
-| `switchyard.routing.error` | `failure_kind`; optional `category`, `phase`, `upstream_status`, and `target` |
+| `switchyard.routing.decision` | `algorithm`, `outcome_id`, `selected_model`, nullable `served_model`, nullable `fallback_used`, and optional `evidence` |
+| `switchyard.routing.error` | `failure_kind`; route-execution failures also include `category`, `phase`, nullable `upstream_status` and `target`, and may include `outcome_id` and `evidence` |
 
 `served_model` and `fallback_used` are `null` when serving metadata is unavailable.
+`evidence` is an object containing the supported string fields `source`, `verdict`,
+`trigger`, and `reason_code`, and numeric fields `score`, `confidence`, and `threshold`.
 
 ## Failure policy
 

--- a/crates/switchyard-nemo-relay-plugin/src/runtime.rs
+++ b/crates/switchyard-nemo-relay-plugin/src/runtime.rs
@@ -202,17 +202,25 @@ impl SwitchyardRuntime {
         });
         match route.execute(request, Some(observer)).await {
             Ok(output) => {
-                self.emit_observations(&mut events, take_observations(&observations), &metadata);
+                let mut outcome_fields = self.emit_observations(
+                    &mut events,
+                    take_observations(&observations),
+                    &metadata,
+                );
                 let served_model = output.response.served_model().map(|model| model.as_str());
+                let mut data = json!({
+                    "algorithm": route.algorithm_name(),
+                    "selected_model": output.selected_model.as_str(),
+                    "served_model": served_model,
+                    "fallback_used": served_model
+                        .map(|model| model != output.selected_model.as_str()),
+                });
+                if let Json::Object(data) = &mut data {
+                    data.append(&mut outcome_fields);
+                }
                 events.push(RoutingEvent::Mark(RoutingMark {
                     name: "switchyard.routing.decision".into(),
-                    data: json!({
-                        "algorithm": route.algorithm_name(),
-                        "selected_model": output.selected_model.as_str(),
-                        "served_model": served_model,
-                        "fallback_used": served_model
-                            .map(|model| model != output.selected_model.as_str()),
-                    }),
+                    data,
                     metadata,
                     severity: Some(LogSeverity::Info),
                 }));
@@ -222,11 +230,16 @@ impl SwitchyardRuntime {
                 }
             }
             Err(error) => {
-                self.emit_observations(&mut events, take_observations(&observations), &metadata);
+                let outcome_fields = self.emit_observations(
+                    &mut events,
+                    take_observations(&observations),
+                    &metadata,
+                );
                 self.route_execution_error_mark(
                     &mut events,
                     &error.execution_error_summary(),
                     None,
+                    outcome_fields,
                 );
                 Execution {
                     result: Err("Switchyard route execution failed".into()),
@@ -249,10 +262,20 @@ impl SwitchyardRuntime {
         events: &mut Vec<RoutingEvent>,
         observations: Vec<RunObservation>,
         metadata: &Json,
-    ) {
+    ) -> Map<String, Json> {
         let mut call_index = 0;
+        let mut outcome_fields = Map::new();
         for observation in observations {
             match observation {
+                RunObservation::Outcome(outcome) => {
+                    outcome_fields.insert(
+                        "outcome_id".into(),
+                        Json::String(outcome.outcome_id().into()),
+                    );
+                    if let Some(evidence) = evidence_for_mark(outcome.evidence) {
+                        outcome_fields.insert("evidence".into(), evidence);
+                    }
+                }
                 RunObservation::LlmCall(call) => {
                     call_index += 1;
                     self.routing_call_events(events, call, call_index, metadata);
@@ -287,6 +310,7 @@ impl SwitchyardRuntime {
                 }
             }
         }
+        outcome_fields
     }
 
     fn routing_call_events(
@@ -338,12 +362,29 @@ impl SwitchyardRuntime {
         events: &mut Vec<RoutingEvent>,
         summary: &RouteErrorSummary,
         metadata: Option<&Json>,
+        outcome_fields: Map<String, Json>,
     ) {
         let metadata = metadata
             .cloned()
             .unwrap_or_else(|| event_metadata(events).unwrap_or_else(|| Json::Object(Map::new())));
-        events.extend(route_execution_error_events(summary, metadata));
+        events.extend(route_execution_error_events(
+            summary,
+            metadata,
+            outcome_fields,
+        ));
     }
+}
+
+fn evidence_for_mark(evidence: Option<Json>) -> Option<Json> {
+    let Some(Json::Object(mut evidence)) = evidence else {
+        return None;
+    };
+    evidence.retain(|name, value| match name.as_str() {
+        "source" | "verdict" | "trigger" | "reason_code" => value.is_string(),
+        "score" | "confidence" | "threshold" => value.is_number(),
+        _ => false,
+    });
+    (!evidence.is_empty()).then_some(Json::Object(evidence))
 }
 
 pub(crate) fn emit_events(runtime: &PluginRuntime, events: Vec<RoutingEvent>) {
@@ -425,6 +466,7 @@ fn returned_events(
             for event in route_execution_error_events(
                 &stream_error_summary(error, served_model.as_ref()),
                 metadata.clone(),
+                Map::new(),
             ) {
                 emit_event(event);
             }
@@ -491,24 +533,40 @@ fn relay_stream_error(error: LlmStreamError) -> String {
     }
 }
 
-fn route_execution_error_mark(summary: &RouteErrorSummary, metadata: Json) -> RoutingMark {
+fn route_execution_error_mark(
+    summary: &RouteErrorSummary,
+    metadata: Json,
+    mut outcome_fields: Map<String, Json>,
+) -> RoutingMark {
+    let mut data = json!({
+        "failure_kind": "route_execution",
+        "category": summary.kind.as_str(),
+        "phase": summary.phase.as_str(),
+        "upstream_status": summary.upstream_status,
+        "target": summary.target.as_ref().map(|target| target.as_str()),
+    });
+    if let Json::Object(data) = &mut data {
+        data.append(&mut outcome_fields);
+    }
     RoutingMark {
         name: "switchyard.routing.error".into(),
-        data: json!({
-            "failure_kind": "route_execution",
-            "category": summary.kind.as_str(),
-            "phase": summary.phase.as_str(),
-            "upstream_status": summary.upstream_status,
-            "target": summary.target.as_ref().map(|target| target.as_str()),
-        }),
+        data,
         metadata,
         severity: Some(LogSeverity::Error),
     }
 }
 
-fn route_execution_error_events(summary: &RouteErrorSummary, metadata: Json) -> Vec<RoutingEvent> {
+fn route_execution_error_events(
+    summary: &RouteErrorSummary,
+    metadata: Json,
+    outcome_fields: Map<String, Json>,
+) -> Vec<RoutingEvent> {
     vec![
-        RoutingEvent::Mark(route_execution_error_mark(summary, metadata.clone())),
+        RoutingEvent::Mark(route_execution_error_mark(
+            summary,
+            metadata.clone(),
+            outcome_fields,
+        )),
         failure_metric(
             "route_execution",
             Some(summary.kind.as_str()),
@@ -894,10 +952,88 @@ mod tests {
             assert_eq!(decision["selected_model"], "target/model");
             assert_eq!(decision["served_model"], "target/model");
             assert_eq!(decision["fallback_used"], false);
+            assert!(decision["outcome_id"].is_string());
             let response = execution.result.expect("target call should succeed");
             assert_eq!(response["object"], "response");
             assert_eq!(response["model"], "target/model");
         }
+    }
+
+    #[tokio::test]
+    async fn failed_answer_keeps_routing_outcome_in_error_mark() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let deployment = json!({
+            "schema_version": 1,
+            "llm_clients": {
+                "local": {
+                    "format": "openai_chat",
+                    "base_url": format!("{}/v1", server.uri()),
+                    "max_retries": 0,
+                }
+            },
+            "targets": {
+                "strong": {"id": "poc/strong", "llm_client": "local"},
+                "weak": {"id": "poc/weak", "llm_client": "local"},
+            },
+            "routes": {
+                "stage": {
+                    "id": "switchyard/stage",
+                    "type": "stage_router",
+                    "capable_target": "strong",
+                    "efficient_target": "weak",
+                    "picker": "efficient_first",
+                    "confidence_threshold": 0.5,
+                }
+            },
+        });
+        let runtime = SwitchyardRuntime::new(crate::config::SwitchyardConfig {
+            priority: 0,
+            switchyard_config_path: None,
+            switchyard_config: Some(
+                deployment
+                    .as_object()
+                    .expect("deployment should be an object")
+                    .clone(),
+            ),
+        })
+        .expect("stage runtime should load");
+        let request = runtime
+            .decode_request(
+                WireFormat::OpenAiChat,
+                RelayRequest {
+                    headers: Map::new(),
+                    content: json!({
+                        "model": "switchyard/stage",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    }),
+                },
+                false,
+            )
+            .expect("request should decode");
+
+        let execution = runtime
+            .execute_buffered(WireFormat::OpenAiChat, request)
+            .await;
+
+        assert!(execution.result.is_err());
+        let error = execution
+            .events
+            .iter()
+            .find_map(|event| match event {
+                RoutingEvent::Mark(mark) if mark.name == "switchyard.routing.error" => {
+                    Some(&mark.data)
+                }
+                RoutingEvent::Mark(_) | RoutingEvent::Metric(_) => None,
+            })
+            .expect("error mark should be emitted");
+        assert!(error["outcome_id"].is_string());
+        assert_eq!(error["evidence"], json!({"source": "fall_open"}));
     }
 
     #[tokio::test]
@@ -1019,6 +1155,7 @@ mod tests {
         let mark = route_execution_error_mark(
             &error.execution_error_summary(),
             json!({"session_id": "session"}),
+            Map::new(),
         );
 
         assert_eq!(mark.name, "switchyard.routing.error");
@@ -1031,6 +1168,33 @@ mod tests {
         assert_eq!(mark.data_schema().name, "switchyard.routing.error");
         assert_eq!(mark.data_schema().version, "1");
         assert!(!mark.data.to_string().contains(secret));
+    }
+
+    #[test]
+    fn decision_evidence_keeps_only_documented_typed_fields() {
+        let evidence = evidence_for_mark(Some(json!({
+            "source": "llm-classifier",
+            "score": 0.9,
+            "confidence": "wrong type",
+            "threshold": 0.5,
+            "verdict": "continue",
+            "trigger": "turn",
+            "reason_code": "test",
+            "unknown": "patient name is Jane Doe",
+            "prompt": {"secret": "do not export"},
+        })));
+
+        assert_eq!(
+            evidence,
+            Some(json!({
+                "source": "llm-classifier",
+                "score": 0.9,
+                "threshold": 0.5,
+                "verdict": "continue",
+                "trigger": "turn",
+                "reason_code": "test",
+            }))
+        );
     }
 
     #[test]

--- a/crates/switchyard-server/src/lib.rs
+++ b/crates/switchyard-server/src/lib.rs
@@ -410,6 +410,7 @@ fn stats_observer(
     classifier_log: Option<(SharedRoutingLog, routing_log::RoutingLogContext)>,
 ) -> RunObserver {
     Arc::new(move |observation| match observation {
+        RunObservation::Outcome(_) => {}
         RunObservation::AnswerCall(call) => {
             let latency_ms = call.duration.as_secs_f64() * 1_000.0;
             if call.is_success {

--- a/docs/integrations/nemo_relay.md
+++ b/docs/integrations/nemo_relay.md
@@ -314,8 +314,8 @@ describes the surrounding event envelope.
 | `switchyard.routing.requested` | Info | Routing `algorithm` for a managed request. |
 | `switchyard.routing.llm_call` | Debug | `call_index`, `selected_model`, `call_role` (`routing` or `answer`), `outcome`, and `latency_ms` for each observed model call. |
 | `switchyard.routing.overhead` | Info | `latency_ms` spent producing the routing outcome, including routing-model calls. This is not the end-to-end request duration. |
-| `switchyard.routing.decision` | Info | `algorithm`, initial `selected_model`, nullable final `served_model`, and nullable `fallback_used`. |
-| `switchyard.routing.error` | Error | Generic failures contain `failure_kind`. Route-execution failures also contain `category` and `phase`, plus nullable `upstream_status` and `target`. |
+| `switchyard.routing.decision` | Info | `algorithm`, `outcome_id`, initial `selected_model`, nullable final `served_model`, nullable `fallback_used`, and optional `evidence`. |
+| `switchyard.routing.error` | Error | Generic failures contain `failure_kind`. Route-execution failures also contain `category`, `phase`, nullable `upstream_status` and `target`, and may contain `outcome_id` and `evidence`. |
 
 Call marks describe Switchyard observations, not every HTTP retry made inside a
 client. `call_role` records whether Switchyard classified the call as routing
@@ -334,6 +334,10 @@ telemetry can report the model that answered.
 selection and `false` when they match. It and `served_model` are `null` when the
 response does not provide serving metadata. If route execution fails before a
 response is available, the error mark describes the terminal failure instead.
+When the algorithm supplies evidence, the plugin includes an object containing
+supported string fields (`source`, `verdict`, `trigger`, and `reason_code`) and
+numeric fields (`score`, `confidence`, and `threshold`). Other fields and values
+of the wrong type are omitted.
 
 ### Metrics
 


### PR DESCRIPTION
## What

- Forward existing libsy `OutcomeMetadata` through the LLM client's run observer.
- Add `outcome_id` and bounded, nested `evidence` to the existing Relay routing decision and route-execution error marks.
- Document the new fields in the Relay plugin's version-1 mark contract.

## Why

#647, #655, and #658 attach an outcome ID and bounded decision evidence to `RoutingOutcome` and the native `libsy.run` span. The Relay plugin does not export Switchyard's native spans, and the LLM client currently consumes that metadata before the plugin builds its marks.

As a result, Relay and Phoenix can show the selected and served models from #612, but not why the route was chosen. If every answer candidate fails, the routing outcome is also missing from the terminal error mark.

This passes the existing metadata through Relay's existing observation callback. It does not change routing, retries, fallback, responses, metrics, configuration, or mark names.

## How

- Add `RunObservation::Outcome(OutcomeMetadata)` and emit it once routing succeeds, before answer candidates run.
- Move the outcome ID and supported evidence fields into `switchyard.routing.decision` on success or `switchyard.routing.error` when all answer candidates fail.
- Keep evidence under an `evidence` object. Only known string fields (`source`, `verdict`, `trigger`, and `reason_code`) and numeric fields (`score`, `confidence`, and `threshold`) are retained.
- Ignore the new observation in `switchyard-server`, where the native `libsy.run` span already records the same metadata.

## Live Phoenix result

Before, the decision mark showed which model was selected and served, but not why:

![Before: routing decision without outcome evidence](https://github.com/user-attachments/assets/28177c88-08de-4afd-9ba2-25091fb66853)

After, a scored Stage decision includes the outcome ID and its bounded evidence:

![After: scored routing decision with source, confidence, and threshold](https://github.com/user-attachments/assets/10d7df38-b3c3-4288-a6bd-356b88a9fb1a)

When both answer candidates fail, the terminal error mark retains the route's outcome ID and evidence:

![After: terminal routing error retaining outcome evidence](https://github.com/user-attachments/assets/e99d7efe-539f-40b9-9136-e0fe282fda50)

## Notes for reviewers

Start with `RunObservation::Outcome` in `crates/libsy-llm-client/src/observation.rs` and its emission in `run.rs`. The Relay projection is in `crates/switchyard-nemo-relay-plugin/src/runtime.rs`.

`RunObservation` gains one public enum variant, so an external exhaustive match against current `main` must handle it. This is source-breaking for git consumers tracking `main`, but not a published API break: the latest released `switchyard-llm-client` is 0.2.0 and does not contain `RunObservation`. No existing function signatures change, and there are no new public methods or structs.

The route-execution regression makes both Stage answer candidates return HTTP 503 with retries disabled, then checks that the error mark retains the outcome ID and evidence.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run --only-group docs mkdocs build --strict`
- `git diff --check`
- Live Relay to Switchyard to Phoenix check with both answer candidates failing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured routing outcome metadata to run observations.
  * Routing telemetry now includes outcome identifiers and supported evidence fields for decisions and execution errors.
  * Evidence fields are filtered to documented string and numeric values.

* **Documentation**
  * Updated integration and plugin documentation to describe routing outcome metadata, evidence, and error fields.

* **Bug Fixes**
  * Preserved existing statistics behavior while supporting the new routing outcome observation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->